### PR TITLE
User/yashasg/new test level

### DIFF
--- a/app/constants.h
+++ b/app/constants.h
@@ -154,9 +154,9 @@ constexpr float SCENE_PAUSE_Y_N       =  580.0f / SCREEN_H;  // ≈ 0.453
 
 // ── Lane Floor ──────────────────────────────────
 constexpr float FLOOR_SHAPE_SIZE     = 36.0f;
-constexpr float FLOOR_SHAPE_SPACING  = 80.0f;
+constexpr float FLOOR_SHAPE_SPACING  = 50.0f;
 constexpr float FLOOR_Y_START        = 12.0f;
-constexpr int   FLOOR_SHAPE_COUNT    = 13;
+constexpr int   FLOOR_SHAPE_COUNT    = 21;
 constexpr float FLOOR_OUTLINE_THICK  = 2.0f;
 constexpr float FLOOR_ALPHA_REST     = 30.0f;
 constexpr float FLOOR_ALPHA_PEAK     = 100.0f;

--- a/app/constants.h
+++ b/app/constants.h
@@ -152,6 +152,18 @@ constexpr float SCENE_SC_PROMPT_Y_N   =  800.0f / SCREEN_H;  // ≈ 0.625
 // Scene – Paused overlay
 constexpr float SCENE_PAUSE_Y_N       =  580.0f / SCREEN_H;  // ≈ 0.453
 
+// ── Lane Floor ──────────────────────────────────
+constexpr float FLOOR_SHAPE_SIZE     = 36.0f;
+constexpr float FLOOR_SHAPE_SPACING  = 80.0f;
+constexpr float FLOOR_Y_START        = 12.0f;
+constexpr int   FLOOR_SHAPE_COUNT    = 13;
+constexpr float FLOOR_OUTLINE_THICK  = 2.0f;
+constexpr float FLOOR_ALPHA_REST     = 30.0f;
+constexpr float FLOOR_ALPHA_PEAK     = 100.0f;
+constexpr float FLOOR_SCALE_REST     = 1.0f;
+constexpr float FLOOR_SCALE_PEAK     = 1.3f;
+constexpr float FLOOR_PULSE_DECAY    = 0.15f;   // seconds
+
 // ── Shape Colors ──────────────────────────────────
 // Used for both obstacles and player character.
 // Index by static_cast<int>(Shape).

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -229,10 +229,10 @@ int main(int argc, char* argv[]) {
         std::vector<BeatMapError> load_errors;
 
         std::string exe_beatmap = std::string(GetApplicationDirectory())
-                                + "content/beatmaps/1_stomper_beatmap.json";
+                                + "content/beatmaps/2_drama_beatmap.json";
         const char* beatmap_paths[] = {
             exe_beatmap.c_str(),
-            "content/beatmaps/1_stomper_beatmap.json",
+            "content/beatmaps/2_drama_beatmap.json",
         };
 
         bool loaded = false;

--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -36,7 +36,15 @@ void collision_system(entt::registry& reg, float /*dt*/) {
             if (rhythm_mode) {
                 auto window_phase = static_cast<WindowPhase>(p_window.phase_raw);
                 if (window_phase == WindowPhase::Active && song->half_window > 0.0f) {
-                    float pct_from_peak = std::abs(song->song_time - p_window.peak_time) / song->half_window;
+                    // Grade timing against the obstacle's expected beat time,
+                    // not the shape window's peak_time.  This decouples timing
+                    // evaluation from same-shape re-press window resets, which
+                    // previously caused cascading Bad→window-shrink→MISS at
+                    // lower BPMs where beat spacing is wider.
+                    auto* beat_info = reg.try_get<BeatInfo>(entity);
+                    float reference_time = beat_info ? beat_info->arrival_time
+                                                     : p_window.peak_time;
+                    float pct_from_peak = std::abs(song->song_time - reference_time) / song->half_window;
                     if (pct_from_peak > 1.0f) pct_from_peak = 1.0f;
                     TimingTier tier = compute_timing_tier(pct_from_peak);
                     reg.emplace<TimingGrade>(entity, tier, 1.0f - pct_from_peak);

--- a/app/systems/render_system.cpp
+++ b/app/systems/render_system.cpp
@@ -309,6 +309,12 @@ void render_system(entt::registry& reg, float /*alpha*/) {
             Color c  = LANE_SHAPE_COLORS[lane];
             c.a      = static_cast<unsigned char>(alpha);
 
+            // Draw connecting vertical line through the full column
+            float line_top = constants::FLOOR_Y_START;
+            float line_bot = constants::FLOOR_Y_START
+                + static_cast<float>(constants::FLOOR_SHAPE_COUNT - 1) * constants::FLOOR_SHAPE_SPACING;
+            DrawLineEx({cx, line_top}, {cx, line_bot}, constants::FLOOR_OUTLINE_THICK, c);
+
             for (int j = 0; j < constants::FLOOR_SHAPE_COUNT; ++j) {
                 float cy = constants::FLOOR_Y_START + static_cast<float>(j) * constants::FLOOR_SHAPE_SPACING;
 

--- a/app/systems/render_system.cpp
+++ b/app/systems/render_system.cpp
@@ -309,14 +309,15 @@ void render_system(entt::registry& reg, float /*alpha*/) {
             Color c  = LANE_SHAPE_COLORS[lane];
             c.a      = static_cast<unsigned char>(alpha);
 
-            // Draw connecting vertical line through the full column
-            float line_top = constants::FLOOR_Y_START;
-            float line_bot = constants::FLOOR_Y_START
-                + static_cast<float>(constants::FLOOR_SHAPE_COUNT - 1) * constants::FLOOR_SHAPE_SPACING;
-            DrawLineEx({cx, line_top}, {cx, line_bot}, constants::FLOOR_OUTLINE_THICK, c);
-
             for (int j = 0; j < constants::FLOOR_SHAPE_COUNT; ++j) {
                 float cy = constants::FLOOR_Y_START + static_cast<float>(j) * constants::FLOOR_SHAPE_SPACING;
+
+                // Draw connecting segment from this shape's bottom edge to next shape's top edge
+                if (j < constants::FLOOR_SHAPE_COUNT - 1) {
+                    float next_cy = cy + constants::FLOOR_SHAPE_SPACING;
+                    DrawLineEx({cx, cy + half}, {cx, next_cy - half},
+                               constants::FLOOR_OUTLINE_THICK, c);
+                }
 
                 switch (lane) {
                     case 0:

--- a/app/systems/render_system.cpp
+++ b/app/systems/render_system.cpp
@@ -12,9 +12,11 @@
 #include "../components/difficulty.h"
 #include "../components/particle.h"
 #include "../components/audio.h"
+#include "../components/song_state.h"
 #include "../constants.h"
 #include "../text_renderer.h"
 #include <raylib.h>
+#include <algorithm>
 #include <cmath>
 
 static void draw_shape(Shape shape, float cx, float cy, float size, Color color) {
@@ -276,12 +278,58 @@ void render_system(entt::registry& reg, float /*alpha*/) {
     // positions need to change.
     BeginMode2D(camera);
 
-    // ── Draw lane lines ─────────────────────────────────────
-    Color lane_color = {40, 40, 60, 255};
-    for (int i = 0; i < constants::LANE_COUNT; ++i) {
-        float lx = constants::LANE_X[i];
-        DrawLineV({lx, 0}, {lx, constants::SCREEN_H * constants::SWIPE_ZONE_SPLIT},
-                  lane_color);
+    // ── Draw lane floors (shaped columns that pulse on beat) ─
+    {
+        auto* song = reg.ctx().find<SongState>();
+        float pulse = 0.0f;
+        if (song && song->playing && song->beat_period > 0.0f && song->current_beat >= 0) {
+            float time_since_beat = song->song_time
+                - (song->offset + static_cast<float>(song->current_beat) * song->beat_period);
+            float pulse_t = std::clamp(time_since_beat / constants::FLOOR_PULSE_DECAY, 0.0f, 1.0f);
+            float ease = 1.0f - (1.0f - pulse_t) * (1.0f - pulse_t);
+            pulse = 1.0f - ease;
+        }
+
+        float alpha = constants::FLOOR_ALPHA_REST
+            + (constants::FLOOR_ALPHA_PEAK - constants::FLOOR_ALPHA_REST) * pulse;
+        float scale = constants::FLOOR_SCALE_REST
+            + (constants::FLOOR_SCALE_PEAK - constants::FLOOR_SCALE_REST) * pulse;
+        float size  = constants::FLOOR_SHAPE_SIZE * scale;
+        float half  = size / 2.0f;
+        float thick = constants::FLOOR_OUTLINE_THICK;
+
+        static const Color LANE_SHAPE_COLORS[3] = {
+            {80,  200, 255, 255},
+            {255, 100, 100, 255},
+            {100, 255, 100, 255},
+        };
+
+        for (int lane = 0; lane < constants::LANE_COUNT; ++lane) {
+            float cx = constants::LANE_X[lane];
+            Color c  = LANE_SHAPE_COLORS[lane];
+            c.a      = static_cast<unsigned char>(alpha);
+
+            for (int j = 0; j < constants::FLOOR_SHAPE_COUNT; ++j) {
+                float cy = constants::FLOOR_Y_START + static_cast<float>(j) * constants::FLOOR_SHAPE_SPACING;
+
+                switch (lane) {
+                    case 0:
+                        DrawRing({cx, cy}, half - thick, half, 0, 360, 36, c);
+                        break;
+                    case 1:
+                        DrawRectangleLinesEx({cx - half, cy - half, size, size}, thick, c);
+                        break;
+                    case 2: {
+                        Vector2 v1 = {cx,        cy - half};
+                        Vector2 v2 = {cx - half, cy + half};
+                        Vector2 v3 = {cx + half, cy + half};
+                        DrawTriangleLines(v1, v3, v2, c);
+                        break;
+                    }
+                    default: break;
+                }
+            }
+        }
     }
 
     // ── Draw obstacles ──────────────────────────────────────

--- a/content/audio/2_drama.wav
+++ b/content/audio/2_drama.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f48e8a9222556e5d028e3bf80dca649b2315b198e5ad93ae5cce269118aa013f
+size 42992764

--- a/content/audio/3_mental_corruption.wav
+++ b/content/audio/3_mental_corruption.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70dc0e3f36c1dfd14cd7fc68f04dd9f9fbeabbef7ee09d09ad76b703a3cae479
+size 39801168

--- a/content/beatmaps/2_drama_analysis.json
+++ b/content/beatmaps/2_drama_analysis.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac56c0b13e7860873323734754a1b826f63d6f0526565d5d3bea806c5d3d7119
+size 370903

--- a/content/beatmaps/2_drama_beatmap.json
+++ b/content/beatmaps/2_drama_beatmap.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e82b0dc4191b671ed7bbcb26c6c26719e6586226bd0454d6f66816cd46a4ad1a
-size 53381
+oid sha256:c7339009a8d507c77bd704f8465c33af654d43d09fe944d1dfb11e925942404d
+size 47175

--- a/content/beatmaps/2_drama_beatmap.json
+++ b/content/beatmaps/2_drama_beatmap.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e82b0dc4191b671ed7bbcb26c6c26719e6586226bd0454d6f66816cd46a4ad1a
+size 53381

--- a/content/beatmaps/3_mental_corruption_analysis.json
+++ b/content/beatmaps/3_mental_corruption_analysis.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:720b4831a4c57ceaf5a4f8b9b10e828b5e76d558fad47928826f6118ee48bbf2
+size 562689

--- a/design-docs/beatmap-integration.md
+++ b/design-docs/beatmap-integration.md
@@ -47,7 +47,7 @@
 ## 1.1 Beatmap JSON (authored file)
 
 ```
-  content/beatmaps/1_stomper_beatmap.json
+  content/beatmaps/2_drama_beatmap.json
   ~3KB, loaded once at game start, never re-read.
 ```
 
@@ -55,10 +55,10 @@
 
 ```json
 {
-  "song_id":      "1_stomper",
-  "title":        "1_stomper",
-  "bpm":          146.24,
-  "offset":       1.694,
+  "song_id":      "2_drama",
+  "title":        "2_drama",
+  "bpm":          119.64,
+  "offset":       1.813,
   "lead_beats":   4,
   "duration_sec": 199.35,
   "difficulties": {
@@ -94,8 +94,8 @@
 ## 1.2 Audio WAV
 
 ```
-  content/audio/1_stomper.wav
-  ~33.6 MB, 16-bit stereo, 44100 Hz, 199.35 seconds.
+  content/audio/2_drama.wav
+  ~41 MB, 16-bit stereo, 44100 Hz, 241.13 seconds.
   Streamed at runtime via raylib LoadMusicStream.
 ```
 
@@ -641,5 +641,5 @@ Ordered by dependency chain. Steps marked ✅ are already on `main`.
 
 ---
 
-*Generated from: `content/beatmaps/1_stomper_analysis.json` → `tools/level_designer.py` → `content/beatmaps/1_stomper_beatmap.json`*
-*Audio source: `content/audio/1_stomper.wav` (33.6 MB, 199.35s, 146.24 BPM)*
+*Generated from: `content/beatmaps/2_drama_analysis.json` → `tools/level_designer.py` → `content/beatmaps/2_drama_beatmap.json`*
+*Audio source: `content/audio/2_drama.wav` (41 MB, 241.13s, 119.64 BPM)*

--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -137,6 +137,7 @@ constexpr int   CHAIN_BONUS      = 10;     // multiplied by chain length
   │  Velocity           8B ← dx, dy                             │
   │  ObstacleTag        0B ← marker                             │
   │  RequiredShape      4B ← shape + lane                       │
+  │  BeatInfo          12B ← beat_index, arrival_time, spawn    │
   │  TimingGrade        5B ← scoring (existential)              │
   │  ScoredTag          0B ← scored marker (prevents re-fire)   │
   └──────────────────────────────────────────────────────────────┘
@@ -193,6 +194,21 @@ struct PlayerShape {
     bool         graded        = false;    // window already graded this cycle
 };
 ```
+
+## BeatInfo (per obstacle entity)
+
+```cpp
+struct BeatInfo {
+    int   beat_index   = 0;       // index into BeatMap::beats
+    float arrival_time = 0.0f;    // absolute song_time when obstacle should be hit
+    float spawn_time   = 0.0f;    // song_time when the obstacle was spawned
+};
+```
+
+`arrival_time` is the authoritative reference for collision timing grades.
+The collision system uses it (when present) instead of `ShapeWindow.peak_time`,
+so that timing evaluation is anchored to the chart's beat rather than the
+player's shape-window lifecycle.
 
 ## SongResults (singleton)
 
@@ -256,7 +272,8 @@ struct SongResults {
   ┌─ COLLISION ────────────────────────────────────────────────┐
   │ collision_system                               [MOD]       │
   │   → checks shape match at obstacle arrival                 │
-  │   → computes TimingGrade from peak_time vs collision time  │
+  │   → computes TimingGrade from BeatInfo.arrival_time        │
+  │     (falls back to ShapeWindow.peak_time if no BeatInfo)   │
   │   → on HIT: applies window_scale shortening if !graded     │
   │   → on MISS: instant game over (no HP drain)               │
   │   → emplaces ScoredTag on both HIT and MISS paths          │
@@ -310,7 +327,17 @@ void shape_window_system(entt::registry& reg, float dt);
   │  CASE: Player shape matches obstacle shape at arrival               │
   ├─────────────────────────────────────────────────────────────────────┤
   │                                                                     │
-  │  TimingGrade = grade_from_peak_time(peak_time, song_time, window)  │
+  │  // Use the obstacle's beat arrival_time for timing,                │
+  │  // falling back to ShapeWindow.peak_time when BeatInfo absent.     │
+  │  auto* beat_info = reg.try_get<BeatInfo>(entity);                   │
+  │  float ref = beat_info ? beat_info->arrival_time                    │
+  │                        : p_window.peak_time;                        │
+  │  float pct = abs(song_time - ref) / half_window;                    │
+  │  TimingGrade = compute_timing_tier(pct);                            │
+  │                                                                     │
+  │  This decouples timing evaluation from the shape window's           │
+  │  peak_time, preventing cascading Bad→window-shrink→MISS             │
+  │  failures at lower BPMs where beat spacing is wider.                │
   │                                                                     │
   │  PERFECT  → pts=300, window_scale=0.50 (remaining window halved)   │
   │  GOOD     → pts=200, window_scale=0.75                             │

--- a/design-docs/tester-personas-tech-spec.md
+++ b/design-docs/tester-personas-tech-spec.md
@@ -528,7 +528,7 @@ a separate system to do the emplacement.
 ## Example Session
 
 ```
-══════ Test Session: PRO | beatmap: 1_stomper | 2026-04-11 05:06 ══════
+══════ Test Session: PRO | beatmap: 2_drama | 2026-04-11 05:06 ══════
 
 [F:0001 T:0.000] [GAME  ] SONG_START bpm=120 beats=48 difficulty=medium
 [F:0060 T:1.000] [GAME  ] OBSTACLE_SPAWN beat=4 kind=ShapeGate shape=Circle lane=1

--- a/docs/asset-bundle-spec.md
+++ b/docs/asset-bundle-spec.md
@@ -12,8 +12,8 @@ The current build produces loose files next to the executable:
 build/
   shapeshifter
   content/
-    beatmaps/1_stomper_beatmap.json
-    audio/1_stomper.wav
+    beatmaps/2_drama_beatmap.json
+    audio/2_drama.wav
   assets/
     fonts/LiberationMono-Regular.ttf
 ```
@@ -57,7 +57,7 @@ Offset      Size    Field
 TOC Entry (120 bytes each):
   Offset  Size  Field
   0       64    logical_path: null-terminated UTF-8
-                e.g. "content/audio/1_stomper.wav"
+                e.g. "content/audio/2_drama.wav"
   64      8     offset: uint64_le  (byte offset from start of DATA blob)
   72      8     size:   uint64_le  (uncompressed size in bytes)
   80      32    sha256: SHA-256 of entry data
@@ -146,7 +146,7 @@ Standalone CMake target in tools/pak_tool/. Not linked into the game.
 pak_tool pack    --input content/ --output content.pak [--sign-key key.bin]
 pak_tool verify  --input content.pak --pub-key pubkey.bin
 pak_tool list    --input content.pak
-pak_tool extract --input content.pak --entry content/audio/1_stomper.wav
+pak_tool extract --input content.pak --entry content/audio/2_drama.wav
 pak_tool keygen  --out-private pak_private.bin --out-public pak_public.bin
 ```
 

--- a/docs/audio-pipeline-spec.md
+++ b/docs/audio-pipeline-spec.md
@@ -8,7 +8,7 @@ DISK                      PARSE                         SINGLETONS (reg.ctx())  
 ─────────────────────     ───────────────               ──────────────────────                     ───────────────────
 
 content/beatmaps/         parse_beat_map()              ┌──────────┐
-  1_stomper_beatmap.json ──────────────────────────────▶│ BeatMap  │─────────────────────────────▶ beat_scheduler_system
+  2_drama_beatmap.json ────────────────────────────────▶│ BeatMap  │─────────────────────────────▶ beat_scheduler_system
                           reads difficulties[medium]     │ .beats[] │                               reads beats[next_spawn_idx]
                           derives song_path              │ .song_path                               creates obstacle entities
                                                          └────┬─────┘
@@ -23,7 +23,7 @@ content/beatmaps/         parse_beat_map()              ┌───────
                                                          └──────────┘
 
 content/audio/            LoadMusicStream()              ┌──────────────┐
-  1_stomper.wav ──────────────────────────────────────▶  │ MusicContext  │◀───────────────────────  song_playback_system
+  2_drama.wav ────────────────────────────────────────▶  │ MusicContext  │◀───────────────────────  song_playback_system
                                                          │ .stream      │  UpdateMusicStream()
                                                          │ .loaded      │  GetMusicTimePlayed()
                                                          │ .started     │  PlayMusicStream()
@@ -119,7 +119,7 @@ None — first change to apply.
 ### Verification
 ```bash
 cmake --build build && ls build/content/beatmaps/ build/content/audio/
-# Expected: 1_stomper_beatmap.json and 1_stomper.wav present
+# Expected: 2_drama_beatmap.json and 2_drama.wav present
 ```
 
 ---
@@ -272,10 +272,10 @@ Existing unit tests (if any for beat_map_loader) should still pass with flat-arr
 // In a test:
 BeatMap map;
 std::vector<BeatMapError> errs;
-bool ok = load_beat_map("content/beatmaps/1_stomper_beatmap.json", map, errs, "easy");
+bool ok = load_beat_map("content/beatmaps/2_drama_beatmap.json", map, errs, "easy");
 assert(ok);
-assert(map.beats.size() == 73);  // easy difficulty has 73 beats
-assert(map.song_path == "content/audio/1_stomper.wav");
+assert(map.beats.size() == 80);  // easy difficulty has 80 beats
+assert(map.song_path == "content/audio/2_drama.wav");
 assert(map.difficulty == "easy");
 ```
 
@@ -427,10 +427,10 @@ Replace with:
 
         // Try path relative to executable first, then CWD
         std::string exe_beatmap = std::string(GetApplicationDirectory())
-                                + "content/beatmaps/1_stomper_beatmap.json";
+                                + "content/beatmaps/2_drama_beatmap.json";
         const char* beatmap_paths[] = {
             exe_beatmap.c_str(),
-            "content/beatmaps/1_stomper_beatmap.json",
+            "content/beatmaps/2_drama_beatmap.json",
         };
 
         bool loaded = false;
@@ -554,8 +554,8 @@ For Emscripten shutdown: `emscripten_set_main_loop` with arg `1` means it never 
 ```
 # Build and run. Check log output:
 # Expected:
-#   Loaded beatmap: .../content/beatmaps/1_stomper_beatmap.json (149 beats, difficulty=medium)
-#   Loaded music: .../content/audio/1_stomper.wav (8799270 frames)
+#   Loaded beatmap: .../content/beatmaps/2_drama_beatmap.json (125 beats, difficulty=medium)
+#   Loaded music: .../content/audio/2_drama.wav
 #   Audio device initialized: 44100 Hz
 ```
 

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -262,12 +262,15 @@ TEST_CASE("collision: BAD timing adjusts window_start, not window_timer", "[coll
     sw.window_timer = 0.0f;
     sw.window_start = song.song_time;
 
-    // Set peak_time far in the past so pct_from_peak > 0.75 → BAD (scale = 0.5)
-    sw.peak_time = song.song_time - song.half_window * 2.0f;
+    // peak_time doesn't affect grading anymore — timing is based on
+    // BeatInfo.arrival_time.  Set arrival_time far from song_time so
+    // pct_from_peak > 0.75 → BAD (scale = 0.5).
+    sw.peak_time = song.song_time;
+    float bad_arrival = song.song_time - song.half_window * 2.0f;
 
     // Spawn an obstacle at the player's position
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
-    reg.emplace<BeatInfo>(obs, 0, song.song_time, song.song_time - song.lead_time);
+    reg.emplace<BeatInfo>(obs, 0, bad_arrival, bad_arrival - song.lead_time);
 
     float original_window_start = sw.window_start;
     collision_system(reg, 0.016f);

--- a/tools/level_designer.py
+++ b/tools/level_designer.py
@@ -462,6 +462,23 @@ def clean_two_lane_jumps(obstacles):
     return result
 
 
+def clean_minimum_gap(obstacles, difficulty):
+    """RULE: Minimum beat gap between any two obstacles.
+    Same-lane or adjacent-lane needs ≥2 beats; cross-lane needs ≥3.
+    At 120 BPM gap=1 is only ~0.5s — too tight even for pro players."""
+    MIN_GAP = {"easy": 2, "medium": 2, "hard": 2}
+    min_gap = MIN_GAP.get(difficulty, 2)
+    if not obstacles or min_gap <= 1:
+        return obstacles
+    result = [obstacles[0]]
+    for obs in obstacles[1:]:
+        gap = obs["beat"] - result[-1]["beat"]
+        if gap < min_gap:
+            continue
+        result.append(obs)
+    return result
+
+
 def clean_breathing_room(obstacles, boundary_beats, difficulty):
     """RULE: No obstacles at section boundaries."""
     if not boundary_beats or not obstacles:
@@ -533,6 +550,7 @@ def clean_level(obstacles, difficulty, boundary_beats):
     4. Type transition (action family switches)
     5. Gap monotony (variety enforcement)
     """
+    obstacles = clean_minimum_gap(obstacles, difficulty)
     obstacles = clean_breathing_room(obstacles, boundary_beats, difficulty)
     obstacles = clean_two_lane_jumps(obstacles)
     obstacles = clean_lane_change_gap(obstacles)


### PR DESCRIPTION
This pull request introduces a new default song and beatmap ("2_drama") to the project, replacing the previous "1_stomper" content across the codebase, documentation, and asset references. It also implements a significant gameplay improvement by decoupling obstacle timing evaluation from the shape window's peak time, using the new `BeatInfo` component for more accurate grading. Additionally, a new visual "lane floor" feature is added to the rendering system, providing pulsing lane indicators synchronized to the beat. The most important changes are grouped below:

**Gameplay and Timing Improvements:**

* The collision system now grades timing against each obstacle's `BeatInfo.arrival_time` rather than the shape window's `peak_time`, preventing cascading timing failures at lower BPMs and improving accuracy. This is achieved by checking for the `BeatInfo` component on entities and using its `arrival_time` for timing evaluation. [[1]](diffhunk://#diff-60bc9c5a9d4f1b3f2ad603d96fa575fd5593aa3459883c4e736b2d17dd942077L39-R47) [[2]](diffhunk://#diff-f364db56a5e5003366436f8b367fd751f2a8b7827f98a4ef4d97c1c0119600d5R198-R212) [[3]](diffhunk://#diff-f364db56a5e5003366436f8b367fd751f2a8b7827f98a4ef4d97c1c0119600d5L259-R276) [[4]](diffhunk://#diff-f364db56a5e5003366436f8b367fd751f2a8b7827f98a4ef4d97c1c0119600d5L313-R340)
* The `BeatInfo` component is documented and specified as the authoritative reference for obstacle timing grades.

**Visual and Rendering Enhancements:**

* A new "lane floor" visualization is implemented: columns of shapes in each lane pulse on every beat, enhancing visual feedback. This includes new constants for layout and pulsing, and new drawing logic in the render system. [[1]](diffhunk://#diff-60935670b60fda177e1bf078508c1c3f294ef967bcb4f2ee99f062fc6d2c4edfR155-R166) [[2]](diffhunk://#diff-8a6cdfdd780055362ddd27bd9dfc6bc2147a92f0796e8b6176a7d66259d5dc4cL279-R339) [[3]](diffhunk://#diff-8a6cdfdd780055362ddd27bd9dfc6bc2147a92f0796e8b6176a7d66259d5dc4cR15-R19)

**Default Song and Beatmap Update:**

* All code, documentation, and test references to "1_stomper" are replaced with "2_drama" for the default beatmap and audio, including file paths, example outputs, and schema documentation. [[1]](diffhunk://#diff-c1b709b8a90bef4573ddad8a9b2fbc5d5dbc85e4dc759f95b6d9905931fec24fL232-R235) [[2]](diffhunk://#diff-a6bbe48f65fbf440fa94b4d1f54a4aa895c59ec97d6263b0be37ebe9b407d955L50-R61) [[3]](diffhunk://#diff-a6bbe48f65fbf440fa94b4d1f54a4aa895c59ec97d6263b0be37ebe9b407d955L97-R98) [[4]](diffhunk://#diff-a6bbe48f65fbf440fa94b4d1f54a4aa895c59ec97d6263b0be37ebe9b407d955L644-R645) [[5]](diffhunk://#diff-101bf169ae80d9f05496a09e3e48a0ed564be220855509e61875d0df86bf7654L531-R531) [[6]](diffhunk://#diff-c755d0708bcdcf09665559f7d344e068897ce3193738ec6500e7e1a6c7f0f29eL15-R16) [[7]](diffhunk://#diff-c755d0708bcdcf09665559f7d344e068897ce3193738ec6500e7e1a6c7f0f29eL60-R60) [[8]](diffhunk://#diff-c755d0708bcdcf09665559f7d344e068897ce3193738ec6500e7e1a6c7f0f29eL149-R149) [[9]](diffhunk://#diff-31a40413913f53e4fa2c0923047f82fb3841dced0d093c2011e0d1160ed1b1ebL11-R11) [[10]](diffhunk://#diff-31a40413913f53e4fa2c0923047f82fb3841dced0d093c2011e0d1160ed1b1ebL26-R26) [[11]](diffhunk://#diff-31a40413913f53e4fa2c0923047f82fb3841dced0d093c2011e0d1160ed1b1ebL122-R122) [[12]](diffhunk://#diff-31a40413913f53e4fa2c0923047f82fb3841dced0d093c2011e0d1160ed1b1ebL275-R278) [[13]](diffhunk://#diff-31a40413913f53e4fa2c0923047f82fb3841dced0d093c2011e0d1160ed1b1ebL430-R433)

**New Assets Added:**

* The following new assets are added to the repository:
  - `content/audio/2_drama.wav`
  - `content/audio/3_mental_corruption.wav`
  - `content/beatmaps/2_drama_beatmap.json`
  - `content/beatmaps/2_drama_analysis.json`
  - `content/beatmaps/3_mental_corruption_analysis.json`

**Documentation Updates:**

* All technical and design documentation is updated to reference the new default assets and to reflect the new timing logic and component structure. [[1]](diffhunk://#diff-a6bbe48f65fbf440fa94b4d1f54a4aa895c59ec97d6263b0be37ebe9b407d955L50-R61) [[2]](diffhunk://#diff-a6bbe48f65fbf440fa94b4d1f54a4aa895c59ec97d6263b0be37ebe9b407d955L97-R98) [[3]](diffhunk://#diff-a6bbe48f65fbf440fa94b4d1f54a4aa895c59ec97d6263b0be37ebe9b407d955L644-R645) [[4]](diffhunk://#diff-f364db56a5e5003366436f8b367fd751f2a8b7827f98a4ef4d97c1c0119600d5R140) [[5]](diffhunk://#diff-f364db56a5e5003366436f8b367fd751f2a8b7827f98a4ef4d97c1c0119600d5R198-R212) [[6]](diffhunk://#diff-f364db56a5e5003366436f8b367fd751f2a8b7827f98a4ef4d97c1c0119600d5L259-R276) [[7]](diffhunk://#diff-f364db56a5e5003366436f8b367fd751f2a8b7827f98a4ef4d97c1c0119600d5L313-R340) [[8]](diffhunk://#diff-101bf169ae80d9f05496a09e3e48a0ed564be220855509e61875d0df86bf7654L531-R531) [[9]](diffhunk://#diff-c755d0708bcdcf09665559f7d344e068897ce3193738ec6500e7e1a6c7f0f29eL15-R16) [[10]](diffhunk://#diff-c755d0708bcdcf09665559f7d344e068897ce3193738ec6500e7e1a6c7f0f29eL60-R60) [[11]](diffhunk://#diff-c755d0708bcdcf09665559f7d344e068897ce3193738ec6500e7e1a6c7f0f29eL149-R149) [[12]](diffhunk://#diff-31a40413913f53e4fa2c0923047f82fb3841dced0d093c2011e0d1160ed1b1ebL11-R11) [[13]](diffhunk://#diff-31a40413913f53e4fa2c0923047f82fb3841dced0d093c2011e0d1160ed1b1ebL26-R26) [[14]](diffhunk://#diff-31a40413913f53e4fa2c0923047f82fb3841dced0d093c2011e0d1160ed1b1ebL122-R122) [[15]](diffhunk://#diff-31a40413913f53e4fa2c0923047f82fb3841dced0d093c2011e0d1160ed1b1ebL275-R278) [[16]](diffhunk://#diff-31a40413913f53e4fa2c0923047f82fb3841dced0d093c2011e0d1160ed1b1ebL430-R433)