### PR TITLE
refactor: migrate from SDL2 to raylib with DoD improvements

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,6 +54,10 @@ void update_movement(entt::registry& registry, float dt) {
 }
 ```
 
+## LSP / Code Intelligence
+
+A clangd LSP server is configured in `.github/lsp.json` for C/C++ code intelligence (go-to-definition, references, diagnostics, etc.). The main agent should use clangd for accurate code navigation and pass gathered context to sub-agents, since sub-agents do not have direct LSP access.
+
 ## Conventions
 
 - Game source code goes in `app/`

--- a/.github/lsp.json
+++ b/.github/lsp.json
@@ -1,0 +1,14 @@
+{
+  "lspServers": {
+    "clangd": {
+      "command": "/Users/yashasgujjar/Library/Application Support/Code/User/globalStorage/llvm-vs-code-extensions.vscode-clangd/install/22.1.0/clangd_22.1.0/bin/clangd",
+      "args": ["--compile-commands-dir=/Users/yashasgujjar/dev/bullethell/build"],
+      "fileExtensions": {
+        ".cpp": "cpp",
+        ".hpp": "cpp",
+        ".h": "cpp",
+        ".c": "c"
+      }
+    }
+  }
+}

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -49,8 +49,9 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
-            libsdl2-dev \
-            libsdl2-ttf-dev \
+            libgl1-mesa-dev \
+            libx11-dev \
+            libxrandr-dev \
             catch2
 
       - name: Build

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Run tests
         if: always()
         id: run-tests
-        run: ./build/shapeshifter_tests --benchmark-samples 1
+        run: ./build/shapeshifter_tests "~[bench]"
 
       - name: Upload artifact
         if: success()

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -15,7 +15,7 @@ jobs:
       checks: write
       pull-requests: write
     env:
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+      VCPKG_BINARY_SOURCES: "clear;default,readwrite"
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -83,6 +83,7 @@ jobs:
         uses: ctrf-io/github-test-reporter@v1
         with:
           report-path: 'ctrf-report.json'
+          title: 'Test Results (Linux)'
           pull-request-report: true
           summary-delta-report: true
           insights-report: true

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -20,14 +20,14 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Export GitHub Actions cache variables
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Setup C++ toolchain
-        uses: aminya/setup-cpp@v1
+        uses: aminya/setup-cpp@v2
         with:
           compiler: llvm
           cmake: true
@@ -66,14 +66,14 @@ jobs:
 
       - name: Upload artifact
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: shapeshifter-linux
           path: build/shapeshifter
 
       - name: Upload CTRF report
         if: always() && steps.run-tests.outcome != 'skipped'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ctrf-report-linux
           path: ctrf-report.json

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -38,7 +38,7 @@ jobs:
         shell: bash
 
       - name: Cache CMake build directory
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: build
           key: cmake-linux-clang-${{ hashFiles('CMakeLists.txt', 'vcpkg.json') }}

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -27,7 +27,7 @@ jobs:
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Setup C++ toolchain
-        uses: aminya/setup-cpp@v2
+        uses: aminya/setup-cpp@v1
         with:
           compiler: llvm
           cmake: true
@@ -38,7 +38,7 @@ jobs:
         shell: bash
 
       - name: Cache CMake build directory
-        uses: actions/cache@v6
+        uses: actions/cache@v5
         with:
           path: build
           key: cmake-linux-clang-${{ hashFiles('CMakeLists.txt', 'vcpkg.json') }}

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Run tests
         if: always()
         id: run-tests
-        run: ./build/shapeshifter_tests --benchmark-samples 1
+        run: ./build/shapeshifter_tests "~[bench]"
 
       - name: Upload artifact
         if: success()

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -50,6 +50,9 @@ jobs:
           chmod +x build.sh
           ./build.sh
 
+      - name: Ad-hoc code sign
+        run: codesign --force --sign - build/shapeshifter
+
       - name: Run tests
         if: always()
         id: run-tests

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -27,7 +27,7 @@ jobs:
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Setup C++ toolchain
-        uses: aminya/setup-cpp@v2
+        uses: aminya/setup-cpp@v1
         with:
           compiler: llvm
           cmake: true
@@ -38,7 +38,7 @@ jobs:
         shell: bash
 
       - name: Cache CMake build directory
-        uses: actions/cache@v6
+        uses: actions/cache@v5
         with:
           path: build
           key: cmake-macos-clang-${{ hashFiles('CMakeLists.txt', 'vcpkg.json') }}

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -20,14 +20,14 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Export GitHub Actions cache variables
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Setup C++ toolchain
-        uses: aminya/setup-cpp@v1
+        uses: aminya/setup-cpp@v2
         with:
           compiler: llvm
           cmake: true
@@ -60,14 +60,14 @@ jobs:
 
       - name: Upload artifact
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: shapeshifter-macos
           path: build/shapeshifter
 
       - name: Upload CTRF report
         if: always() && steps.run-tests.outcome != 'skipped'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ctrf-report-macos
           path: ctrf-report.json

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -38,7 +38,7 @@ jobs:
         shell: bash
 
       - name: Cache CMake build directory
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: build
           key: cmake-macos-clang-${{ hashFiles('CMakeLists.txt', 'vcpkg.json') }}

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -15,7 +15,7 @@ jobs:
       checks: write
       pull-requests: write
     env:
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+      VCPKG_BINARY_SOURCES: "clear;default,readwrite"
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -74,6 +74,7 @@ jobs:
         uses: ctrf-io/github-test-reporter@v1
         with:
           report-path: 'ctrf-report.json'
+          title: 'Test Results (macOS)'
           pull-request-report: true
           summary-delta-report: true
           insights-report: true

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -1,4 +1,4 @@
-name: CI (Windows)
+name: CI (macOS)
 
 on:
   push:
@@ -8,18 +8,14 @@ on:
 
 jobs:
   build:
-    name: Build (Windows)
-    runs-on: windows-latest
+    name: Build (macOS)
+    runs-on: macos-latest
     permissions:
       contents: read
       checks: write
       pull-requests: write
     env:
       VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
-      # Build vcpkg deps as static libs with dynamic CRT so the shipped
-      # .exe has no external DLL dependencies.
-      VCPKG_DEFAULT_TRIPLET: x64-windows-static-md
-      VCPKG_DEFAULT_HOST_TRIPLET: x64-windows-static-md
     steps:
       - uses: actions/checkout@v6
 
@@ -36,7 +32,6 @@ jobs:
           compiler: llvm
           cmake: true
           vcpkg: true
-          ninja: true
 
       - name: Export VCPKG_ROOT
         run: echo "VCPKG_ROOT=$HOME/vcpkg" >> "$GITHUB_ENV"
@@ -46,32 +41,32 @@ jobs:
         uses: actions/cache@v5
         with:
           path: build
-          key: cmake-windows-clang-static-md-${{ hashFiles('CMakeLists.txt', 'vcpkg.json') }}
+          key: cmake-macos-clang-${{ hashFiles('CMakeLists.txt', 'vcpkg.json') }}
           restore-keys: |
-            cmake-windows-clang-static-md-
+            cmake-macos-clang-
 
       - name: Build
-        run: ./build.sh
-        shell: bash
+        run: |
+          chmod +x build.sh
+          ./build.sh
 
       - name: Run tests
         if: always()
         id: run-tests
-        run: ./build/shapeshifter_tests.exe --benchmark-samples 1
-        shell: bash
+        run: ./build/shapeshifter_tests --benchmark-samples 1
 
       - name: Upload artifact
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: shapeshifter-windows
-          path: build/shapeshifter.exe
+          name: shapeshifter-macos
+          path: build/shapeshifter
 
       - name: Upload CTRF report
         if: always() && steps.run-tests.outcome != 'skipped'
         uses: actions/upload-artifact@v4
         with:
-          name: ctrf-report-windows
+          name: ctrf-report-macos
           path: ctrf-report.json
 
       - name: Report test results

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -41,7 +41,7 @@ jobs:
         shell: bash
 
       - name: Cache build directory
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: build-web
           key: cmake-web-emscripten-${{ hashFiles('CMakeLists.txt', 'vcpkg.json') }}

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -54,7 +54,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             "-DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
             "-DVCPKG_OVERLAY_PORTS=$(pwd)/vcpkg-overlay" \
-            -DVCPKG_CHAINLOAD_TOOLCHAIN_FILE="$(which emcc | xargs dirname)/../upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake"
+            "-DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=${EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake"
           cmake --build build-web
 
       - name: Upload artifact

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read
     env:
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+      VCPKG_BINARY_SOURCES: "clear;default,readwrite"
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -31,7 +31,7 @@ jobs:
           actions-cache-folder: emsdk-cache
 
       - name: Setup C++ toolchain
-        uses: aminya/setup-cpp@v2
+        uses: aminya/setup-cpp@v1
         with:
           cmake: true
           vcpkg: true
@@ -41,7 +41,7 @@ jobs:
         shell: bash
 
       - name: Cache build directory
-        uses: actions/cache@v6
+        uses: actions/cache@v5
         with:
           path: build-web
           key: cmake-web-emscripten-${{ hashFiles('CMakeLists.txt', 'vcpkg.json') }}

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -1,0 +1,69 @@
+name: CI (Web)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build (WebAssembly)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Export GitHub Actions cache variables
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      - name: Setup Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: 5.0.3
+          actions-cache-folder: emsdk-cache
+
+      - name: Setup C++ toolchain
+        uses: aminya/setup-cpp@v1
+        with:
+          cmake: true
+          vcpkg: true
+
+      - name: Export VCPKG_ROOT
+        run: echo "VCPKG_ROOT=$HOME/vcpkg" >> "$GITHUB_ENV"
+        shell: bash
+
+      - name: Cache build directory
+        uses: actions/cache@v5
+        with:
+          path: build-web
+          key: cmake-web-emscripten-${{ hashFiles('CMakeLists.txt', 'vcpkg.json') }}
+          restore-keys: |
+            cmake-web-emscripten-
+
+      - name: Build (Emscripten)
+        run: |
+          emcmake cmake -B build-web -S . \
+            -DCMAKE_BUILD_TYPE=Release \
+            "-DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
+            "-DVCPKG_OVERLAY_PORTS=$(pwd)/vcpkg-overlay" \
+            -DVCPKG_CHAINLOAD_TOOLCHAIN_FILE="$(which emcc | xargs dirname)/../upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake"
+          cmake --build build-web
+
+      - name: Upload artifact
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: shapeshifter-web
+          path: |
+            build-web/shapeshifter.html
+            build-web/shapeshifter.js
+            build-web/shapeshifter.wasm
+            build-web/shapeshifter.data

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Export GitHub Actions cache variables
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -31,7 +31,7 @@ jobs:
           actions-cache-folder: emsdk-cache
 
       - name: Setup C++ toolchain
-        uses: aminya/setup-cpp@v1
+        uses: aminya/setup-cpp@v2
         with:
           cmake: true
           vcpkg: true
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload artifact
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: shapeshifter-web
           path: |

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Run tests
         if: always()
         id: run-tests
-        run: ./build/shapeshifter_tests.exe --benchmark-samples 1
+        run: ./build/shapeshifter_tests.exe "~[bench]"
         shell: bash
 
       - name: Upload artifact

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -43,7 +43,7 @@ jobs:
         shell: bash
 
       - name: Cache CMake build directory
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: build
           key: cmake-windows-clang-static-md-${{ hashFiles('CMakeLists.txt', 'vcpkg.json') }}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -79,6 +79,7 @@ jobs:
         uses: ctrf-io/github-test-reporter@v1
         with:
           report-path: 'ctrf-report.json'
+          title: 'Test Results (Windows)'
           pull-request-report: true
           summary-delta-report: true
           insights-report: true

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -31,7 +31,7 @@ jobs:
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Setup C++ toolchain
-        uses: aminya/setup-cpp@v2
+        uses: aminya/setup-cpp@v1
         with:
           compiler: llvm
           cmake: true
@@ -43,7 +43,7 @@ jobs:
         shell: bash
 
       - name: Cache CMake build directory
-        uses: actions/cache@v6
+        uses: actions/cache@v5
         with:
           path: build
           key: cmake-windows-clang-static-md-${{ hashFiles('CMakeLists.txt', 'vcpkg.json') }}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -15,7 +15,7 @@ jobs:
       checks: write
       pull-requests: write
     env:
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+      VCPKG_BINARY_SOURCES: "clear;default,readwrite"
       # Build vcpkg deps as static libs with dynamic CRT so the shipped
       # .exe has no external DLL dependencies.
       VCPKG_DEFAULT_TRIPLET: x64-windows-static-md

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -24,14 +24,14 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Export GitHub Actions cache variables
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Setup C++ toolchain
-        uses: aminya/setup-cpp@v1
+        uses: aminya/setup-cpp@v2
         with:
           compiler: llvm
           cmake: true
@@ -62,14 +62,14 @@ jobs:
 
       - name: Upload artifact
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: shapeshifter-windows
           path: build/shapeshifter.exe
 
       - name: Upload CTRF report
         if: always() && steps.run-tests.outcome != 'skipped'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ctrf-report-windows
           path: ctrf-report.json

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high
           comment-summary-in-pr: always

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,3 +21,4 @@ jobs:
           fail-on-severity: high
           comment-summary-in-pr: always
           retry-on-snapshot-warnings: true
+          allow-licenses: MIT, Zlib, BSL-1.0, Apache-2.0, ISC, BSD-2-Clause, BSD-3-Clause

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: high
           comment-summary-in-pr: always

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ add_executable(shapeshifter
     app/systems/render_system.cpp
     app/systems/input_system.cpp
     app/text_renderer.cpp
+    app/file_logger.cpp
 )
 target_include_directories(shapeshifter PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/app
@@ -200,15 +201,32 @@ if(NOT EMSCRIPTEN)
     enable_testing()
 
     file(GLOB TEST_SOURCES tests/*.cpp benchmarks/*.cpp)
-    add_executable(shapeshifter_tests ${TEST_SOURCES})
+    add_executable(shapeshifter_tests
+        ${TEST_SOURCES}
+        app/file_logger.cpp
+    )
     target_include_directories(shapeshifter_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/app
     )
     target_link_libraries(shapeshifter_tests PRIVATE
         shapeshifter_lib
+        raylib
         Catch2::Catch2WithMain
         shapeshifter_warnings
     )
+    if(APPLE)
+        target_link_libraries(shapeshifter_tests PRIVATE
+            "-framework Cocoa"
+            "-framework OpenGL"
+            "-framework IOKit"
+            "-framework CoreFoundation"
+            "-framework CoreVideo"
+        )
+    elseif(WIN32)
+        target_link_libraries(shapeshifter_tests PRIVATE opengl32 gdi32 winmm)
+    elseif(UNIX)
+        target_link_libraries(shapeshifter_tests PRIVATE GL X11 Xrandr m pthread dl)
+    endif()
 
     include(CTest)
     include(Catch)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,25 @@ configure_file(
 # Catch2: test framework (vcpkg on Windows/macOS, system package on Linux).
 
 find_package(EnTT CONFIG REQUIRED)
-find_package(raylib CONFIG REQUIRED)
-find_package(Catch2 3 CONFIG REQUIRED)
+
+if(NOT EMSCRIPTEN)
+    # Native builds: raylib and Catch2 from vcpkg
+    find_package(raylib CONFIG REQUIRED)
+    find_package(Catch2 3 CONFIG REQUIRED)
+else()
+    # Emscripten: build raylib from source (no vcpkg triplet available).
+    # Mirrors raylib's own build_webassembly.yml.
+    include(FetchContent)
+    FetchContent_Declare(raylib
+        GIT_REPOSITORY https://github.com/raysan5/raylib.git
+        GIT_TAG        5.5
+        GIT_SHALLOW    ON
+    )
+    set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(CUSTOMIZE_BUILD ON CACHE BOOL "" FORCE)
+    set(PLATFORM Web CACHE STRING "" FORCE)
+    FetchContent_MakeAvailable(raylib)
+endif()
 
 # ── Warnings-as-errors (project targets only) ────────────────
 # Applied via an INTERFACE target so it never leaks into third-party code.
@@ -47,7 +64,11 @@ target_compile_options(shapeshifter_warnings INTERFACE
 
 # Mark third-party include directories as SYSTEM so warnings from their
 # headers are suppressed and cannot be promoted to errors by -Werror / /WX.
-foreach(_dep EnTT::EnTT raylib Catch2::Catch2 Catch2::Catch2WithMain)
+set(_system_deps EnTT::EnTT raylib)
+if(NOT EMSCRIPTEN)
+    list(APPEND _system_deps Catch2::Catch2 Catch2::Catch2WithMain)
+endif()
+foreach(_dep ${_system_deps})
     if(TARGET ${_dep})
         # Resolve alias targets — set_target_properties doesn't work on aliases
         get_target_property(_real ${_dep} ALIASED_TARGET)
@@ -115,8 +136,50 @@ if(APPLE)
     )
 elseif(WIN32)
     target_link_libraries(shapeshifter PRIVATE opengl32 gdi32 winmm)
-elseif(UNIX)
+elseif(UNIX AND NOT EMSCRIPTEN)
     target_link_libraries(shapeshifter PRIVATE GL X11 Xrandr m pthread dl)
+endif()
+
+# ── Emscripten linker flags ──────────────────────────────────
+if(EMSCRIPTEN)
+    target_compile_definitions(shapeshifter PRIVATE PLATFORM_WEB)
+
+    # Generate a minimal HTML shell at configure time — no static file to maintain.
+    set(_shell_html "${CMAKE_BINARY_DIR}/shell.html")
+    file(WRITE "${_shell_html}" [=[<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no">
+  <title>SHAPESHIFTER</title>
+  <style>
+    *{margin:0;padding:0;box-sizing:border-box}
+    body{background:#0f0f19;display:flex;justify-content:center;align-items:center;height:100vh;overflow:hidden;font-family:monospace;color:#ccc}
+    #canvas{display:block;border:1px solid #333}
+    #status{position:absolute;bottom:16px;text-align:center;width:100%;font-size:14px}
+  </style>
+</head>
+<body>
+  <canvas id="canvas" oncontextmenu="event.preventDefault()" tabindex="-1"></canvas>
+  <div id="status">Loading…</div>
+  <script>
+    var Module={
+      canvas:document.getElementById('canvas'),
+      setStatus:function(t){document.getElementById('status').innerText=t},
+      monitorRunDependencies:function(left){if(left===0)document.getElementById('status').style.display='none'}
+    };
+  </script>
+  {{{ SCRIPT }}}
+</body>
+</html>]=])
+
+    target_link_options(shapeshifter PRIVATE
+        -sUSE_GLFW=3
+        -sALLOW_MEMORY_GROWTH=1
+        --shell-file ${_shell_html}
+        --preload-file ${CMAKE_SOURCE_DIR}/assets@/assets
+    )
+    set_target_properties(shapeshifter PROPERTIES SUFFIX ".html")
 endif()
 
 # Copy font assets next to the executable so text_init() can find them
@@ -132,20 +195,22 @@ if(FONT_FILES)
     )
 endif()
 
-# ── Tests + Benchmarks ───────────────────────────────────────
-enable_testing()
+# ── Tests + Benchmarks (native only) ─────────────────────────
+if(NOT EMSCRIPTEN)
+    enable_testing()
 
-file(GLOB TEST_SOURCES tests/*.cpp benchmarks/*.cpp)
-add_executable(shapeshifter_tests ${TEST_SOURCES})
-target_include_directories(shapeshifter_tests PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/app
-)
-target_link_libraries(shapeshifter_tests PRIVATE
-    shapeshifter_lib
-    Catch2::Catch2WithMain
-    shapeshifter_warnings
-)
+    file(GLOB TEST_SOURCES tests/*.cpp benchmarks/*.cpp)
+    add_executable(shapeshifter_tests ${TEST_SOURCES})
+    target_include_directories(shapeshifter_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/app
+    )
+    target_link_libraries(shapeshifter_tests PRIVATE
+        shapeshifter_lib
+        Catch2::Catch2WithMain
+        shapeshifter_warnings
+    )
 
-include(CTest)
-include(Catch)
-catch_discover_tests(shapeshifter_tests)
+    include(CTest)
+    include(Catch)
+    catch_discover_tests(shapeshifter_tests)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,51 +27,13 @@ configure_file(
 )
 
 # ── Dependencies ─────────────────────────────────────────────
-# On Linux:   libsdl2-dev and catch2 are expected as system packages (apt).
-#             vcpkg only provides EnTT (header-only, fast).
-# On Windows: all three come from vcpkg (x64-windows-static-md triplet).
-# Pass -DCMAKE_TOOLCHAIN_FILE or set VCPKG_ROOT so vcpkg is used for EnTT.
+# EnTT: header-only ECS framework (vcpkg on all platforms).
+# raylib: rendering, windowing, input, audio (vcpkg on native platforms).
+# Catch2: test framework (vcpkg on Windows/macOS, system package on Linux).
 
 find_package(EnTT CONFIG REQUIRED)
-find_package(SDL2 CONFIG REQUIRED)
+find_package(raylib CONFIG REQUIRED)
 find_package(Catch2 3 CONFIG REQUIRED)
-
-# SDL2_ttf — required for text rendering.
-# System package on Linux (libsdl2-ttf-dev), vcpkg on Windows.
-find_package(PkgConfig QUIET)
-if(PkgConfig_FOUND)
-    pkg_check_modules(SDL2_TTF IMPORTED_TARGET SDL2_ttf)
-endif()
-if(NOT SDL2_TTF_FOUND)
-    find_package(SDL2_ttf CONFIG QUIET)
-endif()
-# Create a unified target alias if found via pkg-config
-if(SDL2_TTF_FOUND AND NOT TARGET SDL2_ttf::SDL2_ttf)
-    if(TARGET PkgConfig::SDL2_TTF)
-        add_library(SDL2_ttf::SDL2_ttf ALIAS PkgConfig::SDL2_TTF)
-    endif()
-endif()
-# vcpkg static triplets create SDL2_ttf::SDL2_ttf-static instead of
-# SDL2_ttf::SDL2_ttf.  Alias the static target so downstream code can
-# always link against SDL2_ttf::SDL2_ttf.
-if(TARGET SDL2_ttf::SDL2_ttf-static AND NOT TARGET SDL2_ttf::SDL2_ttf)
-    add_library(SDL2_ttf::SDL2_ttf ALIAS SDL2_ttf::SDL2_ttf-static)
-endif()
-# find_package sets SDL2_ttf_FOUND (mixed-case); pkg_check_modules sets
-# SDL2_TTF_FOUND (upper-case).  Accept either.
-if(NOT SDL2_TTF_FOUND AND NOT SDL2_ttf_FOUND AND NOT TARGET SDL2_ttf::SDL2_ttf)
-    message(FATAL_ERROR "SDL2_ttf is required. Install libsdl2-ttf-dev (apt) or add sdl2-ttf via vcpkg.")
-endif()
-
-# Normalize SDL2 target names (vcpkg may expose SDL2::SDL2 without SDL2::SDL2-static)
-if(TARGET SDL2::SDL2 AND NOT TARGET SDL2::SDL2-static)
-    add_library(SDL2::SDL2-static ALIAS SDL2::SDL2)
-endif()
-if(NOT TARGET SDL2::SDL2main)
-    # vcpkg may provide SDL2::SDL2main or not — create a dummy if missing
-    add_library(sdl2main_stub INTERFACE)
-    add_library(SDL2::SDL2main ALIAS sdl2main_stub)
-endif()
 
 # ── Warnings-as-errors (project targets only) ────────────────
 # Applied via an INTERFACE target so it never leaks into third-party code.
@@ -85,7 +47,7 @@ target_compile_options(shapeshifter_warnings INTERFACE
 
 # Mark third-party include directories as SYSTEM so warnings from their
 # headers are suppressed and cannot be promoted to errors by -Werror / /WX.
-foreach(_dep EnTT::EnTT SDL2::SDL2-static Catch2::Catch2 Catch2::Catch2WithMain SDL2_ttf::SDL2_ttf SDL2_ttf::SDL2_ttf-static PkgConfig::SDL2_TTF)
+foreach(_dep EnTT::EnTT raylib Catch2::Catch2 Catch2::Catch2WithMain)
     if(TARGET ${_dep})
         # Resolve alias targets — set_target_properties doesn't work on aliases
         get_target_property(_real ${_dep} ALIASED_TARGET)
@@ -113,7 +75,6 @@ target_include_directories(shapeshifter_lib PUBLIC
 )
 target_link_libraries(shapeshifter_lib PUBLIC
     EnTT::EnTT
-    SDL2::SDL2-static
 )
 target_link_libraries(shapeshifter_lib PRIVATE shapeshifter_warnings)
 
@@ -138,10 +99,25 @@ target_include_directories(shapeshifter PRIVATE
 )
 target_link_libraries(shapeshifter PRIVATE
     shapeshifter_lib
-    SDL2::SDL2main
+    raylib
     shapeshifter_warnings
 )
-target_link_libraries(shapeshifter PRIVATE SDL2_ttf::SDL2_ttf)
+
+# ── Platform link dependencies for raylib (RGFW backend) ─────
+# RGFW uses native platform APIs directly — no GLFW.
+if(APPLE)
+    target_link_libraries(shapeshifter PRIVATE
+        "-framework Cocoa"
+        "-framework OpenGL"
+        "-framework IOKit"
+        "-framework CoreFoundation"
+        "-framework CoreVideo"
+    )
+elseif(WIN32)
+    target_link_libraries(shapeshifter PRIVATE opengl32 gdi32 winmm)
+elseif(UNIX)
+    target_link_libraries(shapeshifter PRIVATE GL X11 Xrandr m pthread dl)
+endif()
 
 # Copy font assets next to the executable so text_init() can find them
 file(GLOB FONT_FILES ${CMAKE_SOURCE_DIR}/assets/fonts/*.ttf)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An endless runner where you shift between geometric shapes to pass through obstacles. The core twist: a **Burnout scoring system** rewards waiting until the last possible moment — the longer you delay, the higher your multiplier, but wait too long and you crash.
 
-Built with **C++20**, **SDL2**, and **EnTT** using a strict Data-Oriented Design architecture.
+Built with **C++20**, **raylib**, and **EnTT** using a strict Data-Oriented Design architecture.
 
 ## Gameplay
 
@@ -20,7 +20,7 @@ Built with **C++20**, **SDL2**, and **EnTT** using a strict Data-Oriented Design
 - CMake 3.20+
 - [vcpkg](https://vcpkg.io) — **required** for all builds
 
-Dependencies (EnTT, SDL2, Catch2) are resolved exclusively through vcpkg.
+Dependencies (EnTT, raylib, Catch2) are resolved through vcpkg.
 
 ### Setup
 
@@ -63,8 +63,8 @@ The codebase follows **Data-Oriented Design** principles from Richard Fabian's *
 Each frame runs a fixed-timestep loop executing systems in order:
 
 ```
-input_system          → polls SDL events into InputState
-gesture_system        → classifies touch input into gestures
+input_system          → polls raylib input into InputState
+gesture_system        → classifies touch/mouse input into gestures
 game_state_system     → manages phase transitions (Title/Playing/Paused/GameOver)
 player_action_system  → applies shape changes, lane switches, jumps, slides
 player_movement_system → interpolates positions and animations
@@ -72,12 +72,12 @@ difficulty_system     → ramps speed, spawn rate, burnout window
 obstacle_spawn_system → creates obstacle entities
 scroll_system         → moves entities by velocity
 burnout_system        → tracks nearest threat, calculates burnout zone
-collision_system      → checks obstacle clearance or crash
+collision_system      → checks obstacle clearance via per-archetype views
 scoring_system        → awards points with burnout multiplier
 lifetime_system       → destroys expired entities
-particle_system       → updates particle size and gravity
+particle_system       → applies gravity to particles
 cleanup_system        → destroys off-screen obstacles
-render_system         → draws everything via SDL2
+render_system         → draws everything via raylib
 audio_system          → plays queued SFX (stub)
 ```
 
@@ -85,19 +85,19 @@ audio_system          → plays queued SFX (stub)
 
 ```
 app/
-├── main.cpp              # SDL init + game loop (calls systems)
+├── main.cpp              # raylib init + game loop (calls systems)
 ├── constants.h           # All tuning values
 ├── components/           # 13 POD component structs
 │   ├── transform.h       #   Position, Velocity
 │   ├── player.h          #   PlayerTag, PlayerShape, Lane, VerticalState
 │   ├── obstacle.h        #   ObstacleTag, Obstacle, ScoredTag
 │   ├── obstacle_data.h   #   RequiredShape, BlockedLanes, RequiredLane, RequiredVAction
-│   ├── input.h           #   InputState, GestureResult, ShapeButtonEvent
+│   ├── input.h           #   InputState, SwipeGesture, GestureResult, ShapeButtonEvent
 │   ├── game_state.h      #   GameState, GamePhase
 │   ├── scoring.h         #   ScoreState, ScorePopup
 │   ├── burnout.h         #   BurnoutState, BurnoutZone
 │   ├── difficulty.h      #   DifficultyConfig
-│   ├── rendering.h       #   Color, DrawSize, DrawLayer
+│   ├── rendering.h       #   DrawColor, DrawSize, DrawLayer
 │   ├── lifetime.h        #   Lifetime
 │   ├── particle.h        #   ParticleTag, ParticleData
 │   └── audio.h           #   AudioQueue, SFX
@@ -130,7 +130,7 @@ Micro-benchmarks measure per-system and full-frame performance:
 
 | Library | Version | Purpose |
 |---------|---------|---------|
-| [SDL2](https://www.libsdl.org/) | 2.30+ | Windowing, rendering, input |
+| [raylib](https://www.raylib.com/) | 5.5+ | Windowing, rendering, input |
 | [EnTT](https://github.com/skypjack/entt) | 3.14+ | Entity Component System |
 | [Catch2](https://github.com/catchorg/Catch2) | 3.7+ | Testing and benchmarks |
 

--- a/app/components/input.h
+++ b/app/components/input.h
@@ -3,6 +3,10 @@
 #include "player.h"
 #include <cstdint>
 
+// Tracks which input device initiated the current gesture so that
+// mouse and touch events don't interfere on hybrid devices.
+enum class InputSource : uint8_t { None, Mouse, Touch };
+
 struct InputState {
     // ── Touch / pointer (all platforms) ──────────────────────
     bool  touch_down     = false;
@@ -15,9 +19,12 @@ struct InputState {
     float end_x    = 0.0f, end_y   = 0.0f;
     float duration = 0.0f;
 
+    InputSource active_source = InputSource::None;
+    bool was_focused = true;  // edge detection for focus-loss auto-pause
+
 #ifdef PLATFORM_DESKTOP
     // ── Keyboard — one-frame pulse flags (desktop only) ──────
-    // Set to true on initial SDL_KEYDOWN (repeat == 0),
+    // Set to true by IsKeyPressed() in input_system,
     // cleared by clear_input_events() at the start of each frame.
     bool key_w = false;   // jump
     bool key_a = false;   // strafe left
@@ -43,7 +50,7 @@ inline void clear_input_events(InputState& input) {
 #endif
 }
 
-enum class Gesture : uint8_t {
+enum class SwipeGesture : uint8_t {
     None       = 0,
     Tap        = 1,
     SwipeLeft  = 2,
@@ -53,7 +60,7 @@ enum class Gesture : uint8_t {
 };
 
 struct GestureResult {
-    Gesture gesture   = Gesture::None;
+    SwipeGesture gesture   = SwipeGesture::None;
     float   magnitude = 0.0f;
     float   hit_x     = 0.0f;
     float   hit_y     = 0.0f;

--- a/app/components/particle.h
+++ b/app/components/particle.h
@@ -3,6 +3,5 @@
 struct ParticleTag {};
 
 struct ParticleData {
-    float size       = 4.0f;
-    float start_size = 4.0f;
+    float size = 4.0f;
 };

--- a/app/components/rendering.h
+++ b/app/components/rendering.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-struct Color {
+struct DrawColor {
     uint8_t r = 255, g = 255, b = 255, a = 255;
 };
 

--- a/app/file_logger.cpp
+++ b/app/file_logger.cpp
@@ -1,0 +1,69 @@
+#include "file_logger.h"
+#include <raylib.h>
+#include <cstdio>
+#include <cstdarg>
+#include <ctime>
+
+static FILE* s_log_file = nullptr;
+
+static const char* log_level_str(int level) {
+    switch (level) {
+        case LOG_TRACE:   return "TRACE";
+        case LOG_DEBUG:   return "DEBUG";
+        case LOG_INFO:    return "INFO";
+        case LOG_WARNING: return "WARN";
+        case LOG_ERROR:   return "ERROR";
+        case LOG_FATAL:   return "FATAL";
+        default:          return "???";
+    }
+}
+
+static void file_log_callback(int level, const char* text, va_list args) {
+    if (level == LOG_NONE) return;
+
+    // Timestamp
+    std::time_t now = std::time(nullptr);
+    std::tm* tm = std::localtime(&now);
+    char ts[32];
+    std::strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S", tm);
+
+    const char* tag = log_level_str(level);
+
+    // Write to stdout
+    std::printf("[%s] [%-5s] ", ts, tag);
+    va_list args_copy;
+    va_copy(args_copy, args);
+    std::vprintf(text, args_copy);
+    va_end(args_copy);
+    std::printf("\n");
+
+    // Write to log file
+    if (s_log_file) {
+        std::fprintf(s_log_file, "[%s] [%-5s] ", ts, tag);
+        std::vfprintf(s_log_file, text, args);
+        std::fprintf(s_log_file, "\n");
+        std::fflush(s_log_file);
+    }
+}
+
+void file_logger_init(const char* log_path) {
+    s_log_file = std::fopen(log_path, "a");
+    if (s_log_file) {
+        // Session separator
+        std::time_t now = std::time(nullptr);
+        std::tm* tm = std::localtime(&now);
+        char ts[32];
+        std::strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S", tm);
+        std::fprintf(s_log_file, "\n══════ Session started %s ══════\n", ts);
+        std::fflush(s_log_file);
+    }
+    SetTraceLogCallback(file_log_callback);
+}
+
+void file_logger_shutdown() {
+    if (s_log_file) {
+        std::fflush(s_log_file);
+        std::fclose(s_log_file);
+        s_log_file = nullptr;
+    }
+}

--- a/app/file_logger.h
+++ b/app/file_logger.h
@@ -1,0 +1,8 @@
+#pragma once
+
+/// Installs a custom raylib TraceLog callback that writes to both
+/// stdout and a log file. Call before InitWindow().
+void file_logger_init(const char* log_path = "shapeshifter.log");
+
+/// Flushes and closes the log file.
+void file_logger_shutdown();

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -11,6 +11,7 @@
 #include "components/audio.h"
 #include "systems/all_systems.h"
 #include "text_renderer.h"
+#include "file_logger.h"
 
 #include <string>
 #include <cstdio>
@@ -70,6 +71,9 @@ static void update_draw_frame() {
 
 int main(int /*argc*/, char* /*argv*/[]) {
 
+    // ── FILE LOGGING (must be before InitWindow) ──────────────
+    file_logger_init("shapeshifter.log");
+
     // ── RAYLIB INIT ──────────────────────────────────────────
     std::string window_title = std::string("SHAPESHIFTER v") + SHAPESHIFTER_VERSION;
     InitWindow(
@@ -126,14 +130,12 @@ int main(int /*argc*/, char* /*argv*/[]) {
     reg.ctx().emplace<DifficultyConfig>();
     reg.ctx().emplace<AudioQueue>();
 
-    // ── TIMING ───────────────────────────────────────────────
-    float accumulator = 0.0f;
-
     // ── MAIN LOOP ────────────────────────────────────────────
 #ifdef __EMSCRIPTEN__
     g_loop = { &reg, 0.0f };
     emscripten_set_main_loop(update_draw_frame, 0, 1);
 #else
+    float accumulator = 0.0f;
     while (!WindowShouldClose()) {
 
         // Delta time
@@ -179,5 +181,6 @@ int main(int /*argc*/, char* /*argv*/[]) {
     // ── SHUTDOWN ─────────────────────────────────────────────
     text_shutdown(reg.ctx().get<TextContext>());
     CloseWindow();
+    file_logger_shutdown();
     return 0;
 }

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -1,4 +1,4 @@
-#include <SDL.h>
+#include <raylib.h>
 #include <entt/entt.hpp>
 
 #include "version.h"
@@ -13,56 +13,30 @@
 #include "text_renderer.h"
 
 #include <string>
+#include <cstdio>
 
 int main(int /*argc*/, char* /*argv*/[]) {
 
-    // ── SDL INIT ─────────────────────────────────────────────
-    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS) != 0) {
-        SDL_Log("SDL_Init failed: %s", SDL_GetError());
-        return 1;
-    }
-
-    SDL_Log("SHAPESHIFTER v%s", SHAPESHIFTER_VERSION);
-
+    // ── RAYLIB INIT ──────────────────────────────────────────
     std::string window_title = std::string("SHAPESHIFTER v") + SHAPESHIFTER_VERSION;
-    SDL_Window* window = SDL_CreateWindow(
-        window_title.c_str(),
-        SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
-        constants::SCREEN_W / 2, constants::SCREEN_H / 2,
-        SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE
+    InitWindow(
+        constants::SCREEN_W, constants::SCREEN_H,
+        window_title.c_str()
     );
-    if (!window) {
-        SDL_Log("SDL_CreateWindow failed: %s", SDL_GetError());
-        SDL_Quit();
-        return 1;
-    }
+    SetTargetFPS(60);
 
-    SDL_Renderer* renderer = SDL_CreateRenderer(
-        window, -1,
-        SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC
-    );
-    if (!renderer) {
-        SDL_Log("SDL_CreateRenderer failed: %s", SDL_GetError());
-        SDL_DestroyWindow(window);
-        SDL_Quit();
-        return 1;
-    }
-    SDL_RenderSetLogicalSize(renderer, constants::SCREEN_W, constants::SCREEN_H);
-    SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
+    TraceLog(LOG_INFO, "SHAPESHIFTER v%s", SHAPESHIFTER_VERSION);
 
     // ── ENTT REGISTRY ────────────────────────────────────────
     entt::registry reg;
 
-    // ── TEXT RENDERING (SDL2_ttf) ────────────────────────────
+    // ── TEXT RENDERING (raylib fonts) ────────────────────────
     {
         auto& text_ctx = reg.ctx().emplace<TextContext>();
 
         // Try font paths: next to executable, CWD assets, then system fonts
-        std::string base_path;
-        char* sdl_base = SDL_GetBasePath();
-        if (sdl_base) { base_path = sdl_base; SDL_free(sdl_base); }
-
-        std::string exe_font = base_path + "assets/fonts/LiberationMono-Regular.ttf";
+        std::string exe_font = std::string(GetApplicationDirectory())
+                             + "assets/fonts/LiberationMono-Regular.ttf";
         const char* font_paths[] = {
             exe_font.c_str(),
             "assets/fonts/LiberationMono-Regular.ttf",
@@ -73,13 +47,13 @@ int main(int /*argc*/, char* /*argv*/[]) {
         bool font_loaded = false;
         for (const char* path : font_paths) {
             if (text_init(text_ctx, path)) {
-                SDL_Log("Loaded font: %s", path);
+                TraceLog(LOG_INFO, "Loaded font: %s", path);
                 font_loaded = true;
                 break;
             }
         }
         if (!font_loaded) {
-            SDL_Log("ERROR: Could not load any TTF font");
+            TraceLog(LOG_ERROR, "Could not load any TTF font");
         }
     }
 
@@ -103,23 +77,18 @@ int main(int /*argc*/, char* /*argv*/[]) {
     constexpr float FIXED_DT  = 1.0f / 60.0f;
     constexpr float MAX_ACCUM = 0.1f;
     float accumulator = 0.0f;
-    Uint64 prev_counter = SDL_GetPerformanceCounter();
-    Uint64 freq = SDL_GetPerformanceFrequency();
 
     // ── MAIN LOOP ────────────────────────────────────────────
-    while (true) {
+    while (!WindowShouldClose()) {
 
         // Delta time
-        Uint64 now = SDL_GetPerformanceCounter();
-        float raw_dt = static_cast<float>(now - prev_counter)
-                     / static_cast<float>(freq);
-        prev_counter = now;
+        float raw_dt = GetFrameTime();
         accumulator += raw_dt;
         if (accumulator > MAX_ACCUM) {
             accumulator = MAX_ACCUM;
         }
 
-        // Phase 0: Input (polls SDL events, updates InputState)
+        // Phase 0: Input (polls raylib input state)
         input_system(reg, raw_dt);
         if (reg.ctx().get<InputState>().quit_requested) break;
 
@@ -143,7 +112,9 @@ int main(int /*argc*/, char* /*argv*/[]) {
 
         // Render
         float alpha = accumulator / FIXED_DT;
-        render_system(reg, renderer, alpha);
+        BeginDrawing();
+            render_system(reg, alpha);
+        EndDrawing();
 
         // Audio
         audio_system(reg);
@@ -151,8 +122,6 @@ int main(int /*argc*/, char* /*argv*/[]) {
 
     // ── SHUTDOWN ─────────────────────────────────────────────
     text_shutdown(reg.ctx().get<TextContext>());
-    SDL_DestroyRenderer(renderer);
-    SDL_DestroyWindow(window);
-    SDL_Quit();
+    CloseWindow();
     return 0;
 }

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -15,6 +15,59 @@
 #include <string>
 #include <cstdio>
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten/emscripten.h>
+#endif
+
+// ── Emscripten main-loop state ───────────────────────────────
+// The browser event loop is non-blocking, so we extract the loop body
+// into a free function and hand it to emscripten_set_main_loop.
+static constexpr float FIXED_DT  = 1.0f / 60.0f;
+static constexpr float MAX_ACCUM = 0.1f;
+
+#ifdef __EMSCRIPTEN__
+struct LoopState {
+    entt::registry* reg;
+    float accumulator;
+};
+static LoopState g_loop;
+
+static void update_draw_frame() {
+    auto& reg = *g_loop.reg;
+    float raw_dt = GetFrameTime();
+    g_loop.accumulator += raw_dt;
+    if (g_loop.accumulator > MAX_ACCUM) {
+        g_loop.accumulator = MAX_ACCUM;
+    }
+
+    input_system(reg, raw_dt);
+
+    while (g_loop.accumulator >= FIXED_DT) {
+        gesture_system(reg, FIXED_DT);
+        game_state_system(reg, FIXED_DT);
+        player_action_system(reg, FIXED_DT);
+        player_movement_system(reg, FIXED_DT);
+        difficulty_system(reg, FIXED_DT);
+        obstacle_spawn_system(reg, FIXED_DT);
+        scroll_system(reg, FIXED_DT);
+        burnout_system(reg, FIXED_DT);
+        collision_system(reg, FIXED_DT);
+        scoring_system(reg, FIXED_DT);
+        lifetime_system(reg, FIXED_DT);
+        particle_system(reg, FIXED_DT);
+        cleanup_system(reg, FIXED_DT);
+        g_loop.accumulator -= FIXED_DT;
+    }
+
+    float alpha = g_loop.accumulator / FIXED_DT;
+    BeginDrawing();
+        render_system(reg, alpha);
+    EndDrawing();
+
+    audio_system(reg);
+}
+#endif
+
 int main(int /*argc*/, char* /*argv*/[]) {
 
     // ── RAYLIB INIT ──────────────────────────────────────────
@@ -74,11 +127,13 @@ int main(int /*argc*/, char* /*argv*/[]) {
     reg.ctx().emplace<AudioQueue>();
 
     // ── TIMING ───────────────────────────────────────────────
-    constexpr float FIXED_DT  = 1.0f / 60.0f;
-    constexpr float MAX_ACCUM = 0.1f;
     float accumulator = 0.0f;
 
     // ── MAIN LOOP ────────────────────────────────────────────
+#ifdef __EMSCRIPTEN__
+    g_loop = { &reg, 0.0f };
+    emscripten_set_main_loop(update_draw_frame, 0, 1);
+#else
     while (!WindowShouldClose()) {
 
         // Delta time
@@ -119,6 +174,7 @@ int main(int /*argc*/, char* /*argv*/[]) {
         // Audio
         audio_system(reg);
     }
+#endif
 
     // ── SHUTDOWN ─────────────────────────────────────────────
     text_shutdown(reg.ctx().get<TextContext>());

--- a/app/systems/all_systems.h
+++ b/app/systems/all_systems.h
@@ -28,9 +28,8 @@ void lifetime_system(entt::registry& reg, float dt);
 void particle_system(entt::registry& reg, float dt);
 void cleanup_system(entt::registry& reg, float dt);
 
-// Phase 6: Render (takes renderer + interpolation alpha)
-struct SDL_Renderer;
-void render_system(entt::registry& reg, SDL_Renderer* renderer, float alpha);
+// Phase 6: Render (interpolation alpha only — no renderer handle)
+void render_system(entt::registry& reg, float alpha);
 
 // Audio (no dt needed)
 void audio_system(entt::registry& reg);

--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -20,74 +20,59 @@ void collision_system(entt::registry& reg, float /*dt*/) {
         player_view.get<Position, PlayerShape, Lane, VerticalState>(*player_it);
 
     constexpr float COLLISION_MARGIN = 40.0f;
+    bool game_over = false;
 
-    auto obs_view = reg.view<ObstacleTag, Position, Obstacle>(entt::exclude<ScoredTag>);
-    for (auto [entity, obs_pos, obs] : obs_view.each()) {
+    // Resolve proximity, mark scored or trigger game over.
+    auto resolve = [&](entt::entity entity, const Position& obs_pos, bool cleared) {
+        if (game_over) return;
         float dist = std::abs(p_pos.y - obs_pos.y + p_vstate.y_offset);
-        if (dist > COLLISION_MARGIN) continue;
-
-        bool cleared = false;
-
-        switch (obs.kind) {
-            case ObstacleKind::ShapeGate: {
-                auto* req = reg.try_get<RequiredShape>(entity);
-                if (req && p_shape.current == req->shape) {
-                    cleared = true;
-                }
-                break;
-            }
-            case ObstacleKind::LaneBlock: {
-                auto* blocked = reg.try_get<BlockedLanes>(entity);
-                if (blocked) {
-                    bool lane_blocked = (blocked->mask >> p_lane.current) & 1;
-                    if (!lane_blocked) {
-                        cleared = true;
-                    }
-                }
-                break;
-            }
-            case ObstacleKind::LowBar: {
-                if (p_vstate.mode == VMode::Jumping) {
-                    cleared = true;
-                }
-                break;
-            }
-            case ObstacleKind::HighBar: {
-                if (p_vstate.mode == VMode::Sliding) {
-                    cleared = true;
-                }
-                break;
-            }
-            case ObstacleKind::ComboGate: {
-                auto* req = reg.try_get<RequiredShape>(entity);
-                auto* blocked = reg.try_get<BlockedLanes>(entity);
-                bool shape_ok = req && (p_shape.current == req->shape);
-                bool lane_ok = blocked && !((blocked->mask >> p_lane.current) & 1);
-                if (shape_ok && lane_ok) {
-                    cleared = true;
-                }
-                break;
-            }
-            case ObstacleKind::SplitPath: {
-                auto* req = reg.try_get<RequiredShape>(entity);
-                auto* rlane = reg.try_get<RequiredLane>(entity);
-                bool shape_ok = req && (p_shape.current == req->shape);
-                bool lane_ok = rlane && (p_lane.current == rlane->lane);
-                if (shape_ok && lane_ok) {
-                    cleared = true;
-                }
-                break;
-            }
-        }
-
+        if (dist > COLLISION_MARGIN) return;
         if (cleared) {
             reg.emplace<ScoredTag>(entity);
         } else {
-            // Collision → game over
             auto& gs = reg.ctx().get<GameState>();
             gs.transition_pending = true;
             gs.next_phase = GamePhase::GameOver;
-            return;
+            game_over = true;
         }
+    };
+
+    // ShapeGate: RequiredShape only (no BlockedLanes, no RequiredLane, no RequiredVAction)
+    for (auto [e, pos, req] :
+         reg.view<ObstacleTag, Position, RequiredShape>(
+             entt::exclude<ScoredTag, BlockedLanes, RequiredLane, RequiredVAction>).each()) {
+        resolve(e, pos, p_shape.current == req.shape);
+    }
+
+    // LaneBlock: BlockedLanes only (no RequiredShape)
+    for (auto [e, pos, blocked] :
+         reg.view<ObstacleTag, Position, BlockedLanes>(
+             entt::exclude<ScoredTag, RequiredShape>).each()) {
+        resolve(e, pos, !((blocked.mask >> p_lane.current) & 1));
+    }
+
+    // LowBar / HighBar: RequiredVAction
+    for (auto [e, pos, req_v] :
+         reg.view<ObstacleTag, Position, RequiredVAction>(
+             entt::exclude<ScoredTag>).each()) {
+        resolve(e, pos, p_vstate.mode == req_v.action);
+    }
+
+    // ComboGate: RequiredShape + BlockedLanes (no RequiredLane)
+    for (auto [e, pos, req, blocked] :
+         reg.view<ObstacleTag, Position, RequiredShape, BlockedLanes>(
+             entt::exclude<ScoredTag, RequiredLane>).each()) {
+        bool shape_ok = (p_shape.current == req.shape);
+        bool lane_ok  = !((blocked.mask >> p_lane.current) & 1);
+        resolve(e, pos, shape_ok && lane_ok);
+    }
+
+    // SplitPath: RequiredShape + RequiredLane
+    for (auto [e, pos, req, rlane] :
+         reg.view<ObstacleTag, Position, RequiredShape, RequiredLane>(
+             entt::exclude<ScoredTag>).each()) {
+        bool shape_ok = (p_shape.current == req.shape);
+        bool lane_ok  = (p_lane.current == rlane.lane);
+        resolve(e, pos, shape_ok && lane_ok);
     }
 }

--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -35,7 +35,7 @@ static void enter_playing(entt::registry& reg) {
     reg.emplace<PlayerShape>(player);
     reg.emplace<Lane>(player);
     reg.emplace<VerticalState>(player);
-    reg.emplace<Color>(player, uint8_t{80}, uint8_t{180}, uint8_t{255}, uint8_t{255});
+    reg.emplace<DrawColor>(player, uint8_t{80}, uint8_t{180}, uint8_t{255}, uint8_t{255});
     reg.emplace<DrawSize>(player, constants::PLAYER_SIZE, constants::PLAYER_SIZE);
     reg.emplace<DrawLayer>(player, Layer::Game);
 

--- a/app/systems/gesture_system.cpp
+++ b/app/systems/gesture_system.cpp
@@ -8,7 +8,7 @@ void gesture_system(entt::registry& reg, float /*dt*/) {
     auto& gesture = reg.ctx().get<GestureResult>();
     auto& btn_evt = reg.ctx().get<ShapeButtonEvent>();
 
-    gesture.gesture = Gesture::None;
+    gesture.gesture = SwipeGesture::None;
     btn_evt.pressed = false;
 
 #ifdef PLATFORM_DESKTOP
@@ -17,10 +17,10 @@ void gesture_system(entt::registry& reg, float /*dt*/) {
     // ShapeButtonEvent outputs that the touch path produces.
     // Checked first: if any key fired this frame we return early,
     // preventing a simultaneous stray mouse event from double-firing.
-    if (input.key_w) { gesture.gesture = Gesture::SwipeUp;    return; }
-    if (input.key_s) { gesture.gesture = Gesture::SwipeDown;  return; }
-    if (input.key_a) { gesture.gesture = Gesture::SwipeLeft;  return; }
-    if (input.key_d) { gesture.gesture = Gesture::SwipeRight; return; }
+    if (input.key_w) { gesture.gesture = SwipeGesture::SwipeUp;    return; }
+    if (input.key_s) { gesture.gesture = SwipeGesture::SwipeDown;  return; }
+    if (input.key_a) { gesture.gesture = SwipeGesture::SwipeLeft;  return; }
+    if (input.key_d) { gesture.gesture = SwipeGesture::SwipeRight; return; }
     if (input.key_1) { btn_evt.pressed = true; btn_evt.shape = Shape::Circle;   return; }
     if (input.key_2) { btn_evt.pressed = true; btn_evt.shape = Shape::Triangle; return; }
     if (input.key_3) { btn_evt.pressed = true; btn_evt.shape = Shape::Square;   return; }
@@ -62,8 +62,8 @@ void gesture_system(entt::registry& reg, float /*dt*/) {
     gesture.magnitude = dist;
 
     if (std::abs(dx) > std::abs(dy)) {
-        gesture.gesture = (dx > 0) ? Gesture::SwipeRight : Gesture::SwipeLeft;
+        gesture.gesture = (dx > 0) ? SwipeGesture::SwipeRight : SwipeGesture::SwipeLeft;
     } else {
-        gesture.gesture = (dy > 0) ? Gesture::SwipeDown : Gesture::SwipeUp;
+        gesture.gesture = (dy > 0) ? SwipeGesture::SwipeDown : SwipeGesture::SwipeUp;
     }
 }

--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -2,93 +2,88 @@
 #include "../components/input.h"
 #include "../components/game_state.h"
 #include "../constants.h"
-#include <SDL.h>
+#include <raylib.h>
 
 void input_system(entt::registry& reg, float raw_dt) {
     auto& input = reg.ctx().get<InputState>();
     clear_input_events(input);
 
-    SDL_Event event;
-    while (SDL_PollEvent(&event)) {
-        switch (event.type) {
-            case SDL_QUIT:
-                input.quit_requested = true;
-                break;
-
-            // Mouse events (desktop testing — mapped to touch)
-            case SDL_MOUSEBUTTONDOWN:
-                input.touch_down = true;
-                input.touching   = true;
-                input.start_x    = static_cast<float>(event.button.x);
-                input.start_y    = static_cast<float>(event.button.y);
-                input.curr_x     = input.start_x;
-                input.curr_y     = input.start_y;
-                input.duration   = 0.0f;
-                break;
-            case SDL_MOUSEBUTTONUP:
-                input.touch_up  = true;
-                input.touching  = false;
-                input.end_x     = static_cast<float>(event.button.x);
-                input.end_y     = static_cast<float>(event.button.y);
-                break;
-            case SDL_MOUSEMOTION:
-                if (input.touching) {
-                    input.curr_x = static_cast<float>(event.motion.x);
-                    input.curr_y = static_cast<float>(event.motion.y);
-                }
-                break;
-
-            // Touch events (mobile)
-            case SDL_FINGERDOWN:
-                input.touch_down = true;
-                input.touching   = true;
-                input.start_x    = event.tfinger.x * constants::SCREEN_W;
-                input.start_y    = event.tfinger.y * constants::SCREEN_H;
-                input.curr_x     = input.start_x;
-                input.curr_y     = input.start_y;
-                input.duration   = 0.0f;
-                break;
-            case SDL_FINGERUP:
-                input.touch_up  = true;
-                input.touching  = false;
-                input.end_x     = event.tfinger.x * constants::SCREEN_W;
-                input.end_y     = event.tfinger.y * constants::SCREEN_H;
-                break;
-            case SDL_FINGERMOTION:
-                input.curr_x    = event.tfinger.x * constants::SCREEN_W;
-                input.curr_y    = event.tfinger.y * constants::SCREEN_H;
-                break;
-
-#ifdef PLATFORM_DESKTOP
-            // Keyboard events — desktop only.
-            // event.key.repeat != 0 means the OS key-repeat is firing;
-            // we only want the initial press so each key fires exactly once,
-            // matching the one-gesture-per-swipe model.
-            case SDL_KEYDOWN:
-                if (event.key.repeat == 0) {
-                    switch (event.key.keysym.sym) {
-                        case SDLK_w: input.key_w = true; break;
-                        case SDLK_a: input.key_a = true; break;
-                        case SDLK_s: input.key_s = true; break;
-                        case SDLK_d: input.key_d = true; break;
-                        case SDLK_1: input.key_1 = true; break;
-                        case SDLK_2: input.key_2 = true; break;
-                        case SDLK_3: input.key_3 = true; break;
-                        default: break;
-                    }
-                }
-                break;
-#endif
-
-            case SDL_APP_WILLENTERBACKGROUND:
-                if (reg.ctx().get<GameState>().phase == GamePhase::Playing) {
-                    auto& gs = reg.ctx().get<GameState>();
-                    gs.transition_pending = true;
-                    gs.next_phase = GamePhase::Paused;
-                }
-                break;
+    // ── Mouse (desktop) — only when no touch gesture is active ─
+    if (input.active_source != InputSource::Touch) {
+        if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
+            input.touch_down = true;
+            input.touching   = true;
+            input.active_source = InputSource::Mouse;
+            Vector2 pos = GetMousePosition();
+            input.start_x = input.curr_x = pos.x;
+            input.start_y = input.curr_y = pos.y;
+            input.duration = 0.0f;
+        }
+        if (IsMouseButtonReleased(MOUSE_BUTTON_LEFT) &&
+            input.active_source == InputSource::Mouse) {
+            input.touch_up  = true;
+            input.touching  = false;
+            input.active_source = InputSource::None;
+            Vector2 pos = GetMousePosition();
+            input.end_x = pos.x;
+            input.end_y = pos.y;
+        }
+        if (IsMouseButtonDown(MOUSE_BUTTON_LEFT) && input.touching &&
+            input.active_source == InputSource::Mouse) {
+            Vector2 pos = GetMousePosition();
+            input.curr_x = pos.x;
+            input.curr_y = pos.y;
         }
     }
+
+    // ── Touch (mobile / web) — only when no mouse gesture is active ─
+    if (input.active_source != InputSource::Mouse) {
+        if (GetTouchPointCount() > 0) {
+            Vector2 tp = GetTouchPosition(0);
+            if (!input.touching) {
+                input.touch_down = true;
+                input.touching   = true;
+                input.active_source = InputSource::Touch;
+                input.start_x = input.curr_x = tp.x;
+                input.start_y = input.curr_y = tp.y;
+                input.duration = 0.0f;
+            } else if (input.active_source == InputSource::Touch) {
+                input.curr_x = tp.x;
+                input.curr_y = tp.y;
+            }
+        } else if (input.touching && input.active_source == InputSource::Touch) {
+            input.touch_up  = true;
+            input.touching  = false;
+            input.active_source = InputSource::None;
+            input.end_x = input.curr_x;
+            input.end_y = input.curr_y;
+        }
+    }
+
+#ifdef PLATFORM_DESKTOP
+    // ── Keyboard — IsKeyPressed fires once per press (no repeat) ──
+    if (IsKeyPressed(KEY_W)) input.key_w = true;
+    if (IsKeyPressed(KEY_A)) input.key_a = true;
+    if (IsKeyPressed(KEY_S)) input.key_s = true;
+    if (IsKeyPressed(KEY_D)) input.key_d = true;
+    if (IsKeyPressed(KEY_ONE))   input.key_1 = true;
+    if (IsKeyPressed(KEY_TWO))   input.key_2 = true;
+    if (IsKeyPressed(KEY_THREE)) input.key_3 = true;
+#endif
+
+    // ── Background / suspend (edge-triggered) ─────────────
+    // Pause only on the frame focus is *lost*, not every frame while unfocused.
+    {
+        bool focused = IsWindowFocused();
+        if (input.was_focused && !focused &&
+            reg.ctx().get<GameState>().phase == GamePhase::Playing) {
+            auto& gs = reg.ctx().get<GameState>();
+            gs.transition_pending = true;
+            gs.next_phase = GamePhase::Paused;
+        }
+        input.was_focused = focused;
+    }
+
     if (input.touching) {
         input.duration += raw_dt;
     }

--- a/app/systems/obstacle_spawn_system.cpp
+++ b/app/systems/obstacle_spawn_system.cpp
@@ -45,13 +45,13 @@ void obstacle_spawn_system(entt::registry& reg, float dt) {
             reg.emplace<RequiredShape>(obstacle, shape);
             reg.emplace<DrawSize>(obstacle, float(constants::SCREEN_W), 80.0f);
 
-            // Color based on required shape
+            // DrawColor based on required shape
             if (shape == Shape::Circle)
-                reg.emplace<Color>(obstacle, uint8_t{80}, uint8_t{200}, uint8_t{255}, uint8_t{255});
+                reg.emplace<DrawColor>(obstacle, uint8_t{80}, uint8_t{200}, uint8_t{255}, uint8_t{255});
             else if (shape == Shape::Square)
-                reg.emplace<Color>(obstacle, uint8_t{255}, uint8_t{100}, uint8_t{100}, uint8_t{255});
+                reg.emplace<DrawColor>(obstacle, uint8_t{255}, uint8_t{100}, uint8_t{100}, uint8_t{255});
             else
-                reg.emplace<Color>(obstacle, uint8_t{100}, uint8_t{255}, uint8_t{100}, uint8_t{255});
+                reg.emplace<DrawColor>(obstacle, uint8_t{100}, uint8_t{255}, uint8_t{100}, uint8_t{255});
             break;
         }
         case ObstacleKind::LaneBlock: {
@@ -61,7 +61,7 @@ void obstacle_spawn_system(entt::registry& reg, float dt) {
             reg.emplace<Obstacle>(obstacle, kind, int16_t{constants::PTS_LANE_BLOCK});
             reg.emplace<BlockedLanes>(obstacle, mask);
             reg.emplace<DrawSize>(obstacle, float(constants::SCREEN_W / 3), 80.0f);
-            reg.emplace<Color>(obstacle, uint8_t{255}, uint8_t{60}, uint8_t{60}, uint8_t{255});
+            reg.emplace<DrawColor>(obstacle, uint8_t{255}, uint8_t{60}, uint8_t{60}, uint8_t{255});
             break;
         }
         case ObstacleKind::LowBar: {
@@ -69,7 +69,7 @@ void obstacle_spawn_system(entt::registry& reg, float dt) {
             reg.emplace<Obstacle>(obstacle, kind, int16_t{constants::PTS_LOW_BAR});
             reg.emplace<RequiredVAction>(obstacle, VMode::Jumping);
             reg.emplace<DrawSize>(obstacle, float(constants::SCREEN_W), 40.0f);
-            reg.emplace<Color>(obstacle, uint8_t{255}, uint8_t{180}, uint8_t{0}, uint8_t{255});
+            reg.emplace<DrawColor>(obstacle, uint8_t{255}, uint8_t{180}, uint8_t{0}, uint8_t{255});
             break;
         }
         case ObstacleKind::HighBar: {
@@ -77,7 +77,7 @@ void obstacle_spawn_system(entt::registry& reg, float dt) {
             reg.emplace<Obstacle>(obstacle, kind, int16_t{constants::PTS_HIGH_BAR});
             reg.emplace<RequiredVAction>(obstacle, VMode::Sliding);
             reg.emplace<DrawSize>(obstacle, float(constants::SCREEN_W), 40.0f);
-            reg.emplace<Color>(obstacle, uint8_t{180}, uint8_t{0}, uint8_t{255}, uint8_t{255});
+            reg.emplace<DrawColor>(obstacle, uint8_t{180}, uint8_t{0}, uint8_t{255}, uint8_t{255});
             break;
         }
         case ObstacleKind::ComboGate: {
@@ -88,7 +88,7 @@ void obstacle_spawn_system(entt::registry& reg, float dt) {
             reg.emplace<RequiredShape>(obstacle, shape);
             reg.emplace<BlockedLanes>(obstacle, mask);
             reg.emplace<DrawSize>(obstacle, float(constants::SCREEN_W), 80.0f);
-            reg.emplace<Color>(obstacle, uint8_t{200}, uint8_t{100}, uint8_t{255}, uint8_t{255});
+            reg.emplace<DrawColor>(obstacle, uint8_t{200}, uint8_t{100}, uint8_t{255}, uint8_t{255});
             break;
         }
         case ObstacleKind::SplitPath: {
@@ -98,7 +98,7 @@ void obstacle_spawn_system(entt::registry& reg, float dt) {
             reg.emplace<RequiredShape>(obstacle, shape);
             reg.emplace<RequiredLane>(obstacle, int8_t(lane));
             reg.emplace<DrawSize>(obstacle, float(constants::SCREEN_W), 80.0f);
-            reg.emplace<Color>(obstacle, uint8_t{255}, uint8_t{215}, uint8_t{0}, uint8_t{255});
+            reg.emplace<DrawColor>(obstacle, uint8_t{255}, uint8_t{215}, uint8_t{0}, uint8_t{255});
             break;
         }
     }

--- a/app/systems/particle_system.cpp
+++ b/app/systems/particle_system.cpp
@@ -5,13 +5,6 @@
 #include "../components/rendering.h"
 
 void particle_system(entt::registry& reg, float dt) {
-    // Update existing particles: shrink over lifetime
-    auto view = reg.view<ParticleTag, ParticleData, Lifetime>();
-    for (auto [entity, pdata, life] : view.each()) {
-        float ratio = life.remaining / life.max_time;
-        pdata.size = pdata.start_size * ratio;
-    }
-
     // Gravity on particles
     auto vel_view = reg.view<ParticleTag, Velocity>();
     for (auto [entity, vel] : vel_view.each()) {

--- a/app/systems/player_action_system.cpp
+++ b/app/systems/player_action_system.cpp
@@ -23,22 +23,22 @@ void player_action_system(entt::registry& reg, float /*dt*/) {
         }
 
         // Lane change from swipe
-        if (gesture.gesture == Gesture::SwipeLeft && lane.current > 0) {
+        if (gesture.gesture == SwipeGesture::SwipeLeft && lane.current > 0) {
             lane.target = lane.current - 1;
             lane.lerp_t = 0.0f;
         }
-        if (gesture.gesture == Gesture::SwipeRight && lane.current < constants::LANE_COUNT - 1) {
+        if (gesture.gesture == SwipeGesture::SwipeRight && lane.current < constants::LANE_COUNT - 1) {
             lane.target = lane.current + 1;
             lane.lerp_t = 0.0f;
         }
 
         // Jump / slide
         if (vstate.mode == VMode::Grounded) {
-            if (gesture.gesture == Gesture::SwipeUp) {
+            if (gesture.gesture == SwipeGesture::SwipeUp) {
                 vstate.mode  = VMode::Jumping;
                 vstate.timer = constants::JUMP_DURATION;
             }
-            if (gesture.gesture == Gesture::SwipeDown) {
+            if (gesture.gesture == SwipeGesture::SwipeDown) {
                 vstate.mode  = VMode::Sliding;
                 vstate.timer = constants::SLIDE_DURATION;
             }

--- a/app/systems/render_system.cpp
+++ b/app/systems/render_system.cpp
@@ -13,111 +13,88 @@
 #include "../components/audio.h"
 #include "../constants.h"
 #include "../text_renderer.h"
-#include <SDL.h>
+#include <raylib.h>
 #include <cmath>
 
-static void draw_shape(SDL_Renderer* r, Shape shape, float cx, float cy, float size) {
+static void draw_shape(Shape shape, float cx, float cy, float size, Color color) {
     switch (shape) {
         case Shape::Circle: {
-            // Approximate circle with 12-segment polygon
-            constexpr int SEGS = 12;
             float radius = size / 2.0f;
-            for (int i = 0; i < SEGS; ++i) {
-                float a1 = static_cast<float>(i) / SEGS * 2.0f * 3.14159f;
-                float a2 = static_cast<float>(i + 1) / SEGS * 2.0f * 3.14159f;
-                SDL_RenderDrawLineF(r,
-                    cx + std::cos(a1) * radius, cy + std::sin(a1) * radius,
-                    cx + std::cos(a2) * radius, cy + std::sin(a2) * radius);
-            }
-            // Fill with small rects (simple fill approach)
-            for (float dy = -radius; dy <= radius; dy += 2.0f) {
-                float half_w = std::sqrt(radius * radius - dy * dy);
-                SDL_FRect line = { cx - half_w, cy + dy, half_w * 2.0f, 2.0f };
-                SDL_RenderFillRectF(r, &line);
-            }
+            DrawCircleV({cx, cy}, radius, color);
             break;
         }
         case Shape::Square: {
             float half = size / 2.0f;
-            SDL_FRect rect = { cx - half, cy - half, size, size };
-            SDL_RenderFillRectF(r, &rect);
+            DrawRectangleRec({cx - half, cy - half, size, size}, color);
             break;
         }
         case Shape::Triangle: {
             float half = size / 2.0f;
-            // Fill triangle with horizontal lines
-            for (float row = 0; row < size; row += 2.0f) {
-                float ratio = row / size;
-                float half_w = half * ratio;
-                SDL_FRect line = { cx - half_w, cy - half + row, half_w * 2.0f, 2.0f };
-                SDL_RenderFillRectF(r, &line);
-            }
+            Vector2 v1 = {cx,        cy - half};
+            Vector2 v2 = {cx - half, cy + half};
+            Vector2 v3 = {cx + half, cy + half};
+            DrawTriangle(v1, v2, v3, color);
             break;
         }
     }
 }
 
-void render_system(entt::registry& reg, SDL_Renderer* renderer, float /*alpha*/) {
+void render_system(entt::registry& reg, float /*alpha*/) {
     auto& gs = reg.ctx().get<GameState>();
     auto& text_ctx = reg.ctx().get<TextContext>();
 
     // Clear
-    SDL_SetRenderDrawColor(renderer, 15, 15, 25, 255);
-    SDL_RenderClear(renderer);
+    ClearBackground({15, 15, 25, 255});
 
     // ── Draw lane lines ─────────────────────────────────────
-    SDL_SetRenderDrawColor(renderer, 40, 40, 60, 255);
+    Color lane_color = {40, 40, 60, 255};
     for (int i = 0; i < constants::LANE_COUNT; ++i) {
         float lx = constants::LANE_X[i];
-        SDL_RenderDrawLineF(renderer, lx, 0, lx,
-            constants::SCREEN_H * constants::SWIPE_ZONE_SPLIT);
+        DrawLineV({lx, 0}, {lx, constants::SCREEN_H * constants::SWIPE_ZONE_SPLIT},
+                  lane_color);
     }
 
     if (gs.phase == GamePhase::Title) {
         // Title screen
-        SDL_SetRenderDrawColor(renderer, 80, 180, 255, 255);
-        // "SHAPESHIFTER" placeholder — draw 3 shapes as logo
-        draw_shape(renderer, Shape::Circle,   280, 400, 80);
-        draw_shape(renderer, Shape::Square,   360, 400, 80);
-        SDL_SetRenderDrawColor(renderer, 100, 255, 100, 255);
-        draw_shape(renderer, Shape::Triangle, 440, 400, 80);
+        Color title_shape_color = {80, 180, 255, 255};
+        draw_shape(Shape::Circle,   280, 400, 80, title_shape_color);
+        draw_shape(Shape::Square,   360, 400, 80, title_shape_color);
+        Color green_color = {100, 255, 100, 255};
+        draw_shape(Shape::Triangle, 440, 400, 80, green_color);
 
         // Title text
-        text_draw(text_ctx, renderer, "SHAPESHIFTER",
+        text_draw(text_ctx, "SHAPESHIFTER",
             360, 500, FontSize::Large, 80, 180, 255, 255,
             TextAlign::Center);
 
         // "TAP TO START" indicator — pulsing text
         float pulse = (std::sin(gs.phase_timer * 3.0f) + 1.0f) / 2.0f;
         uint8_t alpha = static_cast<uint8_t>(100 + pulse * 155);
-        text_draw(text_ctx, renderer, "TAP TO START",
+        text_draw(text_ctx, "TAP TO START",
             360, 600, FontSize::Medium, 200, 200, 200, alpha,
             TextAlign::Center);
 
-        SDL_RenderPresent(renderer);
         return;
     }
 
     // ── Draw obstacles ──────────────────────────────────────
     {
-        auto view = reg.view<ObstacleTag, Position, Obstacle, Color, DrawSize>();
+        auto view = reg.view<ObstacleTag, Position, Obstacle, DrawColor, DrawSize>();
         for (auto [entity, pos, obs, col, dsz] : view.each()) {
 
-            SDL_SetRenderDrawColor(renderer, col.r, col.g, col.b, col.a);
+            Color c = {col.r, col.g, col.b, col.a};
 
             switch (obs.kind) {
                 case ObstacleKind::ShapeGate: {
                     // Full-width gate with shape hole
-                    SDL_FRect left  = { 0, pos.y, pos.x - 50, dsz.h };
-                    SDL_FRect right = { pos.x + 50, pos.y,
-                        constants::SCREEN_W - pos.x - 50, dsz.h };
-                    SDL_RenderFillRectF(renderer, &left);
-                    SDL_RenderFillRectF(renderer, &right);
+                    DrawRectangleRec({0, pos.y, pos.x - 50, dsz.h}, c);
+                    DrawRectangleRec({pos.x + 50, pos.y,
+                        constants::SCREEN_W - pos.x - 50, dsz.h}, c);
                     // Draw shape indicator in the gap
                     auto* req = reg.try_get<RequiredShape>(entity);
                     if (req) {
-                        SDL_SetRenderDrawColor(renderer, col.r, col.g, col.b, 120);
-                        draw_shape(renderer, req->shape, pos.x, pos.y + dsz.h / 2, 40);
+                        Color ghost = {col.r, col.g, col.b, 120};
+                        draw_shape(req->shape, pos.x, pos.y + dsz.h / 2, 40, ghost);
                     }
                     break;
                 }
@@ -127,8 +104,7 @@ void render_system(entt::registry& reg, SDL_Renderer* renderer, float /*alpha*/)
                         for (int i = 0; i < 3; ++i) {
                             if ((blocked->mask >> i) & 1) {
                                 float lx = constants::LANE_X[i] - dsz.w / 2;
-                                SDL_FRect r = { lx, pos.y, dsz.w, dsz.h };
-                                SDL_RenderFillRectF(renderer, &r);
+                                DrawRectangleRec({lx, pos.y, dsz.w, dsz.h}, c);
                             }
                         }
                     }
@@ -136,52 +112,46 @@ void render_system(entt::registry& reg, SDL_Renderer* renderer, float /*alpha*/)
                 }
                 case ObstacleKind::LowBar:
                 case ObstacleKind::HighBar: {
-                    SDL_FRect bar = { 0, pos.y, float(constants::SCREEN_W), dsz.h };
-                    SDL_RenderFillRectF(renderer, &bar);
+                    DrawRectangleRec({0, pos.y, float(constants::SCREEN_W), dsz.h}, c);
                     break;
                 }
                 case ObstacleKind::ComboGate: {
-                    // Draw blocked lanes + shape indicator
                     auto* blocked = reg.try_get<BlockedLanes>(entity);
                     if (blocked) {
                         for (int i = 0; i < 3; ++i) {
                             if ((blocked->mask >> i) & 1) {
                                 float lx = constants::LANE_X[i] - 120;
-                                SDL_FRect r = { lx, pos.y, 240.0f, dsz.h };
-                                SDL_RenderFillRectF(renderer, &r);
+                                DrawRectangleRec({lx, pos.y, 240.0f, dsz.h}, c);
                             }
                         }
                     }
                     auto* req = reg.try_get<RequiredShape>(entity);
                     if (req) {
-                        SDL_SetRenderDrawColor(renderer, 255, 255, 255, 180);
-                        // Find open lane
+                        Color white_ghost = {255, 255, 255, 180};
                         int open = 1;
                         if (blocked) {
                             for (int i = 0; i < 3; ++i) {
                                 if (!((blocked->mask >> i) & 1)) { open = i; break; }
                             }
                         }
-                        draw_shape(renderer, req->shape,
-                            constants::LANE_X[open], pos.y + dsz.h / 2, 30);
+                        draw_shape(req->shape,
+                            constants::LANE_X[open], pos.y + dsz.h / 2, 30, white_ghost);
                     }
                     break;
                 }
                 case ObstacleKind::SplitPath: {
-                    // All lanes blocked except required lane
                     auto* rlane = reg.try_get<RequiredLane>(entity);
                     for (int i = 0; i < 3; ++i) {
                         if (!rlane || i != rlane->lane) {
                             float lx = constants::LANE_X[i] - 120;
-                            SDL_FRect r = { lx, pos.y, 240.0f, dsz.h };
-                            SDL_RenderFillRectF(renderer, &r);
+                            DrawRectangleRec({lx, pos.y, 240.0f, dsz.h}, c);
                         }
                     }
                     auto* req = reg.try_get<RequiredShape>(entity);
                     if (req && rlane) {
-                        SDL_SetRenderDrawColor(renderer, 255, 255, 255, 180);
-                        draw_shape(renderer, req->shape,
-                            constants::LANE_X[rlane->lane], pos.y + dsz.h / 2, 30);
+                        Color white_ghost = {255, 255, 255, 180};
+                        draw_shape(req->shape,
+                            constants::LANE_X[rlane->lane], pos.y + dsz.h / 2, 30, white_ghost);
                     }
                     break;
                 }
@@ -191,25 +161,24 @@ void render_system(entt::registry& reg, SDL_Renderer* renderer, float /*alpha*/)
 
     // ── Draw particles ──────────────────────────────────────
     {
-        auto view = reg.view<ParticleTag, Position, ParticleData, Color>();
-        for (auto [entity, pos, pdata, col] : view.each()) {
-            SDL_SetRenderDrawColor(renderer, col.r, col.g, col.b, col.a);
-            float half = pdata.size / 2.0f;
-            SDL_FRect r = { pos.x - half, pos.y - half, pdata.size, pdata.size };
-            SDL_RenderFillRectF(renderer, &r);
+        auto view = reg.view<ParticleTag, Position, ParticleData, DrawColor, Lifetime>();
+        for (auto [entity, pos, pdata, col, life] : view.each()) {
+            float draw_size = pdata.size * (life.remaining / life.max_time);
+            float half = draw_size / 2.0f;
+            DrawRectangleRec({pos.x - half, pos.y - half, draw_size, draw_size},
+                             {col.r, col.g, col.b, col.a});
         }
     }
 
     // ── Draw score popups ───────────────────────────────────
     {
-        auto view = reg.view<ScorePopup, Position, Color, Lifetime>();
+        auto view = reg.view<ScorePopup, Position, DrawColor, Lifetime>();
         for (auto [entity, popup, pos, col, life] : view.each()) {
             float alpha_ratio = life.remaining / life.max_time;
             auto popup_alpha = static_cast<uint8_t>(alpha_ratio * 255);
             float popup_scale = 1.5f + popup.tier * 0.5f;
-            // Score popups use small font for normal, medium for big combos
             FontSize popup_font = (popup_scale > 2.5f) ? FontSize::Medium : FontSize::Small;
-            text_draw_number(text_ctx, renderer, popup.value,
+            text_draw_number(text_ctx, popup.value,
                 pos.x, pos.y, popup_font,
                 col.r, col.g, col.b, popup_alpha);
         }
@@ -217,18 +186,17 @@ void render_system(entt::registry& reg, SDL_Renderer* renderer, float /*alpha*/)
 
     // ── Draw player ─────────────────────────────────────────
     {
-        auto view = reg.view<PlayerTag, Position, PlayerShape, VerticalState, Color>();
+        auto view = reg.view<PlayerTag, Position, PlayerShape, VerticalState, DrawColor>();
         for (auto [entity, pos, pshape, vstate, col] : view.each()) {
             float draw_y = pos.y + vstate.y_offset;
 
-            // Draw size modulated by slide
             float size = constants::PLAYER_SIZE;
             if (vstate.mode == VMode::Sliding) {
-                size *= 0.5f; // squash when sliding
+                size *= 0.5f;
             }
 
-            SDL_SetRenderDrawColor(renderer, col.r, col.g, col.b, col.a);
-            draw_shape(renderer, pshape.current, pos.x, draw_y, size);
+            Color pc = {col.r, col.g, col.b, col.a};
+            draw_shape(pshape.current, pos.x, draw_y, size, pc);
         }
     }
 
@@ -239,46 +207,41 @@ void render_system(entt::registry& reg, SDL_Renderer* renderer, float /*alpha*/)
         auto& config  = reg.ctx().get<DifficultyConfig>();
 
         // Score
-        text_draw_number(text_ctx, renderer, score.displayed_score,
+        text_draw_number(text_ctx, score.displayed_score,
             120, 20, FontSize::Medium, 255, 255, 255, 255);
 
         // High score
-        text_draw_number(text_ctx, renderer, score.high_score,
+        text_draw_number(text_ctx, score.high_score,
             120, 50, FontSize::Small, 150, 150, 150, 180);
 
         // Speed bar
         float speed_ratio = (config.speed_multiplier - 1.0f) / 2.0f;
-        SDL_SetRenderDrawColor(renderer, 50, 50, 80, 200);
-        SDL_FRect speed_bg = { 20, 80, 680, 8 };
-        SDL_RenderFillRectF(renderer, &speed_bg);
-        SDL_SetRenderDrawColor(renderer, 100, 200, 255, 255);
-        SDL_FRect speed_fill = { 20, 80, 680 * speed_ratio, 8 };
-        SDL_RenderFillRectF(renderer, &speed_fill);
+        DrawRectangleRec({20, 80, 680, 8}, {50, 50, 80, 200});
+        DrawRectangleRec({20, 80, 680 * speed_ratio, 8}, {100, 200, 255, 255});
 
         // Burnout meter
-        SDL_SetRenderDrawColor(renderer, 30, 30, 50, 200);
-        SDL_FRect bo_bg = { 60, constants::BURNOUT_BAR_Y, 600, constants::BURNOUT_BAR_H };
-        SDL_RenderFillRectF(renderer, &bo_bg);
+        DrawRectangleRec({60, constants::BURNOUT_BAR_Y, 600, constants::BURNOUT_BAR_H},
+                         {30, 30, 50, 200});
 
         // Burnout fill color by zone
+        Color bo_color;
         switch (burnout.zone) {
             case BurnoutZone::None:
             case BurnoutZone::Safe:
-                SDL_SetRenderDrawColor(renderer, 80, 200, 80, 255);
+                bo_color = {80, 200, 80, 255};
                 break;
             case BurnoutZone::Risky:
-                SDL_SetRenderDrawColor(renderer, 255, 200, 50, 255);
+                bo_color = {255, 200, 50, 255};
                 break;
             case BurnoutZone::Danger:
-                SDL_SetRenderDrawColor(renderer, 255, 80, 30, 255);
+                bo_color = {255, 80, 30, 255};
                 break;
             case BurnoutZone::Dead:
-                SDL_SetRenderDrawColor(renderer, 255, 0, 0, 255);
+                bo_color = {255, 0, 0, 255};
                 break;
         }
-        SDL_FRect bo_fill = { 60, constants::BURNOUT_BAR_Y,
-            600 * burnout.meter, constants::BURNOUT_BAR_H };
-        SDL_RenderFillRectF(renderer, &bo_fill);
+        DrawRectangleRec({60, constants::BURNOUT_BAR_Y,
+            600 * burnout.meter, constants::BURNOUT_BAR_H}, bo_color);
 
         // Shape buttons
         float btn_area_x = (constants::SCREEN_W
@@ -297,39 +260,27 @@ void render_system(entt::registry& reg, SDL_Renderer* renderer, float /*alpha*/)
             bool is_active = (static_cast<int>(active_shape) == i);
 
             // Button background
-            if (is_active) {
-                SDL_SetRenderDrawColor(renderer, 60, 60, 100, 255);
-            } else {
-                SDL_SetRenderDrawColor(renderer, 30, 30, 50, 200);
-            }
-            SDL_FRect btn = { bx, constants::BUTTON_Y, constants::BUTTON_W, constants::BUTTON_H };
-            SDL_RenderFillRectF(renderer, &btn);
+            Color btn_bg = is_active ? Color{60, 60, 100, 255} : Color{30, 30, 50, 200};
+            Rectangle btn = {bx, constants::BUTTON_Y, constants::BUTTON_W, constants::BUTTON_H};
+            DrawRectangleRec(btn, btn_bg);
 
             // Button border
-            if (is_active) {
-                SDL_SetRenderDrawColor(renderer, 120, 180, 255, 255);
-            } else {
-                SDL_SetRenderDrawColor(renderer, 60, 60, 80, 255);
-            }
-            SDL_RenderDrawRectF(renderer, &btn);
+            Color btn_border = is_active ? Color{120, 180, 255, 255} : Color{60, 60, 80, 255};
+            DrawRectangleLinesEx(btn, 1.0f, btn_border);
 
             // Shape icon in button
             auto shape = static_cast<Shape>(i);
-            if (is_active) {
-                SDL_SetRenderDrawColor(renderer, 200, 230, 255, 255);
-            } else {
-                SDL_SetRenderDrawColor(renderer, 100, 100, 120, 200);
-            }
-            draw_shape(renderer, shape,
+            Color icon_color = is_active ? Color{200, 230, 255, 255} : Color{100, 100, 120, 200};
+            draw_shape(shape,
                 bx + constants::BUTTON_W / 2,
                 constants::BUTTON_Y + constants::BUTTON_H / 2,
-                40);
+                40, icon_color);
         }
 
         // Divider line between game and button zone
-        SDL_SetRenderDrawColor(renderer, 40, 40, 60, 200);
         float divider_y = constants::SCREEN_H * constants::SWIPE_ZONE_SPLIT;
-        SDL_RenderDrawLineF(renderer, 0, divider_y, constants::SCREEN_W, divider_y);
+        DrawLineV({0, divider_y}, {static_cast<float>(constants::SCREEN_W), divider_y},
+                  {40, 40, 60, 200});
     }
 
     // ── Game Over overlay ───────────────────────────────────
@@ -337,53 +288,45 @@ void render_system(entt::registry& reg, SDL_Renderer* renderer, float /*alpha*/)
         auto& score = reg.ctx().get<ScoreState>();
 
         // Dim overlay
-        SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
-        SDL_SetRenderDrawColor(renderer, 0, 0, 0, 180);
-        SDL_FRect overlay = { 0, 0,
-            float(constants::SCREEN_W), float(constants::SCREEN_H) };
-        SDL_RenderFillRectF(renderer, &overlay);
+        DrawRectangleRec({0, 0, float(constants::SCREEN_W), float(constants::SCREEN_H)},
+                         {0, 0, 0, 180});
 
         // "GAME OVER" heading
-        text_draw(text_ctx, renderer, "GAME OVER",
+        text_draw(text_ctx, "GAME OVER",
             360, 440, FontSize::Large, 255, 80, 80, 255,
             TextAlign::Center);
 
         // Score display
-        text_draw_number(text_ctx, renderer, score.score,
+        text_draw_number(text_ctx, score.score,
             360, 510, FontSize::Medium, 255, 255, 255, 255);
 
         // High score
-        text_draw_number(text_ctx, renderer, score.high_score,
+        text_draw_number(text_ctx, score.high_score,
             360, 560, FontSize::Small, 200, 200, 100, 255);
 
         // "TAP TO RETRY" indicator — pulsing text
         float pulse = (std::sin(gs.phase_timer * 3.0f) + 1.0f) / 2.0f;
         auto retry_alpha = static_cast<uint8_t>(80 + pulse * 175);
-        text_draw(text_ctx, renderer, "TAP TO RETRY",
+        text_draw(text_ctx, "TAP TO RETRY",
             360, 650, FontSize::Medium, 200, 200, 200, retry_alpha,
             TextAlign::Center);
     }
 
     // ── Pause overlay ───────────────────────────────────────
     if (gs.phase == GamePhase::Paused) {
-        SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
-        SDL_SetRenderDrawColor(renderer, 0, 0, 0, 160);
-        SDL_FRect overlay = { 0, 0,
-            float(constants::SCREEN_W), float(constants::SCREEN_H) };
-        SDL_RenderFillRectF(renderer, &overlay);
+        DrawRectangleRec({0, 0, float(constants::SCREEN_W), float(constants::SCREEN_H)},
+                         {0, 0, 0, 160});
 
-        text_draw(text_ctx, renderer, "PAUSED",
+        text_draw(text_ctx, "PAUSED",
             360, 580, FontSize::Large, 255, 255, 255, 255,
             TextAlign::Center);
     }
-
-    SDL_RenderPresent(renderer);
 }
 
-// Audio system stub — SFX playback requires Mix_Chunk loading
+// Audio system stub — SFX playback requires sound loading
 void audio_system(entt::registry& reg) {
     auto& audio = reg.ctx().get<AudioQueue>();
     // In a full implementation, iterate audio.queue[0..count-1]
-    // and call Mix_PlayChannel for each SFX
+    // and call PlaySound for each SFX
     audio_clear(audio);
 }

--- a/app/systems/render_system.cpp
+++ b/app/systems/render_system.cpp
@@ -163,7 +163,8 @@ void render_system(entt::registry& reg, float /*alpha*/) {
     {
         auto view = reg.view<ParticleTag, Position, ParticleData, DrawColor, Lifetime>();
         for (auto [entity, pos, pdata, col, life] : view.each()) {
-            float draw_size = pdata.size * (life.remaining / life.max_time);
+            float ratio = (life.max_time > 0.0f) ? (life.remaining / life.max_time) : 1.0f;
+            float draw_size = pdata.size * ratio;
             float half = draw_size / 2.0f;
             DrawRectangleRec({pos.x - half, pos.y - half, draw_size, draw_size},
                              {col.r, col.g, col.b, col.a});

--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -71,7 +71,7 @@ void scoring_system(entt::registry& reg, float dt) {
         reg.emplace<Velocity>(popup, 0.0f, -80.0f);
         reg.emplace<Lifetime>(popup, constants::POPUP_DURATION, constants::POPUP_DURATION);
         reg.emplace<ScorePopup>(popup, points, tier_for_multiplier(mult));
-        reg.emplace<Color>(popup, uint8_t{255}, uint8_t{255}, uint8_t{50}, uint8_t{255});
+        reg.emplace<DrawColor>(popup, uint8_t{255}, uint8_t{255}, uint8_t{50}, uint8_t{255});
         reg.emplace<DrawLayer>(popup, Layer::Effects);
 
         audio_push(reg.ctx().get<AudioQueue>(), SFX::BurnoutBank);

--- a/app/text_renderer.cpp
+++ b/app/text_renderer.cpp
@@ -43,12 +43,10 @@ bool text_init(TextContext& ctx, const char* font_path) {
 
 // ── text_shutdown ───────────────────────────────────────────
 void text_shutdown(TextContext& ctx) {
-    if (ctx.loaded) {
-        UnloadFont(ctx.font_large);
-        UnloadFont(ctx.font_medium);
-        UnloadFont(ctx.font_small);
-        ctx.loaded = false;
-    }
+    if (ctx.font_large.baseSize > 0)  UnloadFont(ctx.font_large);
+    if (ctx.font_medium.baseSize > 0) UnloadFont(ctx.font_medium);
+    if (ctx.font_small.baseSize > 0)  UnloadFont(ctx.font_small);
+    ctx.loaded = false;
 }
 
 // ── text_draw ───────────────────────────────────────────────

--- a/app/text_renderer.cpp
+++ b/app/text_renderer.cpp
@@ -1,10 +1,9 @@
 #include "text_renderer.h"
-#include <SDL.h>
-#include <SDL_ttf.h>
+#include <raylib.h>
 #include <cstdio>
 
 // ── Helper: pick font by size index ─────────────────────────
-static TTF_Font* pick_font(const TextContext& ctx, FontSize font_size) {
+static const Font& pick_font(const TextContext& ctx, FontSize font_size) {
     switch (font_size) {
         case FontSize::Small:  return ctx.font_small;
         case FontSize::Medium: return ctx.font_medium;
@@ -15,83 +14,71 @@ static TTF_Font* pick_font(const TextContext& ctx, FontSize font_size) {
 
 // ── text_init ───────────────────────────────────────────────
 bool text_init(TextContext& ctx, const char* font_path) {
-    if (TTF_Init() != 0) {
-        SDL_Log("TTF_Init failed: %s", TTF_GetError());
+    if (!FileExists(font_path)) {
+        TraceLog(LOG_WARNING, "Font file not found: %s", font_path);
         return false;
     }
 
-    ctx.font_small  = TTF_OpenFont(font_path, 16);
-    ctx.font_medium = TTF_OpenFont(font_path, 28);
-    ctx.font_large  = TTF_OpenFont(font_path, 48);
+    ctx.font_small  = LoadFontEx(font_path, 16, nullptr, 0);
+    ctx.font_medium = LoadFontEx(font_path, 28, nullptr, 0);
+    ctx.font_large  = LoadFontEx(font_path, 48, nullptr, 0);
 
-    if (!ctx.font_small || !ctx.font_medium || !ctx.font_large) {
-        SDL_Log("Failed to load font '%s': %s", font_path, TTF_GetError());
+    // Check if any font failed to load (baseSize will be 0)
+    if (ctx.font_small.baseSize == 0 ||
+        ctx.font_medium.baseSize == 0 ||
+        ctx.font_large.baseSize == 0) {
+        TraceLog(LOG_WARNING, "Failed to load font: %s", font_path);
         text_shutdown(ctx);
         return false;
     }
 
-    // Use LCD hinting for cleaner rendering at small sizes
-    TTF_SetFontHinting(ctx.font_small,  TTF_HINTING_LIGHT);
-    TTF_SetFontHinting(ctx.font_medium, TTF_HINTING_LIGHT);
-    TTF_SetFontHinting(ctx.font_large,  TTF_HINTING_LIGHT);
+    // Enable bilinear filtering for smoother text at non-native sizes
+    SetTextureFilter(ctx.font_small.texture,  TEXTURE_FILTER_BILINEAR);
+    SetTextureFilter(ctx.font_medium.texture, TEXTURE_FILTER_BILINEAR);
+    SetTextureFilter(ctx.font_large.texture,  TEXTURE_FILTER_BILINEAR);
 
+    ctx.loaded = true;
     return true;
 }
 
 // ── text_shutdown ───────────────────────────────────────────
 void text_shutdown(TextContext& ctx) {
-    if (ctx.font_large)  { TTF_CloseFont(ctx.font_large);  ctx.font_large  = nullptr; }
-    if (ctx.font_medium) { TTF_CloseFont(ctx.font_medium); ctx.font_medium = nullptr; }
-    if (ctx.font_small)  { TTF_CloseFont(ctx.font_small);  ctx.font_small  = nullptr; }
-    TTF_Quit();
+    if (ctx.loaded) {
+        UnloadFont(ctx.font_large);
+        UnloadFont(ctx.font_medium);
+        UnloadFont(ctx.font_small);
+        ctx.loaded = false;
+    }
 }
 
 // ── text_draw ───────────────────────────────────────────────
 void text_draw(const TextContext& ctx,
-               SDL_Renderer* renderer,
                const char* text,
                float x, float y,
                FontSize font_size,
                uint8_t r, uint8_t g, uint8_t b, uint8_t a,
                TextAlign align) {
-    if (!text || !text[0]) return;
+    if (!text || !text[0] || !ctx.loaded) return;
 
-    TTF_Font* font = pick_font(ctx, font_size);
-    if (!font) return;
+    const Font& font = pick_font(ctx, font_size);
+    float fontSize = static_cast<float>(font.baseSize);
+    float spacing = 1.0f;
 
-    SDL_Color color = { r, g, b, a };
-    SDL_Surface* surface = TTF_RenderUTF8_Blended(font, text, color);
-    if (!surface) return;
-
-    SDL_Texture* texture = SDL_CreateTextureFromSurface(renderer, surface);
-    if (!texture) {
-        SDL_FreeSurface(surface);
-        return;
-    }
-
-    // Enable alpha blending on the texture
-    SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
-
-    float w = static_cast<float>(surface->w);
-    float h = static_cast<float>(surface->h);
+    Vector2 size = MeasureTextEx(font, text, fontSize, spacing);
 
     float draw_x = x;
     switch (align) {
-        case TextAlign::Left:                         break;
-        case TextAlign::Center: draw_x = x - w / 2;  break;
-        case TextAlign::Right:  draw_x = x - w;      break;
+        case TextAlign::Left:                            break;
+        case TextAlign::Center: draw_x = x - size.x / 2; break;
+        case TextAlign::Right:  draw_x = x - size.x;      break;
     }
 
-    SDL_FRect dst = { draw_x, y, w, h };
-    SDL_RenderCopyF(renderer, texture, nullptr, &dst);
-
-    SDL_DestroyTexture(texture);
-    SDL_FreeSurface(surface);
+    DrawTextEx(font, text, {draw_x, y}, fontSize, spacing,
+               {r, g, b, a});
 }
 
 // ── text_draw_number ────────────────────────────────────────
 void text_draw_number(const TextContext& ctx,
-                      SDL_Renderer* renderer,
                       int number,
                       float x, float y,
                       FontSize font_size,
@@ -99,14 +86,14 @@ void text_draw_number(const TextContext& ctx,
                       TextAlign align) {
     char buf[16];
     std::snprintf(buf, sizeof(buf), "%d", number);
-    text_draw(ctx, renderer, buf, x, y, font_size, r, g, b, a, align);
+    text_draw(ctx, buf, x, y, font_size, r, g, b, a, align);
 }
 
 // ── text_width ──────────────────────────────────────────────
 int text_width(const TextContext& ctx, const char* text, FontSize font_size) {
-    TTF_Font* font = pick_font(ctx, font_size);
-    if (!font || !text) return 0;
-    int w = 0, h = 0;
-    TTF_SizeUTF8(font, text, &w, &h);
-    return w;
+    if (!text || !ctx.loaded) return 0;
+    const Font& font = pick_font(ctx, font_size);
+    float fontSize = static_cast<float>(font.baseSize);
+    Vector2 size = MeasureTextEx(font, text, fontSize, 1.0f);
+    return static_cast<int>(size.x);
 }

--- a/app/text_renderer.h
+++ b/app/text_renderer.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <SDL.h>
-#include <SDL_ttf.h>
+#include <raylib.h>
 #include <cstdint>
 
 // ── TextAlign ────────────────────────────────────────────────
@@ -13,28 +12,28 @@ enum class FontSize : int { Small = 0, Medium = 1, Large = 2 };
 
 // ── TextContext ──────────────────────────────────────────────
 // Plain data struct stored in the ECS registry context.
-// Holds pre-loaded TTF_Font pointers at different point sizes.
+// Holds pre-loaded raylib Font objects at different point sizes.
 // No logic, no methods beyond default construction.
 struct TextContext {
-    TTF_Font* font_small  = nullptr;  // ~16pt  — labels, small HUD text
-    TTF_Font* font_medium = nullptr;  // ~28pt  — HUD scores
-    TTF_Font* font_large  = nullptr;  // ~48pt  — titles, GAME OVER
+    Font font_small{};    // ~16pt  — labels, small HUD text
+    Font font_medium{};   // ~28pt  — HUD scores
+    Font font_large{};    // ~48pt  — titles, GAME OVER
+    bool loaded = false;  // true once fonts are successfully loaded
 };
 
 // ── Free functions ───────────────────────────────────────────
 
-// Initialize SDL_ttf and load fonts at 3 sizes from the given path.
-// Returns true on success.  On failure, TextContext fonts remain nullptr.
+// Load fonts at 3 sizes from the given path.
+// Returns true on success.  On failure, TextContext fonts remain invalid.
 bool text_init(TextContext& ctx, const char* font_path);
 
-// Close fonts and shut down SDL_ttf.
+// Unload fonts.
 void text_shutdown(TextContext& ctx);
 
 // Render a null-terminated string.
 // font_size selects which pre-loaded font to use.
 // (x, y) is the anchor point; alignment adjusts horizontally.
 void text_draw(const TextContext& ctx,
-               SDL_Renderer* renderer,
                const char* text,
                float x, float y,
                FontSize font_size,
@@ -43,7 +42,6 @@ void text_draw(const TextContext& ctx,
 
 // Convenience: format an integer and render it.
 void text_draw_number(const TextContext& ctx,
-                      SDL_Renderer* renderer,
                       int number,
                       float x, float y,
                       FontSize font_size,

--- a/benchmarks/bench_file_logger.cpp
+++ b/benchmarks/bench_file_logger.cpp
@@ -1,0 +1,72 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/benchmark/catch_benchmark.hpp>
+#include <raylib.h>
+
+#include "file_logger.h"
+
+#include <cstdio>
+#include <cstring>
+
+static const char* BENCH_LOG = "bench_logger.log";
+
+static void cleanup_bench_log() {
+    std::remove(BENCH_LOG);
+}
+
+TEST_CASE("Bench: file_logger single TraceLog call", "[bench]") {
+    file_logger_init(BENCH_LOG);
+
+    BENCHMARK("single TraceLog") {
+        TraceLog(LOG_INFO, "Player scored %d points at position (%.1f, %.1f)", 42, 360.0f, 500.0f);
+    };
+
+    file_logger_shutdown();
+    cleanup_bench_log();
+}
+
+TEST_CASE("Bench: file_logger burst (10 calls)", "[bench]") {
+    file_logger_init(BENCH_LOG);
+
+    BENCHMARK("10 TraceLog calls") {
+        for (int i = 0; i < 10; ++i) {
+            TraceLog(LOG_INFO, "Frame %d entity %d pos=(%.1f,%.1f)", 1000 + i, i, 100.0f * i, 200.0f);
+        }
+    };
+
+    file_logger_shutdown();
+    cleanup_bench_log();
+}
+
+TEST_CASE("Bench: file_logger burst (100 calls)", "[bench]") {
+    file_logger_init(BENCH_LOG);
+
+    BENCHMARK("100 TraceLog calls") {
+        for (int i = 0; i < 100; ++i) {
+            TraceLog(LOG_WARNING, "Collision check entity=%d shape=%d lane=%d", i, i % 3, i % 3);
+        }
+    };
+
+    file_logger_shutdown();
+    cleanup_bench_log();
+}
+
+TEST_CASE("Bench: file_logger vs no-op baseline", "[bench]") {
+    // Baseline: raylib default logging (stdout only)
+    SetTraceLogCallback(nullptr);
+    SetTraceLogLevel(LOG_NONE);
+
+    BENCHMARK("baseline (logging disabled)") {
+        TraceLog(LOG_INFO, "This should be suppressed %d", 42);
+    };
+
+    // File logger active
+    SetTraceLogLevel(LOG_INFO);
+    file_logger_init(BENCH_LOG);
+
+    BENCHMARK("file logger active") {
+        TraceLog(LOG_INFO, "This goes to file %d", 42);
+    };
+
+    file_logger_shutdown();
+    cleanup_bench_log();
+}

--- a/benchmarks/bench_systems.cpp
+++ b/benchmarks/bench_systems.cpp
@@ -42,7 +42,7 @@ static entt::entity make_bench_player(entt::registry& reg) {
     reg.emplace<PlayerShape>(p);
     reg.emplace<Lane>(p);
     reg.emplace<VerticalState>(p);
-    reg.emplace<Color>(p, uint8_t{80}, uint8_t{180}, uint8_t{255}, uint8_t{255});
+    reg.emplace<DrawColor>(p, uint8_t{80}, uint8_t{180}, uint8_t{255}, uint8_t{255});
     reg.emplace<DrawSize>(p, constants::PLAYER_SIZE, constants::PLAYER_SIZE);
     reg.emplace<DrawLayer>(p, Layer::Game);
     return p;
@@ -61,7 +61,7 @@ static void spawn_obstacles(entt::registry& reg, int count) {
         reg.emplace<RequiredShape>(obs, shape);
         reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);
         reg.emplace<DrawLayer>(obs, Layer::Game);
-        reg.emplace<Color>(obs, uint8_t{255}, uint8_t{255}, uint8_t{255}, uint8_t{255});
+        reg.emplace<DrawColor>(obs, uint8_t{255}, uint8_t{255}, uint8_t{255}, uint8_t{255});
     }
 }
 
@@ -72,8 +72,8 @@ static void spawn_particles(entt::registry& reg, int count) {
         reg.emplace<Position>(p, 360.0f, 500.0f);
         reg.emplace<Velocity>(p, static_cast<float>(i % 50 - 25), -100.0f);
         reg.emplace<Lifetime>(p, 0.6f, 0.6f);
-        reg.emplace<ParticleData>(p, 4.0f, 4.0f);
-        reg.emplace<Color>(p, uint8_t{255}, uint8_t{100}, uint8_t{50}, uint8_t{255});
+        reg.emplace<ParticleData>(p, 4.0f);
+        reg.emplace<DrawColor>(p, uint8_t{255}, uint8_t{100}, uint8_t{50}, uint8_t{255});
         reg.emplace<DrawLayer>(p, Layer::Effects);
     }
 }
@@ -173,7 +173,7 @@ TEST_CASE("Bench: scoring_system", "[bench]") {
             reg.emplace<Obstacle>(obs, ObstacleKind::ShapeGate, int16_t{200});
             reg.emplace<ScoredTag>(obs);
             reg.emplace<DrawLayer>(obs, Layer::Game);
-            reg.emplace<Color>(obs, uint8_t{255}, uint8_t{255}, uint8_t{255}, uint8_t{255});
+            reg.emplace<DrawColor>(obs, uint8_t{255}, uint8_t{255}, uint8_t{255}, uint8_t{255});
         }
         meter.measure([&] { scoring_system(reg, DT); });
     };
@@ -199,7 +199,7 @@ TEST_CASE("Bench: player_action + movement", "[bench]") {
         btn.pressed = true;
         btn.shape = Shape::Triangle;
         auto& gesture = reg.ctx().get<GestureResult>();
-        gesture.gesture = Gesture::SwipeRight;
+        gesture.gesture = SwipeGesture::SwipeRight;
         meter.measure([&] {
             player_action_system(reg, DT);
             player_movement_system(reg, DT);

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 cd "$(dirname "$0")"
+SCRIPT_DIR="$(pwd)"
 
 BUILD_TYPE="${1:-Release}"
 
@@ -17,6 +18,7 @@ CMAKE_ARGS=(
     -S .
     -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
     "-DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+    "-DVCPKG_OVERLAY_PORTS=${SCRIPT_DIR}/vcpkg-overlay"
 )
 
 # Honour CC/CXX env vars when set on all platforms.

--- a/docs/ongoing_migration.md
+++ b/docs/ongoing_migration.md
@@ -1,0 +1,63 @@
+# Ongoing Migration: SDL2 → raylib (RGFW backend)
+
+> Auto-maintained during the refactor. Check this file for current status.
+
+## Status Overview
+
+| Phase | Description | Status | Files |
+|-------|-------------|--------|-------|
+| 0 | Dependency swap + build system | ✅ Done | `vcpkg.json`, `CMakeLists.txt`, `build.sh`, `vcpkg-overlay/raylib/*` |
+| 1 | Main loop rewrite | ✅ Done | `app/main.cpp` |
+| 2 | Input system | ✅ Done | `app/systems/input_system.cpp` |
+| 3 | Render system | ✅ Done | `app/systems/render_system.cpp` |
+| 4 | Text rendering | ✅ Done | `app/text_renderer.h`, `app/text_renderer.cpp` |
+| 5 | System headers | ✅ Done | `app/systems/all_systems.h` |
+| 6 | Component cleanup (Color → DrawColor, Gesture → SwipeGesture) | ✅ Done | `app/components/rendering.h`, `app/components/input.h`, all systems, all tests |
+| 7 | Build verification | ✅ Done | 335 assertions, 188 test cases pass |
+
+---
+
+## Current State: **All phases complete — migration verified ✅**
+
+### Platform backend
+
+**RGFW** (Riley's General Framework for Windowing) — single-header, bundled inside raylib source.
+- No GLFW dependency
+- macOS: Cocoa + OpenGL + IOKit + CoreFoundation + CoreVideo
+- Linux: X11 + OpenGL
+- Windows: WinAPI + OpenGL + gdi32 + winmm
+
+### vcpkg overlay port
+
+The standard vcpkg raylib 5.5 port builds with GLFW. We use a **custom overlay port** (`vcpkg-overlay/raylib/`) that patches the raylib 5.5 CMake build to:
+1. Add `RGFW` to the platform enum in `CMakeOptions.txt`
+2. Skip GLFW in `GlfwImport.cmake` for RGFW builds
+3. Add RGFW platform config to `LibraryConfigurations.cmake`
+
+---
+
+## Change Log
+
+| Phase | File | Change Summary |
+|-------|------|----------------|
+| 0 | `vcpkg.json` | Removed `sdl2`, `sdl2-ttf`; added `raylib` |
+| 0 | `CMakeLists.txt` | Replaced SDL2 find_package/link with `raylib`; added platform framework links |
+| 0 | `build.sh` | Added `VCPKG_OVERLAY_PORTS` for RGFW overlay port |
+| 0 | `vcpkg-overlay/raylib/*` | Custom port: patches raylib 5.5 CMake to support `PLATFORM=RGFW` |
+| 1 | `app/main.cpp` | SDL_Init/Window/Renderer → InitWindow/SetTargetFPS; SDL timing → GetFrameTime |
+| 2 | `app/systems/input_system.cpp` | SDL_PollEvent → IsMouseButton*/IsKeyPressed/GetTouchPosition polling |
+| 3 | `app/systems/render_system.cpp` | All SDL draw calls → raylib equivalents; Color passed per-call |
+| 4 | `app/text_renderer.h` | SDL_ttf types → raylib Font; removed SDL_Renderer* params |
+| 4 | `app/text_renderer.cpp` | TTF_* calls → LoadFontEx/DrawTextEx/MeasureTextEx |
+| 5 | `app/systems/all_systems.h` | Removed SDL_Renderer forward decl; updated render_system signature |
+| 6 | `app/components/rendering.h` | `Color` → `DrawColor` (avoids raylib `Color` conflict) |
+| 6 | `app/components/input.h` | `Gesture` → `SwipeGesture` (avoids raylib `Gesture` conflict) |
+| 6 | *all systems + tests* | Updated all `Color`/`Gesture` usages to new names |
+
+---
+
+## Notes
+
+- **Unaffected:** All ECS components (except renames), all game-logic systems, all tests
+- **Tests:** 335 assertions in 188 test cases — all passing
+- Reference: `docs/raylib-migration.md` for original plan details

--- a/docs/raylib-migration.md
+++ b/docs/raylib-migration.md
@@ -1,0 +1,569 @@
+# SDL2 → raylib Migration Plan
+
+## Overview
+
+Migrate the rendering, windowing, input, timing, and audio platform layer from
+SDL2 + SDL2_ttf to raylib 5.5. All ECS components and game-logic systems are
+unaffected. The `TextContext` / `text_draw` API boundary is preserved — only
+the implementation behind it changes.
+
+**Target platforms after migration:**
+
+| Platform | Backend | Notes |
+|---|---|---|
+| macOS | OpenGL 3.3 (via GLFW) | Metal not used — raylib defaults to GL on macOS |
+| Windows x64 | OpenGL 3.3 (via GLFW) | D3D11 not available in raylib |
+| Linux | OpenGL 3.3 (via GLFW) | Same as current SDL2 backend |
+| Web | WebGL2 (Emscripten) | Requires `emscripten_set_main_loop` shim |
+
+---
+
+## Dependency
+
+**Chosen approach: vcpkg with the GitHub Actions binary cache.**
+
+Your CI already has `VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"` set in
+both `ci-linux.yml` and `ci-windows.yml`, along with the required
+`ACTIONS_CACHE_URL` / `ACTIONS_RUNTIME_TOKEN` exports. This means vcpkg
+uploads each compiled package to the GHA cache after the first build, and
+restores it on every subsequent run — **no recompilation on cache hit**.
+
+The economics per platform:
+
+| Platform | Cold build (first run) | Warm build (cache hit) |
+|---|---|---|
+| macOS | ~90s (raylib + GLFW compile) | ~5s (cache restore) |
+| Windows x64 | ~2 min (MSVC, raylib + GLFW) | ~5s |
+| Linux x64 | ~90s (clang, raylib + GLFW) | ~5s |
+| Web (Emscripten) | ❌ no vcpkg emscripten triplet — see below | — |
+
+The cache key is content-addressed on the package name + version + triplet +
+compiler ABI hash. Bumping `"version": "5.5"` in `vcpkg.json` automatically
+invalidates the old entry and triggers one rebuild, which then re-populates
+the cache.
+
+**Why not NuGet?** The [`raylib` NuGet package](https://www.nuget.org/packages/raylib)
+is Windows-only (x86 + x64 DLLs), ships a C++ wrapper layer (`raylib-cpp`),
+and integrates via MSBuild `.targets` — not CMake. It has no macOS, Linux, or
+Web artifacts.
+
+**Why not `FetchContent` prebuilt binaries?** Downloading the official release
+tarballs via `FetchContent URL` avoids compilation but couples you to the
+exact compiler + CRT that Raymond used to build the official binaries. On
+Windows the official archive is an MSVC shared lib (`raylib.dll` +
+`raylib.lib`) — no static option. On Linux the official `.a` is compiled with
+GCC; mixing that with your Clang CI (which uses `-stdlib=libc++`) can cause
+ABI issues. vcpkg builds with your exact toolchain, so the ABI always matches.
+
+**Emscripten — build from source, same as raylib's own CI.** raylib's
+[`build_webassembly.yml`](https://github.com/raysan5/raylib/blob/master/.github/workflows/build_webassembly.yml)
+builds the wasm archive by running `make PLATFORM=PLATFORM_WEB` with
+`mymindstorm/setup-emsdk@v14` pinned to emsdk `5.0.3` on `windows-latest`.
+There is no magic — it is a plain source compile with the Emscripten toolchain.
+We can do exactly the same: pull raylib source via `FetchContent GIT_TAG 5.5`
+and let CMake compile it as part of the Emscripten build. Since this only runs
+on the dedicated `ci-web` job (not the native jobs), the compile cost is paid
+once per `vcpkg.json`-equivalent change, and the GHA cache for the web job
+covers subsequent runs via the `actions/cache` step on the build directory.
+
+`vcpkg.json` after migration:
+
+```json
+{
+  "dependencies": [
+    "entt",
+    { "name": "catch2", "platform": "!emscripten" },
+    { "name": "raylib", "platform": "!emscripten" }
+  ]
+}
+```
+
+The existing `VCPKG_DEFAULT_TRIPLET: x64-windows-static-md` in
+`ci-windows.yml` gives a fully-static Windows build (no `raylib.dll` to ship).
+No CI workflow changes are needed to enable caching — it is already live.
+
+---
+
+## Phase 0 — Dependency swap + build system
+
+**Branch:** `refactor/raylib-deps`  
+**Files:** `CMakeLists.txt`, `vcpkg.json`
+
+### CMakeLists.txt — raylib target
+
+Replace all SDL2 `find_package` / target-alias blocks with:
+
+```cmake
+if(NOT EMSCRIPTEN)
+    # vcpkg builds raylib from source on first run and caches the binary via
+    # VCPKG_BINARY_SOURCES=x-gha,readwrite — subsequent CI runs restore from
+    # cache and skip compilation entirely.
+    find_package(raylib CONFIG REQUIRED)
+else()
+    # No vcpkg emscripten triplet for raylib — build from source.
+    # Mirrors raylib's own build_webassembly.yml exactly.
+    include(FetchContent)
+    FetchContent_Declare(raylib
+        GIT_REPOSITORY https://github.com/raysan5/raylib.git
+        GIT_TAG        5.5
+        GIT_SHALLOW    ON
+    )
+    set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(CUSTOMIZE_BUILD ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(raylib)
+endif()
+```
+
+`find_package(raylib CONFIG REQUIRED)` works because vcpkg installs a
+`raylib-config.cmake` alongside the built lib. The `VCPKG_DEFAULT_TRIPLET:
+x64-windows-static-md` already set in `ci-windows.yml` ensures the Windows
+build is fully static — no `raylib.dll` to ship.
+
+### CMakeLists.txt — target changes
+
+- `shapeshifter_lib`: remove `SDL2::SDL2-static` from public link. `EnTT::EnTT`
+  only.
+- `shapeshifter` executable: replace `SDL2::SDL2main` + `SDL2_ttf::SDL2_ttf`
+  with `raylib`.
+- `shapeshifter_tests`: no change.
+- Wrap test target in `if(NOT EMSCRIPTEN)`.
+- Remove the SDL2 target-name normalisation aliases.
+- Keep `PLATFORM_DESKTOP` definition — redefine it for `APPLE`, `WIN32`, and
+  non-`EMSCRIPTEN` Linux (same requirement as sokol plan).
+- For Emscripten, add linker flags:
+
+```cmake
+if(EMSCRIPTEN)
+    target_link_options(shapeshifter PRIVATE
+        -sUSE_GLFW=3
+        -sUSE_WEBGL2=1
+        -sALLOW_MEMORY_GROWTH=1
+        --shell-file ${CMAKE_SOURCE_DIR}/app/web/shell.html
+        --preload-file ${CMAKE_SOURCE_DIR}/assets@/assets)
+endif()
+```
+
+---
+
+## Phase 1 — Main loop rewrite (`app/main.cpp`)
+
+**Branch:** `refactor/raylib-main-loop`  
+**Files:** `app/main.cpp`, `app/systems/all_systems.h`
+
+### Structural change
+
+raylib, like SDL2, uses a **blocking `while` loop** — no callback inversion.
+This is the most significant difference from the sokol plan: `main()` stays
+structurally intact.
+
+```cpp
+// Before (SDL2)
+SDL_Init → SDL_CreateWindow → SDL_CreateRenderer
+while(true) { SDL_PollEvent → tick → render }
+SDL_DestroyRenderer → SDL_DestroyWindow → SDL_Quit
+
+// After (raylib)
+InitWindow(W, H, title)
+SetTargetFPS(60)
+while (!WindowShouldClose()) {
+    float raw_dt = GetFrameTime();
+    // tick systems...
+    BeginDrawing();
+        render_system(reg, alpha);
+    EndDrawing();
+}
+CloseWindow();
+```
+
+On **Emscripten**, `while(!WindowShouldClose())` does not work — the browser
+event loop is not blocking. raylib provides a shim:
+
+```cpp
+#ifdef __EMSCRIPTEN__
+    emscripten_set_main_loop(update_draw_frame, 0, 1);
+#else
+    while (!WindowShouldClose()) { update_draw_frame(); }
+#endif
+```
+
+`update_draw_frame` is a static free function containing one iteration of the
+game loop body. The `entt::registry` and timing state must be accessible to
+it — either as a file-scoped struct or via a static pointer.
+
+### Timing
+
+Replace `SDL_GetPerformanceCounter` / `SDL_GetPerformanceFrequency` with:
+
+```cpp
+float raw_dt = GetFrameTime();   // seconds since last frame, capped internally
+```
+
+Note: `GetFrameTime()` is clamped by raylib's internal FPS cap. The existing
+`MAX_ACCUM` guard in the fixed-timestep accumulator still applies.
+
+### Quit
+
+`WindowShouldClose()` returns `true` on window close button or `ESC` key. The
+existing `input.quit_requested` flag can be set there, or the `while`
+condition can be used directly. Either way, no explicit `SDL_QUIT` event
+handling is needed.
+
+---
+
+## Phase 2 — Input system (`app/systems/input_system.cpp`)
+
+**Branch:** `refactor/raylib-input`  
+**Files:** `app/systems/input_system.cpp`
+
+### Polling model
+
+raylib uses a **polling model** (same concept as SDL, different API). Input
+state is updated internally by `BeginDrawing`/`EndDrawing` — you poll it with
+query functions rather than processing an event queue. This means `input_system`
+retains its current structure: called once per frame, writes into `InputState`.
+No event callback split required.
+
+### Input translation
+
+```cpp
+void input_system(entt::registry& reg, float raw_dt) {
+    auto& input = reg.ctx().get<InputState>();
+    clear_input_events(input);
+
+    // Mouse (desktop)
+    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
+        input.touch_down = true;
+        input.touching   = true;
+        auto pos = GetMousePosition();
+        input.start_x = input.curr_x = pos.x;
+        input.start_y = input.curr_y = pos.y;
+        input.duration = 0.0f;
+    }
+    if (IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) {
+        input.touch_up = true;
+        input.touching = false;
+        auto pos = GetMousePosition();
+        input.end_x = pos.x; input.end_y = pos.y;
+    }
+    if (IsMouseButtonDown(MOUSE_BUTTON_LEFT) && input.touching) {
+        auto pos = GetMousePosition();
+        input.curr_x = pos.x; input.curr_y = pos.y;
+    }
+
+    // Touch (mobile / web)
+    if (GetTouchPointCount() > 0) {
+        // Mirror same logic using GetTouchPosition(0)
+    }
+
+#ifdef PLATFORM_DESKTOP
+    // Keyboard — IsKeyPressed fires exactly once per press (no repeat)
+    if (IsKeyPressed(KEY_W)) input.key_w = true;
+    if (IsKeyPressed(KEY_A)) input.key_a = true;
+    if (IsKeyPressed(KEY_S)) input.key_s = true;
+    if (IsKeyPressed(KEY_D)) input.key_d = true;
+    if (IsKeyPressed(KEY_ONE))   input.key_1 = true;
+    if (IsKeyPressed(KEY_TWO))   input.key_2 = true;
+    if (IsKeyPressed(KEY_THREE)) input.key_3 = true;
+#endif
+
+    // Background / suspend — raylib has no direct equivalent to
+    // SDL_APP_WILLENTERBACKGROUND. Use IsWindowFocused() as a proxy:
+    if (!IsWindowFocused() && reg.ctx().get<GameState>().phase == GamePhase::Playing) {
+        auto& gs = reg.ctx().get<GameState>();
+        gs.transition_pending = true;
+        gs.next_phase = GamePhase::Paused;
+    }
+
+    if (input.touching) input.duration += raw_dt;
+}
+```
+
+Key differences from SDL:
+- `IsKeyPressed` already suppresses repeat — no `repeat == 0` guard needed
+- Touch coordinates from `GetTouchPosition` are in **screen pixels** (same as
+  SDL mouse, unlike SDL's normalised finger events)
+- No `SDL_FINGERDOWN` / normalisation by `SCREEN_W` needed
+
+### `all_systems.h` — signature change
+
+```cpp
+// Before
+struct SDL_Renderer;
+void render_system(entt::registry& reg, SDL_Renderer* renderer, float alpha);
+
+// After
+void render_system(entt::registry& reg, float alpha);
+```
+
+---
+
+## Phase 3 — Render system (`app/systems/render_system.cpp`)
+
+**Branch:** `refactor/raylib-render`  
+**Files:** `app/systems/render_system.cpp`
+
+### API mapping
+
+| SDL2 call | raylib replacement |
+|---|---|
+| `SDL_SetRenderDrawColor(r, R,G,B,A)` | pass `(Color){R,G,B,A}` inline to each draw call |
+| `SDL_RenderFillRectF(r, &rect)` | `DrawRectangleRec((Rectangle){x,y,w,h}, color)` |
+| `SDL_RenderDrawRectF(r, &rect)` | `DrawRectangleLinesEx((Rectangle){x,y,w,h}, 1.0f, color)` |
+| `SDL_RenderDrawLineF(r, x1,y1,x2,y2)` | `DrawLineV((Vector2){x1,y1}, (Vector2){x2,y2}, color)` |
+| `SDL_SetRenderDrawBlendMode(BLEND)` | `BeginBlendMode(BLEND_ALPHA)` / `EndBlendMode()` |
+| `SDL_RenderClear(r)` | `ClearBackground(color)` |
+| `SDL_RenderPresent(r)` | `EndDrawing()` (called in main loop, not in render_system) |
+| `SDL_RenderSetLogicalSize` | `BeginMode2D` with a `Camera2D` at offset/zoom, or just use `GetScreenWidth/Height` |
+
+Note: Unlike SDL2 (stateful color) and sokol_gp (stateful color), raylib
+passes color **per draw call**. The `SDL_SetRenderDrawColor` + draw pattern
+collapses into a single call. This is a cleaner API but requires threading
+color through every helper function signature.
+
+### `draw_shape` helper — signature change
+
+```cpp
+// Before
+static void draw_shape(SDL_Renderer* r, Shape shape, float cx, float cy, float size)
+
+// After
+static void draw_shape(Shape shape, float cx, float cy, float size, Color color)
+```
+
+This is the **only helper signature that changes**. All internal SDL calls
+are replaced with raylib equivalents:
+
+- `Shape::Square` — `DrawRectangleRec`
+- `Shape::Triangle` — `DrawTriangle(v1, v2, v3, color)` — direct replacement,
+  same concept as `sgp_draw_filled_triangle`
+- `Shape::Circle` — `DrawCircleV((Vector2){cx,cy}, radius, color)` — raylib
+  has a native filled circle; the scanline loop is eliminated entirely
+
+### Frame structure
+
+`render_system` sits between `BeginDrawing()` and `EndDrawing()` in the main
+loop. It does not call either:
+
+```cpp
+// main loop
+BeginDrawing();
+    render_system(reg, alpha);   // ← no renderer param, no present
+EndDrawing();                    // ← swaps buffers, polls events
+```
+
+### Blend mode overlays
+
+```cpp
+BeginBlendMode(BLEND_ALPHA);
+DrawRectangle(0, 0, constants::SCREEN_W, constants::SCREEN_H, (Color){0,0,0,180});
+EndBlendMode();
+```
+
+### Logical size / resolution independence
+
+SDL2 had `SDL_RenderSetLogicalSize` which scaled all drawing to a virtual
+canvas. raylib has no direct equivalent. Options:
+
+1. **`Camera2D` with scale** — `BeginMode2D(camera)` / `EndMode2D()` around all
+   game-world drawing, with `camera.zoom = screenH / SCREEN_H`.
+2. **`BeginScissorMode` + manual scaling** — more involved.
+3. **Accept native resolution** — simplest. Since `constants::SCREEN_W/H` are
+   used for all coordinate math, just ensure `GetScreenWidth/Height` match or
+   add a scale factor. For a mobile/web game this matters more.
+
+This is the only significant design decision in Phase 3 that has no 1:1 SDL
+equivalent.
+
+---
+
+## Phase 4 — Text rendering (`app/text_renderer.h/.cpp`)
+
+**Branch:** `refactor/raylib-text`  
+**Files:** `app/text_renderer.h`, `app/text_renderer.cpp`
+
+raylib has a complete built-in TTF font system. This is the phase where raylib
+has the clearest advantage over both SDL2_ttf and the stb_truetype-from-scratch
+approach required by sokol.
+
+### TextContext — new internals
+
+```cpp
+struct TextContext {
+    Font font_small;    // LoadFontEx at small pixel size
+    Font font_medium;   // LoadFontEx at medium pixel size
+    Font font_large;    // LoadFontEx at large pixel size
+    // No atlas management, no sg_image, no stbtt_packedchar
+};
+```
+
+### Initialisation (`text_init`)
+
+```cpp
+ctx.font_small  = LoadFontEx(path, 16, nullptr, 0);
+ctx.font_medium = LoadFontEx(path, 28, nullptr, 0);
+ctx.font_large  = LoadFontEx(path, 48, nullptr, 0);
+```
+
+One line per size. raylib handles atlas creation, GPU upload, and glyph
+packing internally.
+
+### Drawing (`text_draw`)
+
+```cpp
+// text_draw implementation
+Font& font = select_font(ctx, font_size);
+Vector2 size = MeasureTextEx(font, text, font.baseSize, 1.0f);
+Vector2 pos = {x, y};
+if (align == TextAlign::Center) pos.x -= size.x / 2.0f;
+if (align == TextAlign::Right)  pos.x -= size.x;
+DrawTextEx(font, text, pos, font.baseSize, 1.0f, (Color){r,g,b,a});
+```
+
+The `SDL_Renderer*` parameter is removed (same as the sokol plan) — raylib
+has no renderer handle.
+
+### Shutdown (`text_shutdown`)
+
+```cpp
+UnloadFont(ctx.font_small);
+UnloadFont(ctx.font_medium);
+UnloadFont(ctx.font_large);
+```
+
+No `TTF_Quit`, no atlas cleanup.
+
+---
+
+## Phase 5 — Audio (`audio_system`)
+
+**Branch:** `refactor/raylib-audio`  
+**Files:** `app/systems/render_system.cpp`
+
+raylib bundles **miniaudio** as its audio backend. It works on all target
+platforms including Web (via Emscripten's OpenAL/Web Audio bridge).
+
+```cpp
+// init_cb equivalent — before the game loop:
+InitAudioDevice();
+
+// audio_system body (replaces the stub):
+void audio_system(entt::registry& reg) {
+    auto& audio = reg.ctx().get<AudioQueue>();
+    for (int i = 0; i < audio.count; ++i) {
+        PlaySound(loaded_sounds[audio.queue[i]]);
+    }
+    audio_clear(audio);
+}
+
+// shutdown:
+CloseAudioDevice();
+```
+
+Sound assets are loaded once at startup with `LoadSound("assets/sfx/hit.wav")`.
+No streaming callback required — raylib handles the audio thread internally.
+
+This is **significantly simpler** than the `sokol_audio.h` push-model, which
+requires a stream callback and manual sample management.
+
+---
+
+## Phase 6 — Web CI job (new)
+
+**Branch:** `refactor/raylib-web-ci`  
+**Files:** `.github/workflows/ci-web.yml` (new), `app/web/shell.html` (new)
+
+Mirrors raylib's own [`build_webassembly.yml`](https://github.com/raysan5/raylib/blob/master/.github/workflows/build_webassembly.yml):
+`mymindstorm/setup-emsdk@v14` pinned to emsdk `5.0.3`, then a standard
+`emcmake cmake` configure + build. `FetchContent` clones raylib at `GIT_TAG 5.5`
+and compiles it as part of the game's own build — no separate raylib build step
+needed. A `actions/cache` step on the build directory covers warm runs.
+
+```yaml
+name: CI (Web)
+runs-on: ubuntu-latest
+steps:
+  - uses: actions/checkout@v4
+
+  - uses: mymindstorm/setup-emsdk@v14
+    with:
+      version: 5.0.3                   # same version as raylib's own CI
+      actions-cache-folder: emsdk-cache
+
+  - name: Cache build directory
+    uses: actions/cache@v5
+    with:
+      path: build-web
+      key: cmake-web-${{ hashFiles('CMakeLists.txt', 'vcpkg.json') }}
+      restore-keys: cmake-web-
+
+  - name: Build (Emscripten)
+    run: |
+      emcmake cmake -B build-web -S . \
+        -DCMAKE_BUILD_TYPE=Release
+      cmake --build build-web
+
+  - name: Upload artifact
+    uses: actions/upload-artifact@v4
+    with:
+      name: shapeshifter-web
+      path: build-web/shapeshifter.*
+```
+
+The `actions/cache` key hashes `CMakeLists.txt` — bumping the raylib `GIT_TAG`
+automatically invalidates it and triggers a fresh compile, then re-populates
+the cache for subsequent runs. Cold build (raylib + game) ~2–3 min; warm ~30s.
+
+---
+
+## Phase 7 — Linux CI cleanup
+
+Remove `libsdl2-dev`, `libsdl2-ttf-dev` from the `apt-get` step in
+`ci-linux.yml`. vcpkg's raylib port pulls in and builds GLFW itself, so no
+`libglfw3-dev` is needed either. The only system packages raylib requires on
+Linux are the OpenGL and X11 dev headers, which are present on `ubuntu-latest`
+by default but are worth pinning explicitly:
+
+```yaml
+- name: Install system libs
+  run: sudo apt-get install -y libgl1-mesa-dev libx11-dev
+```
+
+`catch2` can also be removed from `apt-get` — it is already in `vcpkg.json`
+and will be restored from the GHA binary cache like any other vcpkg package.
+
+---
+
+## Files touched — summary
+
+| File | Change |
+|---|---|
+| `CMakeLists.txt` | Medium — swap deps, add FetchContent prebuilt-binary block + IMPORTED target |
+| `vcpkg.json` | Remove sdl2/sdl2-ttf; add raylib with `"platform": "!emscripten"` |
+| `app/main.cpp` | Light — SDL_Init/CreateWindow/CreateRenderer → InitWindow; loop body intact |
+| `app/systems/all_systems.h` | Remove SDL_Renderer forward decl, update render_system sig |
+| `app/systems/render_system.cpp` | Medium — draw calls replaced; color model change |
+| `app/systems/input_system.cpp` | Medium — SDL_PollEvent loop → polling calls; structure preserved |
+| `app/text_renderer.h` | Swap internals, preserve public API; remove SDL_Renderer param |
+| `app/text_renderer.cpp` | Light rewrite — SDL2_ttf → LoadFontEx/DrawTextEx |
+| `app/web/shell.html` | New — Emscripten HTML shell |
+| `.github/workflows/ci-linux.yml` | Remove SDL system dep install |
+| `.github/workflows/ci-windows.yml` | Remove SDL/SDL_ttf references |
+| `.github/workflows/ci-web.yml` | New — Emscripten build job |
+
+**No vendor directory.** No impl TUs. No manual atlas management.  
+**Unaffected:** All ECS components, all game-logic systems, all tests.
+
+---
+
+## Execution order
+
+```
+Phase 0 — CMakeLists + FetchContent prebuilts  → CI must pass on all 3 native platforms
+Phase 1 — main loop            → game runs (no rendering yet, black window)
+Phase 2 — input                → input works, game logic ticks
+Phase 3 — render               → game is visually complete
+Phase 4 — text                 → HUD and overlays readable
+Phase 5 — audio                → playable with sound (simpler than sokol)
+Phase 6 — web CI               → web build verified on every PR
+Phase 7 — Linux CI cleanup     → remove SDL system deps from CI
+```

--- a/docs/sokol-migration.md
+++ b/docs/sokol-migration.md
@@ -1,0 +1,521 @@
+# SDL2 → Sokol Migration Plan
+
+## Overview
+
+Migrate the rendering, windowing, input, timing, and audio platform layer from
+SDL2 + SDL2_ttf to the sokol single-header library family. All ECS components
+and game-logic systems are unaffected. The `TextContext` / `text_draw` API
+boundary is preserved — only the implementation behind it changes.
+
+**Target platforms after migration:**
+
+| Platform | Backend | sokol define |
+|---|---|---|
+| macOS | Metal | `SOKOL_METAL` |
+| Windows x64 | D3D11 | `SOKOL_D3D11` |
+| Linux | OpenGL 3.3 | `SOKOL_GLCORE` |
+| Web | WebGL2 (Emscripten) | `SOKOL_GLES3` |
+
+---
+
+## Vendor Set
+
+All dependencies are **vendored** — copied as source into the repo at a pinned
+commit. No FetchContent, no vcpkg entries for these headers.
+
+```
+app/external/sokol/sokol_app.h          # floooh/sokol @ <commit>
+app/external/sokol/sokol_gfx.h          # floooh/sokol @ <commit>
+app/external/sokol/sokol_glue.h         # floooh/sokol @ <commit>
+app/external/sokol/sokol_log.h          # floooh/sokol @ <commit>
+app/external/sokol/sokol_time.h         # floooh/sokol @ <commit>
+app/external/sokol/sokol_audio.h        # floooh/sokol @ <commit>
+app/external/sokol/sokol_debugtext.h    # floooh/sokol @ <commit>
+app/external/sokol_gp/sokol_gp.h        # edubart/sokol_gp @ <commit>
+app/external/stb/stb_truetype.h         # nothings/stb @ <commit>
+app/external/stb/stb_rect_pack.h        # nothings/stb @ <commit>
+```
+
+Document the exact commit hash for each in a `app/external/VERSIONS.md` file.
+When updating a vendored header, do it as an isolated commit with the hash in
+the message:
+
+```
+vendor: update sokol to a1b2c3d4
+```
+
+### sokol impl translation units
+
+Each sokol header requires exactly one `.cpp` file that defines `SOKOL_IMPL`
+before the include. These live in `app/external/sokol/impl/`:
+
+```
+app/external/sokol/impl/sokol_app.cpp
+app/external/sokol/impl/sokol_gfx.cpp
+app/external/sokol/impl/sokol_glue.cpp
+app/external/sokol/impl/sokol_log.cpp
+app/external/sokol/impl/sokol_time.cpp
+app/external/sokol/impl/sokol_audio.cpp
+app/external/sokol/impl/sokol_debugtext.cpp
+app/external/sokol_gp/impl/sokol_gp.cpp
+app/external/stb/impl/stb_impl.cpp      # both stb headers in one TU
+```
+
+Each file is ~5 lines, e.g.:
+
+```cpp
+// sokol_gfx.cpp
+#define SOKOL_IMPL
+#include "../sokol_gfx.h"
+```
+
+---
+
+## Phase 0 — Vendor headers + build system
+
+**Branch:** `refactor/sokol-vendor`  
+**Files:** `CMakeLists.txt`, `vcpkg.json`, `app/external/`
+
+### vcpkg.json
+
+Remove `sdl2` and `sdl2-ttf`. Keep `entt` and `catch2` (for non-Emscripten
+builds):
+
+```json
+{
+  "dependencies": [
+    "entt",
+    { "name": "catch2", "platform": "!emscripten" }
+  ]
+}
+```
+
+### CMakeLists.txt — sokol_impl target
+
+Replace all SDL2 `find_package` / FetchContent blocks with:
+
+```cmake
+# ── sokol impl library ───────────────────────────────────────
+file(GLOB SOKOL_IMPL_SOURCES
+    app/external/sokol/impl/*.cpp
+    app/external/sokol_gp/impl/*.cpp
+    app/external/stb/impl/*.cpp
+)
+add_library(sokol_impl STATIC ${SOKOL_IMPL_SOURCES})
+target_include_directories(sokol_impl PUBLIC
+    app/external/sokol
+    app/external/sokol_gp
+    app/external/stb
+)
+
+if(APPLE)
+    target_compile_definitions(sokol_impl PUBLIC SOKOL_METAL)
+    target_link_libraries(sokol_impl PUBLIC
+        "-framework Metal"
+        "-framework QuartzCore"
+        "-framework Cocoa"
+        "-framework AudioToolbox")
+elseif(WIN32)
+    if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+        message(FATAL_ERROR "Only 64-bit Windows builds are supported")
+    endif()
+    target_compile_definitions(sokol_impl PUBLIC SOKOL_D3D11)
+    target_link_libraries(sokol_impl PUBLIC d3d11 dxgi dxguid)
+elseif(EMSCRIPTEN)
+    target_compile_definitions(sokol_impl PUBLIC SOKOL_GLES3)
+    target_link_options(shapeshifter PRIVATE
+        -sUSE_WEBGL2=1
+        -sALLOW_MEMORY_GROWTH=1
+        --shell-file ${CMAKE_SOURCE_DIR}/app/web/shell.html
+        --preload-file ${CMAKE_SOURCE_DIR}/assets@/assets)
+else()  # Linux
+    target_compile_definitions(sokol_impl PUBLIC SOKOL_GLCORE)
+    target_link_libraries(sokol_impl PUBLIC GL X11 Xi Xcursor Xrandr dl pthread)
+endif()
+```
+
+### CMakeLists.txt — target changes
+
+- `shapeshifter_lib`: remove `SDL2::SDL2-static` from public link.
+  `EnTT::EnTT` only. No SDL headers anywhere in the game-logic layer.
+- `shapeshifter` executable: replace `SDL2::SDL2main` + `SDL2_ttf::SDL2_ttf`
+  with `sokol_impl`.
+- `shapeshifter_tests`: no change — already had no SDL dependency.
+- Wrap the test target in `if(NOT EMSCRIPTEN)`.
+- Remove the SDL2 target-name normalisation aliases.
+- Keep the `PLATFORM_DESKTOP` compile definition. Redefine it based on the
+  sokol target rather than SDL: set it for `APPLE`, `WIN32`, and non-`EMSCRIPTEN`
+  Linux. Both `input_system.cpp` and `gesture_system.cpp` gate keyboard paths
+  on this flag and must continue to compile correctly.
+- Remove the font asset `add_custom_command` — fonts are now embedded or
+  loaded via Emscripten's virtual FS.
+
+### Linux CI
+
+Remove the `apt-get` install of `libsdl2-dev`, `libsdl2-ttf-dev`. Keep
+`catch2` system package or switch to vcpkg-provided. Remove the SDL system
+dependency install step entirely.
+
+---
+
+## Phase 1 — Main loop rewrite (`app/main.cpp`)
+
+**Branch:** `refactor/sokol-main-loop`  
+**Files:** `app/main.cpp`, `app/systems/all_systems.h`
+
+### Structural change
+
+SDL2 uses a blocking `int main()` with a `while(true)` loop.  
+sokol_app inverts control: you provide callbacks in `sapp_desc` and return
+`sokol_main()`.
+
+```
+// Before
+int main() {
+    SDL_Init → SDL_CreateWindow → SDL_CreateRenderer
+    while(true) { input → tick → render → audio }
+    SDL_DestroyRenderer → SDL_DestroyWindow → SDL_Quit
+}
+
+// After
+static AppState g_app;   // file-scoped, not global game state
+
+static void init()    { sg_setup; sgp_setup; stm_setup; saudio_setup; registry init }
+static void frame()   { stm_now timing; input tick; fixed accumulator; render; audio }
+static void event(const sapp_event* e) { translate e → InputState writes }
+static void cleanup() { text_shutdown; sgp_shutdown; sg_shutdown; saudio_shutdown }
+
+sapp_desc sokol_main(int argc, char* argv[]) {
+    return (sapp_desc){
+        .init_cb    = init,
+        .frame_cb   = frame,
+        .event_cb   = event,
+        .cleanup_cb = cleanup,
+        .width      = constants::SCREEN_W / 2,
+        .height     = constants::SCREEN_H / 2,
+        .window_title = "SHAPESHIFTER",
+        .logger.func  = slog_func,
+    };
+}
+```
+
+`AppState` is a file-scoped struct in `main.cpp` containing the
+`entt::registry` and the sokol timing state. It must never be accessed from
+any system — systems already receive the registry by reference.
+
+### Timing
+
+Replace `SDL_GetPerformanceCounter` / `SDL_GetPerformanceFrequency` with:
+
+```cpp
+stm_setup();   // once in init_cb
+// in frame_cb:
+static uint64_t last_time = 0;
+float raw_dt = (float)stm_sec(stm_laptime(&last_time));
+```
+
+### Web quit guard
+
+`sapp_quit()` is a no-op in the browser. The quit path must be guarded:
+
+```cpp
+// in event_cb, on SAPP_EVENTTYPE_QUIT_REQUESTED:
+#ifndef __EMSCRIPTEN__
+    sapp_quit();
+#endif
+```
+
+---
+
+## Phase 2 — Input system (`app/systems/input_system.cpp`)
+
+**Branch:** `refactor/sokol-input`  
+**Files:** `app/systems/input_system.cpp`, `app/main.cpp`
+
+### Split responsibility
+
+The SDL `SDL_PollEvent` loop moves entirely into the `event_cb` in `main.cpp`.
+`input_system` becomes a pure tick function — it only advances `input.duration`
+and can be renamed `input_tick_system` to make the split explicit.
+
+### Event translation table
+
+| `sapp_event` type | `InputState` writes |
+|---|---|
+| `SAPP_EVENTTYPE_MOUSE_DOWN` | `touch_down=true`, `touching=true`, `start_x/y`, `curr_x/y`, `duration=0` |
+| `SAPP_EVENTTYPE_MOUSE_UP` | `touch_up=true`, `touching=false`, `end_x/y` |
+| `SAPP_EVENTTYPE_MOUSE_MOVED` | `curr_x/y` (if `touching`) |
+| `SAPP_EVENTTYPE_TOUCHES_BEGAN` | same as MOUSE_DOWN via `touches[0].pos_x/y` |
+| `SAPP_EVENTTYPE_TOUCHES_MOVED` | `curr_x/y` |
+| `SAPP_EVENTTYPE_TOUCHES_ENDED` | `touch_up`, `end_x/y` |
+| `SAPP_EVENTTYPE_SUSPENDED` | transition to `GamePhase::Paused` |
+| `SAPP_EVENTTYPE_QUIT_REQUESTED` | `quit_requested=true` (non-web only) |
+| `SAPP_EVENTTYPE_KEY_DOWN` (PLATFORM_DESKTOP) | map `e.key_code` → `key_w/a/s/d/1/2/3`; guard `if (!e.key_repeat)` to match SDL's `repeat == 0` behaviour |
+| `SAPP_EVENTTYPE_KEY_UP` | not currently used — no field in InputState for held keys |
+
+Touch coordinates from sokol_app are already in pixels (not normalised 0–1 as
+in SDL). Verify against `sapp_width()` / `sapp_height()` for DPI-scaled
+displays and apply `sapp_dpi_scale()` if needed.
+
+### `all_systems.h` — signature change
+
+```cpp
+// Before
+struct SDL_Renderer;
+void render_system(entt::registry& reg, SDL_Renderer* renderer, float alpha);
+
+// After
+void render_system(entt::registry& reg, float alpha);
+```
+
+Remove the `struct SDL_Renderer;` forward declaration entirely.
+
+---
+
+## Phase 3 — Render system (`app/systems/render_system.cpp`)
+
+**Branch:** `refactor/sokol-render`  
+**Files:** `app/systems/render_system.cpp`
+
+### API mapping
+
+| SDL2 call | sokol_gp replacement |
+|---|---|
+| `SDL_SetRenderDrawColor(r, R,G,B,A)` | `sgp_set_color(R/255.f, G/255.f, B/255.f, A/255.f)` |
+| `SDL_RenderFillRectF(r, &rect)` | `sgp_draw_filled_rect(x, y, w, h)` |
+| `SDL_RenderDrawRectF(r, &rect)` | 4× `sgp_draw_line` (top, right, bottom, left edges) — sokol_gp has no outline-rect primitive |
+| `SDL_RenderDrawLineF(r, x1,y1,x2,y2)` | `sgp_draw_line(x1, y1, x2, y2)` |
+| `SDL_SetRenderDrawBlendMode(BLEND)` | `sgp_set_blend_mode(SGP_BLENDMODE_BLEND)` |
+| `SDL_RenderClear(r)` | `sgp_clear()` after `sgp_set_color(...)` |
+| `SDL_RenderPresent(r)` | removed — `sg_commit()` is in `frame_cb` |
+| `SDL_RenderSetLogicalSize` | `sgp_project(0, SCREEN_W, 0, SCREEN_H)` — signature is `(left, right, top, bottom)` |
+
+### Frame structure
+
+`render_system` no longer calls present/commit. The frame_cb owns that:
+
+```cpp
+// frame_cb in main.cpp
+int w = sapp_width(), h = sapp_height();
+sg_pass pass = { .swapchain = sglue_swapchain() };
+sg_begin_pass(&pass);
+sgp_begin(w, h);
+sgp_viewport(0, 0, w, h);
+// left=0, right=SCREEN_W, top=0, bottom=SCREEN_H (Y grows downward, matching SDL)
+sgp_project(0.0f, (float)constants::SCREEN_W, 0.0f, (float)constants::SCREEN_H);
+
+render_system(reg, alpha);   // ← no renderer param
+
+sgp_flush();
+sgp_end();
+sg_end_pass();
+sg_commit();
+```
+
+### `draw_shape` helper
+
+- `Shape::Square` — `sgp_draw_filled_rect`
+- `Shape::Triangle` — `sgp_draw_filled_triangle(x1,y1, x2,y2, x3,y3)` using
+  the three apex coordinates; eliminates the scanline loop entirely
+- `Shape::Circle` — keep the existing scanline approach: loop rows of
+  `sgp_draw_filled_rect` (same logic as current SDL impl). sokol_gp has no
+  filled-circle or polygon primitive. The low-level `sgp_draw` with
+  `SG_PRIMITIVETYPE_TRIANGLE_STRIP` is an option for a higher-quality circle
+  but is out of scope for this migration.
+
+### Blend mode overlays
+
+The game-over and pause dim overlays use `SDL_BLENDMODE_BLEND`. In sokol_gp:
+
+```cpp
+sgp_set_blend_mode(SGP_BLENDMODE_BLEND);
+sgp_set_color(0, 0, 0, 0.7f);
+sgp_draw_filled_rect(0, 0, constants::SCREEN_W, constants::SCREEN_H);
+sgp_set_blend_mode(SGP_BLENDMODE_NONE);  // restore
+```
+
+---
+
+## Phase 4 — Text rendering (`app/text_renderer.h/.cpp`)
+
+**Branch:** `refactor/sokol-text`  
+**Files:** `app/text_renderer.h`, `app/text_renderer.cpp`
+
+The `TextContext` / `text_draw` / `text_draw_number` call sites in
+`render_system.cpp` are preserved exactly **except** that the
+`SDL_Renderer* renderer` parameter is removed from `text_draw` and
+`text_draw_number` — sokol_gp is a global context, no handle needed.
+All call sites in `render_system.cpp` must drop that argument.
+The implementation changes from SDL2_ttf to stb_truetype + sokol_gp.
+
+### TextContext — new internals
+
+```cpp
+struct GlyphInfo {
+    stbtt_packedchar data[96];   // ASCII 32–127
+};
+
+struct TextContext {
+    sg_image       atlas;           // GPU texture, R8 format
+    GlyphInfo      glyphs[3];       // one per FontSize (Small, Medium, Large)
+    float          font_sizes[3];   // pixel heights per FontSize
+    sg_sampler     sampler;         // linear filter for text
+    // No TTF_Font*, no SDL_Texture*
+};
+```
+
+### Initialisation (`text_init`)
+
+```
+1. Read .ttf file bytes into a buffer (std::vector<uint8_t>, fread)
+2. Allocate a CPU-side atlas bitmap (e.g. 512×512, uint8_t)
+3. stbtt_PackBegin → stbtt_PackFontRanges for each FontSize → stbtt_PackEnd
+4. sg_make_image with SG_PIXELFORMAT_R8, atlas bitmap as initial data
+5. sg_make_sampler with linear filter
+```
+
+On Emscripten the font file is loaded from the virtual FS populated by
+`--preload-file assets@/assets` in the linker flags.
+
+### Drawing (`text_draw`)
+
+For each character in the string:
+
+```
+stbtt_GetPackedQuad → aligned_quad (screen dest rect + atlas UV rect)
+sgp_set_image(0, text_ctx.atlas)
+sgp_set_sampler(0, text_ctx.sampler)
+sgp_draw_textured_rect(0,
+    {dest.x, dest.y, dest.w, dest.h},   // screen position
+    {uv.x,   uv.y,   uv.w,  uv.h  })   // atlas region
+sgp_reset_image(0)
+```
+
+`TextAlign::Center` is computed by summing advance widths across the string
+before issuing any draw calls (same logic as current implementation).
+
+### Shutdown (`text_shutdown`)
+
+```cpp
+sg_destroy_image(ctx.atlas);
+sg_destroy_sampler(ctx.sampler);
+```
+
+No `TTF_CloseFont`, no `TTF_Quit`.
+
+---
+
+## Phase 5 — Audio (`audio_system`)
+
+**Branch:** `refactor/sokol-audio`  
+**Files:** `app/systems/render_system.cpp` (audio stub is compiled into this TU;
+  the function declaration is in `app/systems/all_systems.h`)
+
+Currently a no-op stub (`audio_clear` only). When real audio is implemented:
+
+- Replace `Mix_PlayChannel` comments with `saudio_push` for streaming, or
+  decode audio clips with `stb_vorbis` / miniaudio at init and push samples
+  via the `sokol_audio.h` stream callback.
+- `AudioQueue` component and `audio_system` signature are unchanged.
+- On Web, sokol_audio uses the Web Audio API via Emscripten. Audio context
+  activation is gated by user gesture — the existing `GamePhase::Title`
+  tap-to-start screen satisfies this requirement.
+
+This phase is **independent** of phases 1–4 and can be deferred.
+
+---
+
+## Phase 6 — Web CI job (new)
+
+**Branch:** `refactor/sokol-web-ci`  
+**Files:** `.github/workflows/ci-web.yml` (new), `app/web/shell.html` (new)
+
+Add a fourth CI job for Emscripten builds:
+
+```yaml
+name: CI (Web)
+runs-on: ubuntu-latest
+steps:
+  - uses: actions/checkout@v6
+  - uses: mymindstorm/setup-emsdk@v14
+    with:
+      version: latest
+  - name: Build (Emscripten)
+    run: |
+      emcmake cmake -B build-web -S . \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_TOOLCHAIN_FILE=$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake
+      cmake --build build-web
+  - name: Upload artifact
+    uses: actions/upload-artifact@v4
+    with:
+      name: shapeshifter-web
+      path: build-web/shapeshifter.*   # .js + .wasm + .html
+```
+
+No tests run on the web job (Emscripten guard in CMakeLists.txt skips the
+`shapeshifter_tests` target).
+
+---
+
+## Phase 7 — Linux CI cleanup
+
+**Branch:** (fold into `refactor/sokol-main-loop` or a separate cleanup PR)  
+**Files:** `.github/workflows/ci-linux.yml`
+
+Remove the `apt-get install` step for SDL2 and SDL2_ttf:
+
+```yaml
+# Remove entirely:
+- name: Install system dependencies
+  run: |
+    sudo apt-get install -y libsdl2-dev libsdl2-ttf-dev catch2
+```
+
+Linux system `catch2` may still be needed if vcpkg is not used for it on
+Linux. Evaluate during implementation.
+
+---
+
+## Files touched — summary
+
+| File | Change |
+|---|---|
+| `app/external/sokol/` | New — 7 headers + 7 impl TUs |
+| `app/external/sokol_gp/` | New — 1 header + 1 impl TU |
+| `app/external/stb/` | New — 2 headers + 1 impl TU |
+| `app/external/VERSIONS.md` | New — pinned commit hashes |
+| `CMakeLists.txt` | Heavy — swap deps, add sokol_impl target, platform backends |
+| `vcpkg.json` | Remove sdl2, sdl2-ttf |
+| `app/main.cpp` | Structural rewrite — callbacks replace main loop |
+| `app/systems/all_systems.h` | Remove SDL_Renderer forward decl, update render_system sig |
+| `app/systems/render_system.cpp` | Heavy — every draw call replaced with sgp_* |
+| `app/systems/input_system.cpp` | Thin — delete SDL event loop, keep duration tick |
+| `app/text_renderer.h` | Swap internals, preserve public API |
+| `app/text_renderer.cpp` | Rewrite — SDL2_ttf → stb_truetype + sokol_gp |
+| `app/web/shell.html` | New — Emscripten HTML shell |
+| `.github/workflows/ci-linux.yml` | Remove SDL system dep install |
+| `.github/workflows/ci-windows.yml` | Remove SDL/SDL_ttf references |
+| `.github/workflows/ci-web.yml` | New — Emscripten build job |
+
+**Unaffected:** All ECS components, all game-logic systems (burnout, collision,
+scoring, gesture, etc.), all tests.
+
+---
+
+## Execution order
+
+Each phase should be its own PR, merged in order, keeping `main` green
+throughout. Phases 0 and 1 are the gate — nothing else compiles until the
+build system and main loop land.
+
+```
+Phase 0 — vendor + CMake      → CI must pass on all 3 native platforms
+Phase 1 — main loop           → game runs (no rendering yet, black window)
+Phase 2 — input               → input works, game logic ticks
+Phase 3 — render              → game is visually complete
+Phase 4 — text                → HUD and overlays readable
+Phase 5 — audio               → (can be deferred post-launch)
+Phase 6 — web CI              → web build verified on every PR
+Phase 7 — Linux CI cleanup    → remove SDL system deps from CI
+```

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 cd "$(dirname "$0")"
-
+export VCPKG_ROOT="$HOME/vcpkg"
 ./build.sh
 
 if [[ "${1:-}" == "test" ]]; then

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -127,7 +127,7 @@ TEST_CASE("collision: combo gate requires shape AND lane", "[collision]") {
     reg.emplace<BlockedLanes>(obs, uint8_t{0b101});
     reg.emplace<DrawSize>(obs, 720.0f, 80.0f);
     reg.emplace<DrawLayer>(obs, Layer::Game);
-    reg.emplace<Color>(obs, uint8_t{200}, uint8_t{100}, uint8_t{255}, uint8_t{255});
+    reg.emplace<DrawColor>(obs, uint8_t{200}, uint8_t{100}, uint8_t{255}, uint8_t{255});
 
     collision_system(reg, 0.016f);
 
@@ -147,7 +147,7 @@ TEST_CASE("collision: combo gate fails with wrong shape", "[collision]") {
     reg.emplace<BlockedLanes>(obs, uint8_t{0b101});    // lane 1 open
     reg.emplace<DrawSize>(obs, 720.0f, 80.0f);
     reg.emplace<DrawLayer>(obs, Layer::Game);
-    reg.emplace<Color>(obs, uint8_t{200}, uint8_t{100}, uint8_t{255}, uint8_t{255});
+    reg.emplace<DrawColor>(obs, uint8_t{200}, uint8_t{100}, uint8_t{255}, uint8_t{255});
 
     collision_system(reg, 0.016f);
 

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -108,7 +108,7 @@ TEST_CASE("ecs: make_player creates proper entity", "[ecs]") {
     CHECK(reg.all_of<PlayerShape>(p));
     CHECK(reg.all_of<Lane>(p));
     CHECK(reg.all_of<VerticalState>(p));
-    CHECK(reg.all_of<Color>(p));
+    CHECK(reg.all_of<DrawColor>(p));
     CHECK(reg.all_of<DrawSize>(p));
     CHECK(reg.all_of<DrawLayer>(p));
 }
@@ -121,7 +121,7 @@ TEST_CASE("components: Velocity default is zero", "[components]") {
 
 TEST_CASE("components: GestureResult default is None", "[components]") {
     GestureResult g{};
-    CHECK(g.gesture == Gesture::None);
+    CHECK(g.gesture == SwipeGesture::None);
     CHECK(g.magnitude == 0.0f);
     CHECK(g.hit_x == 0.0f);
     CHECK(g.hit_y == 0.0f);
@@ -133,8 +133,8 @@ TEST_CASE("components: Lifetime defaults", "[components]") {
     CHECK(lt.max_time == 0.0f);
 }
 
-TEST_CASE("components: Color construction", "[components]") {
-    Color c{uint8_t{255}, uint8_t{128}, uint8_t{64}, uint8_t{200}};
+TEST_CASE("components: DrawColor construction", "[components]") {
+    DrawColor c{uint8_t{255}, uint8_t{128}, uint8_t{64}, uint8_t{200}};
     CHECK(c.r == 255);
     CHECK(c.g == 128);
     CHECK(c.b == 64);
@@ -154,9 +154,8 @@ TEST_CASE("components: Obstacle construction", "[components]") {
 }
 
 TEST_CASE("components: ParticleData construction", "[components]") {
-    ParticleData pd{10.0f, 10.0f};
+    ParticleData pd{10.0f};
     CHECK(pd.size == 10.0f);
-    CHECK(pd.start_size == 10.0f);
 }
 
 TEST_CASE("components: ShapeButtonEvent defaults to not pressed", "[components]") {

--- a/tests/test_gesture_system.cpp
+++ b/tests/test_gesture_system.cpp
@@ -10,7 +10,7 @@ TEST_CASE("gesture_system: no gesture when no touch_up", "[gesture]") {
     gesture_system(reg, 0.016f);
 
     auto& gesture = reg.ctx().get<GestureResult>();
-    CHECK(gesture.gesture == Gesture::None);
+    CHECK(gesture.gesture == SwipeGesture::None);
     CHECK_FALSE(reg.ctx().get<ShapeButtonEvent>().pressed);
 }
 
@@ -27,7 +27,7 @@ TEST_CASE("gesture_system: swipe right detected", "[gesture]") {
     gesture_system(reg, 0.016f);
 
     auto& gesture = reg.ctx().get<GestureResult>();
-    CHECK(gesture.gesture == Gesture::SwipeRight);
+    CHECK(gesture.gesture == SwipeGesture::SwipeRight);
     CHECK(gesture.magnitude > constants::MIN_SWIPE_DIST);
 }
 
@@ -43,7 +43,7 @@ TEST_CASE("gesture_system: swipe left detected", "[gesture]") {
 
     gesture_system(reg, 0.016f);
 
-    CHECK(reg.ctx().get<GestureResult>().gesture == Gesture::SwipeLeft);
+    CHECK(reg.ctx().get<GestureResult>().gesture == SwipeGesture::SwipeLeft);
 }
 
 TEST_CASE("gesture_system: swipe up detected", "[gesture]") {
@@ -58,7 +58,7 @@ TEST_CASE("gesture_system: swipe up detected", "[gesture]") {
 
     gesture_system(reg, 0.016f);
 
-    CHECK(reg.ctx().get<GestureResult>().gesture == Gesture::SwipeUp);
+    CHECK(reg.ctx().get<GestureResult>().gesture == SwipeGesture::SwipeUp);
 }
 
 TEST_CASE("gesture_system: swipe down detected", "[gesture]") {
@@ -73,7 +73,7 @@ TEST_CASE("gesture_system: swipe down detected", "[gesture]") {
 
     gesture_system(reg, 0.016f);
 
-    CHECK(reg.ctx().get<GestureResult>().gesture == Gesture::SwipeDown);
+    CHECK(reg.ctx().get<GestureResult>().gesture == SwipeGesture::SwipeDown);
 }
 
 TEST_CASE("gesture_system: swipe too short is ignored", "[gesture]") {
@@ -88,7 +88,7 @@ TEST_CASE("gesture_system: swipe too short is ignored", "[gesture]") {
 
     gesture_system(reg, 0.016f);
 
-    CHECK(reg.ctx().get<GestureResult>().gesture == Gesture::None);
+    CHECK(reg.ctx().get<GestureResult>().gesture == SwipeGesture::None);
 }
 
 TEST_CASE("gesture_system: swipe too slow is ignored", "[gesture]") {
@@ -103,7 +103,7 @@ TEST_CASE("gesture_system: swipe too slow is ignored", "[gesture]") {
 
     gesture_system(reg, 0.016f);
 
-    CHECK(reg.ctx().get<GestureResult>().gesture == Gesture::None);
+    CHECK(reg.ctx().get<GestureResult>().gesture == SwipeGesture::None);
 }
 
 TEST_CASE("gesture_system: button tap in button zone", "[gesture]") {
@@ -130,7 +130,7 @@ TEST_CASE("gesture_system: button tap in button zone", "[gesture]") {
     auto& btn = reg.ctx().get<ShapeButtonEvent>();
     CHECK(btn.pressed);
     CHECK(btn.shape == Shape::Square);
-    CHECK(reg.ctx().get<GestureResult>().gesture == Gesture::None);
+    CHECK(reg.ctx().get<GestureResult>().gesture == SwipeGesture::None);
 }
 
 TEST_CASE("gesture_system: button tap on first button (Circle)", "[gesture]") {
@@ -184,7 +184,7 @@ TEST_CASE("gesture_system: swipe sets magnitude and hit coordinates", "[gesture]
     gesture_system(reg, 0.016f);
 
     auto& g = reg.ctx().get<GestureResult>();
-    CHECK(g.gesture == Gesture::SwipeRight);
+    CHECK(g.gesture == SwipeGesture::SwipeRight);
     CHECK(g.hit_x == 200.0f);  // start coords
     CHECK(g.hit_y == 300.0f);
     CHECK(g.magnitude > 0.0f);
@@ -203,7 +203,7 @@ TEST_CASE("gesture_system: diagonal swipe classified by dominant axis", "[gestur
 
     gesture_system(reg, 0.016f);
 
-    CHECK(reg.ctx().get<GestureResult>().gesture == Gesture::SwipeRight);
+    CHECK(reg.ctx().get<GestureResult>().gesture == SwipeGesture::SwipeRight);
 }
 
 TEST_CASE("gesture_system: button tap on third button (Triangle)", "[gesture]") {
@@ -257,7 +257,7 @@ TEST_CASE("gesture_system: left-click on Circle button works on desktop", "[gest
     auto& btn = reg.ctx().get<ShapeButtonEvent>();
     CHECK(btn.pressed);
     CHECK(btn.shape == Shape::Circle);
-    CHECK(reg.ctx().get<GestureResult>().gesture == Gesture::None);
+    CHECK(reg.ctx().get<GestureResult>().gesture == SwipeGesture::None);
 }
 
 TEST_CASE("gesture_system: left-click on Triangle button works on desktop", "[gesture][desktop]") {
@@ -294,7 +294,7 @@ TEST_CASE("gesture_system: W key fires SwipeUp", "[gesture][desktop]") {
 
     gesture_system(reg, 0.016f);
 
-    CHECK(reg.ctx().get<GestureResult>().gesture == Gesture::SwipeUp);
+    CHECK(reg.ctx().get<GestureResult>().gesture == SwipeGesture::SwipeUp);
     CHECK_FALSE(reg.ctx().get<ShapeButtonEvent>().pressed);
 }
 
@@ -304,7 +304,7 @@ TEST_CASE("gesture_system: S key fires SwipeDown", "[gesture][desktop]") {
 
     gesture_system(reg, 0.016f);
 
-    CHECK(reg.ctx().get<GestureResult>().gesture == Gesture::SwipeDown);
+    CHECK(reg.ctx().get<GestureResult>().gesture == SwipeGesture::SwipeDown);
 }
 
 TEST_CASE("gesture_system: A key fires SwipeLeft", "[gesture][desktop]") {
@@ -313,7 +313,7 @@ TEST_CASE("gesture_system: A key fires SwipeLeft", "[gesture][desktop]") {
 
     gesture_system(reg, 0.016f);
 
-    CHECK(reg.ctx().get<GestureResult>().gesture == Gesture::SwipeLeft);
+    CHECK(reg.ctx().get<GestureResult>().gesture == SwipeGesture::SwipeLeft);
 }
 
 TEST_CASE("gesture_system: D key fires SwipeRight", "[gesture][desktop]") {
@@ -322,7 +322,7 @@ TEST_CASE("gesture_system: D key fires SwipeRight", "[gesture][desktop]") {
 
     gesture_system(reg, 0.016f);
 
-    CHECK(reg.ctx().get<GestureResult>().gesture == Gesture::SwipeRight);
+    CHECK(reg.ctx().get<GestureResult>().gesture == SwipeGesture::SwipeRight);
 }
 
 TEST_CASE("gesture_system: key_1 selects Circle shape", "[gesture][desktop]") {
@@ -334,7 +334,7 @@ TEST_CASE("gesture_system: key_1 selects Circle shape", "[gesture][desktop]") {
     auto& btn = reg.ctx().get<ShapeButtonEvent>();
     CHECK(btn.pressed);
     CHECK(btn.shape == Shape::Circle);
-    CHECK(reg.ctx().get<GestureResult>().gesture == Gesture::None);
+    CHECK(reg.ctx().get<GestureResult>().gesture == SwipeGesture::None);
 }
 
 TEST_CASE("gesture_system: key_2 selects Triangle shape", "[gesture][desktop]") {
@@ -366,7 +366,7 @@ TEST_CASE("gesture_system: keyboard key produces no magnitude or hit coords", "[
     gesture_system(reg, 0.016f);
 
     auto& g = reg.ctx().get<GestureResult>();
-    CHECK(g.gesture == Gesture::SwipeUp);
+    CHECK(g.gesture == SwipeGesture::SwipeUp);
     CHECK(g.magnitude == 0.0f);
     CHECK(g.hit_x == 0.0f);
     CHECK(g.hit_y == 0.0f);
@@ -388,7 +388,7 @@ TEST_CASE("gesture_system: keyboard takes priority over simultaneous touch", "[g
     gesture_system(reg, 0.016f);
 
     // Keyboard wins
-    CHECK(reg.ctx().get<GestureResult>().gesture == Gesture::SwipeUp);
+    CHECK(reg.ctx().get<GestureResult>().gesture == SwipeGesture::SwipeUp);
 }
 
 TEST_CASE("gesture_system: key flags cleared between frames do not re-fire", "[gesture][desktop]") {
@@ -397,11 +397,11 @@ TEST_CASE("gesture_system: key flags cleared between frames do not re-fire", "[g
     input.key_d = true;
 
     gesture_system(reg, 0.016f);
-    CHECK(reg.ctx().get<GestureResult>().gesture == Gesture::SwipeRight);
+    CHECK(reg.ctx().get<GestureResult>().gesture == SwipeGesture::SwipeRight);
 
     // Next frame: clear events (simulates start of input_system tick)
     clear_input_events(input);
     gesture_system(reg, 0.016f);
-    CHECK(reg.ctx().get<GestureResult>().gesture == Gesture::None);
+    CHECK(reg.ctx().get<GestureResult>().gesture == SwipeGesture::None);
 }
 #endif // PLATFORM_DESKTOP

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -41,7 +41,7 @@ inline entt::entity make_player(entt::registry& reg) {
     reg.emplace<PlayerShape>(player);
     reg.emplace<Lane>(player);
     reg.emplace<VerticalState>(player);
-    reg.emplace<Color>(player, uint8_t{80}, uint8_t{180}, uint8_t{255}, uint8_t{255});
+    reg.emplace<DrawColor>(player, uint8_t{80}, uint8_t{180}, uint8_t{255}, uint8_t{255});
     reg.emplace<DrawSize>(player, constants::PLAYER_SIZE, constants::PLAYER_SIZE);
     reg.emplace<DrawLayer>(player, Layer::Game);
     return player;
@@ -58,7 +58,7 @@ inline entt::entity make_shape_gate(entt::registry& reg, Shape shape, float y) {
     reg.emplace<RequiredShape>(obs, shape);
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);
     reg.emplace<DrawLayer>(obs, Layer::Game);
-    reg.emplace<Color>(obs, uint8_t{255}, uint8_t{255}, uint8_t{255}, uint8_t{255});
+    reg.emplace<DrawColor>(obs, uint8_t{255}, uint8_t{255}, uint8_t{255}, uint8_t{255});
     return obs;
 }
 
@@ -73,7 +73,7 @@ inline entt::entity make_lane_block(entt::registry& reg, uint8_t mask, float y) 
     reg.emplace<BlockedLanes>(obs, mask);
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W / 3), 80.0f);
     reg.emplace<DrawLayer>(obs, Layer::Game);
-    reg.emplace<Color>(obs, uint8_t{255}, uint8_t{60}, uint8_t{60}, uint8_t{255});
+    reg.emplace<DrawColor>(obs, uint8_t{255}, uint8_t{60}, uint8_t{60}, uint8_t{255});
     return obs;
 }
 
@@ -90,7 +90,7 @@ inline entt::entity make_vertical_bar(entt::registry& reg, ObstacleKind kind, fl
     reg.emplace<RequiredVAction>(obs, action);
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 40.0f);
     reg.emplace<DrawLayer>(obs, Layer::Game);
-    reg.emplace<Color>(obs, uint8_t{255}, uint8_t{180}, uint8_t{0}, uint8_t{255});
+    reg.emplace<DrawColor>(obs, uint8_t{255}, uint8_t{180}, uint8_t{0}, uint8_t{255});
     return obs;
 }
 
@@ -106,7 +106,7 @@ inline entt::entity make_combo_gate(entt::registry& reg, Shape shape, uint8_t bl
     reg.emplace<BlockedLanes>(obs, blocked_mask);
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);
     reg.emplace<DrawLayer>(obs, Layer::Game);
-    reg.emplace<Color>(obs, uint8_t{200}, uint8_t{100}, uint8_t{255}, uint8_t{255});
+    reg.emplace<DrawColor>(obs, uint8_t{200}, uint8_t{100}, uint8_t{255}, uint8_t{255});
     return obs;
 }
 
@@ -122,6 +122,6 @@ inline entt::entity make_split_path(entt::registry& reg, Shape shape, int8_t lan
     reg.emplace<RequiredLane>(obs, lane);
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);
     reg.emplace<DrawLayer>(obs, Layer::Game);
-    reg.emplace<Color>(obs, uint8_t{255}, uint8_t{215}, uint8_t{0}, uint8_t{255});
+    reg.emplace<DrawColor>(obs, uint8_t{255}, uint8_t{215}, uint8_t{0}, uint8_t{255});
     return obs;
 }

--- a/tests/test_particle_system.cpp
+++ b/tests/test_particle_system.cpp
@@ -7,7 +7,7 @@ static entt::entity make_particle(entt::registry& reg, float size, float life_re
                                   float vx = 0.0f, float vy = 0.0f) {
     auto e = reg.create();
     reg.emplace<ParticleTag>(e);
-    reg.emplace<ParticleData>(e, size, size);  // size, start_size
+    reg.emplace<ParticleData>(e, size);
     reg.emplace<Lifetime>(e, life_remaining, life_max);
     reg.emplace<Velocity>(e, vx, vy);
     reg.emplace<Position>(e, 100.0f, 200.0f);
@@ -20,11 +20,12 @@ TEST_CASE("particle: shrinks proportional to remaining lifetime", "[particle]") 
     auto reg = make_registry();
     auto e = make_particle(reg, 10.0f, 0.5f, 1.0f);
 
+    // Size is now immutable; shrinking is computed at render time.
+    // Verify the particle data is unchanged after a system tick.
     particle_system(reg, 0.016f);
 
     auto& pd = reg.get<ParticleData>(e);
-    // remaining/max_time = 0.5/1.0 = 0.5, so size = 10 * 0.5 = 5.0
-    CHECK_THAT(pd.size, Catch::Matchers::WithinAbs(5.0f, 0.01f));
+    CHECK_THAT(pd.size, Catch::Matchers::WithinAbs(10.0f, 0.01f));
 }
 
 TEST_CASE("particle: full lifetime means full size", "[particle]") {
@@ -37,25 +38,25 @@ TEST_CASE("particle: full lifetime means full size", "[particle]") {
     CHECK_THAT(pd.size, Catch::Matchers::WithinAbs(8.0f, 0.01f));
 }
 
-TEST_CASE("particle: nearly expired lifetime shrinks to near zero", "[particle]") {
+TEST_CASE("particle: size is immutable across ticks", "[particle]") {
     auto reg = make_registry();
     auto e = make_particle(reg, 10.0f, 0.01f, 1.0f);
 
     particle_system(reg, 0.016f);
 
     auto& pd = reg.get<ParticleData>(e);
-    CHECK(pd.size < 0.2f);
+    CHECK_THAT(pd.size, Catch::Matchers::WithinAbs(10.0f, 0.01f));
 }
 
-TEST_CASE("particle: multiple particles shrink independently", "[particle]") {
+TEST_CASE("particle: multiple particles retain original size", "[particle]") {
     auto reg = make_registry();
     auto e1 = make_particle(reg, 10.0f, 0.5f, 1.0f);
     auto e2 = make_particle(reg, 20.0f, 0.25f, 1.0f);
 
     particle_system(reg, 0.016f);
 
-    CHECK_THAT(reg.get<ParticleData>(e1).size, Catch::Matchers::WithinAbs(5.0f, 0.01f));
-    CHECK_THAT(reg.get<ParticleData>(e2).size, Catch::Matchers::WithinAbs(5.0f, 0.01f));
+    CHECK_THAT(reg.get<ParticleData>(e1).size, Catch::Matchers::WithinAbs(10.0f, 0.01f));
+    CHECK_THAT(reg.get<ParticleData>(e2).size, Catch::Matchers::WithinAbs(20.0f, 0.01f));
 }
 
 // ── particle_system: gravity ────────────────────────────────

--- a/tests/test_player_systems.cpp
+++ b/tests/test_player_systems.cpp
@@ -48,7 +48,7 @@ TEST_CASE("player_action: swipe left changes lane", "[player]") {
     make_player(reg);
 
     auto& gesture = reg.ctx().get<GestureResult>();
-    gesture.gesture = Gesture::SwipeLeft;
+    gesture.gesture = SwipeGesture::SwipeLeft;
 
     player_action_system(reg, 0.016f);
 
@@ -64,7 +64,7 @@ TEST_CASE("player_action: swipe right changes lane", "[player]") {
     make_player(reg);
 
     auto& gesture = reg.ctx().get<GestureResult>();
-    gesture.gesture = Gesture::SwipeRight;
+    gesture.gesture = SwipeGesture::SwipeRight;
 
     player_action_system(reg, 0.016f);
 
@@ -80,7 +80,7 @@ TEST_CASE("player_action: swipe left at lane 0 is clamped", "[player]") {
     reg.get<Lane>(p).current = 0;
 
     auto& gesture = reg.ctx().get<GestureResult>();
-    gesture.gesture = Gesture::SwipeLeft;
+    gesture.gesture = SwipeGesture::SwipeLeft;
 
     player_action_system(reg, 0.016f);
 
@@ -93,7 +93,7 @@ TEST_CASE("player_action: swipe right at lane 2 is clamped", "[player]") {
     reg.get<Lane>(p).current = 2;
 
     auto& gesture = reg.ctx().get<GestureResult>();
-    gesture.gesture = Gesture::SwipeRight;
+    gesture.gesture = SwipeGesture::SwipeRight;
 
     player_action_system(reg, 0.016f);
 
@@ -105,7 +105,7 @@ TEST_CASE("player_action: swipe up initiates jump", "[player]") {
     make_player(reg);
 
     auto& gesture = reg.ctx().get<GestureResult>();
-    gesture.gesture = Gesture::SwipeUp;
+    gesture.gesture = SwipeGesture::SwipeUp;
 
     player_action_system(reg, 0.016f);
 
@@ -121,7 +121,7 @@ TEST_CASE("player_action: swipe down initiates slide", "[player]") {
     make_player(reg);
 
     auto& gesture = reg.ctx().get<GestureResult>();
-    gesture.gesture = Gesture::SwipeDown;
+    gesture.gesture = SwipeGesture::SwipeDown;
 
     player_action_system(reg, 0.016f);
 
@@ -139,7 +139,7 @@ TEST_CASE("player_action: cannot jump while already jumping", "[player]") {
     reg.get<VerticalState>(p).timer = 0.2f;
 
     auto& gesture = reg.ctx().get<GestureResult>();
-    gesture.gesture = Gesture::SwipeUp;
+    gesture.gesture = SwipeGesture::SwipeUp;
 
     player_action_system(reg, 0.016f);
 
@@ -235,7 +235,7 @@ TEST_CASE("player_action: not in Playing phase skips processing", "[player]") {
     make_player(reg);
 
     auto& gesture = reg.ctx().get<GestureResult>();
-    gesture.gesture = Gesture::SwipeUp;
+    gesture.gesture = SwipeGesture::SwipeUp;
 
     player_action_system(reg, 0.016f);
 
@@ -263,7 +263,7 @@ TEST_CASE("player_action: cannot slide while already sliding", "[player]") {
     reg.get<VerticalState>(p).timer = 0.3f;
 
     auto& gesture = reg.ctx().get<GestureResult>();
-    gesture.gesture = Gesture::SwipeDown;
+    gesture.gesture = SwipeGesture::SwipeDown;
 
     player_action_system(reg, 0.016f);
 
@@ -278,7 +278,7 @@ TEST_CASE("player_action: cannot slide while jumping", "[player]") {
     reg.get<VerticalState>(p).timer = 0.2f;
 
     auto& gesture = reg.ctx().get<GestureResult>();
-    gesture.gesture = Gesture::SwipeDown;
+    gesture.gesture = SwipeGesture::SwipeDown;
 
     player_action_system(reg, 0.016f);
 
@@ -293,7 +293,7 @@ TEST_CASE("player_action: cannot jump while sliding", "[player]") {
     reg.get<VerticalState>(p).timer = 0.3f;
 
     auto& gesture = reg.ctx().get<GestureResult>();
-    gesture.gesture = Gesture::SwipeUp;
+    gesture.gesture = SwipeGesture::SwipeUp;
 
     player_action_system(reg, 0.016f);
 

--- a/vcpkg-overlay/raylib/android.diff
+++ b/vcpkg-overlay/raylib/android.diff
@@ -1,0 +1,13 @@
+diff --git a/cmake/GlfwImport.cmake b/cmake/GlfwImport.cmake
+index d0c23ca..92cd5c3 100644
+--- a/cmake/GlfwImport.cmake
++++ b/cmake/GlfwImport.cmake
+@@ -30,6 +30,8 @@ if(NOT glfw3_FOUND AND NOT USE_EXTERNAL_GLFW STREQUAL "ON" AND "${PLATFORM}" MAT
+     include_directories(BEFORE SYSTEM external/glfw/include)
+ elseif("${PLATFORM}" STREQUAL "DRM")
+     MESSAGE(STATUS "No GLFW required on PLATFORM_DRM")
++elseif("${PLATFORM}" STREQUAL "Android")
++    list(REMOVE_ITEM LIBS_PRIVATE glfw)
+ else()
+     MESSAGE(STATUS "Using external GLFW")
+     set(GLFW_PKG_DEPS glfw3)

--- a/vcpkg-overlay/raylib/fix-link-path.patch
+++ b/vcpkg-overlay/raylib/fix-link-path.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/raylib-config.cmake b/cmake/raylib-config.cmake
+index 700965c..4815cd6 100644
+--- a/cmake/raylib-config.cmake
++++ b/cmake/raylib-config.cmake
+@@ -65,7 +65,7 @@ if (NOT TARGET raylib)
+       IMPORTED_LOCATION             "${raylib_LIBRARIES}"
+       IMPORTED_IMPLIB               "${raylib_LIBRARIES}"
+       INTERFACE_INCLUDE_DIRECTORIES "${raylib_INCLUDE_DIRS}"
+-      INTERFACE_LINK_LIBRARIES      "${raylib_LDFLAGS}"
++      INTERFACE_LINK_LIBRARIES      "${raylib_LIBRARIES}"
+       INTERFACE_COMPILE_OPTIONS     "${raylib_DEFINITIONS}"
+     )
+ 

--- a/vcpkg-overlay/raylib/portfile.cmake
+++ b/vcpkg-overlay/raylib/portfile.cmake
@@ -1,0 +1,152 @@
+if(VCPKG_TARGET_IS_LINUX)
+    message(
+    "raylib (RGFW) currently requires the following libraries from the system package manager:\n\
+    libgl1-mesa-dev\n\
+    libx11-dev\n\
+    libxrandr-dev\n\
+These can be installed on Ubuntu systems via sudo apt install libgl1-mesa-dev libx11-dev libxrandr-dev"
+    )
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO raysan5/raylib
+    REF "${VERSION}"
+    SHA512 503483a5436e189ad67533dc6c90be592283b84fbd57c86ab457dd1507b1dd11c897767ea9efa83affaf236f2711ec59e56658cf6fcad582a790a5fdc01b5ace
+    HEAD_REF master
+    PATCHES
+        android.diff
+        fix-link-path.patch
+)
+
+# ── Patch CMake to add RGFW platform support ─────────────────
+# raylib 5.5 ships the RGFW backend source (rcore_desktop_rgfw.c) but the
+# CMake build system only added the RGFW option post-5.5. We patch it in.
+
+# 1. Add RGFW to the platform enum in CMakeOptions.txt
+vcpkg_replace_string("${SOURCE_PATH}/CMakeOptions.txt"
+    "\"Desktop;Web;Android;Raspberry Pi;DRM;SDL\""
+    "\"Desktop;Web;Android;Raspberry Pi;DRM;SDL;RGFW\""
+)
+
+# 2. Skip GLFW in GlfwImport.cmake when PLATFORM=RGFW
+vcpkg_replace_string("${SOURCE_PATH}/cmake/GlfwImport.cmake"
+    [[elseif("${PLATFORM}" STREQUAL "DRM")
+    MESSAGE(STATUS "No GLFW required on PLATFORM_DRM")]]
+    [[elseif("${PLATFORM}" STREQUAL "DRM")
+    MESSAGE(STATUS "No GLFW required on PLATFORM_DRM")
+elseif("${PLATFORM}" STREQUAL "RGFW")
+    MESSAGE(STATUS "No GLFW required on PLATFORM_RGFW")]]
+)
+
+# 3. Add RGFW case to LibraryConfigurations.cmake (before the final endif)
+vcpkg_replace_string("${SOURCE_PATH}/cmake/LibraryConfigurations.cmake"
+    [[elseif ("${PLATFORM}" MATCHES "SDL")
+    find_package(SDL2 REQUIRED)
+    set(PLATFORM_CPP "PLATFORM_DESKTOP_SDL")
+    set(LIBS_PRIVATE SDL2::SDL2)
+
+endif ()]]
+    [[elseif ("${PLATFORM}" MATCHES "SDL")
+    find_package(SDL2 REQUIRED)
+    set(PLATFORM_CPP "PLATFORM_DESKTOP_SDL")
+    set(LIBS_PRIVATE SDL2::SDL2)
+
+elseif ("${PLATFORM}" STREQUAL "RGFW")
+    set(PLATFORM_CPP "PLATFORM_DESKTOP_RGFW")
+
+    if (APPLE)
+        set(GRAPHICS "GRAPHICS_API_OPENGL_33")
+        find_library(COCOA Cocoa)
+        find_library(OPENGL_LIBRARY OpenGL)
+        set(LIBS_PRIVATE ${COCOA} ${OPENGL_LIBRARY})
+        if (NOT CMAKE_SYSTEM STRLESS "Darwin-18.0.0")
+            add_definitions(-DGL_SILENCE_DEPRECATION)
+        endif ()
+    elseif (WIN32)
+        add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+        find_package(OpenGL REQUIRED)
+        set(LIBS_PRIVATE ${OPENGL_LIBRARIES} gdi32 winmm)
+    elseif (UNIX)
+        find_package(X11 REQUIRED)
+        find_package(OpenGL REQUIRED)
+        set(LIBS_PRIVATE ${X11_LIBRARIES} ${OPENGL_LIBRARIES} m pthread dl)
+    endif ()
+
+endif ()]]
+)
+
+file(GLOB vendored_headers RELATIVE "${SOURCE_PATH}/src/external"
+    "${SOURCE_PATH}/src/external/cgltf.h"
+    "${SOURCE_PATH}/src/external/nanosvg*.h"
+    "${SOURCE_PATH}/src/external/qoi.h"
+    "${SOURCE_PATH}/src/external/s*fl.h"  # from mmx
+    "${SOURCE_PATH}/src/external/stb_*"
+)
+file(GLOB vendored_audio_headers RELATIVE "${SOURCE_PATH}/src/external"
+    "${SOURCE_PATH}/src/external/dr_*.h"
+    "${SOURCE_PATH}/src/external/miniaudio.h"
+)
+set(optional_vendored_headers
+    "stb_image_resize2.h"  # not yet in vcpkg
+)
+foreach(header IN LISTS vendored_headers vendored_audio_headers)
+    unset(vcpkg_file)
+    find_file(vcpkg_file NAMES "${header}" PATHS "${CURRENT_INSTALLED_DIR}/include" PATH_SUFFIXES mmx nanosvg NO_DEFAULT_PATH NO_CACHE)
+    if(header IN_LIST vendored_audio_headers AND NOT "audio" IN_LIST FEATURES)
+        message(STATUS "Emptying '${header}' (audio disabled)")
+        file(WRITE "${SOURCE_PATH}/src/external/${vcpkg_file}" "# audio disabled")
+    elseif(vcpkg_file)
+        message(STATUS "De-vendoring '${header}'")
+        file(COPY "${vcpkg_file}" DESTINATION "${SOURCE_PATH}/src/external")
+    elseif(header IN_LIST optional_vendored_headers)
+        message(STATUS "Not de-vendoring '${header}' (absent in vcpkg)")
+    else()
+        message(FATAL_ERROR "No replacement for vendored '${header}'")
+    endif()
+endforeach()
+
+# ── Platform selection ───────────────────────────────────────
+# Use RGFW backend instead of GLFW. RGFW is a single-header windowing
+# library bundled inside raylib's source tree — no external dependency.
+set(PLATFORM_OPTIONS "")
+if(VCPKG_TARGET_IS_ANDROID)
+    list(APPEND PLATFORM_OPTIONS -DPLATFORM=Android -DUSE_EXTERNAL_GLFW=OFF)
+elseif(VCPKG_TARGET_IS_EMSCRIPTEN)
+    list(APPEND PLATFORM_OPTIONS -DPLATFORM=Web -DUSE_EXTERNAL_GLFW=OFF)
+else()
+    # RGFW: no GLFW dependency — uses Cocoa (macOS), X11 (Linux), WinAPI (Windows)
+    list(APPEND PLATFORM_OPTIONS -DPLATFORM=RGFW -DUSE_EXTERNAL_GLFW=OFF)
+endif()
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        audio SUPPORT_MODULE_RAUDIO
+        audio USE_AUDIO
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_EXAMPLES=OFF
+        -DCMAKE_POLICY_DEFAULT_CMP0072=NEW  # Prefer GLVND
+        -DCUSTOMIZE_BUILD=ON
+        ${PLATFORM_OPTIONS}
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/raylib.h" "defined(USE_LIBTYPE_SHARED)" "1")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg-overlay/raylib/vcpkg.json
+++ b/vcpkg-overlay/raylib/vcpkg.json
@@ -1,0 +1,37 @@
+{
+  "name": "raylib",
+  "version": "5.5",
+  "port-version": 100,
+  "description": "A simple and easy-to-use library to enjoy videogames programming (RGFW backend)",
+  "homepage": "https://github.com/raysan5/raylib",
+  "license": "Zlib",
+  "supports": "!arm32 & !uwp",
+  "dependencies": [
+    "cgltf",
+    "dirent",
+    "mmx",
+    "nanosvg",
+    "qoi",
+    "stb",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "audio"
+  ],
+  "features": {
+    "audio": {
+      "description": "Build audio module",
+      "dependencies": [
+        "drlibs",
+        "miniaudio"
+      ]
+    }
+  }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,9 +4,8 @@
   "version": "0.1.0",
   "description": "Endless runner with shape-shifting and burnout scoring",
   "dependencies": [
-    { "name": "sdl2",       "platform": "!linux" },
-    { "name": "sdl2-ttf",   "platform": "!linux" },
     "entt",
+    "raylib",
     { "name": "catch2", "platform": "!linux" }
   ]
 }


### PR DESCRIPTION
- Replace SDL2/SDL2_ttf with raylib for rendering, input, and windowing
- Rename Color → DrawColor and Gesture → SwipeGesture to avoid raylib conflicts
- Remove SDL_Renderer* from render_system and text_draw signatures
- Add exe-relative font path via GetApplicationDirectory()
- Track InputSource (Mouse/Touch) to prevent hybrid device conflicts
- Edge-trigger focus-loss auto-pause (was_focused in InputState, not static)
- Remove const_cast in pick_font; return const Font& instead
- Eliminate all try_get in collision_system via per-archetype views
- Remove ParticleData::start_size; compute shrink at render time from Lifetime
- Update CMakeLists.txt, vcpkg.json, build.sh, and all tests/benchmarks