### PR TITLE
fix: bump C++ standard to 20 and silence nodiscard warnings

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run tests
         if: always()
         id: run-tests
-        run: ./build/shapeshifter_tests.exe
+        run: ./build/Release/shapeshifter_tests.exe
         shell: bash
 
       - name: Upload artifact
@@ -48,7 +48,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: shapeshifter-windows
-          path: build/shapeshifter.exe
+          path: build/Release/shapeshifter.exe
 
       - name: Upload CTRF report
         if: always() && steps.run-tests.outcome != 'skipped'

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run tests
         if: always()
         id: run-tests
-        run: ./build/shapeshifter_tests
+        run: ./build/shapeshifter_tests.exe
         shell: bash
 
       - name: Upload artifact

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(shapeshifter VERSION 0.1 LANGUAGES CXX)
 # (MSVC rejects them in C++17 mode with error C7555)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # ── Version (major.minor.githash) ────────────────────────────

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.20)
 project(shapeshifter VERSION 0.1 LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+# C++20 required: designated initializers are used throughout the codebase
+# (MSVC rejects them in C++17 mode with error C7555)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An endless runner where you shift between geometric shapes to pass through obstacles. The core twist: a **Burnout scoring system** rewards waiting until the last possible moment — the longer you delay, the higher your multiplier, but wait too long and you crash.
 
-Built with **C++17**, **SDL2**, and **EnTT** using a strict Data-Oriented Design architecture.
+Built with **C++20**, **SDL2**, and **EnTT** using a strict Data-Oriented Design architecture.
 
 ## Gameplay
 
@@ -16,7 +16,7 @@ Built with **C++17**, **SDL2**, and **EnTT** using a strict Data-Oriented Design
 
 ### Prerequisites
 
-- C++17 compiler (Clang or GCC)
+- C++20 compiler (Clang, GCC, or MSVC)
 - CMake 3.20+
 - SDL2 development libraries
 

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -1,5 +1,5 @@
 # SHAPESHIFTER — Technical Architecture Document
-## Data-Oriented Design · C++17 · SDL2 · EnTT v3.16.0
+## Data-Oriented Design · C++20 · SDL2 · EnTT v3.16.0
 
 > **Guiding principle**: Data lives in flat structs. Logic lives in free functions.
 > The `entt::registry` is the single source of truth. No globals. No virtuals.

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -88,14 +88,14 @@ TEST_CASE("components: GameState defaults to title", "[components]") {
 TEST_CASE("ecs: make_registry creates all singletons", "[ecs]") {
     auto reg = make_registry();
     // These should not throw
-    reg.ctx().get<InputState>();
-    reg.ctx().get<GestureResult>();
-    reg.ctx().get<ShapeButtonEvent>();
-    reg.ctx().get<GameState>();
-    reg.ctx().get<ScoreState>();
-    reg.ctx().get<BurnoutState>();
-    reg.ctx().get<DifficultyConfig>();
-    reg.ctx().get<AudioQueue>();
+    (void)reg.ctx().get<InputState>();
+    (void)reg.ctx().get<GestureResult>();
+    (void)reg.ctx().get<ShapeButtonEvent>();
+    (void)reg.ctx().get<GameState>();
+    (void)reg.ctx().get<ScoreState>();
+    (void)reg.ctx().get<BurnoutState>();
+    (void)reg.ctx().get<DifficultyConfig>();
+    (void)reg.ctx().get<AudioQueue>();
     CHECK(true);  // if we got here, all singletons exist
 }
 

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -96,7 +96,7 @@ TEST_CASE("ecs: make_registry creates all singletons", "[ecs]") {
     static_cast<void>(reg.ctx().get<BurnoutState>());
     static_cast<void>(reg.ctx().get<DifficultyConfig>());
     static_cast<void>(reg.ctx().get<AudioQueue>());
-    CHECK(true);  // if we got here, all singletons exist
+    SUCCEED("all required singletons exist in registry context");
 }
 
 TEST_CASE("ecs: make_player creates proper entity", "[ecs]") {

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -88,14 +88,14 @@ TEST_CASE("components: GameState defaults to title", "[components]") {
 TEST_CASE("ecs: make_registry creates all singletons", "[ecs]") {
     auto reg = make_registry();
     // These should not throw
-    (void)reg.ctx().get<InputState>();
-    (void)reg.ctx().get<GestureResult>();
-    (void)reg.ctx().get<ShapeButtonEvent>();
-    (void)reg.ctx().get<GameState>();
-    (void)reg.ctx().get<ScoreState>();
-    (void)reg.ctx().get<BurnoutState>();
-    (void)reg.ctx().get<DifficultyConfig>();
-    (void)reg.ctx().get<AudioQueue>();
+    static_cast<void>(reg.ctx().get<InputState>());
+    static_cast<void>(reg.ctx().get<GestureResult>());
+    static_cast<void>(reg.ctx().get<ShapeButtonEvent>());
+    static_cast<void>(reg.ctx().get<GameState>());
+    static_cast<void>(reg.ctx().get<ScoreState>());
+    static_cast<void>(reg.ctx().get<BurnoutState>());
+    static_cast<void>(reg.ctx().get<DifficultyConfig>());
+    static_cast<void>(reg.ctx().get<AudioQueue>());
     CHECK(true);  // if we got here, all singletons exist
 }
 


### PR DESCRIPTION
- CMakeLists.txt: bump CMAKE_CXX_STANDARD from 17 to 20 with comment explaining why (MSVC error C7555 with designated initializers)
- tests/test_components.cpp: cast nodiscard return values with (void) to fix [-Wunused-result] warnings on Linux CI

Agent-Logs-Url: https://github.com/yashasg/friendly-parakeet/sessions/4e442af7-68d0-4217-a46c-a0053197a541