### PR TITLE
feat: isometric perspective projection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,7 @@ if(NOT EMSCRIPTEN)
     add_executable(shapeshifter_tests
         ${TEST_SOURCES}
         app/file_logger.cpp
+        app/perspective.cpp
         app/systems/song_playback_system.cpp
     )
     target_include_directories(shapeshifter_tests PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ endif()
 # ── Main executable ──────────────────────────────────────────
 add_executable(shapeshifter
     app/main.cpp
+    app/perspective.cpp
     app/systems/render_system.cpp
     app/systems/input_system.cpp
     app/systems/song_playback_system.cpp

--- a/app/constants.h
+++ b/app/constants.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 
 namespace constants {
 
@@ -174,5 +175,8 @@ constexpr ShapeColor SHAPE_COLORS[] = {
     { 100, 255, 100, 255 },   // Triangle — green
     {  80, 180, 255, 255 },   // Hexagon  — neutral blue
 };
+
+// ── Perspective / Isometric Effect ───────────────
+constexpr float VANISHING_POINT_Y  = -640.0f;
 
 } // namespace constants

--- a/app/constants.h
+++ b/app/constants.h
@@ -177,12 +177,35 @@ constexpr ShapeColor SHAPE_COLORS[] = {
 };
 
 // ── Perspective / Isometric Effect ───────────────
-// Controls how aggressively lanes converge toward the top.
-// Convergence angle θ = 2·atan(360 / (SCREEN_H - VP_Y))
-//   VP_Y = -761  → θ ≈ 20°  (top ≈ 37% width)
-//   VP_Y = -1060 → θ ≈ 17°  (top ≈ 45% width)
-//   VP_Y = -1455 → θ ≈ 15°  (top ≈ 54% width)
-//   VP_Y = -5120 → θ ≈  6°  (top ≈ 80% width, very subtle)
-constexpr float VANISHING_POINT_Y  = -1060.0f;
+// PERSPECTIVE_ANGLE_DEG is the full convergence angle (degrees) between
+// the left and right edges of the playfield as they recede toward the
+// vanishing point.  0° = flat (no perspective), 20° = noticeable.
+//
+//    angle →  VP_Y (derived)  → top-of-screen width
+//      5°      -7860              ~96%  (barely visible)
+//     10°      -3820              ~91%
+//     15°      -1455              ~54%
+//     17°      -1060              ~45%
+//     20°      -761               ~37%
+//
+// The vanishing point is derived at compile time:
+//   VP_Y = SCREEN_H - (SCREEN_W / 2) / tan(angle / 2)
+constexpr float PERSPECTIVE_ANGLE_DEG = 17.0f;
+
+namespace detail {
+    constexpr float deg_to_rad(float deg) { return deg * 3.14159265358979f / 180.0f; }
+    // tan() is not constexpr in C++17, so we use a rational approximation
+    // valid for small angles (0–45°).  Max error < 0.001 in that range.
+    constexpr float tan_approx(float rad) {
+        // Padé [3/2] approximant: tan(x) ≈ x(1 - x²/15) / (1 - 2x²/5)
+        float x2 = rad * rad;
+        return rad * (1.0f - x2 / 15.0f) / (1.0f - 2.0f * x2 / 5.0f);
+    }
+    constexpr float half_angle_rad = deg_to_rad(PERSPECTIVE_ANGLE_DEG / 2.0f);
+    constexpr float tan_half = tan_approx(half_angle_rad);
+} // namespace detail
+
+constexpr float VANISHING_POINT_Y = static_cast<float>(SCREEN_H)
+    - (static_cast<float>(SCREEN_W) / 2.0f) / detail::tan_half;
 
 } // namespace constants

--- a/app/constants.h
+++ b/app/constants.h
@@ -177,6 +177,12 @@ constexpr ShapeColor SHAPE_COLORS[] = {
 };
 
 // ── Perspective / Isometric Effect ───────────────
-constexpr float VANISHING_POINT_Y  = -640.0f;
+// Controls how aggressively lanes converge toward the top.
+// Convergence angle θ = 2·atan(360 / (SCREEN_H - VP_Y))
+//   VP_Y = -761  → θ ≈ 20°  (top ≈ 37% width)
+//   VP_Y = -1060 → θ ≈ 17°  (top ≈ 45% width)
+//   VP_Y = -1455 → θ ≈ 15°  (top ≈ 54% width)
+//   VP_Y = -5120 → θ ≈  6°  (top ≈ 80% width, very subtle)
+constexpr float VANISHING_POINT_Y  = -1060.0f;
 
 } // namespace constants

--- a/app/perspective.cpp
+++ b/app/perspective.cpp
@@ -370,8 +370,8 @@ void flush_world_tris(entt::registry& reg, const FloorParams& fp) {
             float ix2 = px + shape_verts::CIRCLE[next_idx].x * inner_r;
             float iy2 = cy + shape_verts::CIRCLE[next_idx].y * inner_r;
             rlColor4ub(r, g, b, a);
-            rlVertex2f(ox1, oy1); rlVertex2f(ox2, oy2); rlVertex2f(ix1, iy1);
-            rlVertex2f(ix1, iy1); rlVertex2f(ox2, oy2); rlVertex2f(ix2, iy2);
+            rlVertex2f(ox1, oy1); rlVertex2f(ix1, iy1); rlVertex2f(ox2, oy2);
+            rlVertex2f(ix1, iy1); rlVertex2f(ix2, iy2); rlVertex2f(ox2, oy2);
         }
     };
 

--- a/app/perspective.cpp
+++ b/app/perspective.cpp
@@ -87,13 +87,11 @@ void draw_line(float x1, float y1, float x2, float y2, float thick, Color c) {
 
 // ── Projected ring (annulus) ─────────────────────────────────────────────────
 void draw_ring(float cx, float cy, float inner_r, float outer_r, int segments, Color c) {
-    // Use the full 24-segment circle table regardless of 'segments' param;
-    // caller can pass fewer if desired, but we cap to the table size.
     int seg = (segments > 0 && segments < shape_verts::CIRCLE_SEGMENTS)
               ? segments : shape_verts::CIRCLE_SEGMENTS;
 
     for (int i = 0; i < seg; ++i) {
-        int next = (i + 1) % shape_verts::CIRCLE_SEGMENTS;
+        int next = (i + 1) % seg;
 
         Vector2 outer1 = project(cx + shape_verts::CIRCLE[i].x    * outer_r,
                                  cy + shape_verts::CIRCLE[i].y    * outer_r);

--- a/app/perspective.cpp
+++ b/app/perspective.cpp
@@ -1,0 +1,140 @@
+#include "perspective.h"
+#include "shape_vertices.h"
+#include <raylib.h>
+
+namespace perspective {
+
+// ── Filled rectangle (axis-aligned in world → trapezoid after projection) ────
+void draw_rect(float x, float y, float w, float h, Color c) {
+    // Four corners at their own y-values
+    float top_y = y;
+    float bot_y = y + h;
+
+    Vector2 tl = project(x,     top_y);
+    Vector2 tr = project(x + w, top_y);
+    Vector2 br = project(x + w, bot_y);
+    Vector2 bl = project(x,     bot_y);
+
+    // Two triangles — CCW winding for raylib
+    DrawTriangle(tl, bl, tr, c);
+    DrawTriangle(tr, bl, br, c);
+}
+
+// ── Filled shape (Circle, Square, Triangle, Hexagon) ─────────────────────────
+void draw_shape(Shape shape, float cx, float cy, float size, Color c) {
+    switch (shape) {
+        case Shape::Circle: {
+            float r = size / 2.0f;
+            Vector2 centre = project(cx, cy);
+            for (int i = 0; i < shape_verts::CIRCLE_SEGMENTS; ++i) {
+                int next = (i + 1) % shape_verts::CIRCLE_SEGMENTS;
+                Vector2 v1 = project(cx + shape_verts::CIRCLE[i].x    * r,
+                                     cy + shape_verts::CIRCLE[i].y    * r);
+                Vector2 v2 = project(cx + shape_verts::CIRCLE[next].x * r,
+                                     cy + shape_verts::CIRCLE[next].y * r);
+                // CCW: centre, v2, v1  (vertices go CCW in the table,
+                // so fan triangle centre→v2→v1 keeps CCW screen winding)
+                DrawTriangle(centre, v2, v1, c);
+            }
+            break;
+        }
+        case Shape::Square: {
+            float half = size / 2.0f;
+            Vector2 corners[4];
+            for (int i = 0; i < 4; ++i) {
+                corners[i] = project(cx + shape_verts::SQUARE[i].x * half,
+                                     cy + shape_verts::SQUARE[i].y * half);
+            }
+            // TL(0), TR(1), BR(2), BL(3) — two CCW triangles
+            DrawTriangle(corners[0], corners[3], corners[1], c);
+            DrawTriangle(corners[1], corners[3], corners[2], c);
+            break;
+        }
+        case Shape::Triangle: {
+            float half = size / 2.0f;
+            Vector2 verts[3];
+            for (int i = 0; i < 3; ++i) {
+                verts[i] = project(cx + shape_verts::TRIANGLE[i].x * half,
+                                   cy + shape_verts::TRIANGLE[i].y * half);
+            }
+            // Apex(0), BaseLeft(1), BaseRight(2) — CCW
+            DrawTriangle(verts[0], verts[1], verts[2], c);
+            break;
+        }
+        case Shape::Hexagon: {
+            float radius = size * 0.6f;  // matches existing render_system scale
+            Vector2 centre = project(cx, cy);
+            for (int i = 0; i < shape_verts::HEX_SEGMENTS; ++i) {
+                int next = (i + 1) % shape_verts::HEX_SEGMENTS;
+                Vector2 v1 = project(cx + shape_verts::HEXAGON[i].x    * radius,
+                                     cy + shape_verts::HEXAGON[i].y    * radius);
+                Vector2 v2 = project(cx + shape_verts::HEXAGON[next].x * radius,
+                                     cy + shape_verts::HEXAGON[next].y * radius);
+                // CCW fan: centre→v2→v1
+                DrawTriangle(centre, v2, v1, c);
+            }
+            break;
+        }
+    }
+}
+
+// ── Projected line ───────────────────────────────────────────────────────────
+void draw_line(float x1, float y1, float x2, float y2, float thick, Color c) {
+    Vector2 a = project(x1, y1);
+    Vector2 b = project(x2, y2);
+    DrawLineEx(a, b, thick, c);
+}
+
+// ── Projected ring (annulus) ─────────────────────────────────────────────────
+void draw_ring(float cx, float cy, float inner_r, float outer_r, int segments, Color c) {
+    // Use the full 24-segment circle table regardless of 'segments' param;
+    // caller can pass fewer if desired, but we cap to the table size.
+    int seg = (segments > 0 && segments < shape_verts::CIRCLE_SEGMENTS)
+              ? segments : shape_verts::CIRCLE_SEGMENTS;
+
+    for (int i = 0; i < seg; ++i) {
+        int next = (i + 1) % shape_verts::CIRCLE_SEGMENTS;
+
+        Vector2 outer1 = project(cx + shape_verts::CIRCLE[i].x    * outer_r,
+                                 cy + shape_verts::CIRCLE[i].y    * outer_r);
+        Vector2 outer2 = project(cx + shape_verts::CIRCLE[next].x * outer_r,
+                                 cy + shape_verts::CIRCLE[next].y * outer_r);
+        Vector2 inner1 = project(cx + shape_verts::CIRCLE[i].x    * inner_r,
+                                 cy + shape_verts::CIRCLE[i].y    * inner_r);
+        Vector2 inner2 = project(cx + shape_verts::CIRCLE[next].x * inner_r,
+                                 cy + shape_verts::CIRCLE[next].y * inner_r);
+
+        // Two CCW triangles per segment forming the ring quad
+        DrawTriangle(outer1, outer2, inner1, c);
+        DrawTriangle(inner1, outer2, inner2, c);
+    }
+}
+
+// ── Projected rectangle outline ──────────────────────────────────────────────
+void draw_rect_lines(float x, float y, float w, float h, float thick, Color c) {
+    float top_y = y;
+    float bot_y = y + h;
+
+    Vector2 tl = project(x,     top_y);
+    Vector2 tr = project(x + w, top_y);
+    Vector2 br = project(x + w, bot_y);
+    Vector2 bl = project(x,     bot_y);
+
+    DrawLineEx(tl, tr, thick, c);
+    DrawLineEx(tr, br, thick, c);
+    DrawLineEx(br, bl, thick, c);
+    DrawLineEx(bl, tl, thick, c);
+}
+
+// ── Projected triangle outline ───────────────────────────────────────────────
+void draw_tri_lines(Vector2 v1, Vector2 v2, Vector2 v3, Color c) {
+    Vector2 p1 = project(v1.x, v1.y);
+    Vector2 p2 = project(v2.x, v2.y);
+    Vector2 p3 = project(v3.x, v3.y);
+
+    DrawLineV(p1, p2, c);
+    DrawLineV(p2, p3, c);
+    DrawLineV(p3, p1, c);
+}
+
+} // namespace perspective

--- a/app/perspective.cpp
+++ b/app/perspective.cpp
@@ -1,11 +1,13 @@
 #include "perspective.h"
 #include "shape_vertices.h"
 #include "components/transform.h"
+#include "components/player.h"
 #include "components/obstacle.h"
 #include "components/obstacle_data.h"
 #include "components/rendering.h"
 #include "components/particle.h"
 #include "components/lifetime.h"
+#include "components/song_state.h"
 #include <raylib.h>
 #include <rlgl.h>
 
@@ -243,6 +245,226 @@ void flush_world_rects(entt::registry& reg) {
             float half = sz / 2.0f;
             emit_quad(pos.x - half, pos.y - half, sz, sz,
                       col.r, col.g, col.b, col.a);
+        }
+    }
+
+    rlEnd();
+}
+
+// ── Pass 1: All world-space lines in one RL_LINES batch ─────────────────────
+void flush_world_lines(entt::registry& reg, const FloorParams& fp) {
+    (void)reg; // registry available for future line-emitting entities
+
+    static const Color LANE_COLORS[3] = {
+        {80, 200, 255, 255}, {255, 100, 100, 255}, {100, 255, 100, 255},
+    };
+
+    rlBegin(RL_LINES);
+
+    // ── Corridor edges ──────────────────────────────────────
+    {
+        constexpr float sw = static_cast<float>(constants::SCREEN_W);
+        constexpr float sh = static_cast<float>(constants::SCREEN_H);
+        Vector2 lt = project(0.0f, 0.0f);
+        Vector2 lb = project(0.0f, sh);
+        Vector2 rt = project(sw, 0.0f);
+        Vector2 rb = project(sw, sh);
+        rlColor4ub(40, 40, 60, 120);
+        rlVertex2f(lt.x, lt.y); rlVertex2f(lb.x, lb.y);
+        rlVertex2f(rt.x, rt.y); rlVertex2f(rb.x, rb.y);
+    }
+
+    // ── Floor connectors + outlines (lanes 1,2 only — lane 0 is rings) ──
+    for (int lane = 0; lane < constants::LANE_COUNT; ++lane) {
+        float cx = constants::LANE_X[lane];
+        Color c = LANE_COLORS[lane];
+        c.a = fp.alpha;
+
+        for (int j = 0; j < constants::FLOOR_SHAPE_COUNT; ++j) {
+            float cy = constants::FLOOR_Y_START
+                + static_cast<float>(j) * constants::FLOOR_SHAPE_SPACING;
+            float d     = depth(cy);
+            float px    = project_x(cx, cy);
+            float p_half = fp.half * d;
+
+            // Connector to next shape
+            if (j < constants::FLOOR_SHAPE_COUNT - 1) {
+                float next_cy = cy + constants::FLOOR_SHAPE_SPACING;
+                Vector2 a = project(cx, cy + fp.half);
+                Vector2 b = project(cx, next_cy - fp.half);
+                rlColor4ub(c.r, c.g, c.b, c.a);
+                rlVertex2f(a.x, a.y); rlVertex2f(b.x, b.y);
+            }
+
+            // Lane 1 (square outline): 4 lines
+            if (lane == 1) {
+                float l = px - p_half, r = px + p_half;
+                float t = cy - p_half, b = cy + p_half;
+                rlColor4ub(c.r, c.g, c.b, c.a);
+                rlVertex2f(l, t); rlVertex2f(r, t);
+                rlVertex2f(r, t); rlVertex2f(r, b);
+                rlVertex2f(r, b); rlVertex2f(l, b);
+                rlVertex2f(l, b); rlVertex2f(l, t);
+            }
+
+            // Lane 2 (triangle outline): 3 lines
+            if (lane == 2) {
+                float apex_x = px, apex_y = cy - p_half;
+                float bl_x = px - p_half, bl_y = cy + p_half;
+                float br_x = px + p_half, br_y = cy + p_half;
+                rlColor4ub(c.r, c.g, c.b, c.a);
+                rlVertex2f(apex_x, apex_y); rlVertex2f(br_x, br_y);
+                rlVertex2f(br_x, br_y);     rlVertex2f(bl_x, bl_y);
+                rlVertex2f(bl_x, bl_y);     rlVertex2f(apex_x, apex_y);
+            }
+        }
+    }
+
+    rlEnd();
+}
+
+// ── Pass 3: All world-space triangles in one RL_TRIANGLES batch ─────────────
+// Floor rings (lane 0), ghost shapes (obstacle indicators), and player shape.
+void flush_world_tris(entt::registry& reg, const FloorParams& fp) {
+    static const Color LANE0_COLOR = {80, 200, 255, 255};
+
+    rlBegin(RL_TRIANGLES);
+
+    // Helper: emit a fan shape from cached vertex table (perspective-projected)
+    auto emit_fan = [](const shape_verts::V2* table, int count, float radius,
+                       float cx, float cy, uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
+        Vector2 centre = project(cx, cy);
+        Vector2 prev = project(cx + table[0].x * radius, cy + table[0].y * radius);
+        for (int i = 0; i < count; ++i) {
+            int next = (i + 1) % count;
+            Vector2 cur = project(cx + table[next].x * radius,
+                                  cy + table[next].y * radius);
+            rlColor4ub(r, g, b, a);
+            rlVertex2f(centre.x, centre.y);
+            rlVertex2f(cur.x, cur.y);
+            rlVertex2f(prev.x, prev.y);
+            prev = cur;
+        }
+    };
+
+    // Helper: emit a flat ring (not perspective-projected — avoids double-perspective)
+    auto emit_flat_ring = [](float px, float cy, float inner_r, float outer_r,
+                             int segs, uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
+        for (int i = 0; i < segs; ++i) {
+            int next = (i + 1) % shape_verts::CIRCLE_SEGMENTS;
+            float ox1 = px + shape_verts::CIRCLE[i].x * outer_r;
+            float oy1 = cy + shape_verts::CIRCLE[i].y * outer_r;
+            float ox2 = px + shape_verts::CIRCLE[next].x * outer_r;
+            float oy2 = cy + shape_verts::CIRCLE[next].y * outer_r;
+            float ix1 = px + shape_verts::CIRCLE[i].x * inner_r;
+            float iy1 = cy + shape_verts::CIRCLE[i].y * inner_r;
+            float ix2 = px + shape_verts::CIRCLE[next].x * inner_r;
+            float iy2 = cy + shape_verts::CIRCLE[next].y * inner_r;
+            rlColor4ub(r, g, b, a);
+            rlVertex2f(ox1, oy1); rlVertex2f(ox2, oy2); rlVertex2f(ix1, iy1);
+            rlVertex2f(ix1, iy1); rlVertex2f(ox2, oy2); rlVertex2f(ix2, iy2);
+        }
+    };
+
+    // Helper: emit a perspective shape
+    auto emit_shape = [&emit_fan](Shape shape, float cx, float cy, float sz,
+                                   uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
+        switch (shape) {
+            case Shape::Circle:
+                emit_fan(shape_verts::CIRCLE, shape_verts::CIRCLE_SEGMENTS,
+                         sz / 2.0f, cx, cy, r, g, b, a);
+                break;
+            case Shape::Square: {
+                float half = sz / 2.0f;
+                Vector2 v[4];
+                for (int i = 0; i < 4; ++i)
+                    v[i] = project(cx + shape_verts::SQUARE[i].x * half,
+                                   cy + shape_verts::SQUARE[i].y * half);
+                rlColor4ub(r, g, b, a);
+                rlVertex2f(v[0].x, v[0].y); rlVertex2f(v[3].x, v[3].y); rlVertex2f(v[1].x, v[1].y);
+                rlVertex2f(v[1].x, v[1].y); rlVertex2f(v[3].x, v[3].y); rlVertex2f(v[2].x, v[2].y);
+                break;
+            }
+            case Shape::Triangle: {
+                float half = sz / 2.0f;
+                Vector2 v[3];
+                for (int i = 0; i < 3; ++i)
+                    v[i] = project(cx + shape_verts::TRIANGLE[i].x * half,
+                                   cy + shape_verts::TRIANGLE[i].y * half);
+                rlColor4ub(r, g, b, a);
+                rlVertex2f(v[0].x, v[0].y); rlVertex2f(v[1].x, v[1].y); rlVertex2f(v[2].x, v[2].y);
+                break;
+            }
+            case Shape::Hexagon:
+                emit_fan(shape_verts::HEXAGON, shape_verts::HEX_SEGMENTS,
+                         sz * 0.6f, cx, cy, r, g, b, a);
+                break;
+        }
+    };
+
+    // ── Floor rings (lane 0 only) ────────────────────────────
+    {
+        Color c = LANE0_COLOR;
+        c.a = fp.alpha;
+        for (int j = 0; j < constants::FLOOR_SHAPE_COUNT; ++j) {
+            float cy = constants::FLOOR_Y_START
+                + static_cast<float>(j) * constants::FLOOR_SHAPE_SPACING;
+            float d = depth(cy);
+            float px = project_x(constants::LANE_X[0], cy);
+            float p_half  = fp.half * d;
+            float p_thick = fp.thick * d;
+            emit_flat_ring(px, cy, p_half - p_thick, p_half, 12,
+                           c.r, c.g, c.b, c.a);
+        }
+    }
+
+    // ── Ghost shapes (obstacle indicators) ───────────────────
+    {
+        auto view = reg.view<ObstacleTag, Position, Obstacle, DrawColor, DrawSize>();
+        for (auto [entity, pos, obs, col, dsz] : view.each()) {
+            switch (obs.kind) {
+                case ObstacleKind::ShapeGate: {
+                    auto* req = reg.try_get<RequiredShape>(entity);
+                    if (req) emit_shape(req->shape, pos.x, pos.y + dsz.h / 2, 40,
+                                        col.r, col.g, col.b, 120);
+                    break;
+                }
+                case ObstacleKind::ComboGate: {
+                    auto* req = reg.try_get<RequiredShape>(entity);
+                    if (req) {
+                        auto* blocked = reg.try_get<BlockedLanes>(entity);
+                        int open = 1;
+                        if (blocked) {
+                            for (int i = 0; i < 3; ++i)
+                                if (!((blocked->mask >> i) & 1)) { open = i; break; }
+                        }
+                        emit_shape(req->shape, constants::LANE_X[open],
+                                   pos.y + dsz.h / 2, 30, 255, 255, 255, 180);
+                    }
+                    break;
+                }
+                case ObstacleKind::SplitPath: {
+                    auto* req = reg.try_get<RequiredShape>(entity);
+                    auto* rlane = reg.try_get<RequiredLane>(entity);
+                    if (req && rlane)
+                        emit_shape(req->shape, constants::LANE_X[rlane->lane],
+                                   pos.y + dsz.h / 2, 30, 255, 255, 255, 180);
+                    break;
+                }
+                default: break;
+            }
+        }
+    }
+
+    // ── Player shape ─────────────────────────────────────────
+    {
+        auto view = reg.view<PlayerTag, Position, PlayerShape, VerticalState, DrawColor>();
+        for (auto [entity, pos, pshape, vstate, col] : view.each()) {
+            float draw_y = pos.y + vstate.y_offset;
+            float sz = constants::PLAYER_SIZE;
+            if (vstate.mode == VMode::Sliding) sz *= 0.5f;
+            emit_shape(pshape.current, pos.x, draw_y, sz,
+                       col.r, col.g, col.b, col.a);
         }
     }
 

--- a/app/perspective.cpp
+++ b/app/perspective.cpp
@@ -251,9 +251,9 @@ void flush_world_rects(entt::registry& reg) {
     rlEnd();
 }
 
-// ── Pass 1: All world-space lines in one RL_LINES batch ─────────────────────
-void flush_world_lines(entt::registry& reg, const FloorParams& fp) {
-    (void)reg; // registry available for future line-emitting entities
+// ── Pass 1: Floor lines (background layer) ──────────────────────────────────
+void flush_floor_lines(entt::registry& reg, const FloorParams& fp) {
+    (void)reg;
 
     static const Color LANE_COLORS[3] = {
         {80, 200, 255, 255}, {255, 100, 100, 255}, {100, 255, 100, 255},
@@ -261,7 +261,7 @@ void flush_world_lines(entt::registry& reg, const FloorParams& fp) {
 
     rlBegin(RL_LINES);
 
-    // ── Corridor edges ──────────────────────────────────────
+    // Corridor edges
     {
         constexpr float sw = static_cast<float>(constants::SCREEN_W);
         constexpr float sh = static_cast<float>(constants::SCREEN_H);
@@ -274,7 +274,7 @@ void flush_world_lines(entt::registry& reg, const FloorParams& fp) {
         rlVertex2f(rt.x, rt.y); rlVertex2f(rb.x, rb.y);
     }
 
-    // ── Floor connectors + outlines (lanes 1,2 only — lane 0 is rings) ──
+    // Floor connectors + outlines
     for (int lane = 0; lane < constants::LANE_COUNT; ++lane) {
         float cx = constants::LANE_X[lane];
         Color c = LANE_COLORS[lane];
@@ -287,30 +287,26 @@ void flush_world_lines(entt::registry& reg, const FloorParams& fp) {
             float px    = project_x(cx, cy);
             float p_half = fp.half * d;
 
-            // Connector to next shape (use depth-scaled half for both endpoints)
             if (j < constants::FLOOR_SHAPE_COUNT - 1) {
                 float next_cy = cy + constants::FLOOR_SHAPE_SPACING;
                 float next_d  = depth(next_cy);
                 float next_p_half = fp.half * next_d;
-                // Start from bottom edge of current shape, end at top edge of next
                 Vector2 a = project(cx, cy + p_half);
                 Vector2 b = project(cx, next_cy - next_p_half);
                 rlColor4ub(c.r, c.g, c.b, c.a);
                 rlVertex2f(a.x, a.y); rlVertex2f(b.x, b.y);
             }
 
-            // Lane 1 (square outline): 4 lines
             if (lane == 1) {
                 float l = px - p_half, r = px + p_half;
-                float t = cy - p_half, b = cy + p_half;
+                float t = cy - p_half, bt = cy + p_half;
                 rlColor4ub(c.r, c.g, c.b, c.a);
                 rlVertex2f(l, t); rlVertex2f(r, t);
-                rlVertex2f(r, t); rlVertex2f(r, b);
-                rlVertex2f(r, b); rlVertex2f(l, b);
-                rlVertex2f(l, b); rlVertex2f(l, t);
+                rlVertex2f(r, t); rlVertex2f(r, bt);
+                rlVertex2f(r, bt); rlVertex2f(l, bt);
+                rlVertex2f(l, bt); rlVertex2f(l, t);
             }
 
-            // Lane 2 (triangle outline): 3 lines
             if (lane == 2) {
                 float apex_x = px, apex_y = cy - p_half;
                 float bl_x = px - p_half, bl_y = cy + p_half;
@@ -326,13 +322,46 @@ void flush_world_lines(entt::registry& reg, const FloorParams& fp) {
     rlEnd();
 }
 
-// ── Pass 3: All world-space triangles in one RL_TRIANGLES batch ─────────────
-// Floor rings (lane 0), ghost shapes (obstacle indicators), and player shape.
-void flush_world_tris(entt::registry& reg, const FloorParams& fp) {
+// ── Pass 2: Floor rings (background layer) ──────────────────────────────────
+void flush_floor_rings(const FloorParams& fp) {
     static const Color LANE0_COLOR = {80, 200, 255, 255};
+    Color c = LANE0_COLOR;
+    c.a = fp.alpha;
 
     rlBegin(RL_TRIANGLES);
+    for (int j = 0; j < constants::FLOOR_SHAPE_COUNT; ++j) {
+        float cy = constants::FLOOR_Y_START
+            + static_cast<float>(j) * constants::FLOOR_SHAPE_SPACING;
+        float d = depth(cy);
+        float px = project_x(constants::LANE_X[0], cy);
+        float p_half  = fp.half * d;
+        float p_thick = fp.thick * d;
+        float inner_r = p_half - p_thick;
+        float outer_r = p_half;
 
+        int seg = 12;
+        for (int i = 0; i < seg; ++i) {
+            int idx      = (i * shape_verts::CIRCLE_SEGMENTS) / seg;
+            int next_idx = ((i + 1) * shape_verts::CIRCLE_SEGMENTS) / seg
+                           % shape_verts::CIRCLE_SEGMENTS;
+            float ox1 = px + shape_verts::CIRCLE[idx].x * outer_r;
+            float oy1 = cy + shape_verts::CIRCLE[idx].y * outer_r;
+            float ox2 = px + shape_verts::CIRCLE[next_idx].x * outer_r;
+            float oy2 = cy + shape_verts::CIRCLE[next_idx].y * outer_r;
+            float ix1 = px + shape_verts::CIRCLE[idx].x * inner_r;
+            float iy1 = cy + shape_verts::CIRCLE[idx].y * inner_r;
+            float ix2 = px + shape_verts::CIRCLE[next_idx].x * inner_r;
+            float iy2 = cy + shape_verts::CIRCLE[next_idx].y * inner_r;
+            rlColor4ub(c.r, c.g, c.b, c.a);
+            rlVertex2f(ox1, oy1); rlVertex2f(ix1, iy1); rlVertex2f(ox2, oy2);
+            rlVertex2f(ix1, iy1); rlVertex2f(ix2, iy2); rlVertex2f(ox2, oy2);
+        }
+    }
+    rlEnd();
+}
+
+// ── Pass 4: Gameplay triangles (ghost shapes + player) ──────────────────────
+void flush_gameplay_tris(entt::registry& reg) {
     // Helper: emit a fan shape from cached vertex table (perspective-projected)
     auto emit_fan = [](const shape_verts::V2* table, int count, float radius,
                        float cx, float cy, uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
@@ -350,32 +379,6 @@ void flush_world_tris(entt::registry& reg, const FloorParams& fp) {
         }
     };
 
-    // Helper: emit a flat ring (not perspective-projected — avoids double-perspective)
-    auto emit_flat_ring = [](float px, float cy, float inner_r, float outer_r,
-                             int segs, uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
-        // Map segs evenly across the full 24-vertex circle table
-        // so the ring always closes (same fix as draw_ring).
-        int seg = (segs > 0 && segs <= shape_verts::CIRCLE_SEGMENTS)
-                  ? segs : shape_verts::CIRCLE_SEGMENTS;
-        for (int i = 0; i < seg; ++i) {
-            int idx      = (i       * shape_verts::CIRCLE_SEGMENTS) / seg;
-            int next_idx = ((i + 1) * shape_verts::CIRCLE_SEGMENTS) / seg
-                           % shape_verts::CIRCLE_SEGMENTS;
-            float ox1 = px + shape_verts::CIRCLE[idx].x * outer_r;
-            float oy1 = cy + shape_verts::CIRCLE[idx].y * outer_r;
-            float ox2 = px + shape_verts::CIRCLE[next_idx].x * outer_r;
-            float oy2 = cy + shape_verts::CIRCLE[next_idx].y * outer_r;
-            float ix1 = px + shape_verts::CIRCLE[idx].x * inner_r;
-            float iy1 = cy + shape_verts::CIRCLE[idx].y * inner_r;
-            float ix2 = px + shape_verts::CIRCLE[next_idx].x * inner_r;
-            float iy2 = cy + shape_verts::CIRCLE[next_idx].y * inner_r;
-            rlColor4ub(r, g, b, a);
-            rlVertex2f(ox1, oy1); rlVertex2f(ix1, iy1); rlVertex2f(ox2, oy2);
-            rlVertex2f(ix1, iy1); rlVertex2f(ix2, iy2); rlVertex2f(ox2, oy2);
-        }
-    };
-
-    // Helper: emit a perspective shape
     auto emit_shape = [&emit_fan](Shape shape, float cx, float cy, float sz,
                                    uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
         switch (shape) {
@@ -411,23 +414,9 @@ void flush_world_tris(entt::registry& reg, const FloorParams& fp) {
         }
     };
 
-    // ── Floor rings (lane 0 only) ────────────────────────────
-    {
-        Color c = LANE0_COLOR;
-        c.a = fp.alpha;
-        for (int j = 0; j < constants::FLOOR_SHAPE_COUNT; ++j) {
-            float cy = constants::FLOOR_Y_START
-                + static_cast<float>(j) * constants::FLOOR_SHAPE_SPACING;
-            float d = depth(cy);
-            float px = project_x(constants::LANE_X[0], cy);
-            float p_half  = fp.half * d;
-            float p_thick = fp.thick * d;
-            emit_flat_ring(px, cy, p_half - p_thick, p_half, 12,
-                           c.r, c.g, c.b, c.a);
-        }
-    }
+    rlBegin(RL_TRIANGLES);
 
-    // ── Ghost shapes (obstacle indicators) ───────────────────
+    // Ghost shapes (obstacle indicators)
     {
         auto view = reg.view<ObstacleTag, Position, Obstacle, DrawColor, DrawSize>();
         for (auto [entity, pos, obs, col, dsz] : view.each()) {
@@ -465,7 +454,7 @@ void flush_world_tris(entt::registry& reg, const FloorParams& fp) {
         }
     }
 
-    // ── Player shape ─────────────────────────────────────────
+    // Player shape
     {
         auto view = reg.view<PlayerTag, Position, PlayerShape, VerticalState, DrawColor>();
         for (auto [entity, pos, pshape, vstate, col] : view.each()) {

--- a/app/perspective.cpp
+++ b/app/perspective.cpp
@@ -1,6 +1,13 @@
 #include "perspective.h"
 #include "shape_vertices.h"
+#include "components/transform.h"
+#include "components/obstacle.h"
+#include "components/obstacle_data.h"
+#include "components/rendering.h"
+#include "components/particle.h"
+#include "components/lifetime.h"
 #include <raylib.h>
+#include <rlgl.h>
 
 namespace perspective {
 
@@ -141,6 +148,105 @@ void draw_tri_lines(Vector2 v1, Vector2 v2, Vector2 v3, Color c) {
     DrawLineV(p1, p2, c);
     DrawLineV(p2, p3, c);
     DrawLineV(p3, p1, c);
+}
+
+// ── Batched rect flush from ECS ──────────────────────────────────────────────
+// Queries registry for ObstacleTag and ParticleTag entities, projects their
+// rect geometry, and submits everything in a single RL_QUADS batch.
+void flush_world_rects(entt::registry& reg) {
+    rlBegin(RL_QUADS);
+
+    // Helper: emit one projected quad
+    auto emit_quad = [](float x, float y, float w, float h,
+                        uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
+        float d_top = depth(y);
+        float d_bot = depth(y + h);
+        float tl_x = CENTER + (x     - CENTER) * d_top;
+        float tr_x = CENTER + (x + w - CENTER) * d_top;
+        float bl_x = CENTER + (x     - CENTER) * d_bot;
+        float br_x = CENTER + (x + w - CENTER) * d_bot;
+
+        rlColor4ub(r, g, b, a);
+        rlVertex2f(tl_x, y);
+        rlVertex2f(bl_x, y + h);
+        rlVertex2f(br_x, y + h);
+        rlVertex2f(tr_x, y);
+    };
+
+    // ── Obstacles: iterate by ObstacleTag ────────────────────
+    {
+        auto view = reg.view<ObstacleTag, Position, Obstacle, DrawColor, DrawSize>();
+        for (auto [entity, pos, obs, col, dsz] : view.each()) {
+            switch (obs.kind) {
+                case ObstacleKind::ShapeGate:
+                    emit_quad(0, pos.y, pos.x - 50, dsz.h, col.r, col.g, col.b, col.a);
+                    emit_quad(pos.x + 50, pos.y,
+                              constants::SCREEN_W - pos.x - 50, dsz.h,
+                              col.r, col.g, col.b, col.a);
+                    break;
+
+                case ObstacleKind::LaneBlock: {
+                    auto* blocked = reg.try_get<BlockedLanes>(entity);
+                    if (blocked) {
+                        for (int i = 0; i < 3; ++i) {
+                            if ((blocked->mask >> i) & 1) {
+                                float lx = constants::LANE_X[i] - dsz.w / 2;
+                                emit_quad(lx, pos.y, dsz.w, dsz.h,
+                                          col.r, col.g, col.b, col.a);
+                            }
+                        }
+                    }
+                    break;
+                }
+
+                case ObstacleKind::LowBar:
+                case ObstacleKind::HighBar:
+                    emit_quad(0, pos.y, static_cast<float>(constants::SCREEN_W),
+                              dsz.h, col.r, col.g, col.b, col.a);
+                    break;
+
+                case ObstacleKind::ComboGate: {
+                    auto* blocked = reg.try_get<BlockedLanes>(entity);
+                    if (blocked) {
+                        for (int i = 0; i < 3; ++i) {
+                            if ((blocked->mask >> i) & 1) {
+                                float lx = constants::LANE_X[i] - 120;
+                                emit_quad(lx, pos.y, 240.0f, dsz.h,
+                                          col.r, col.g, col.b, col.a);
+                            }
+                        }
+                    }
+                    break;
+                }
+
+                case ObstacleKind::SplitPath: {
+                    auto* rlane = reg.try_get<RequiredLane>(entity);
+                    for (int i = 0; i < 3; ++i) {
+                        if (!rlane || i != rlane->lane) {
+                            float lx = constants::LANE_X[i] - 120;
+                            emit_quad(lx, pos.y, 240.0f, dsz.h,
+                                      col.r, col.g, col.b, col.a);
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    // ── Particles: iterate by ParticleTag ────────────────────
+    {
+        auto view = reg.view<ParticleTag, Position, ParticleData, DrawColor, Lifetime>();
+        for (auto [entity, pos, pdata, col, life] : view.each()) {
+            float ratio = (life.max_time > 0.0f) ? (life.remaining / life.max_time) : 1.0f;
+            float sz = pdata.size * ratio;
+            float half = sz / 2.0f;
+            emit_quad(pos.x - half, pos.y - half, sz, sz,
+                      col.r, col.g, col.b, col.a);
+        }
+    }
+
+    rlEnd();
 }
 
 } // namespace perspective

--- a/app/perspective.cpp
+++ b/app/perspective.cpp
@@ -353,16 +353,22 @@ void flush_world_tris(entt::registry& reg, const FloorParams& fp) {
     // Helper: emit a flat ring (not perspective-projected — avoids double-perspective)
     auto emit_flat_ring = [](float px, float cy, float inner_r, float outer_r,
                              int segs, uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
-        for (int i = 0; i < segs; ++i) {
-            int next = (i + 1) % shape_verts::CIRCLE_SEGMENTS;
-            float ox1 = px + shape_verts::CIRCLE[i].x * outer_r;
-            float oy1 = cy + shape_verts::CIRCLE[i].y * outer_r;
-            float ox2 = px + shape_verts::CIRCLE[next].x * outer_r;
-            float oy2 = cy + shape_verts::CIRCLE[next].y * outer_r;
-            float ix1 = px + shape_verts::CIRCLE[i].x * inner_r;
-            float iy1 = cy + shape_verts::CIRCLE[i].y * inner_r;
-            float ix2 = px + shape_verts::CIRCLE[next].x * inner_r;
-            float iy2 = cy + shape_verts::CIRCLE[next].y * inner_r;
+        // Map segs evenly across the full 24-vertex circle table
+        // so the ring always closes (same fix as draw_ring).
+        int seg = (segs > 0 && segs <= shape_verts::CIRCLE_SEGMENTS)
+                  ? segs : shape_verts::CIRCLE_SEGMENTS;
+        for (int i = 0; i < seg; ++i) {
+            int idx      = (i       * shape_verts::CIRCLE_SEGMENTS) / seg;
+            int next_idx = ((i + 1) * shape_verts::CIRCLE_SEGMENTS) / seg
+                           % shape_verts::CIRCLE_SEGMENTS;
+            float ox1 = px + shape_verts::CIRCLE[idx].x * outer_r;
+            float oy1 = cy + shape_verts::CIRCLE[idx].y * outer_r;
+            float ox2 = px + shape_verts::CIRCLE[next_idx].x * outer_r;
+            float oy2 = cy + shape_verts::CIRCLE[next_idx].y * outer_r;
+            float ix1 = px + shape_verts::CIRCLE[idx].x * inner_r;
+            float iy1 = cy + shape_verts::CIRCLE[idx].y * inner_r;
+            float ix2 = px + shape_verts::CIRCLE[next_idx].x * inner_r;
+            float iy2 = cy + shape_verts::CIRCLE[next_idx].y * inner_r;
             rlColor4ub(r, g, b, a);
             rlVertex2f(ox1, oy1); rlVertex2f(ox2, oy2); rlVertex2f(ix1, iy1);
             rlVertex2f(ix1, iy1); rlVertex2f(ox2, oy2); rlVertex2f(ix2, iy2);

--- a/app/perspective.cpp
+++ b/app/perspective.cpp
@@ -5,17 +5,22 @@
 namespace perspective {
 
 // ── Filled rectangle (axis-aligned in world → trapezoid after projection) ────
+// Depth only depends on y, and a rect has only 2 y-values (top/bottom).
+// Compute depth once per scanline instead of once per corner.
 void draw_rect(float x, float y, float w, float h, Color c) {
-    // Four corners at their own y-values
-    float top_y = y;
-    float bot_y = y + h;
+    float d_top = depth(y);
+    float d_bot = depth(y + h);
 
-    Vector2 tl = project(x,     top_y);
-    Vector2 tr = project(x + w, top_y);
-    Vector2 br = project(x + w, bot_y);
-    Vector2 bl = project(x,     bot_y);
+    float tl_x = CENTER + (x     - CENTER) * d_top;
+    float tr_x = CENTER + (x + w - CENTER) * d_top;
+    float bl_x = CENTER + (x     - CENTER) * d_bot;
+    float br_x = CENTER + (x + w - CENTER) * d_bot;
 
-    // Two triangles — CCW winding for raylib
+    Vector2 tl = {tl_x, y};
+    Vector2 tr = {tr_x, y};
+    Vector2 bl = {bl_x, y + h};
+    Vector2 br = {br_x, y + h};
+
     DrawTriangle(tl, bl, tr, c);
     DrawTriangle(tr, bl, br, c);
 }
@@ -26,15 +31,15 @@ void draw_shape(Shape shape, float cx, float cy, float size, Color c) {
         case Shape::Circle: {
             float r = size / 2.0f;
             Vector2 centre = project(cx, cy);
+            // Pre-project first vertex; reuse as prev in the loop
+            Vector2 prev = project(cx + shape_verts::CIRCLE[0].x * r,
+                                   cy + shape_verts::CIRCLE[0].y * r);
             for (int i = 0; i < shape_verts::CIRCLE_SEGMENTS; ++i) {
                 int next = (i + 1) % shape_verts::CIRCLE_SEGMENTS;
-                Vector2 v1 = project(cx + shape_verts::CIRCLE[i].x    * r,
-                                     cy + shape_verts::CIRCLE[i].y    * r);
-                Vector2 v2 = project(cx + shape_verts::CIRCLE[next].x * r,
-                                     cy + shape_verts::CIRCLE[next].y * r);
-                // CCW: centre, v2, v1  (vertices go CCW in the table,
-                // so fan triangle centre→v2→v1 keeps CCW screen winding)
-                DrawTriangle(centre, v2, v1, c);
+                Vector2 cur = project(cx + shape_verts::CIRCLE[next].x * r,
+                                      cy + shape_verts::CIRCLE[next].y * r);
+                DrawTriangle(centre, cur, prev, c);
+                prev = cur;
             }
             break;
         }
@@ -62,16 +67,16 @@ void draw_shape(Shape shape, float cx, float cy, float size, Color c) {
             break;
         }
         case Shape::Hexagon: {
-            float radius = size * 0.6f;  // matches existing render_system scale
+            float radius = size * 0.6f;
             Vector2 centre = project(cx, cy);
+            Vector2 prev = project(cx + shape_verts::HEXAGON[0].x * radius,
+                                   cy + shape_verts::HEXAGON[0].y * radius);
             for (int i = 0; i < shape_verts::HEX_SEGMENTS; ++i) {
                 int next = (i + 1) % shape_verts::HEX_SEGMENTS;
-                Vector2 v1 = project(cx + shape_verts::HEXAGON[i].x    * radius,
-                                     cy + shape_verts::HEXAGON[i].y    * radius);
-                Vector2 v2 = project(cx + shape_verts::HEXAGON[next].x * radius,
-                                     cy + shape_verts::HEXAGON[next].y * radius);
-                // CCW fan: centre→v2→v1
-                DrawTriangle(centre, v2, v1, c);
+                Vector2 cur = project(cx + shape_verts::HEXAGON[next].x * radius,
+                                      cy + shape_verts::HEXAGON[next].y * radius);
+                DrawTriangle(centre, cur, prev, c);
+                prev = cur;
             }
             break;
         }
@@ -106,7 +111,6 @@ void draw_ring(float cx, float cy, float inner_r, float outer_r, int segments, C
         Vector2 inner2 = project(cx + shape_verts::CIRCLE[next_idx].x * inner_r,
                                  cy + shape_verts::CIRCLE[next_idx].y * inner_r);
 
-        // Two CCW triangles per segment forming the ring quad
         DrawTriangle(outer1, outer2, inner1, c);
         DrawTriangle(inner1, outer2, inner2, c);
     }
@@ -114,13 +118,13 @@ void draw_ring(float cx, float cy, float inner_r, float outer_r, int segments, C
 
 // ── Projected rectangle outline ──────────────────────────────────────────────
 void draw_rect_lines(float x, float y, float w, float h, float thick, Color c) {
-    float top_y = y;
-    float bot_y = y + h;
+    float d_top = depth(y);
+    float d_bot = depth(y + h);
 
-    Vector2 tl = project(x,     top_y);
-    Vector2 tr = project(x + w, top_y);
-    Vector2 br = project(x + w, bot_y);
-    Vector2 bl = project(x,     bot_y);
+    Vector2 tl = {CENTER + (x     - CENTER) * d_top, y};
+    Vector2 tr = {CENTER + (x + w - CENTER) * d_top, y};
+    Vector2 br = {CENTER + (x + w - CENTER) * d_bot, y + h};
+    Vector2 bl = {CENTER + (x     - CENTER) * d_bot, y + h};
 
     DrawLineEx(tl, tr, thick, c);
     DrawLineEx(tr, br, thick, c);

--- a/app/perspective.cpp
+++ b/app/perspective.cpp
@@ -287,11 +287,14 @@ void flush_world_lines(entt::registry& reg, const FloorParams& fp) {
             float px    = project_x(cx, cy);
             float p_half = fp.half * d;
 
-            // Connector to next shape
+            // Connector to next shape (use depth-scaled half for both endpoints)
             if (j < constants::FLOOR_SHAPE_COUNT - 1) {
                 float next_cy = cy + constants::FLOOR_SHAPE_SPACING;
-                Vector2 a = project(cx, cy + fp.half);
-                Vector2 b = project(cx, next_cy - fp.half);
+                float next_d  = depth(next_cy);
+                float next_p_half = fp.half * next_d;
+                // Start from bottom edge of current shape, end at top edge of next
+                Vector2 a = project(cx, cy + p_half);
+                Vector2 b = project(cx, next_cy - next_p_half);
                 rlColor4ub(c.r, c.g, c.b, c.a);
                 rlVertex2f(a.x, a.y); rlVertex2f(b.x, b.y);
             }

--- a/app/perspective.cpp
+++ b/app/perspective.cpp
@@ -87,20 +87,24 @@ void draw_line(float x1, float y1, float x2, float y2, float thick, Color c) {
 
 // ── Projected ring (annulus) ─────────────────────────────────────────────────
 void draw_ring(float cx, float cy, float inner_r, float outer_r, int segments, Color c) {
-    int seg = (segments > 0 && segments < shape_verts::CIRCLE_SEGMENTS)
+    int seg = (segments > 0 && segments <= shape_verts::CIRCLE_SEGMENTS)
               ? segments : shape_verts::CIRCLE_SEGMENTS;
 
     for (int i = 0; i < seg; ++i) {
-        int next = (i + 1) % seg;
+        // Map evenly across the full 0..CIRCLE_SEGMENTS table so the ring
+        // always closes correctly, regardless of the requested segment count.
+        int idx      = (i       * shape_verts::CIRCLE_SEGMENTS) / seg;
+        int next_idx = ((i + 1) * shape_verts::CIRCLE_SEGMENTS) / seg
+                       % shape_verts::CIRCLE_SEGMENTS;
 
-        Vector2 outer1 = project(cx + shape_verts::CIRCLE[i].x    * outer_r,
-                                 cy + shape_verts::CIRCLE[i].y    * outer_r);
-        Vector2 outer2 = project(cx + shape_verts::CIRCLE[next].x * outer_r,
-                                 cy + shape_verts::CIRCLE[next].y * outer_r);
-        Vector2 inner1 = project(cx + shape_verts::CIRCLE[i].x    * inner_r,
-                                 cy + shape_verts::CIRCLE[i].y    * inner_r);
-        Vector2 inner2 = project(cx + shape_verts::CIRCLE[next].x * inner_r,
-                                 cy + shape_verts::CIRCLE[next].y * inner_r);
+        Vector2 outer1 = project(cx + shape_verts::CIRCLE[idx].x      * outer_r,
+                                 cy + shape_verts::CIRCLE[idx].y      * outer_r);
+        Vector2 outer2 = project(cx + shape_verts::CIRCLE[next_idx].x * outer_r,
+                                 cy + shape_verts::CIRCLE[next_idx].y * outer_r);
+        Vector2 inner1 = project(cx + shape_verts::CIRCLE[idx].x      * inner_r,
+                                 cy + shape_verts::CIRCLE[idx].y      * inner_r);
+        Vector2 inner2 = project(cx + shape_verts::CIRCLE[next_idx].x * inner_r,
+                                 cy + shape_verts::CIRCLE[next_idx].y * inner_r);
 
         // Two CCW triangles per segment forming the ring quad
         DrawTriangle(outer1, outer2, inner1, c);

--- a/app/perspective.h
+++ b/app/perspective.h
@@ -35,11 +35,24 @@ void draw_ring(float cx, float cy, float inner_r, float outer_r, int segments, C
 void draw_rect_lines(float x, float y, float w, float h, float thick, Color c);
 void draw_tri_lines(Vector2 v1, Vector2 v2, Vector2 v3, Color c);
 
-// ── Batched rect rendering from ECS ─────────────────────────────────────────
-// Queries the registry for all obstacle and particle entities, computes
-// their perspective-projected rect geometry, and submits everything in a
-// single rlgl RL_QUADS batch.  No manual push() from application code —
-// the batch reads the ECS by tag.
+// ── GPU-batched render passes ────────────────────────────────────────────────
+// Three ordered passes, each a single rlgl begin/end.  Sorted by primitive
+// type (lines → quads → triangles) to minimize GPU state changes.
+//
+//   Pass 1: RL_LINES      — corridor edges, floor connectors, floor outlines
+//   Pass 2: RL_QUADS      — obstacle rects, particle rects
+//   Pass 3: RL_TRIANGLES  — floor rings, ghost shapes, player shape
+
+// Floor geometry params (computed per-frame from SongState pulse).
+struct FloorParams {
+    float size;
+    float half;
+    float thick;
+    uint8_t alpha;
+};
+
+void flush_world_lines(entt::registry& reg, const FloorParams& fp);
 void flush_world_rects(entt::registry& reg);
+void flush_world_tris(entt::registry& reg, const FloorParams& fp);
 
 } // namespace perspective

--- a/app/perspective.h
+++ b/app/perspective.h
@@ -36,12 +36,13 @@ void draw_rect_lines(float x, float y, float w, float h, float thick, Color c);
 void draw_tri_lines(Vector2 v1, Vector2 v2, Vector2 v3, Color c);
 
 // ── GPU-batched render passes ────────────────────────────────────────────────
-// Three ordered passes, each a single rlgl begin/end.  Sorted by primitive
-// type (lines → quads → triangles) to minimize GPU state changes.
+// Four ordered passes.  Sorted by LAYER first (background before gameplay),
+// then by primitive type within each layer.
 //
-//   Pass 1: RL_LINES      — corridor edges, floor connectors, floor outlines
-//   Pass 2: RL_QUADS      — obstacle rects, particle rects
-//   Pass 3: RL_TRIANGLES  — floor rings, ghost shapes, player shape
+//   Pass 1: RL_LINES      — floor connectors + outlines + corridor edges
+//   Pass 2: RL_TRIANGLES  — floor rings (lane 0 circles)
+//   Pass 3: RL_QUADS      — obstacle rects + particle rects
+//   Pass 4: RL_TRIANGLES  — ghost shapes + player shape
 
 // Floor geometry params (computed per-frame from SongState pulse).
 struct FloorParams {
@@ -51,8 +52,9 @@ struct FloorParams {
     uint8_t alpha;
 };
 
-void flush_world_lines(entt::registry& reg, const FloorParams& fp);
+void flush_floor_lines(entt::registry& reg, const FloorParams& fp);
+void flush_floor_rings(const FloorParams& fp);
 void flush_world_rects(entt::registry& reg);
-void flush_world_tris(entt::registry& reg, const FloorParams& fp);
+void flush_gameplay_tris(entt::registry& reg);
 
 } // namespace perspective

--- a/app/perspective.h
+++ b/app/perspective.h
@@ -2,23 +2,33 @@
 #include "constants.h"
 #include "components/player.h"
 #include <raylib.h>
+#include <algorithm>
 
 namespace perspective {
 
-inline Vector2 project(float x, float y) {
-    constexpr float center = constants::SCREEN_W / 2.0f;
-    constexpr float vp_y   = constants::VANISHING_POINT_Y;
-    constexpr float range  = static_cast<float>(constants::SCREEN_H) - vp_y;
+// Pre-computed reciprocal — multiplication instead of division in the hot path.
+// Called 1000–10000× per frame; division is 10–20 cycles, multiply is 3–5.
+constexpr float CENTER    = constants::SCREEN_W / 2.0f;
+constexpr float VP_Y      = constants::VANISHING_POINT_Y;
+constexpr float RANGE     = static_cast<float>(constants::SCREEN_H) - VP_Y;
+constexpr float INV_RANGE = 1.0f / RANGE;
 
-    float depth = (y - vp_y) / range;
-    if (depth < 0.01f) depth = 0.01f;
-    if (depth > 1.5f)  depth = 1.5f;
-
-    return { center + (x - center) * depth, y };
+// Compute depth factor for a given y.  Useful when callers need depth
+// separately (e.g., floor shapes that scale size by depth then draw flat).
+inline float depth(float y) {
+    return std::clamp((y - VP_Y) * INV_RANGE, 0.01f, 1.5f);
 }
 
+// Project a world-space vertex.  x is warped toward centre; y is unchanged.
+inline Vector2 project(float x, float y) {
+    float d = depth(y);
+    return { CENTER + (x - CENTER) * d, y };
+}
+
+// Project just the x component (avoids constructing a Vector2).
 inline float project_x(float x, float y) {
-    return project(x, y).x;
+    float d = depth(y);
+    return CENTER + (x - CENTER) * d;
 }
 
 void draw_rect(float x, float y, float w, float h, Color c);

--- a/app/perspective.h
+++ b/app/perspective.h
@@ -1,31 +1,28 @@
 #pragma once
 #include "constants.h"
 #include "components/player.h"
+#include <entt/entt.hpp>
 #include <raylib.h>
 #include <algorithm>
+#include <cstdint>
 
 namespace perspective {
 
 // Pre-computed reciprocal — multiplication instead of division in the hot path.
-// Called 1000–10000× per frame; division is 10–20 cycles, multiply is 3–5.
 constexpr float CENTER    = constants::SCREEN_W / 2.0f;
 constexpr float VP_Y      = constants::VANISHING_POINT_Y;
 constexpr float RANGE     = static_cast<float>(constants::SCREEN_H) - VP_Y;
 constexpr float INV_RANGE = 1.0f / RANGE;
 
-// Compute depth factor for a given y.  Useful when callers need depth
-// separately (e.g., floor shapes that scale size by depth then draw flat).
 inline float depth(float y) {
     return std::clamp((y - VP_Y) * INV_RANGE, 0.01f, 1.5f);
 }
 
-// Project a world-space vertex.  x is warped toward centre; y is unchanged.
 inline Vector2 project(float x, float y) {
     float d = depth(y);
     return { CENTER + (x - CENTER) * d, y };
 }
 
-// Project just the x component (avoids constructing a Vector2).
 inline float project_x(float x, float y) {
     float d = depth(y);
     return CENTER + (x - CENTER) * d;
@@ -37,5 +34,12 @@ void draw_line(float x1, float y1, float x2, float y2, float thick, Color c);
 void draw_ring(float cx, float cy, float inner_r, float outer_r, int segments, Color c);
 void draw_rect_lines(float x, float y, float w, float h, float thick, Color c);
 void draw_tri_lines(Vector2 v1, Vector2 v2, Vector2 v3, Color c);
+
+// ── Batched rect rendering from ECS ─────────────────────────────────────────
+// Queries the registry for all obstacle and particle entities, computes
+// their perspective-projected rect geometry, and submits everything in a
+// single rlgl RL_QUADS batch.  No manual push() from application code —
+// the batch reads the ECS by tag.
+void flush_world_rects(entt::registry& reg);
 
 } // namespace perspective

--- a/app/perspective.h
+++ b/app/perspective.h
@@ -1,0 +1,31 @@
+#pragma once
+#include "constants.h"
+#include "components/player.h"
+#include <raylib.h>
+
+namespace perspective {
+
+inline Vector2 project(float x, float y) {
+    constexpr float center = constants::SCREEN_W / 2.0f;
+    constexpr float vp_y   = constants::VANISHING_POINT_Y;
+    constexpr float range  = static_cast<float>(constants::SCREEN_H) - vp_y;
+
+    float depth = (y - vp_y) / range;
+    if (depth < 0.01f) depth = 0.01f;
+    if (depth > 1.5f)  depth = 1.5f;
+
+    return { center + (x - center) * depth, y };
+}
+
+inline float project_x(float x, float y) {
+    return project(x, y).x;
+}
+
+void draw_rect(float x, float y, float w, float h, Color c);
+void draw_shape(Shape shape, float cx, float cy, float size, Color c);
+void draw_line(float x1, float y1, float x2, float y2, float thick, Color c);
+void draw_ring(float cx, float cy, float inner_r, float outer_r, int segments, Color c);
+void draw_rect_lines(float x, float y, float w, float h, float thick, Color c);
+void draw_tri_lines(Vector2 v1, Vector2 v2, Vector2 v3, Color c);
+
+} // namespace perspective

--- a/app/shape_vertices.h
+++ b/app/shape_vertices.h
@@ -1,0 +1,51 @@
+#pragma once
+#include <cstdint>
+
+namespace shape_verts {
+
+struct V2 { float x, y; };
+
+// Circle: 24 perimeter points, unit radius, starting at 0° going CCW
+constexpr int CIRCLE_SEGMENTS = 24;
+constexpr V2 CIRCLE[CIRCLE_SEGMENTS] = {
+    { 1.000000f,  0.000000f}, { 0.965926f,  0.258819f},
+    { 0.866025f,  0.500000f}, { 0.707107f,  0.707107f},
+    { 0.500000f,  0.866025f}, { 0.258819f,  0.965926f},
+    { 0.000000f,  1.000000f}, {-0.258819f,  0.965926f},
+    {-0.500000f,  0.866025f}, {-0.707107f,  0.707107f},
+    {-0.866025f,  0.500000f}, {-0.965926f,  0.258819f},
+    {-1.000000f,  0.000000f}, {-0.965926f, -0.258819f},
+    {-0.866025f, -0.500000f}, {-0.707107f, -0.707107f},
+    {-0.500000f, -0.866025f}, {-0.258819f, -0.965926f},
+    { 0.000000f, -1.000000f}, { 0.258819f, -0.965926f},
+    { 0.500000f, -0.866025f}, { 0.707107f, -0.707107f},
+    { 0.866025f, -0.500000f}, { 0.965926f, -0.258819f},
+};
+
+// Hexagon: 6 perimeter points, pointy-top (-90° offset), unit radius
+constexpr int HEX_SEGMENTS = 6;
+constexpr V2 HEXAGON[HEX_SEGMENTS] = {
+    { 0.000000f, -1.000000f},
+    { 0.866025f, -0.500000f},
+    { 0.866025f,  0.500000f},
+    { 0.000000f,  1.000000f},
+    {-0.866025f,  0.500000f},
+    {-0.866025f, -0.500000f},
+};
+
+// Square: 4 corners, unit half-extent
+constexpr V2 SQUARE[4] = {
+    {-1.0f, -1.0f},  // top-left
+    { 1.0f, -1.0f},  // top-right
+    { 1.0f,  1.0f},  // bot-right
+    {-1.0f,  1.0f},  // bot-left
+};
+
+// Triangle: 3 vertices, unit half-extent
+constexpr V2 TRIANGLE[3] = {
+    { 0.0f, -1.0f},  // apex
+    {-1.0f,  1.0f},  // base-left
+    { 1.0f,  1.0f},  // base-right
+};
+
+} // namespace shape_verts

--- a/app/systems/render_system.cpp
+++ b/app/systems/render_system.cpp
@@ -445,9 +445,13 @@ void render_system(entt::registry& reg, float /*alpha*/) {
 
                 // Connecting lines stay perspective-projected (they define lane convergence)
                 if (j < constants::FLOOR_SHAPE_COUNT - 1) {
-                    float next_cy = cy + constants::FLOOR_SHAPE_SPACING;
-                    perspective::draw_line(cx, cy + half, cx, next_cy - half,
-                               constants::FLOOR_OUTLINE_THICK, c);
+                    float next_cy     = cy + constants::FLOOR_SHAPE_SPACING;
+                    float next_d      = perspective::depth(next_cy);
+                    float next_p_half = half * next_d;
+                    float next_p_thick = thick * next_d;
+                    float connector_thick = std::min(p_thick, next_p_thick);
+                    perspective::draw_line(cx, cy + p_half, cx, next_cy - next_p_half,
+                               connector_thick, c);
                 }
 
                 // Draw flat shapes at projected position with depth-scaled size

--- a/app/systems/render_system.cpp
+++ b/app/systems/render_system.cpp
@@ -475,20 +475,20 @@ void render_system(entt::registry& reg, float /*alpha*/) {
         }
     }
 
-    // ── Draw obstacles ──────────────────────────────────────
+    // ── Batch-draw all obstacle rects + particle rects ─────
+    // Single rlgl RL_QUADS batch: queries ObstacleTag and ParticleTag
+    // entities from the registry, projects their rect vertices, and
+    // submits everything in one draw call.
+    if (gs.phase != GamePhase::Title) {
+        perspective::flush_world_rects(reg);
+    }
+
+    // ── Draw obstacle ghost shapes (layered on top of rects) ─
     if (gs.phase != GamePhase::Title) {
         auto view = reg.view<ObstacleTag, Position, Obstacle, DrawColor, DrawSize>();
         for (auto [entity, pos, obs, col, dsz] : view.each()) {
-
-            Color c = {col.r, col.g, col.b, col.a};
-
             switch (obs.kind) {
                 case ObstacleKind::ShapeGate: {
-                    // Full-width gate with shape hole
-                    perspective::draw_rect(0, pos.y, pos.x - 50, dsz.h, c);
-                    perspective::draw_rect(pos.x + 50, pos.y,
-                        constants::SCREEN_W - pos.x - 50, dsz.h, c);
-                    // Draw shape indicator in the gap
                     auto* req = reg.try_get<RequiredShape>(entity);
                     if (req) {
                         Color ghost = {col.r, col.g, col.b, 120};
@@ -496,36 +496,11 @@ void render_system(entt::registry& reg, float /*alpha*/) {
                     }
                     break;
                 }
-                case ObstacleKind::LaneBlock: {
-                    auto* blocked = reg.try_get<BlockedLanes>(entity);
-                    if (blocked) {
-                        for (int i = 0; i < 3; ++i) {
-                            if ((blocked->mask >> i) & 1) {
-                                float lx = constants::LANE_X[i] - dsz.w / 2;
-                                perspective::draw_rect(lx, pos.y, dsz.w, dsz.h, c);
-                            }
-                        }
-                    }
-                    break;
-                }
-                case ObstacleKind::LowBar:
-                case ObstacleKind::HighBar: {
-                    perspective::draw_rect(0, pos.y, static_cast<float>(constants::SCREEN_W), dsz.h, c);
-                    break;
-                }
                 case ObstacleKind::ComboGate: {
-                    auto* blocked = reg.try_get<BlockedLanes>(entity);
-                    if (blocked) {
-                        for (int i = 0; i < 3; ++i) {
-                            if ((blocked->mask >> i) & 1) {
-                                float lx = constants::LANE_X[i] - 120;
-                                perspective::draw_rect(lx, pos.y, 240.0f, dsz.h, c);
-                            }
-                        }
-                    }
                     auto* req = reg.try_get<RequiredShape>(entity);
                     if (req) {
                         Color white_ghost = {255, 255, 255, 180};
+                        auto* blocked = reg.try_get<BlockedLanes>(entity);
                         int open = 1;
                         if (blocked) {
                             for (int i = 0; i < 3; ++i) {
@@ -538,14 +513,8 @@ void render_system(entt::registry& reg, float /*alpha*/) {
                     break;
                 }
                 case ObstacleKind::SplitPath: {
-                    auto* rlane = reg.try_get<RequiredLane>(entity);
-                    for (int i = 0; i < 3; ++i) {
-                        if (!rlane || i != rlane->lane) {
-                            float lx = constants::LANE_X[i] - 120;
-                            perspective::draw_rect(lx, pos.y, 240.0f, dsz.h, c);
-                        }
-                    }
                     auto* req = reg.try_get<RequiredShape>(entity);
+                    auto* rlane = reg.try_get<RequiredLane>(entity);
                     if (req && rlane) {
                         Color white_ghost = {255, 255, 255, 180};
                         perspective::draw_shape(req->shape,
@@ -553,19 +522,8 @@ void render_system(entt::registry& reg, float /*alpha*/) {
                     }
                     break;
                 }
+                default: break;
             }
-        }
-    }
-
-    // ── Draw particles ──────────────────────────────────────
-    {
-        auto view = reg.view<ParticleTag, Position, ParticleData, DrawColor, Lifetime>();
-        for (auto [entity, pos, pdata, col, life] : view.each()) {
-            float ratio = (life.max_time > 0.0f) ? (life.remaining / life.max_time) : 1.0f;
-            float draw_size = pdata.size * ratio;
-            float half = draw_size / 2.0f;
-            perspective::draw_rect(pos.x - half, pos.y - half, draw_size, draw_size,
-                             {col.r, col.g, col.b, col.a});
         }
     }
 

--- a/app/systems/render_system.cpp
+++ b/app/systems/render_system.cpp
@@ -15,12 +15,13 @@
 #include "../components/song_state.h"
 #include "../constants.h"
 #include "../text_renderer.h"
+#include "../perspective.h"
 #include <raylib.h>
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
 
-static void draw_shape(Shape shape, float cx, float cy, float size, Color color) {
+static void draw_shape_flat(Shape shape, float cx, float cy, float size, Color color) {
     switch (shape) {
         case Shape::Circle: {
             float radius = size / 2.0f;
@@ -68,10 +69,10 @@ static void draw_title_scene(const TextContext& text_ctx, const GameState& gs) {
     const float cx        = constants::VIEWPORT_CX_N * constants::SCREEN_W;
 
     Color title_shape_color = {80, 180, 255, 255};
-    draw_shape(Shape::Circle, cx - shape_off, shapes_y, shape_sz, title_shape_color);
-    draw_shape(Shape::Square, cx,             shapes_y, shape_sz, title_shape_color);
+    draw_shape_flat(Shape::Circle, cx - shape_off, shapes_y, shape_sz, title_shape_color);
+    draw_shape_flat(Shape::Square, cx,             shapes_y, shape_sz, title_shape_color);
     Color green_color = {100, 255, 100, 255};
-    draw_shape(Shape::Triangle, cx + shape_off, shapes_y, shape_sz, green_color);
+    draw_shape_flat(Shape::Triangle, cx + shape_off, shapes_y, shape_sz, green_color);
 
     text_draw(text_ctx, "SHAPESHIFTER",
         cx, constants::SCENE_TITLE_TEXT_Y_N * constants::SCREEN_H,
@@ -232,7 +233,7 @@ static void draw_hud(entt::registry& reg, const TextContext& text_ctx) {
 
         auto shape = static_cast<Shape>(i);
         Color icon_color = is_active ? Color{200, 230, 255, 255} : Color{100, 100, 120, 200};
-        draw_shape(shape, btn_cx, btn_cy, btn_radius * 1.2f, icon_color);
+        draw_shape_flat(shape, btn_cx, btn_cy, btn_radius * 1.2f, icon_color);
 
         if (nearest_dist[i] > 0.0f && nearest_dist[i] < ring_appear_dist) {
             float ratio = (nearest_dist[i] - perfect_dist)
@@ -421,22 +422,19 @@ void render_system(entt::registry& reg, float /*alpha*/) {
                 // Draw connecting segment from this shape's bottom edge to next shape's top edge
                 if (j < constants::FLOOR_SHAPE_COUNT - 1) {
                     float next_cy = cy + constants::FLOOR_SHAPE_SPACING;
-                    DrawLineEx({cx, cy + half}, {cx, next_cy - half},
+                    perspective::draw_line(cx, cy + half, cx, next_cy - half,
                                constants::FLOOR_OUTLINE_THICK, c);
                 }
 
                 switch (lane) {
                     case 0:
-                        DrawRing({cx, cy}, half - thick, half, 0, 360, 12, c);
+                        perspective::draw_ring(cx, cy, half - thick, half, 12, c);
                         break;
                     case 1:
-                        DrawRectangleLinesEx({cx - half, cy - half, size, size}, thick, c);
+                        perspective::draw_rect_lines(cx - half, cy - half, size, size, thick, c);
                         break;
                     case 2: {
-                        Vector2 v1 = {cx,        cy - half};
-                        Vector2 v2 = {cx - half, cy + half};
-                        Vector2 v3 = {cx + half, cy + half};
-                        DrawTriangleLines(v1, v3, v2, c);
+                        perspective::draw_tri_lines({cx, cy - half}, {cx - half, cy + half}, {cx + half, cy + half}, c);
                         break;
                     }
                     default: break;
@@ -455,14 +453,14 @@ void render_system(entt::registry& reg, float /*alpha*/) {
             switch (obs.kind) {
                 case ObstacleKind::ShapeGate: {
                     // Full-width gate with shape hole
-                    DrawRectangleRec({0, pos.y, pos.x - 50, dsz.h}, c);
-                    DrawRectangleRec({pos.x + 50, pos.y,
-                        constants::SCREEN_W - pos.x - 50, dsz.h}, c);
+                    perspective::draw_rect(0, pos.y, pos.x - 50, dsz.h, c);
+                    perspective::draw_rect(pos.x + 50, pos.y,
+                        constants::SCREEN_W - pos.x - 50, dsz.h, c);
                     // Draw shape indicator in the gap
                     auto* req = reg.try_get<RequiredShape>(entity);
                     if (req) {
                         Color ghost = {col.r, col.g, col.b, 120};
-                        draw_shape(req->shape, pos.x, pos.y + dsz.h / 2, 40, ghost);
+                        perspective::draw_shape(req->shape, pos.x, pos.y + dsz.h / 2, 40, ghost);
                     }
                     break;
                 }
@@ -472,7 +470,7 @@ void render_system(entt::registry& reg, float /*alpha*/) {
                         for (int i = 0; i < 3; ++i) {
                             if ((blocked->mask >> i) & 1) {
                                 float lx = constants::LANE_X[i] - dsz.w / 2;
-                                DrawRectangleRec({lx, pos.y, dsz.w, dsz.h}, c);
+                                perspective::draw_rect(lx, pos.y, dsz.w, dsz.h, c);
                             }
                         }
                     }
@@ -480,7 +478,7 @@ void render_system(entt::registry& reg, float /*alpha*/) {
                 }
                 case ObstacleKind::LowBar:
                 case ObstacleKind::HighBar: {
-                    DrawRectangleRec({0, pos.y, float(constants::SCREEN_W), dsz.h}, c);
+                    perspective::draw_rect(0, pos.y, static_cast<float>(constants::SCREEN_W), dsz.h, c);
                     break;
                 }
                 case ObstacleKind::ComboGate: {
@@ -489,7 +487,7 @@ void render_system(entt::registry& reg, float /*alpha*/) {
                         for (int i = 0; i < 3; ++i) {
                             if ((blocked->mask >> i) & 1) {
                                 float lx = constants::LANE_X[i] - 120;
-                                DrawRectangleRec({lx, pos.y, 240.0f, dsz.h}, c);
+                                perspective::draw_rect(lx, pos.y, 240.0f, dsz.h, c);
                             }
                         }
                     }
@@ -502,7 +500,7 @@ void render_system(entt::registry& reg, float /*alpha*/) {
                                 if (!((blocked->mask >> i) & 1)) { open = i; break; }
                             }
                         }
-                        draw_shape(req->shape,
+                        perspective::draw_shape(req->shape,
                             constants::LANE_X[open], pos.y + dsz.h / 2, 30, white_ghost);
                     }
                     break;
@@ -512,13 +510,13 @@ void render_system(entt::registry& reg, float /*alpha*/) {
                     for (int i = 0; i < 3; ++i) {
                         if (!rlane || i != rlane->lane) {
                             float lx = constants::LANE_X[i] - 120;
-                            DrawRectangleRec({lx, pos.y, 240.0f, dsz.h}, c);
+                            perspective::draw_rect(lx, pos.y, 240.0f, dsz.h, c);
                         }
                     }
                     auto* req = reg.try_get<RequiredShape>(entity);
                     if (req && rlane) {
                         Color white_ghost = {255, 255, 255, 180};
-                        draw_shape(req->shape,
+                        perspective::draw_shape(req->shape,
                             constants::LANE_X[rlane->lane], pos.y + dsz.h / 2, 30, white_ghost);
                     }
                     break;
@@ -534,7 +532,7 @@ void render_system(entt::registry& reg, float /*alpha*/) {
             float ratio = (life.max_time > 0.0f) ? (life.remaining / life.max_time) : 1.0f;
             float draw_size = pdata.size * ratio;
             float half = draw_size / 2.0f;
-            DrawRectangleRec({pos.x - half, pos.y - half, draw_size, draw_size},
+            perspective::draw_rect(pos.x - half, pos.y - half, draw_size, draw_size,
                              {col.r, col.g, col.b, col.a});
         }
     }
@@ -556,15 +554,17 @@ void render_system(entt::registry& reg, float /*alpha*/) {
                     case 1: grade_text = "OK";      grade_font = FontSize::Small;  break;
                     case 0: grade_text = "BAD";     grade_font = FontSize::Small;  break;
                 }
+                Vector2 pp = perspective::project(pos.x, pos.y);
                 text_draw(text_ctx, grade_text,
-                    pos.x, pos.y, grade_font,
+                    pp.x, pp.y, grade_font,
                     col.r, col.g, col.b, popup_alpha,
                     TextAlign::Center);
             } else {
                 // Non-timed obstacle: show score number
                 FontSize popup_font = FontSize::Small;
+                Vector2 pp = perspective::project(pos.x, pos.y);
                 text_draw_number(text_ctx, popup.value,
-                    pos.x, pos.y, popup_font,
+                    pp.x, pp.y, popup_font,
                     col.r, col.g, col.b, popup_alpha);
             }
         }
@@ -582,7 +582,7 @@ void render_system(entt::registry& reg, float /*alpha*/) {
             }
 
             Color pc = {col.r, col.g, col.b, col.a};
-            draw_shape(pshape.current, pos.x, draw_y, size, pc);
+            perspective::draw_shape(pshape.current, pos.x, draw_y, size, pc);
         }
     }
 

--- a/app/systems/render_system.cpp
+++ b/app/systems/render_system.cpp
@@ -407,13 +407,14 @@ void render_system(entt::registry& reg, float /*alpha*/) {
         floor_params.alpha = static_cast<uint8_t>(alpha_f);
     }
 
-    // ── 3 GPU batches sorted by primitive type ───────────────
-    // Minimizes GPU state changes: one rlBegin/rlEnd per primitive.
-    perspective::flush_world_lines(reg, floor_params);   // Pass 1: RL_LINES
+    // ── 4 GPU batches sorted by layer then primitive type ───
+    // Background (floor) renders first, gameplay on top.
+    perspective::flush_floor_lines(reg, floor_params);   // Pass 1: floor lines
+    perspective::flush_floor_rings(floor_params);         // Pass 2: floor circles
     if (gs.phase != GamePhase::Title) {
-        perspective::flush_world_rects(reg);              // Pass 2: RL_QUADS
+        perspective::flush_world_rects(reg);              // Pass 3: obstacle + particle rects
+        perspective::flush_gameplay_tris(reg);            // Pass 4: ghost shapes + player
     }
-    perspective::flush_world_tris(reg, floor_params);    // Pass 3: RL_TRIANGLES
 
     // ── Draw timing grade popups ───────────────────────────
     {

--- a/app/systems/render_system.cpp
+++ b/app/systems/render_system.cpp
@@ -385,6 +385,22 @@ void render_system(entt::registry& reg, float /*alpha*/) {
     // positions need to change.
     BeginMode2D(camera);
 
+    // ── Draw perspective corridor edges ──────────────────────
+    // Subtle converging lines along the left and right edges of the
+    // playfield to frame the perspective and prevent the narrowing
+    // lanes from looking like they're being clipped.
+    {
+        Color edge_color = {40, 40, 60, 120};
+        // Left edge: x=0 from bottom to top
+        perspective::draw_line(0.0f, 0.0f, 0.0f, static_cast<float>(constants::SCREEN_H),
+                               1.5f, edge_color);
+        // Right edge: x=SCREEN_W from bottom to top
+        perspective::draw_line(static_cast<float>(constants::SCREEN_W), 0.0f,
+                               static_cast<float>(constants::SCREEN_W),
+                               static_cast<float>(constants::SCREEN_H),
+                               1.5f, edge_color);
+    }
+
     // ── Draw lane floors (shaped columns that pulse on beat) ─
     {
         auto* song = reg.ctx().find<SongState>();

--- a/app/systems/render_system.cpp
+++ b/app/systems/render_system.cpp
@@ -435,19 +435,13 @@ void render_system(entt::registry& reg, float /*alpha*/) {
             for (int j = 0; j < constants::FLOOR_SHAPE_COUNT; ++j) {
                 float cy = constants::FLOOR_Y_START + static_cast<float>(j) * constants::FLOOR_SHAPE_SPACING;
 
-                // Project centre position and scale size by depth.
-                // The shape itself is drawn FLAT at the projected position
-                // to avoid double-perspective (lane convergence already
-                // provides the perspective; distorting the shape too is 2×).
-                Vector2 pc = perspective::project(cx, cy);
-                constexpr float vp_y   = constants::VANISHING_POINT_Y;
-                constexpr float range  = static_cast<float>(constants::SCREEN_H) - vp_y;
-                float depth = (cy - vp_y) / range;
-                if (depth < 0.01f) depth = 0.01f;
-                if (depth > 1.5f)  depth = 1.5f;
-                float p_half  = half * depth;
-                float p_thick = thick * depth;
-                float p_size  = size * depth;
+                // Project centre and scale size by depth.
+                // Shapes drawn FLAT to avoid double-perspective.
+                float d = perspective::depth(cy);
+                float px = perspective::project_x(cx, cy);
+                float p_half  = half * d;
+                float p_thick = thick * d;
+                float p_size  = size * d;
 
                 // Connecting lines stay perspective-projected (they define lane convergence)
                 if (j < constants::FLOOR_SHAPE_COUNT - 1) {
@@ -459,15 +453,15 @@ void render_system(entt::registry& reg, float /*alpha*/) {
                 // Draw flat shapes at projected position with depth-scaled size
                 switch (lane) {
                     case 0:
-                        DrawRing({pc.x, pc.y}, p_half - p_thick, p_half, 0, 360, 12, c);
+                        DrawRing({px, cy}, p_half - p_thick, p_half, 0, 360, 12, c);
                         break;
                     case 1:
-                        DrawRectangleLinesEx({pc.x - p_half, pc.y - p_half, p_size, p_size}, p_thick, c);
+                        DrawRectangleLinesEx({px - p_half, cy - p_half, p_size, p_size}, p_thick, c);
                         break;
                     case 2: {
-                        Vector2 v1 = {pc.x,          pc.y - p_half};
-                        Vector2 v2 = {pc.x - p_half, pc.y + p_half};
-                        Vector2 v3 = {pc.x + p_half, pc.y + p_half};
+                        Vector2 v1 = {px,          cy - p_half};
+                        Vector2 v2 = {px - p_half, cy + p_half};
+                        Vector2 v3 = {px + p_half, cy + p_half};
                         DrawTriangleLines(v1, v3, v2, c);
                         break;
                     }

--- a/app/systems/render_system.cpp
+++ b/app/systems/render_system.cpp
@@ -435,22 +435,40 @@ void render_system(entt::registry& reg, float /*alpha*/) {
             for (int j = 0; j < constants::FLOOR_SHAPE_COUNT; ++j) {
                 float cy = constants::FLOOR_Y_START + static_cast<float>(j) * constants::FLOOR_SHAPE_SPACING;
 
-                // Draw connecting segment from this shape's bottom edge to next shape's top edge
+                // Project centre position and scale size by depth.
+                // The shape itself is drawn FLAT at the projected position
+                // to avoid double-perspective (lane convergence already
+                // provides the perspective; distorting the shape too is 2×).
+                Vector2 pc = perspective::project(cx, cy);
+                constexpr float vp_y   = constants::VANISHING_POINT_Y;
+                constexpr float range  = static_cast<float>(constants::SCREEN_H) - vp_y;
+                float depth = (cy - vp_y) / range;
+                if (depth < 0.01f) depth = 0.01f;
+                if (depth > 1.5f)  depth = 1.5f;
+                float p_half  = half * depth;
+                float p_thick = thick * depth;
+                float p_size  = size * depth;
+
+                // Connecting lines stay perspective-projected (they define lane convergence)
                 if (j < constants::FLOOR_SHAPE_COUNT - 1) {
                     float next_cy = cy + constants::FLOOR_SHAPE_SPACING;
                     perspective::draw_line(cx, cy + half, cx, next_cy - half,
                                constants::FLOOR_OUTLINE_THICK, c);
                 }
 
+                // Draw flat shapes at projected position with depth-scaled size
                 switch (lane) {
                     case 0:
-                        perspective::draw_ring(cx, cy, half - thick, half, 12, c);
+                        DrawRing({pc.x, pc.y}, p_half - p_thick, p_half, 0, 360, 12, c);
                         break;
                     case 1:
-                        perspective::draw_rect_lines(cx - half, cy - half, size, size, thick, c);
+                        DrawRectangleLinesEx({pc.x - p_half, pc.y - p_half, p_size, p_size}, p_thick, c);
                         break;
                     case 2: {
-                        perspective::draw_tri_lines({cx, cy - half}, {cx - half, cy + half}, {cx + half, cy + half}, c);
+                        Vector2 v1 = {pc.x,          pc.y - p_half};
+                        Vector2 v2 = {pc.x - p_half, pc.y + p_half};
+                        Vector2 v3 = {pc.x + p_half, pc.y + p_half};
+                        DrawTriangleLines(v1, v3, v2, c);
                         break;
                     }
                     default: break;

--- a/app/systems/render_system.cpp
+++ b/app/systems/render_system.cpp
@@ -385,23 +385,8 @@ void render_system(entt::registry& reg, float /*alpha*/) {
     // positions need to change.
     BeginMode2D(camera);
 
-    // ── Draw perspective corridor edges ──────────────────────
-    // Subtle converging lines along the left and right edges of the
-    // playfield to frame the perspective and prevent the narrowing
-    // lanes from looking like they're being clipped.
-    {
-        Color edge_color = {40, 40, 60, 120};
-        // Left edge: x=0 from bottom to top
-        perspective::draw_line(0.0f, 0.0f, 0.0f, static_cast<float>(constants::SCREEN_H),
-                               1.5f, edge_color);
-        // Right edge: x=SCREEN_W from bottom to top
-        perspective::draw_line(static_cast<float>(constants::SCREEN_W), 0.0f,
-                               static_cast<float>(constants::SCREEN_W),
-                               static_cast<float>(constants::SCREEN_H),
-                               1.5f, edge_color);
-    }
-
-    // ── Draw lane floors (shaped columns that pulse on beat) ─
+    // ── Compute floor pulse params (shared across GPU batches) ─
+    perspective::FloorParams floor_params{};
     {
         auto* song = reg.ctx().find<SongState>();
         float pulse = 0.0f;
@@ -412,120 +397,23 @@ void render_system(entt::registry& reg, float /*alpha*/) {
             float ease = 1.0f - (1.0f - pulse_t) * (1.0f - pulse_t);
             pulse = 1.0f - ease;
         }
-
-        float alpha = constants::FLOOR_ALPHA_REST
+        float alpha_f = constants::FLOOR_ALPHA_REST
             + (constants::FLOOR_ALPHA_PEAK - constants::FLOOR_ALPHA_REST) * pulse;
         float scale = constants::FLOOR_SCALE_REST
             + (constants::FLOOR_SCALE_PEAK - constants::FLOOR_SCALE_REST) * pulse;
-        float size  = constants::FLOOR_SHAPE_SIZE * scale;
-        float half  = size / 2.0f;
-        float thick = constants::FLOOR_OUTLINE_THICK;
-
-        static const Color LANE_SHAPE_COLORS[3] = {
-            {80,  200, 255, 255},
-            {255, 100, 100, 255},
-            {100, 255, 100, 255},
-        };
-
-        for (int lane = 0; lane < constants::LANE_COUNT; ++lane) {
-            float cx = constants::LANE_X[lane];
-            Color c  = LANE_SHAPE_COLORS[lane];
-            c.a      = static_cast<unsigned char>(alpha);
-
-            for (int j = 0; j < constants::FLOOR_SHAPE_COUNT; ++j) {
-                float cy = constants::FLOOR_Y_START + static_cast<float>(j) * constants::FLOOR_SHAPE_SPACING;
-
-                // Project centre and scale size by depth.
-                // Shapes drawn FLAT to avoid double-perspective.
-                float d = perspective::depth(cy);
-                float px = perspective::project_x(cx, cy);
-                float p_half  = half * d;
-                float p_thick = thick * d;
-                float p_size  = size * d;
-
-                // Connecting lines stay perspective-projected (they define lane convergence)
-                if (j < constants::FLOOR_SHAPE_COUNT - 1) {
-                    float next_cy     = cy + constants::FLOOR_SHAPE_SPACING;
-                    float next_d      = perspective::depth(next_cy);
-                    float next_p_half = half * next_d;
-                    float next_p_thick = thick * next_d;
-                    float connector_thick = std::min(p_thick, next_p_thick);
-                    perspective::draw_line(cx, cy + p_half, cx, next_cy - next_p_half,
-                               connector_thick, c);
-                }
-
-                // Draw flat shapes at projected position with depth-scaled size
-                switch (lane) {
-                    case 0:
-                        DrawRing({px, cy}, p_half - p_thick, p_half, 0, 360, 12, c);
-                        break;
-                    case 1:
-                        DrawRectangleLinesEx({px - p_half, cy - p_half, p_size, p_size}, p_thick, c);
-                        break;
-                    case 2: {
-                        Vector2 v1 = {px,          cy - p_half};
-                        Vector2 v2 = {px - p_half, cy + p_half};
-                        Vector2 v3 = {px + p_half, cy + p_half};
-                        DrawTriangleLines(v1, v3, v2, c);
-                        break;
-                    }
-                    default: break;
-                }
-            }
-        }
+        floor_params.size  = constants::FLOOR_SHAPE_SIZE * scale;
+        floor_params.half  = floor_params.size / 2.0f;
+        floor_params.thick = constants::FLOOR_OUTLINE_THICK;
+        floor_params.alpha = static_cast<uint8_t>(alpha_f);
     }
 
-    // ── Batch-draw all obstacle rects + particle rects ─────
-    // Single rlgl RL_QUADS batch: queries ObstacleTag and ParticleTag
-    // entities from the registry, projects their rect vertices, and
-    // submits everything in one draw call.
+    // ── 3 GPU batches sorted by primitive type ───────────────
+    // Minimizes GPU state changes: one rlBegin/rlEnd per primitive.
+    perspective::flush_world_lines(reg, floor_params);   // Pass 1: RL_LINES
     if (gs.phase != GamePhase::Title) {
-        perspective::flush_world_rects(reg);
+        perspective::flush_world_rects(reg);              // Pass 2: RL_QUADS
     }
-
-    // ── Draw obstacle ghost shapes (layered on top of rects) ─
-    if (gs.phase != GamePhase::Title) {
-        auto view = reg.view<ObstacleTag, Position, Obstacle, DrawColor, DrawSize>();
-        for (auto [entity, pos, obs, col, dsz] : view.each()) {
-            switch (obs.kind) {
-                case ObstacleKind::ShapeGate: {
-                    auto* req = reg.try_get<RequiredShape>(entity);
-                    if (req) {
-                        Color ghost = {col.r, col.g, col.b, 120};
-                        perspective::draw_shape(req->shape, pos.x, pos.y + dsz.h / 2, 40, ghost);
-                    }
-                    break;
-                }
-                case ObstacleKind::ComboGate: {
-                    auto* req = reg.try_get<RequiredShape>(entity);
-                    if (req) {
-                        Color white_ghost = {255, 255, 255, 180};
-                        auto* blocked = reg.try_get<BlockedLanes>(entity);
-                        int open = 1;
-                        if (blocked) {
-                            for (int i = 0; i < 3; ++i) {
-                                if (!((blocked->mask >> i) & 1)) { open = i; break; }
-                            }
-                        }
-                        perspective::draw_shape(req->shape,
-                            constants::LANE_X[open], pos.y + dsz.h / 2, 30, white_ghost);
-                    }
-                    break;
-                }
-                case ObstacleKind::SplitPath: {
-                    auto* req = reg.try_get<RequiredShape>(entity);
-                    auto* rlane = reg.try_get<RequiredLane>(entity);
-                    if (req && rlane) {
-                        Color white_ghost = {255, 255, 255, 180};
-                        perspective::draw_shape(req->shape,
-                            constants::LANE_X[rlane->lane], pos.y + dsz.h / 2, 30, white_ghost);
-                    }
-                    break;
-                }
-                default: break;
-            }
-        }
-    }
+    perspective::flush_world_tris(reg, floor_params);    // Pass 3: RL_TRIANGLES
 
     // ── Draw timing grade popups ───────────────────────────
     {

--- a/benchmarks/bench_perspective.cpp
+++ b/benchmarks/bench_perspective.cpp
@@ -1,0 +1,252 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/benchmark/catch_benchmark.hpp>
+
+#include "perspective.h"
+#include "shape_vertices.h"
+#include "constants.h"
+
+// ── Perspective projection benchmarks ───────────────────────
+// Measures the hot-path costs introduced by the isometric perspective
+// system: vertex projection, shape drawing, and floor initialization.
+
+// Prevent the compiler from optimising away benchmark results
+template<typename T>
+static void do_not_optimize(T const& val) {
+    asm volatile("" : : "r,m"(val) : "memory");
+}
+
+TEST_CASE("Bench: perspective::project single vertex", "[bench][perspective]") {
+    BENCHMARK("project(180, 640)") {
+        auto v = perspective::project(180.0f, 640.0f);
+        do_not_optimize(v);
+        return v;
+    };
+}
+
+TEST_CASE("Bench: perspective::project_x single vertex", "[bench][perspective]") {
+    BENCHMARK("project_x(180, 640)") {
+        float x = perspective::project_x(180.0f, 640.0f);
+        do_not_optimize(x);
+        return x;
+    };
+}
+
+TEST_CASE("Bench: project all 3 lanes at N depths", "[bench][perspective]") {
+    BENCHMARK_ADVANCED("3 lanes × 21 floor positions")(Catch::Benchmark::Chronometer meter) {
+        meter.measure([&] {
+            float sum = 0.0f;
+            for (int lane = 0; lane < 3; ++lane) {
+                float cx = constants::LANE_X[lane];
+                for (int j = 0; j < constants::FLOOR_SHAPE_COUNT; ++j) {
+                    float cy = constants::FLOOR_Y_START
+                        + static_cast<float>(j) * constants::FLOOR_SHAPE_SPACING;
+                    sum += perspective::project_x(cx, cy);
+                }
+            }
+            do_not_optimize(sum);
+            return sum;
+        });
+    };
+}
+
+TEST_CASE("Bench: perspective shape vertex projection — Circle", "[bench][perspective]") {
+    BENCHMARK_ADVANCED("24-segment circle (project only)")(Catch::Benchmark::Chronometer meter) {
+        meter.measure([&] {
+            float sum = 0.0f;
+            float r = 32.0f;
+            float cx = 360.0f, cy = 500.0f;
+            Vector2 centre = perspective::project(cx, cy);
+            sum += centre.x;
+            for (int i = 0; i < shape_verts::CIRCLE_SEGMENTS; ++i) {
+                int next = (i + 1) % shape_verts::CIRCLE_SEGMENTS;
+                Vector2 v1 = perspective::project(
+                    cx + shape_verts::CIRCLE[i].x * r,
+                    cy + shape_verts::CIRCLE[i].y * r);
+                Vector2 v2 = perspective::project(
+                    cx + shape_verts::CIRCLE[next].x * r,
+                    cy + shape_verts::CIRCLE[next].y * r);
+                sum += v1.x + v2.x;
+            }
+            do_not_optimize(sum);
+            return sum;
+        });
+    };
+}
+
+TEST_CASE("Bench: perspective shape vertex projection — Square", "[bench][perspective]") {
+    BENCHMARK_ADVANCED("4-vertex trapezoid (project only)")(Catch::Benchmark::Chronometer meter) {
+        meter.measure([&] {
+            float sum = 0.0f;
+            float half = 32.0f;
+            float cx = 360.0f, cy = 500.0f;
+            for (int i = 0; i < 4; ++i) {
+                Vector2 v = perspective::project(
+                    cx + shape_verts::SQUARE[i].x * half,
+                    cy + shape_verts::SQUARE[i].y * half);
+                sum += v.x;
+            }
+            do_not_optimize(sum);
+            return sum;
+        });
+    };
+}
+
+TEST_CASE("Bench: perspective shape vertex projection — Triangle", "[bench][perspective]") {
+    BENCHMARK_ADVANCED("3-vertex triangle (project only)")(Catch::Benchmark::Chronometer meter) {
+        meter.measure([&] {
+            float sum = 0.0f;
+            float half = 32.0f;
+            float cx = 360.0f, cy = 500.0f;
+            for (int i = 0; i < 3; ++i) {
+                Vector2 v = perspective::project(
+                    cx + shape_verts::TRIANGLE[i].x * half,
+                    cy + shape_verts::TRIANGLE[i].y * half);
+                sum += v.x;
+            }
+            do_not_optimize(sum);
+            return sum;
+        });
+    };
+}
+
+TEST_CASE("Bench: perspective shape vertex projection — Hexagon", "[bench][perspective]") {
+    BENCHMARK_ADVANCED("6-segment fan (project only)")(Catch::Benchmark::Chronometer meter) {
+        meter.measure([&] {
+            float sum = 0.0f;
+            float radius = 64.0f * 0.6f;
+            float cx = 360.0f, cy = 500.0f;
+            Vector2 centre = perspective::project(cx, cy);
+            sum += centre.x;
+            for (int i = 0; i < shape_verts::HEX_SEGMENTS; ++i) {
+                int next = (i + 1) % shape_verts::HEX_SEGMENTS;
+                Vector2 v1 = perspective::project(
+                    cx + shape_verts::HEXAGON[i].x * radius,
+                    cy + shape_verts::HEXAGON[i].y * radius);
+                Vector2 v2 = perspective::project(
+                    cx + shape_verts::HEXAGON[next].x * radius,
+                    cy + shape_verts::HEXAGON[next].y * radius);
+                sum += v1.x + v2.x;
+            }
+            do_not_optimize(sum);
+            return sum;
+        });
+    };
+}
+
+TEST_CASE("Bench: perspective rect projection (obstacle trapezoid)", "[bench][perspective]") {
+    BENCHMARK_ADVANCED("full-width bar (4 projects)")(Catch::Benchmark::Chronometer meter) {
+        meter.measure([&] {
+            Vector2 tl = perspective::project(0.0f, 300.0f);
+            Vector2 tr = perspective::project(720.0f, 300.0f);
+            Vector2 bl = perspective::project(0.0f, 320.0f);
+            Vector2 br = perspective::project(720.0f, 320.0f);
+            float sum = tl.x + tr.x + bl.x + br.x;
+            do_not_optimize(sum);
+            return sum;
+        });
+    };
+}
+
+TEST_CASE("Bench: perspective line projection", "[bench][perspective]") {
+    BENCHMARK_ADVANCED("floor connector (2 projects)")(Catch::Benchmark::Chronometer meter) {
+        meter.measure([&] {
+            Vector2 a = perspective::project(180.0f, 100.0f);
+            Vector2 b = perspective::project(180.0f, 150.0f);
+            float sum = a.x + b.x;
+            do_not_optimize(sum);
+            return sum;
+        });
+    };
+}
+
+TEST_CASE("Bench: floor shape initialisation (flat draw at projected pos)", "[bench][perspective]") {
+    BENCHMARK_ADVANCED("3 lanes × 21 shapes (project + depth scale)")(Catch::Benchmark::Chronometer meter) {
+        meter.measure([&] {
+            float sum = 0.0f;
+            constexpr float vp_y  = constants::VANISHING_POINT_Y;
+            constexpr float range = static_cast<float>(constants::SCREEN_H) - vp_y;
+            float size = constants::FLOOR_SHAPE_SIZE;
+            float half = size / 2.0f;
+
+            for (int lane = 0; lane < 3; ++lane) {
+                float cx = constants::LANE_X[lane];
+                for (int j = 0; j < constants::FLOOR_SHAPE_COUNT; ++j) {
+                    float cy = constants::FLOOR_Y_START
+                        + static_cast<float>(j) * constants::FLOOR_SHAPE_SPACING;
+
+                    Vector2 pc = perspective::project(cx, cy);
+                    float depth = (cy - vp_y) / range;
+                    if (depth < 0.01f) depth = 0.01f;
+                    if (depth > 1.5f)  depth = 1.5f;
+                    float p_half = half * depth;
+
+                    sum += pc.x + pc.y + p_half;
+                }
+            }
+            do_not_optimize(sum);
+            return sum;
+        });
+    };
+}
+
+TEST_CASE("Bench: typical obstacle batch projection", "[bench][perspective]") {
+    BENCHMARK_ADVANCED("10 obstacles (project vertices only)")(Catch::Benchmark::Chronometer meter) {
+        meter.measure([&] {
+            float sum = 0.0f;
+            for (int i = 0; i < 10; ++i) {
+                float y = constants::SPAWN_Y + static_cast<float>(i) * 120.0f;
+                float lx = constants::LANE_X[i % 3] - 60.0f;
+                // Rect: 4 projects
+                sum += perspective::project_x(lx, y);
+                sum += perspective::project_x(lx + 120.0f, y);
+                sum += perspective::project_x(lx, y + 80.0f);
+                sum += perspective::project_x(lx + 120.0f, y + 80.0f);
+                // Shape: project centre + vertices
+                auto shape = static_cast<Shape>(i % 3);
+                float cx = constants::LANE_X[i % 3];
+                float cy = y + 40.0f;
+                float half = 20.0f;
+                int nverts = (shape == Shape::Circle) ? 24
+                           : (shape == Shape::Hexagon) ? 6
+                           : (shape == Shape::Square) ? 4 : 3;
+                sum += perspective::project_x(cx, cy);
+                for (int v = 0; v < nverts; ++v) {
+                    sum += perspective::project_x(cx + half, cy + half);
+                }
+            }
+            do_not_optimize(sum);
+            return sum;
+        });
+    };
+}
+
+TEST_CASE("Bench: vertex table lookup vs trig (comparison)", "[bench][perspective]") {
+    BENCHMARK_ADVANCED("table lookup: 24 circle vertices")(Catch::Benchmark::Chronometer meter) {
+        meter.measure([&] {
+            float sum = 0.0f;
+            float r = 32.0f;
+            for (int i = 0; i < shape_verts::CIRCLE_SEGMENTS; ++i) {
+                float wx = 360.0f + shape_verts::CIRCLE[i].x * r;
+                float wy = 640.0f + shape_verts::CIRCLE[i].y * r;
+                sum += perspective::project_x(wx, wy);
+            }
+            do_not_optimize(sum);
+            return sum;
+        });
+    };
+
+    BENCHMARK_ADVANCED("trig: 24 circle vertices (cosf/sinf)")(Catch::Benchmark::Chronometer meter) {
+        meter.measure([&] {
+            float sum = 0.0f;
+            float r = 32.0f;
+            for (int i = 0; i < 24; ++i) {
+                float angle = static_cast<float>(i) * (2.0f * 3.14159265f / 24.0f);
+                float wx = 360.0f + cosf(angle) * r;
+                float wy = 640.0f + sinf(angle) * r;
+                sum += perspective::project_x(wx, wy);
+            }
+            do_not_optimize(sum);
+            return sum;
+        });
+    };
+}

--- a/benchmarks/bench_perspective.cpp
+++ b/benchmarks/bench_perspective.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/benchmark/catch_benchmark.hpp>
+#include <catch2/benchmark/catch_optimizer.hpp>
 
 #include "perspective.h"
 #include "shape_vertices.h"
@@ -9,16 +10,10 @@
 // Measures the hot-path costs introduced by the isometric perspective
 // system: vertex projection, shape drawing, and floor initialization.
 
-// Prevent the compiler from optimising away benchmark results
-template<typename T>
-static void do_not_optimize(T const& val) {
-    asm volatile("" : : "r,m"(val) : "memory");
-}
-
 TEST_CASE("Bench: perspective::project single vertex", "[bench][perspective]") {
     BENCHMARK("project(180, 640)") {
         auto v = perspective::project(180.0f, 640.0f);
-        do_not_optimize(v);
+        Catch::Benchmark::deoptimize_value(v);
         return v;
     };
 }
@@ -26,7 +21,7 @@ TEST_CASE("Bench: perspective::project single vertex", "[bench][perspective]") {
 TEST_CASE("Bench: perspective::project_x single vertex", "[bench][perspective]") {
     BENCHMARK("project_x(180, 640)") {
         float x = perspective::project_x(180.0f, 640.0f);
-        do_not_optimize(x);
+        Catch::Benchmark::deoptimize_value(x);
         return x;
     };
 }
@@ -43,7 +38,7 @@ TEST_CASE("Bench: project all 3 lanes at N depths", "[bench][perspective]") {
                     sum += perspective::project_x(cx, cy);
                 }
             }
-            do_not_optimize(sum);
+            Catch::Benchmark::deoptimize_value(sum);
             return sum;
         });
     };
@@ -67,7 +62,7 @@ TEST_CASE("Bench: perspective shape vertex projection — Circle", "[bench][pers
                     cy + shape_verts::CIRCLE[next].y * r);
                 sum += v1.x + v2.x;
             }
-            do_not_optimize(sum);
+            Catch::Benchmark::deoptimize_value(sum);
             return sum;
         });
     };
@@ -85,7 +80,7 @@ TEST_CASE("Bench: perspective shape vertex projection — Square", "[bench][pers
                     cy + shape_verts::SQUARE[i].y * half);
                 sum += v.x;
             }
-            do_not_optimize(sum);
+            Catch::Benchmark::deoptimize_value(sum);
             return sum;
         });
     };
@@ -103,7 +98,7 @@ TEST_CASE("Bench: perspective shape vertex projection — Triangle", "[bench][pe
                     cy + shape_verts::TRIANGLE[i].y * half);
                 sum += v.x;
             }
-            do_not_optimize(sum);
+            Catch::Benchmark::deoptimize_value(sum);
             return sum;
         });
     };
@@ -127,7 +122,7 @@ TEST_CASE("Bench: perspective shape vertex projection — Hexagon", "[bench][per
                     cy + shape_verts::HEXAGON[next].y * radius);
                 sum += v1.x + v2.x;
             }
-            do_not_optimize(sum);
+            Catch::Benchmark::deoptimize_value(sum);
             return sum;
         });
     };
@@ -141,7 +136,7 @@ TEST_CASE("Bench: perspective rect projection (obstacle trapezoid)", "[bench][pe
             Vector2 bl = perspective::project(0.0f, 320.0f);
             Vector2 br = perspective::project(720.0f, 320.0f);
             float sum = tl.x + tr.x + bl.x + br.x;
-            do_not_optimize(sum);
+            Catch::Benchmark::deoptimize_value(sum);
             return sum;
         });
     };
@@ -153,7 +148,7 @@ TEST_CASE("Bench: perspective line projection", "[bench][perspective]") {
             Vector2 a = perspective::project(180.0f, 100.0f);
             Vector2 b = perspective::project(180.0f, 150.0f);
             float sum = a.x + b.x;
-            do_not_optimize(sum);
+            Catch::Benchmark::deoptimize_value(sum);
             return sum;
         });
     };
@@ -183,7 +178,7 @@ TEST_CASE("Bench: floor shape initialisation (flat draw at projected pos)", "[be
                     sum += pc.x + pc.y + p_half;
                 }
             }
-            do_not_optimize(sum);
+            Catch::Benchmark::deoptimize_value(sum);
             return sum;
         });
     };
@@ -214,7 +209,7 @@ TEST_CASE("Bench: typical obstacle batch projection", "[bench][perspective]") {
                     sum += perspective::project_x(cx + half, cy + half);
                 }
             }
-            do_not_optimize(sum);
+            Catch::Benchmark::deoptimize_value(sum);
             return sum;
         });
     };
@@ -230,7 +225,7 @@ TEST_CASE("Bench: vertex table lookup vs trig (comparison)", "[bench][perspectiv
                 float wy = 640.0f + shape_verts::CIRCLE[i].y * r;
                 sum += perspective::project_x(wx, wy);
             }
-            do_not_optimize(sum);
+            Catch::Benchmark::deoptimize_value(sum);
             return sum;
         });
     };
@@ -245,7 +240,7 @@ TEST_CASE("Bench: vertex table lookup vs trig (comparison)", "[bench][perspectiv
                 float wy = 640.0f + sinf(angle) * r;
                 sum += perspective::project_x(wx, wy);
             }
-            do_not_optimize(sum);
+            Catch::Benchmark::deoptimize_value(sum);
             return sum;
         });
     };

--- a/design-docs/isometric-perspective.md
+++ b/design-docs/isometric-perspective.md
@@ -1,0 +1,556 @@
+# Isometric Perspective Effect — Technical Spec (Per-Vertex)
+
+## Goal
+
+Make the flat 2D game look like the player is viewing a track receding
+into the distance.  Every **vertex** of every world-space primitive is
+individually projected through the perspective math, so shapes naturally
+distort — a square becomes a trapezoid, a triangle's top vertex pulls
+inward, circles compress at the top.
+
+```
+  Current (flat)                  Target (pseudo-isometric)
+
+  ┌──────────────┐                  ╱──────────╲       ← far / narrow
+  │  ○  ■  ▲     │                 ╱  ○  ■  ▲   ╲
+  │              │                ╱              ╲
+  │              │               ╱                ╲
+  │              │              ╱                  ╲
+  │   PLAYER     │             ╱     PLAYER         ╲
+  └──────────────┘            ╱──────────────────────╲ ← near / full-width
+```
+
+The three lanes converge toward a vanishing point above the screen:
+
+```
+              * VP (y = -640, above screen)
+             ╱|╲
+            ╱ | ╲
+           ╱  |  ╲
+    y=0   ╱───┼───╲──── top of viewport
+         ╱    |    ╲
+        ╱   ○ | ■   ╲
+       ╱      |      ╲
+ y=1280╱───PLAYER───╲── bottom of viewport
+      ╱────────────────╲
+```
+
+---
+
+## Why Per-VERTEX, Not Per-Object Uniform Scale
+
+Transforming (centre, size) uniformly keeps shapes geometrically flat:
+
+```
+  Uniform scale (wrong)          Per-vertex (correct)
+
+  ┌────┐  ← same width           ╱──╲   ← top edge narrower
+  │    │     top & bottom        ╱    ╲     (vertices at smaller y
+  └────┘                        ╱──────╲    pulled closer to centre)
+
+  Square stays square.          Square becomes trapezoid.
+  Still looks flat.             Looks like a surface receding away.
+```
+
+Each vertex has its **own y-coordinate**, and therefore its own depth
+factor.  A shape spanning y=400..464 will have its top vertices more
+compressed than its bottom vertices, because the top is "further away."
+
+---
+
+## Core Principle: Project Every Vertex
+
+The single atomic operation is:
+
+```
+  project_vertex(x, y)  →  (x', y)
+
+  x' = CENTER_X + (x - CENTER_X) * depth(y)
+  y' = y                   // y is unchanged
+
+  where:
+    depth(y) = (y - VP_Y) / (SCREEN_H - VP_Y)
+```
+
+**Every point that gets handed to a raylib draw function** goes through
+this.  Not centres.  Not bounding boxes.  Individual vertices.
+
+```
+Parameters (constants.h):
+  CENTER_X  = SCREEN_W / 2.0    = 360.0
+  VP_Y      = -640.0            // vanishing point, above the screen
+  BOTTOM_Y  = SCREEN_H          = 1280.0
+```
+
+### Visual Example — Lane Positions
+
+```
+  y       depth    scale    Lane0(180)→x'   Lane1(360)→x'   Lane2(540)→x'
+  ────    ─────    ─────    ──────────────   ──────────────   ──────────────
+  -640    0.000    0.000      360 (VP)         360              360
+     0    0.333    0.333      300              360              420
+   640    0.667    0.667      240              360              480
+  1280    1.000    1.000      180              360              540
+```
+
+```
+     300  360  420       ← y=0   (top, scale=0.33)
+      :   :    :
+    240   360   480      ← y=640 (mid, scale=0.67)
+      :   :      :
+   180    360    540     ← y=1280 (bottom, scale=1.0)
+```
+
+---
+
+## Per-Shape Vertex Projection
+
+### Square (4 vertices → trapezoid)
+
+```
+  Before (flat):                After (per-vertex):
+
+  V0─────────V1                 V0'───V1'        ← both at y=cy-half
+  │          │                   ╱      ╲           (smaller depth, pulled in)
+  │   (cx)   │                  ╱        ╲
+  │          │                 ╱          ╲
+  V3─────────V2               V3'────────V2'     ← both at y=cy+half
+                                                    (larger depth, wider)
+
+  V0 = (cx-half, cy-half)  →  V0' = (proj_x(cx-half, cy-half), cy-half)
+  V1 = (cx+half, cy-half)  →  V1' = (proj_x(cx+half, cy-half), cy-half)
+  V2 = (cx+half, cy+half)  →  V2' = (proj_x(cx+half, cy+half), cy+half)
+  V3 = (cx-half, cy+half)  →  V3' = (proj_x(cx-half, cy+half), cy+half)
+
+  Draw as two triangles: (V0', V3', V1') and (V1', V3', V2')
+```
+
+### Triangle (3 vertices)
+
+```
+  Before:               After:
+
+      V0                    V0'          ← apex at cy-half
+     ╱  ╲                  ╱  ╲            (most compressed)
+    ╱    ╲               ╱      ╲
+  V1──────V2           V1'──────V2'      ← base at cy+half
+                                           (least compressed)
+
+  V0 = (cx,      cy-half)  →  V0' = (proj_x(cx,      cy-half), cy-half)
+  V1 = (cx-half, cy+half)  →  V1' = (proj_x(cx-half, cy+half), cy+half)
+  V2 = (cx+half, cy+half)  →  V2' = (proj_x(cx+half, cy+half), cy+half)
+```
+
+Triangle base stays wide, apex pulls toward centre — natural perspective.
+
+### Circle (N vertices around perimeter)
+
+```
+  Before:               After:
+
+    ╭────╮                ╭──╮           ← top vertices compressed
+   │      │              ╱    ╲
+   │      │             │      │         ← middle at cy, normal width
+   │      │              ╲    ╱
+    ╰────╯                ╰────╯         ← bottom vertices full width
+
+  For each vertex i of N segments:
+    angle = i * (2π / N)
+    vx = cx + radius * cos(angle)
+    vy = cy + radius * sin(angle)
+
+    vx' = proj_x(vx, vy)
+    vy' = vy
+
+  Draw as N triangles from (proj_x(cx, cy), cy) to consecutive edge vertices.
+```
+
+The circle becomes slightly egg-shaped / wider at the bottom — this is
+the correct perspective distortion.
+
+### Hexagon (6 vertices)
+
+Same as circle but with 6 points.  Each vertex projected independently.
+
+### Rectangle obstacles (full-width bars, lane blocks, gates)
+
+Already shown in the square example.  Each corner is a vertex with its
+own y, so top edge is narrower than bottom edge.
+
+```
+  Full-width bar at y=300, h=20:
+
+  Before:                        After:
+  ┌──────────────────────┐       ╱──────────────────╲     ← y=300
+  └──────────────────────┘       ╲────────────────────╱   ← y=320
+
+  Top-left:  proj_x(0,   300)   Top-right:  proj_x(720, 300)
+  Bot-left:  proj_x(0,   320)   Bot-right:  proj_x(720, 320)
+```
+
+---
+
+## Pre-Cached Unit Vertex Buffers
+
+**No trig at draw time.**  Every shape's vertices are pre-computed as
+`constexpr` unit-space arrays (centred at origin, radius = 1.0).  At
+draw time the hot loop is:
+
+```
+  for each unit vertex (ux, uy):
+      world_x = cx + ux * radius
+      world_y = cy + uy * radius
+      screen_x = project_x(world_x, world_y)
+      screen_y = world_y                        // y unchanged
+      → emit to DrawTriangle
+```
+
+No `cosf`, no `sinf`, no `DEG2RAD` — just multiply + add + project.
+
+### Unit vertex tables (constexpr)
+
+All centred at (0, 0), unit radius = 1.0.  Stored in `app/shape_vertices.h`.
+
+```
+  CIRCLE (24 segments):
+  ┌──────────────────────────────────────┐
+  │  i=0:  (cos(0°),     sin(0°))       │    { 1.000,  0.000 }
+  │  i=1:  (cos(15°),    sin(15°))      │    { 0.966,  0.259 }
+  │  i=2:  (cos(30°),    sin(30°))      │    { 0.866,  0.500 }
+  │  ...                                │
+  │  i=23: (cos(345°),   sin(345°))     │    { 0.966, -0.259 }
+  └──────────────────────────────────────┘
+  24 perimeter vertices.  Centre is implicit (0, 0).
+  Draw as 24 fan triangles: centre → v[i] → v[i+1 mod 24]
+
+  HEXAGON (6 segments, pointy-top, offset -90°):
+  ┌──────────────────────────────────────┐
+  │  i=0:  (cos(-90°),   sin(-90°))     │    { 0.000, -1.000 }  ← top
+  │  i=1:  (cos(-30°),   sin(-30°))     │    { 0.866, -0.500 }
+  │  i=2:  (cos(30°),    sin(30°))      │    { 0.866,  0.500 }
+  │  i=3:  (cos(90°),    sin(90°))      │    { 0.000,  1.000 }  ← bottom
+  │  i=4:  (cos(150°),   sin(150°))     │    {-0.866,  0.500 }
+  │  i=5:  (cos(210°),   sin(210°))     │    {-0.866, -0.500 }
+  └──────────────────────────────────────┘
+  6 perimeter vertices.  Radius scale = 0.6 applied at draw time.
+  Draw as 6 fan triangles: centre → v[i] → v[i+1 mod 6]
+
+  SQUARE (4 vertices, half-extent = 1.0):
+  ┌──────────────────────────────────────┐
+  │  v0 = (-1, -1)   v1 = (+1, -1)      │    top-left, top-right
+  │  v2 = (+1, +1)   v3 = (-1, +1)      │    bot-right, bot-left
+  └──────────────────────────────────────┘
+  4 vertices.  Scale by half = size / 2.
+  Draw as 2 triangles: (v0, v3, v1), (v1, v3, v2)
+
+  TRIANGLE (3 vertices, half-extent = 1.0):
+  ┌──────────────────────────────────────┐
+  │  v0 = ( 0, -1)                       │    apex
+  │  v1 = (-1, +1)                       │    base-left
+  │  v2 = (+1, +1)                       │    base-right
+  └──────────────────────────────────────┘
+  3 vertices.  Scale by half = size / 2.
+  Draw as 1 triangle: (v0, v1, v2)
+```
+
+### File: `app/shape_vertices.h`
+
+```cpp
+#pragma once
+#include <cstdint>
+
+namespace shape_verts {
+
+struct V2 { float x, y; };
+
+// ── Circle: 24 perimeter points, unit radius ────
+constexpr int CIRCLE_SEGMENTS = 24;
+constexpr V2 CIRCLE[CIRCLE_SEGMENTS] = {
+    { 1.000000f,  0.000000f}, { 0.965926f,  0.258819f},
+    { 0.866025f,  0.500000f}, { 0.707107f,  0.707107f},
+    { 0.500000f,  0.866025f}, { 0.258819f,  0.965926f},
+    { 0.000000f,  1.000000f}, {-0.258819f,  0.965926f},
+    {-0.500000f,  0.866025f}, {-0.707107f,  0.707107f},
+    {-0.866025f,  0.500000f}, {-0.965926f,  0.258819f},
+    {-1.000000f,  0.000000f}, {-0.965926f, -0.258819f},
+    {-0.866025f, -0.500000f}, {-0.707107f, -0.707107f},
+    {-0.500000f, -0.866025f}, {-0.258819f, -0.965926f},
+    { 0.000000f, -1.000000f}, { 0.258819f, -0.965926f},
+    { 0.500000f, -0.866025f}, { 0.707107f, -0.707107f},
+    { 0.866025f, -0.500000f}, { 0.965926f, -0.258819f},
+};
+
+// ── Hexagon: 6 perimeter points, pointy-top (-90° offset), unit radius ──
+constexpr int HEX_SEGMENTS = 6;
+constexpr V2 HEXAGON[HEX_SEGMENTS] = {
+    { 0.000000f, -1.000000f},  //   0° - 90° = top
+    { 0.866025f, -0.500000f},  //  60° - 90°
+    { 0.866025f,  0.500000f},  // 120° - 90°
+    { 0.000000f,  1.000000f},  // 180° - 90° = bottom
+    {-0.866025f,  0.500000f},  // 240° - 90°
+    {-0.866025f, -0.500000f},  // 300° - 90°
+};
+
+// ── Square: 4 corners, unit half-extent ─────────
+constexpr V2 SQUARE[4] = {
+    {-1.0f, -1.0f},  // top-left
+    { 1.0f, -1.0f},  // top-right
+    { 1.0f,  1.0f},  // bot-right
+    {-1.0f,  1.0f},  // bot-left
+};
+
+// ── Triangle: 3 vertices, unit half-extent ──────
+constexpr V2 TRIANGLE[3] = {
+    { 0.0f, -1.0f},  // apex
+    {-1.0f,  1.0f},  // base-left
+    { 1.0f,  1.0f},  // base-right
+};
+
+} // namespace shape_verts
+```
+
+### Draw-time hot path (perspective.cpp)
+
+Zero trig.  Just table lookup → scale → offset → project:
+
+```cpp
+void perspective::draw_shape(Shape shape, float cx, float cy,
+                             float size, Color c) {
+    switch (shape) {
+        case Shape::Circle: {
+            float r = size / 2.0f;
+            Vector2 center = project(cx, cy);
+            for (int i = 0; i < shape_verts::CIRCLE_SEGMENTS; ++i) {
+                int j = (i + 1) % shape_verts::CIRCLE_SEGMENTS;
+                // Lookup unit vertex, scale, offset — no trig
+                float wx1 = cx + shape_verts::CIRCLE[i].x * r;
+                float wy1 = cy + shape_verts::CIRCLE[i].y * r;
+                float wx2 = cx + shape_verts::CIRCLE[j].x * r;
+                float wy2 = cy + shape_verts::CIRCLE[j].y * r;
+                // Project each vertex at its own y
+                Vector2 p1 = project(wx1, wy1);
+                Vector2 p2 = project(wx2, wy2);
+                DrawTriangle(center, p2, p1, c);
+            }
+            break;
+        }
+        case Shape::Hexagon: {
+            float r = size * 0.6f;
+            Vector2 center = project(cx, cy);
+            for (int i = 0; i < shape_verts::HEX_SEGMENTS; ++i) {
+                int j = (i + 1) % shape_verts::HEX_SEGMENTS;
+                float wx1 = cx + shape_verts::HEXAGON[i].x * r;
+                float wy1 = cy + shape_verts::HEXAGON[i].y * r;
+                float wx2 = cx + shape_verts::HEXAGON[j].x * r;
+                float wy2 = cy + shape_verts::HEXAGON[j].y * r;
+                Vector2 p1 = project(wx1, wy1);
+                Vector2 p2 = project(wx2, wy2);
+                DrawTriangle(center, p2, p1, c);
+            }
+            break;
+        }
+        case Shape::Square: {
+            float half = size / 2.0f;
+            Vector2 v[4];
+            for (int i = 0; i < 4; ++i) {
+                float wx = cx + shape_verts::SQUARE[i].x * half;
+                float wy = cy + shape_verts::SQUARE[i].y * half;
+                v[i] = project(wx, wy);
+            }
+            // TL(0), BL(3), TR(1) then TR(1), BL(3), BR(2)
+            DrawTriangle(v[0], v[3], v[1], c);
+            DrawTriangle(v[1], v[3], v[2], c);
+            break;
+        }
+        case Shape::Triangle: {
+            float half = size / 2.0f;
+            Vector2 v[3];
+            for (int i = 0; i < 3; ++i) {
+                float wx = cx + shape_verts::TRIANGLE[i].x * half;
+                float wy = cy + shape_verts::TRIANGLE[i].y * half;
+                v[i] = project(wx, wy);
+            }
+            DrawTriangle(v[0], v[1], v[2], c);
+            break;
+        }
+    }
+}
+```
+
+### Performance comparison
+
+```
+  Before (trig at draw time):           After (cached vertices):
+  ┌──────────────────────────┐          ┌──────────────────────────┐
+  │  per circle:             │          │  per circle:             │
+  │    24× cosf()  = 24 trig│          │    24× table[i].x * r   │
+  │    24× sinf()  = 24 trig│          │    24× table[i].y * r   │
+  │    total: 48 trig calls  │          │    total: 0 trig calls   │
+  │                          │          │    48 mul + 48 add       │
+  │  per hexagon:            │          │  per hexagon:            │
+  │    12 trig calls         │          │    0 trig calls          │
+  └──────────────────────────┘          └──────────────────────────┘
+```
+
+---
+
+## Implementation Structure
+
+### New file: `app/shape_vertices.h`
+
+Pre-cached constexpr unit vertex tables (shown above).
+
+### New file: `app/perspective.h`
+
+Pure helper — no game logic, no registry access:
+
+```cpp
+#pragma once
+#include "constants.h"
+#include <raylib.h>
+
+namespace perspective {
+
+// Project a single vertex: x is warped toward centre based on y-depth.
+// y is unchanged.
+inline Vector2 project(float x, float y) {
+    constexpr float center = constants::SCREEN_W / 2.0f;
+    constexpr float vp_y   = constants::VANISHING_POINT_Y;
+    constexpr float range  = static_cast<float>(constants::SCREEN_H) - vp_y;
+
+    float depth = (y - vp_y) / range;
+    if (depth < 0.01f) depth = 0.01f;
+    if (depth > 1.5f)  depth = 1.5f;
+
+    return { center + (x - center) * depth, y };
+}
+
+// Convenience: project just the x component
+inline float project_x(float x, float y) {
+    return project(x, y).x;
+}
+
+// ── Perspective shape drawing (all vertices projected) ──────
+
+// Replaces DrawRectangleRec — draws a trapezoid with 4 projected vertices
+void draw_rect(float x, float y, float w, float h, Color c);
+
+// Replaces draw_shape — reads from cached vertex tables, projects per-vertex
+void draw_shape(Shape shape, float cx, float cy, float size, Color c);
+
+// Replaces DrawLineEx — both endpoints projected
+void draw_line(float x1, float y1, float x2, float y2, float thick, Color c);
+
+// Replaces DrawRing — ring outline with projected vertices from circle table
+void draw_ring(float cx, float cy, float inner_r, float outer_r,
+               int segments, Color c);
+
+// Replaces DrawRectangleLinesEx — outline trapezoid, 4 projected edges
+void draw_rect_lines(float x, float y, float w, float h, float thick, Color c);
+
+// Replaces DrawTriangleLines — outline triangle, 3 projected vertices
+void draw_tri_lines(Vector2 v1, Vector2 v2, Vector2 v3, Color c);
+
+} // namespace perspective
+```
+
+### New file: `app/perspective.cpp`
+
+Uses `shape_vertices.h` tables — zero trig at draw time.
+Full implementation shown in the "Draw-time hot path" section above.
+
+### Constants to add: `app/constants.h`
+
+```cpp
+// ── Perspective / Isometric Effect ───────────────
+constexpr float VANISHING_POINT_Y  = -640.0f;   // above screen
+// depth(y) = (y - VP_Y) / (SCREEN_H - VP_Y)
+// At y=0:    depth = 640/1920 ≈ 0.33  (top 1/3 scale)
+// At y=1280: depth = 1920/1920 = 1.0  (full scale)
+```
+
+---
+
+## Render System Changes
+
+### Pattern: replace ALL world-space draws
+
+Every raylib draw call between `BeginMode2D` / `EndMode2D` is replaced
+with its `perspective::` equivalent.  The new functions handle vertex
+projection internally.
+
+| Before | After |
+|---|---|
+| `draw_shape(shape, cx, cy, size, c)` | `perspective::draw_shape(shape, cx, cy, size, c)` |
+| `DrawRectangleRec({x, y, w, h}, c)` | `perspective::draw_rect(x, y, w, h, c)` |
+| `DrawLineEx({x1,y1}, {x2,y2}, t, c)` | `perspective::draw_line(x1, y1, x2, y2, t, c)` |
+| `DrawRing({cx,cy}, r1, r2, ...)` | `perspective::draw_ring(cx, cy, r1, r2, segs, c)` |
+| `DrawRectangleLinesEx({x,y,w,h}, t, c)` | `perspective::draw_rect_lines(x, y, w, h, t, c)` |
+| `DrawTriangleLines(v1, v3, v2, c)` | `perspective::draw_tri_lines(v1, v3, v2, c)` |
+
+The old `static draw_shape()` function at the top of render_system.cpp is
+replaced entirely by `perspective::draw_shape()`.
+
+### NOT transformed (viewport-space, lines 590–618)
+
+- HUD (score, buttons, burnout bar, approach rings)
+- Title screen, Level select
+- Overlays (game over, song complete, paused)
+- Input zones
+
+---
+
+## Input & Collision
+
+**No changes needed.**
+
+- Collision operates in logical space (Position components) — unaffected.
+- HUD buttons are in viewport space — unaffected.
+- Swipe gestures are direction-based — unaffected.
+
+---
+
+## Edge Cases
+
+1. **Objects above y=0** (SPAWN_Y = -120): depth ≈ 0.27, very compressed.
+   They grow as they scroll down — natural "approaching" feel.
+
+2. **Player at y=920**: depth ≈ 0.81.  Player shape is slightly compressed
+   at the top edge, wider at the bottom.  Acceptable.  Could clamp to 1.0
+   if undesired.
+
+3. **Lane connecting lines**: Each endpoint projected at its own y, so
+   lines angle inward toward the vanishing point — this IS the desired
+   converging-lane effect.
+
+4. **Circle at top of screen**: Becomes egg-shaped (wider bottom, narrower
+   top) — correct perspective for a circle on a receding surface.
+
+5. **DrawRing for lane floor circles**: Must be rebuilt as projected
+   triangles (inner/outer radius vertices each projected).  The existing
+   `DrawRing` call won't work since it can't per-vertex project.
+
+---
+
+## Testing
+
+- Existing unit tests: unaffected (they test gameplay logic, not rendering)
+- Visual verification: set VP_Y to -99999 (≈flat) to revert to current look
+- Lane convergence: floor shapes should form three converging columns
+- Shape fidelity: squares become trapezoids, triangles taper naturally
+
+---
+
+## File Changes Summary
+
+| File | Change |
+|---|---|
+| `app/constants.h` | Add `VANISHING_POINT_Y` constant |
+| `app/shape_vertices.h` | **New** — `constexpr` unit vertex tables for all shapes (zero runtime trig) |
+| `app/perspective.h` | **New** — `project()`, all perspective draw function declarations |
+| `app/perspective.cpp` | **New** — per-vertex draw implementations using cached vertex tables |
+| `app/systems/render_system.cpp` | Replace all world-space draw calls with `perspective::` calls |
+| `CMakeLists.txt` | Add `perspective.cpp` to sources |
+
+No changes to: ECS components, game logic systems, input system, collision,
+scoring, HUD, overlays, or menus.

--- a/design-docs/isometric-perspective.md
+++ b/design-docs/isometric-perspective.md
@@ -23,7 +23,7 @@ inward, circles compress at the top.
 The three lanes converge toward a vanishing point above the screen:
 
 ```
-              * VP (y = -640, above screen)
+              * VP (y = -1060, above screen)
              ╱|╲
             ╱ | ╲
            ╱  |  ╲
@@ -78,7 +78,7 @@ this.  Not centres.  Not bounding boxes.  Individual vertices.
 ```
 Parameters (constants.h):
   CENTER_X  = SCREEN_W / 2.0    = 360.0
-  VP_Y      = -640.0            // vanishing point, above the screen
+  VP_Y      = -1060.0           // vanishing point, above the screen (~17° convergence)
   BOTTOM_Y  = SCREEN_H          = 1280.0
 ```
 
@@ -87,16 +87,16 @@ Parameters (constants.h):
 ```
   y       depth    scale    Lane0(180)→x'   Lane1(360)→x'   Lane2(540)→x'
   ────    ─────    ─────    ──────────────   ──────────────   ──────────────
-  -640    0.000    0.000      360 (VP)         360              360
-     0    0.333    0.333      300              360              420
-   640    0.667    0.667      240              360              480
+ -1060    0.000    0.000      360 (VP)         360              360
+     0    0.453    0.453      279              360              441
+   640    0.726    0.726      229              360              491
   1280    1.000    1.000      180              360              540
 ```
 
 ```
-     300  360  420       ← y=0   (top, scale=0.33)
+     279  360  441       ← y=0   (top, scale=0.45)
       :   :    :
-    240   360   480      ← y=640 (mid, scale=0.67)
+    229   360   491      ← y=640 (mid, scale=0.73)
       :   :      :
    180    360    540     ← y=1280 (bottom, scale=1.0)
 ```
@@ -463,10 +463,11 @@ Full implementation shown in the "Draw-time hot path" section above.
 
 ```cpp
 // ── Perspective / Isometric Effect ───────────────
-constexpr float VANISHING_POINT_Y  = -640.0f;   // above screen
+constexpr float PERSPECTIVE_ANGLE_DEG = 17.0f;    // full convergence angle
+// VP_Y is derived at compile time from PERSPECTIVE_ANGLE_DEG (~17° → -1060)
 // depth(y) = (y - VP_Y) / (SCREEN_H - VP_Y)
-// At y=0:    depth = 640/1920 ≈ 0.33  (top 1/3 scale)
-// At y=1280: depth = 1920/1920 = 1.0  (full scale)
+// At y=0:    depth ≈ 0.453  (top ~45% scale)
+// At y=1280: depth = 1.0    (full scale)
 ```
 
 ---

--- a/tests/test_level_select_system.cpp
+++ b/tests/test_level_select_system.cpp
@@ -1,0 +1,296 @@
+#include <catch2/catch_test_macros.hpp>
+#include "test_helpers.h"
+
+// ── Helper: set up registry in LevelSelect phase ─────────────────────
+static entt::registry make_level_select_registry() {
+    auto reg = make_registry();
+    reg.ctx().get<GameState>().phase = GamePhase::LevelSelect;
+    return reg;
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase guard
+// ═══════════════════════════════════════════════════════════════════════
+
+TEST_CASE("level_select — phase guard: does nothing when not LevelSelect",
+          "[level_select]") {
+    auto reg = make_registry();
+    auto& gs  = reg.ctx().get<GameState>();
+    gs.phase  = GamePhase::Playing;          // NOT LevelSelect
+    auto& lss = reg.ctx().get<LevelSelectState>();
+    lss.selected_level = 0;
+
+    auto& input  = reg.ctx().get<InputState>();
+    input.touch_up = true;
+    input.end_x    = 360.0f;
+    input.end_y    = 490.0f;                 // would hit card 1 if active
+
+    level_select_system(reg, 0.016f);
+    REQUIRE(lss.selected_level == 0);        // unchanged
+    REQUIRE(lss.selected_difficulty == 1);   // unchanged
+    REQUIRE_FALSE(lss.confirmed);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// No input → no change
+// ═══════════════════════════════════════════════════════════════════════
+
+TEST_CASE("level_select — no input: state unchanged", "[level_select]") {
+    auto reg  = make_level_select_registry();
+    auto& lss = reg.ctx().get<LevelSelectState>();
+
+    // No touch_up, no keys — defaults are all false/zero
+    level_select_system(reg, 0.016f);
+
+    CHECK(lss.selected_level == 0);
+    CHECK(lss.selected_difficulty == 1);
+    CHECK_FALSE(lss.confirmed);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Touch — card selection
+// ═══════════════════════════════════════════════════════════════════════
+
+TEST_CASE("level_select — touch card 0", "[level_select]") {
+    auto reg    = make_level_select_registry();
+    auto& input = reg.ctx().get<InputState>();
+    auto& lss   = reg.ctx().get<LevelSelectState>();
+    lss.selected_level = 1;                  // start elsewhere
+
+    input.touch_up = true;
+    input.end_x    = 360.0f;
+    input.end_y    = 250.0f;                 // card 0: y ∈ [200, 400]
+
+    level_select_system(reg, 0.016f);
+    REQUIRE(lss.selected_level == 0);
+}
+
+TEST_CASE("level_select — touch card 1", "[level_select]") {
+    auto reg    = make_level_select_registry();
+    auto& input = reg.ctx().get<InputState>();
+    auto& lss   = reg.ctx().get<LevelSelectState>();
+
+    input.touch_up = true;
+    input.end_x    = 360.0f;
+    input.end_y    = 490.0f;                 // card 1: y ∈ [440, 640]
+
+    level_select_system(reg, 0.016f);
+    REQUIRE(lss.selected_level == 1);
+}
+
+TEST_CASE("level_select — touch card 2", "[level_select]") {
+    auto reg    = make_level_select_registry();
+    auto& input = reg.ctx().get<InputState>();
+    auto& lss   = reg.ctx().get<LevelSelectState>();
+
+    input.touch_up = true;
+    input.end_x    = 360.0f;
+    input.end_y    = 730.0f;                 // card 2: y ∈ [680, 880]
+
+    level_select_system(reg, 0.016f);
+    REQUIRE(lss.selected_level == 2);
+}
+
+TEST_CASE("level_select — touch outside cards: no change", "[level_select]") {
+    auto reg    = make_level_select_registry();
+    auto& input = reg.ctx().get<InputState>();
+    auto& lss   = reg.ctx().get<LevelSelectState>();
+
+    input.touch_up = true;
+    input.end_x    = 30.0f;                  // x < 60 → outside card bounds
+    input.end_y    = 300.0f;
+
+    level_select_system(reg, 0.016f);
+    CHECK(lss.selected_level == 0);          // unchanged
+    CHECK(lss.selected_difficulty == 1);     // unchanged
+    CHECK_FALSE(lss.confirmed);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Touch — difficulty button selection
+//   With selected_level = 0:  card_y = 200,  diff_y = 320
+//   btn0 (easy):   x ∈ [90, 270],  y ∈ [310, 380]   (incl. 10px pad)
+//   btn1 (medium): x ∈ [270, 450], y ∈ [310, 380]
+//   btn2 (hard):   x ∈ [450, 630], y ∈ [310, 380]
+// ═══════════════════════════════════════════════════════════════════════
+
+TEST_CASE("level_select — touch difficulty easy", "[level_select]") {
+    auto reg    = make_level_select_registry();
+    auto& input = reg.ctx().get<InputState>();
+    auto& lss   = reg.ctx().get<LevelSelectState>();
+    lss.selected_level = 0;
+
+    input.touch_up = true;
+    input.end_x    = 180.0f;                 // btn0: x ∈ [90, 270]
+    input.end_y    = 340.0f;                 // diff_y region: y ∈ [310, 380]
+
+    level_select_system(reg, 0.016f);
+    REQUIRE(lss.selected_difficulty == 0);
+}
+
+TEST_CASE("level_select — touch difficulty medium", "[level_select]") {
+    auto reg    = make_level_select_registry();
+    auto& input = reg.ctx().get<InputState>();
+    auto& lss   = reg.ctx().get<LevelSelectState>();
+    lss.selected_level      = 0;
+    lss.selected_difficulty = 0;             // start at easy
+
+    input.touch_up = true;
+    input.end_x    = 360.0f;                 // btn1: x ∈ [270, 450]
+    input.end_y    = 340.0f;
+
+    level_select_system(reg, 0.016f);
+    REQUIRE(lss.selected_difficulty == 1);
+}
+
+TEST_CASE("level_select — touch difficulty hard", "[level_select]") {
+    auto reg    = make_level_select_registry();
+    auto& input = reg.ctx().get<InputState>();
+    auto& lss   = reg.ctx().get<LevelSelectState>();
+    lss.selected_level = 0;
+
+    input.touch_up = true;
+    input.end_x    = 540.0f;                 // btn2: x ∈ [450, 630]
+    input.end_y    = 340.0f;
+
+    level_select_system(reg, 0.016f);
+    REQUIRE(lss.selected_difficulty == 2);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Touch — START button
+//   x ∈ [200, 520], y ∈ [1040, 1120]  (incl. 10px pad)
+// ═══════════════════════════════════════════════════════════════════════
+
+TEST_CASE("level_select — touch START button confirms", "[level_select]") {
+    auto reg    = make_level_select_registry();
+    auto& input = reg.ctx().get<InputState>();
+    auto& lss   = reg.ctx().get<LevelSelectState>();
+
+    input.touch_up = true;
+    input.end_x    = 360.0f;                 // center of START
+    input.end_y    = 1080.0f;                // middle of START y-range
+
+    level_select_system(reg, 0.016f);
+    REQUIRE(lss.confirmed);
+}
+
+TEST_CASE("level_select — touch outside START button: no confirm",
+          "[level_select]") {
+    auto reg    = make_level_select_registry();
+    auto& input = reg.ctx().get<InputState>();
+    auto& lss   = reg.ctx().get<LevelSelectState>();
+
+    input.touch_up = true;
+    input.end_x    = 360.0f;
+    input.end_y    = 1200.0f;                // below START (y > 1120)
+
+    level_select_system(reg, 0.016f);
+    REQUIRE_FALSE(lss.confirmed);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Keyboard navigation (desktop / web only)
+// ═══════════════════════════════════════════════════════════════════════
+
+#ifdef PLATFORM_HAS_KEYBOARD
+
+TEST_CASE("level_select — key W cycles level up", "[level_select][keyboard]") {
+    auto reg    = make_level_select_registry();
+    auto& input = reg.ctx().get<InputState>();
+    auto& lss   = reg.ctx().get<LevelSelectState>();
+    lss.selected_level = 1;
+
+    input.key_w = true;
+    level_select_system(reg, 0.016f);
+    REQUIRE(lss.selected_level == 0);        // 1 → 0
+}
+
+TEST_CASE("level_select — key S cycles level down", "[level_select][keyboard]") {
+    auto reg    = make_level_select_registry();
+    auto& input = reg.ctx().get<InputState>();
+    auto& lss   = reg.ctx().get<LevelSelectState>();
+    lss.selected_level = 0;
+
+    input.key_s = true;
+    level_select_system(reg, 0.016f);
+    REQUIRE(lss.selected_level == 1);        // 0 → 1
+}
+
+TEST_CASE("level_select — key A cycles difficulty left", "[level_select][keyboard]") {
+    auto reg    = make_level_select_registry();
+    auto& input = reg.ctx().get<InputState>();
+    auto& lss   = reg.ctx().get<LevelSelectState>();
+    // default selected_difficulty = 1 (medium)
+
+    input.key_a = true;
+    level_select_system(reg, 0.016f);
+    REQUIRE(lss.selected_difficulty == 0);   // 1 → 0
+}
+
+TEST_CASE("level_select — key D cycles difficulty right", "[level_select][keyboard]") {
+    auto reg    = make_level_select_registry();
+    auto& input = reg.ctx().get<InputState>();
+    auto& lss   = reg.ctx().get<LevelSelectState>();
+    // default selected_difficulty = 1 (medium)
+
+    input.key_d = true;
+    level_select_system(reg, 0.016f);
+    REQUIRE(lss.selected_difficulty == 2);   // 1 → 2
+}
+
+TEST_CASE("level_select — key Enter confirms", "[level_select][keyboard]") {
+    auto reg    = make_level_select_registry();
+    auto& input = reg.ctx().get<InputState>();
+    auto& lss   = reg.ctx().get<LevelSelectState>();
+
+    input.key_enter = true;
+    level_select_system(reg, 0.016f);
+    REQUIRE(lss.confirmed);
+}
+
+TEST_CASE("level_select — key W wraps level 0 → 2", "[level_select][keyboard]") {
+    auto reg    = make_level_select_registry();
+    auto& input = reg.ctx().get<InputState>();
+    auto& lss   = reg.ctx().get<LevelSelectState>();
+    lss.selected_level = 0;
+
+    input.key_w = true;
+    level_select_system(reg, 0.016f);
+    REQUIRE(lss.selected_level == 2);        // (0 - 1 + 3) % 3 = 2
+}
+
+TEST_CASE("level_select — key S wraps level 2 → 0", "[level_select][keyboard]") {
+    auto reg    = make_level_select_registry();
+    auto& input = reg.ctx().get<InputState>();
+    auto& lss   = reg.ctx().get<LevelSelectState>();
+    lss.selected_level = 2;
+
+    input.key_s = true;
+    level_select_system(reg, 0.016f);
+    REQUIRE(lss.selected_level == 0);        // (2 + 1) % 3 = 0
+}
+
+TEST_CASE("level_select — key A wraps difficulty 0 → 2", "[level_select][keyboard]") {
+    auto reg    = make_level_select_registry();
+    auto& input = reg.ctx().get<InputState>();
+    auto& lss   = reg.ctx().get<LevelSelectState>();
+    lss.selected_difficulty = 0;
+
+    input.key_a = true;
+    level_select_system(reg, 0.016f);
+    REQUIRE(lss.selected_difficulty == 2);   // (0 - 1 + 3) % 3 = 2
+}
+
+TEST_CASE("level_select — key D wraps difficulty 2 → 0", "[level_select][keyboard]") {
+    auto reg    = make_level_select_registry();
+    auto& input = reg.ctx().get<InputState>();
+    auto& lss   = reg.ctx().get<LevelSelectState>();
+    lss.selected_difficulty = 2;
+
+    input.key_d = true;
+    level_select_system(reg, 0.016f);
+    REQUIRE(lss.selected_difficulty == 0);   // (2 + 1) % 3 = 0
+}
+
+#endif // PLATFORM_HAS_KEYBOARD

--- a/tests/test_perspective.cpp
+++ b/tests/test_perspective.cpp
@@ -370,3 +370,114 @@ TEST_CASE("shape_verts::TRIANGLE — exact vertices", "[shape_verts]") {
 TEST_CASE("shape_verts::TRIANGLE — table size is 3", "[shape_verts]") {
     static_assert(sizeof(shape_verts::TRIANGLE) / sizeof(shape_verts::V2) == 3);
 }
+
+// ═════════════════════════════════════════════════════════════════════════════
+// §3  Floor geometry regression tests
+// ═════════════════════════════════════════════════════════════════════════════
+// These tests verify invariants of the floor rendering pipeline that have
+// broken in the past (connector-to-shape edge alignment, shape visibility).
+
+TEST_CASE("floor: connector endpoints match depth-scaled shape edges", "[floor][regression]") {
+    // The connector between floor shape j and j+1 must start at the
+    // bottom edge of shape j (cy + half*depth) and end at the top edge
+    // of shape j+1 (next_cy - half*next_depth).
+    //
+    // BUG HISTORY: connectors used un-scaled fp.half instead of
+    // depth-scaled p_half, causing gaps at the top of the screen.
+
+    constexpr float half = constants::FLOOR_SHAPE_SIZE / 2.0f;
+
+    for (int j = 0; j < constants::FLOOR_SHAPE_COUNT - 1; ++j) {
+        float cy = constants::FLOOR_Y_START
+            + static_cast<float>(j) * constants::FLOOR_SHAPE_SPACING;
+        float next_cy = cy + constants::FLOOR_SHAPE_SPACING;
+
+        float d      = perspective::depth(cy);
+        float next_d = perspective::depth(next_cy);
+
+        float shape_bottom_edge = cy + half * d;
+        float next_shape_top_edge = next_cy - half * next_d;
+
+        // Connector must span from shape_bottom_edge to next_shape_top_edge.
+        // The gap must be non-negative (shapes don't overlap).
+        INFO("j=" << j << " cy=" << cy << " shape_bottom=" << shape_bottom_edge
+             << " next_top=" << next_shape_top_edge);
+        CHECK(next_shape_top_edge >= shape_bottom_edge);
+    }
+}
+
+TEST_CASE("floor: all shapes within visible screen bounds", "[floor][regression]") {
+    // Every floor shape centre, after perspective projection, must be
+    // within the render texture (0..SCREEN_W x 0..SCREEN_H).
+
+    constexpr float half = constants::FLOOR_SHAPE_SIZE / 2.0f;
+
+    for (int lane = 0; lane < constants::LANE_COUNT; ++lane) {
+        float cx = constants::LANE_X[lane];
+        for (int j = 0; j < constants::FLOOR_SHAPE_COUNT; ++j) {
+            float cy = constants::FLOOR_Y_START
+                + static_cast<float>(j) * constants::FLOOR_SHAPE_SPACING;
+
+            float d    = perspective::depth(cy);
+            float px   = perspective::project_x(cx, cy);
+            float p_half = half * d;
+
+            INFO("lane=" << lane << " j=" << j << " px=" << px << " p_half=" << p_half);
+            // Shape centre within screen
+            CHECK(px >= 0.0f);
+            CHECK(px <= static_cast<float>(constants::SCREEN_W));
+            // Shape edges within reasonable bounds (allow small overshoot)
+            CHECK(px - p_half >= -p_half);  // left edge not wildly off-screen
+            CHECK(px + p_half <= constants::SCREEN_W + p_half);  // right edge
+        }
+    }
+}
+
+TEST_CASE("floor: depth-scaled shape size decreases toward top", "[floor][regression]") {
+    // Shapes nearer the top of the screen (lower y) must be smaller
+    // than shapes nearer the bottom (higher y).
+
+    constexpr float half = constants::FLOOR_SHAPE_SIZE / 2.0f;
+
+    for (int lane = 0; lane < constants::LANE_COUNT; ++lane) {
+        float prev_p_half = 0.0f;
+        for (int j = 0; j < constants::FLOOR_SHAPE_COUNT; ++j) {
+            float cy = constants::FLOOR_Y_START
+                + static_cast<float>(j) * constants::FLOOR_SHAPE_SPACING;
+            float d = perspective::depth(cy);
+            float p_half = half * d;
+
+            if (j > 0) {
+                INFO("lane=" << lane << " j=" << j);
+                CHECK(p_half >= prev_p_half);
+            }
+            prev_p_half = p_half;
+        }
+    }
+}
+
+TEST_CASE("floor: connector uses depth-scaled half, not flat half", "[floor][regression]") {
+    // Direct regression for the double-perspective connector bug.
+    // At the top of the screen, depth < 1.0, so depth-scaled half < flat half.
+    // If connectors used flat half, the start y would be BELOW the depth-scaled
+    // shape edge, causing visible gaps.
+
+    constexpr float half = constants::FLOOR_SHAPE_SIZE / 2.0f;
+    float cy_top = constants::FLOOR_Y_START;  // y=12, near top
+    float d_top = perspective::depth(cy_top);
+
+    // depth at top should be < 1.0 (this is what makes the bug visible)
+    REQUIRE(d_top < 1.0f);
+
+    float scaled_half = half * d_top;
+    float flat_half   = half;
+
+    // The connector start must use scaled_half, not flat_half
+    float correct_start   = cy_top + scaled_half;
+    float incorrect_start = cy_top + flat_half;
+
+    // If using flat_half, connector starts further down than the shape edge
+    CHECK(incorrect_start > correct_start);
+    // The correct start matches the actual shape edge
+    CHECK_THAT(correct_start, WithinAbs(cy_top + half * d_top, 0.001));
+}

--- a/tests/test_perspective.cpp
+++ b/tests/test_perspective.cpp
@@ -100,52 +100,51 @@ TEST_CASE("perspective::project — lateral ordering with three lanes", "[perspe
 }
 
 // ── Known values at key y positions ─────────────────────────────────────────
-// Manual depth calculations (VP_Y = VANISHING_POINT_Y, range = SCREEN_H − VP_Y):
-//   depth = (y − VP_Y) / range
-//   project_x(x, y) = 360 + (x − 360) * clamp(depth, 0.01, 1.5)
+// Known-value tests compute expected results from the actual constants so
+// they stay correct regardless of PERSPECTIVE_ANGLE_DEG / VP_Y tuning.
+
+static float expected_px(float x, float y) {
+    constexpr float center = constants::SCREEN_W / 2.0f;
+    constexpr float vp_y   = constants::VANISHING_POINT_Y;
+    constexpr float range  = static_cast<float>(constants::SCREEN_H) - vp_y;
+    float depth = (y - vp_y) / range;
+    if (depth < 0.01f) depth = 0.01f;
+    if (depth > 1.5f)  depth = 1.5f;
+    return center + (x - center) * depth;
+}
 
 TEST_CASE("perspective::project — known value at vanishing point", "[perspective]") {
-    // VP_Y = −1060; depth = (−1060 + 1060) / 2340 = 0 → clamped to 0.01
-    // project(0, VP_Y) = 360 + (0−360)*0.01 = 356.4
     constexpr float vp_y = constants::VANISHING_POINT_Y;
     Vector2 p = perspective::project(0.0f, vp_y);
+    // At VP, depth clamps to 0.01: project(0) = 360 + (0-360)*0.01 = 356.4
     CHECK_THAT(p.x, WithinAbs(356.4, 0.01));
     CHECK_THAT(p.y, WithinAbs(vp_y, 0.01));
 }
 
 TEST_CASE("perspective::project — known value at spawn y=-120", "[perspective]") {
-    // depth = (−120 + 1060) / 2340 = 940/2340 ≈ 0.4017
-    // Lane0 (x=180): 360 + (180−360)*0.4017 ≈ 287.69
     float px = perspective::project_x(180.0f, constants::SPAWN_Y);
-    CHECK_THAT(px, WithinAbs(287.69, 0.02));
+    CHECK_THAT(px, WithinAbs(expected_px(180.0f, constants::SPAWN_Y), 0.02));
 }
 
 TEST_CASE("perspective::project — known value at top of screen y=0", "[perspective]") {
-    // depth = (0 + 1060) / 2340 = 1060/2340 ≈ 0.4530
-    // Lane0: 360 + (180−360)*0.4530 ≈ 278.46
     float px = perspective::project_x(180.0f, 0.0f);
-    CHECK_THAT(px, WithinAbs(278.46, 0.01));
+    CHECK_THAT(px, WithinAbs(expected_px(180.0f, 0.0f), 0.01));
 }
 
 TEST_CASE("perspective::project — known value at mid-screen y=640", "[perspective]") {
-    // depth = (640 + 1060) / 2340 = 1700/2340 ≈ 0.7265
-    // Lane0: 360 + (180−360)*0.7265 ≈ 229.23
     float px = perspective::project_x(180.0f, 640.0f);
-    CHECK_THAT(px, WithinAbs(229.23, 0.01));
+    CHECK_THAT(px, WithinAbs(expected_px(180.0f, 640.0f), 0.01));
 }
 
 TEST_CASE("perspective::project — known value at player y=920", "[perspective]") {
-    // depth = (920 + 1060) / 2340 = 1980/2340 ≈ 0.8462
-    // Lane0: 360 + (180−360)*0.8462 ≈ 207.69
     float px = perspective::project_x(180.0f, constants::PLAYER_Y);
-    CHECK_THAT(px, WithinAbs(207.69, 0.01));
+    CHECK_THAT(px, WithinAbs(expected_px(180.0f, constants::PLAYER_Y), 0.01));
 }
 
 TEST_CASE("perspective::project — known value at bottom y=1280", "[perspective]") {
-    // depth = (1280 − VP_Y) / range = 2340/2340 = 1.0
-    // Lane0: 360 + (180−360)*1.0 = 180 (identity — no perspective shift)
+    // depth = 1.0 at bottom → Lane0: 360 + (180−360)*1.0 = 180 (identity)
     float px = perspective::project_x(180.0f, 1280.0f);
-    CHECK_THAT(px, WithinAbs(180.0, 0.01));
+    CHECK_THAT(px, WithinAbs(expected_px(180.0f, 1280.0f), 0.01));
 }
 
 // ── Clamping behaviour ──────────────────────────────────────────────────────

--- a/tests/test_perspective.cpp
+++ b/tests/test_perspective.cpp
@@ -509,3 +509,140 @@ TEST_CASE("floor ring: sub-segment count covers full circle", "[floor][regressio
                     % shape_verts::CIRCLE_SEGMENTS;
     CHECK(last_next == 0);  // closes the ring
 }
+
+// ═════════════════════════════════════════════════════════════════════════════
+// §4  Winding order regression tests
+// ═════════════════════════════════════════════════════════════════════════════
+// All triangles submitted to rlgl must be CCW (counter-clockwise).
+// CW triangles get back-face culled and are invisible.
+// In screen space (y-down), CCW winding produces a NEGATIVE cross product.
+// These tests verify correct winding for all batched geometry.
+
+static float cross2d(float ax, float ay, float bx, float by,
+                     float cx, float cy) {
+    return (bx - ax) * (cy - ay) - (by - ay) * (cx - ax);
+}
+
+TEST_CASE("winding: flat ring triangles are CCW", "[winding][regression]") {
+    // Simulate emit_flat_ring for a ring at screen centre.
+    // Both triangles of each segment must have positive cross product (CCW).
+    constexpr float px = 360.0f, cy = 500.0f;
+    constexpr float outer_r = 20.0f, inner_r = 17.0f;
+    constexpr int seg = 12;
+
+    for (int i = 0; i < seg; ++i) {
+        int idx      = (i * shape_verts::CIRCLE_SEGMENTS) / seg;
+        int next_idx = ((i + 1) * shape_verts::CIRCLE_SEGMENTS) / seg
+                       % shape_verts::CIRCLE_SEGMENTS;
+
+        float ox1 = px + shape_verts::CIRCLE[idx].x * outer_r;
+        float oy1 = cy + shape_verts::CIRCLE[idx].y * outer_r;
+        float ox2 = px + shape_verts::CIRCLE[next_idx].x * outer_r;
+        float oy2 = cy + shape_verts::CIRCLE[next_idx].y * outer_r;
+        float ix1 = px + shape_verts::CIRCLE[idx].x * inner_r;
+        float iy1 = cy + shape_verts::CIRCLE[idx].y * inner_r;
+        float ix2 = px + shape_verts::CIRCLE[next_idx].x * inner_r;
+        float iy2 = cy + shape_verts::CIRCLE[next_idx].y * inner_r;
+
+        // Triangle 1: outer1 → inner1 → outer2 (must be CCW = positive cross)
+        float cross1 = cross2d(ox1, oy1, ix1, iy1, ox2, oy2);
+        INFO("ring seg=" << i << " tri1 cross=" << cross1);
+        CHECK(cross1 < 0.0f);
+
+        // Triangle 2: inner1 → inner2 → outer2 (must be CCW = positive cross)
+        float cross2 = cross2d(ix1, iy1, ix2, iy2, ox2, oy2);
+        INFO("ring seg=" << i << " tri2 cross=" << cross2);
+        CHECK(cross2 < 0.0f);
+    }
+}
+
+TEST_CASE("winding: perspective circle fan triangles are CCW", "[winding][regression]") {
+    // Circle fan: centre → cur → prev (from emit_fan / draw_shape Circle).
+    // The circle table goes CCW, so fan triangles centre→v[i+1]→v[i]
+    // should be CCW in screen space after projection.
+    constexpr float cx = 360.0f, cy = 500.0f, r = 32.0f;
+    Vector2 centre = perspective::project(cx, cy);
+
+    Vector2 prev = perspective::project(
+        cx + shape_verts::CIRCLE[0].x * r,
+        cy + shape_verts::CIRCLE[0].y * r);
+
+    for (int i = 0; i < shape_verts::CIRCLE_SEGMENTS; ++i) {
+        int next = (i + 1) % shape_verts::CIRCLE_SEGMENTS;
+        Vector2 cur = perspective::project(
+            cx + shape_verts::CIRCLE[next].x * r,
+            cy + shape_verts::CIRCLE[next].y * r);
+
+        // Fan triangle: centre → cur → prev
+        float cross = cross2d(centre.x, centre.y, cur.x, cur.y, prev.x, prev.y);
+        INFO("circle fan i=" << i << " cross=" << cross);
+        CHECK(cross < 0.0f);
+        prev = cur;
+    }
+}
+
+TEST_CASE("winding: perspective hexagon fan triangles are CCW", "[winding][regression]") {
+    constexpr float cx = 360.0f, cy = 500.0f, radius = 64.0f * 0.6f;
+    Vector2 centre = perspective::project(cx, cy);
+
+    Vector2 prev = perspective::project(
+        cx + shape_verts::HEXAGON[0].x * radius,
+        cy + shape_verts::HEXAGON[0].y * radius);
+
+    for (int i = 0; i < shape_verts::HEX_SEGMENTS; ++i) {
+        int next = (i + 1) % shape_verts::HEX_SEGMENTS;
+        Vector2 cur = perspective::project(
+            cx + shape_verts::HEXAGON[next].x * radius,
+            cy + shape_verts::HEXAGON[next].y * radius);
+
+        float cross = cross2d(centre.x, centre.y, cur.x, cur.y, prev.x, prev.y);
+        INFO("hex fan i=" << i << " cross=" << cross);
+        CHECK(cross < 0.0f);
+        prev = cur;
+    }
+}
+
+TEST_CASE("winding: perspective square trapezoid triangles are CCW", "[winding][regression]") {
+    // Square → trapezoid: two triangles from 4 projected corners.
+    // v0=TL, v1=TR, v2=BR, v3=BL. Tris: (v0,v3,v1) and (v1,v3,v2).
+    constexpr float cx = 360.0f, cy = 500.0f, half = 32.0f;
+    Vector2 v[4];
+    for (int i = 0; i < 4; ++i)
+        v[i] = perspective::project(cx + shape_verts::SQUARE[i].x * half,
+                                    cy + shape_verts::SQUARE[i].y * half);
+
+    float cross1 = cross2d(v[0].x, v[0].y, v[3].x, v[3].y, v[1].x, v[1].y);
+    CHECK(cross1 < 0.0f);
+    float cross2 = cross2d(v[1].x, v[1].y, v[3].x, v[3].y, v[2].x, v[2].y);
+    CHECK(cross2 < 0.0f);
+}
+
+TEST_CASE("winding: perspective triangle shape is CCW", "[winding][regression]") {
+    constexpr float cx = 360.0f, cy = 500.0f, half = 32.0f;
+    Vector2 v[3];
+    for (int i = 0; i < 3; ++i)
+        v[i] = perspective::project(cx + shape_verts::TRIANGLE[i].x * half,
+                                    cy + shape_verts::TRIANGLE[i].y * half);
+
+    float cross = cross2d(v[0].x, v[0].y, v[1].x, v[1].y, v[2].x, v[2].y);
+    CHECK(cross < 0.0f);
+}
+
+TEST_CASE("winding: perspective rect (obstacle quad) triangles are CCW", "[winding][regression]") {
+    // draw_rect produces two triangles from 4 projected corners.
+    // TL→BL→TR and TR→BL→BR.
+    float d_top = perspective::depth(300.0f);
+    float d_bot = perspective::depth(320.0f);
+
+    float tl_x = perspective::CENTER + (0.0f   - perspective::CENTER) * d_top;
+    float tr_x = perspective::CENTER + (720.0f - perspective::CENTER) * d_top;
+    float bl_x = perspective::CENTER + (0.0f   - perspective::CENTER) * d_bot;
+    float br_x = perspective::CENTER + (720.0f - perspective::CENTER) * d_bot;
+
+    // Triangle 1: TL → BL → TR
+    float cross1 = cross2d(tl_x, 300.0f, bl_x, 320.0f, tr_x, 300.0f);
+    CHECK(cross1 < 0.0f);
+    // Triangle 2: TR → BL → BR
+    float cross2 = cross2d(tr_x, 300.0f, bl_x, 320.0f, br_x, 320.0f);
+    CHECK(cross2 < 0.0f);
+}

--- a/tests/test_perspective.cpp
+++ b/tests/test_perspective.cpp
@@ -1,0 +1,373 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include "perspective.h"
+#include "shape_vertices.h"
+#include "constants.h"
+#include <cmath>
+
+using Catch::Matchers::WithinAbs;
+
+// ═════════════════════════════════════════════════════════════════════════════
+// §1  perspective::project() / perspective::project_x() — projection math
+// ═════════════════════════════════════════════════════════════════════════════
+
+// ── Centre-line invariance ──────────────────────────────────────────────────
+// x = SCREEN_W / 2 = 360 must always project to x = 360 regardless of y,
+// because center + (center − center) * depth = center for any depth.
+
+TEST_CASE("perspective::project — centre-line invariance", "[perspective]") {
+    constexpr float center = constants::SCREEN_W / 2.0f;  // 360
+    constexpr float vp_y   = constants::VANISHING_POINT_Y;
+
+    for (float y : {vp_y, 0.0f, 640.0f, 1280.0f}) {
+        CAPTURE(y);
+        Vector2 p = perspective::project(center, y);
+        CHECK_THAT(p.x, WithinAbs(center, 0.01));
+    }
+}
+
+// ── Y-preservation ──────────────────────────────────────────────────────────
+// The projected y must always equal the input y (only x is scaled by depth).
+
+TEST_CASE("perspective::project — y-preservation", "[perspective]") {
+    constexpr float vp_y = constants::VANISHING_POINT_Y;
+    const float xs[] = {0.0f, 180.0f, 360.0f, 540.0f, 720.0f};
+    const float ys[] = {vp_y - 200.0f, vp_y, constants::SPAWN_Y, 0.0f,
+                        640.0f, constants::PLAYER_Y, 1280.0f, 2000.0f};
+
+    for (float x : xs) {
+        for (float y : ys) {
+            CAPTURE(x, y);
+            Vector2 p = perspective::project(x, y);
+            CHECK_THAT(p.y, WithinAbs(y, 0.01));
+        }
+    }
+}
+
+// ── Depth monotonicity ──────────────────────────────────────────────────────
+// For x ≠ 360, |project_x(x, y) − 360| must increase as y increases —
+// objects spread further from the vanishing point as they approach the camera.
+
+TEST_CASE("perspective::project — depth monotonicity (lane 0, x=180)", "[perspective]") {
+    constexpr float center = 360.0f;
+    constexpr float x      = 180.0f;  // left of centre
+
+    float prev_spread = 0.0f;
+    for (float y : {0.0f, 640.0f, 1280.0f}) {
+        float spread = std::abs(perspective::project_x(x, y) - center);
+        CAPTURE(y, spread);
+        CHECK(spread > prev_spread);
+        prev_spread = spread;
+    }
+}
+
+TEST_CASE("perspective::project — depth monotonicity (lane 2, x=540)", "[perspective]") {
+    constexpr float center = 360.0f;
+    constexpr float x      = 540.0f;  // right of centre
+
+    float prev_spread = 0.0f;
+    for (float y : {0.0f, 640.0f, 1280.0f}) {
+        float spread = std::abs(perspective::project_x(x, y) - center);
+        CAPTURE(y, spread);
+        CHECK(spread > prev_spread);
+        prev_spread = spread;
+    }
+}
+
+// ── Lateral ordering preservation ───────────────────────────────────────────
+// For x1 < x2 at the same y, project_x(x1, y) < project_x(x2, y).
+
+TEST_CASE("perspective::project — lateral ordering preservation", "[perspective]") {
+    constexpr float x1 = 180.0f;
+    constexpr float x2 = 540.0f;
+
+    for (float y : {constants::VANISHING_POINT_Y, constants::SPAWN_Y,
+                     0.0f, 640.0f, constants::PLAYER_Y, 1280.0f}) {
+        CAPTURE(y);
+        CHECK(perspective::project_x(x1, y) < perspective::project_x(x2, y));
+    }
+}
+
+TEST_CASE("perspective::project — lateral ordering with three lanes", "[perspective]") {
+    for (float y : {0.0f, 640.0f, 1280.0f}) {
+        CAPTURE(y);
+        float px0 = perspective::project_x(180.0f, y);
+        float px1 = perspective::project_x(360.0f, y);
+        float px2 = perspective::project_x(540.0f, y);
+        CHECK(px0 < px1);
+        CHECK(px1 < px2);
+    }
+}
+
+// ── Known values at key y positions ─────────────────────────────────────────
+// Manual depth calculations (VP_Y = VANISHING_POINT_Y, range = SCREEN_H − VP_Y):
+//   depth = (y − VP_Y) / range
+//   project_x(x, y) = 360 + (x − 360) * clamp(depth, 0.01, 1.5)
+
+TEST_CASE("perspective::project — known value at vanishing point", "[perspective]") {
+    // VP_Y = −1060; depth = (−1060 + 1060) / 2340 = 0 → clamped to 0.01
+    // project(0, VP_Y) = 360 + (0−360)*0.01 = 356.4
+    constexpr float vp_y = constants::VANISHING_POINT_Y;
+    Vector2 p = perspective::project(0.0f, vp_y);
+    CHECK_THAT(p.x, WithinAbs(356.4, 0.01));
+    CHECK_THAT(p.y, WithinAbs(vp_y, 0.01));
+}
+
+TEST_CASE("perspective::project — known value at spawn y=-120", "[perspective]") {
+    // depth = (−120 + 1060) / 2340 = 940/2340 ≈ 0.4017
+    // Lane0 (x=180): 360 + (180−360)*0.4017 ≈ 287.69
+    float px = perspective::project_x(180.0f, constants::SPAWN_Y);
+    CHECK_THAT(px, WithinAbs(287.69, 0.02));
+}
+
+TEST_CASE("perspective::project — known value at top of screen y=0", "[perspective]") {
+    // depth = (0 + 1060) / 2340 = 1060/2340 ≈ 0.4530
+    // Lane0: 360 + (180−360)*0.4530 ≈ 278.46
+    float px = perspective::project_x(180.0f, 0.0f);
+    CHECK_THAT(px, WithinAbs(278.46, 0.01));
+}
+
+TEST_CASE("perspective::project — known value at mid-screen y=640", "[perspective]") {
+    // depth = (640 + 1060) / 2340 = 1700/2340 ≈ 0.7265
+    // Lane0: 360 + (180−360)*0.7265 ≈ 229.23
+    float px = perspective::project_x(180.0f, 640.0f);
+    CHECK_THAT(px, WithinAbs(229.23, 0.01));
+}
+
+TEST_CASE("perspective::project — known value at player y=920", "[perspective]") {
+    // depth = (920 + 1060) / 2340 = 1980/2340 ≈ 0.8462
+    // Lane0: 360 + (180−360)*0.8462 ≈ 207.69
+    float px = perspective::project_x(180.0f, constants::PLAYER_Y);
+    CHECK_THAT(px, WithinAbs(207.69, 0.01));
+}
+
+TEST_CASE("perspective::project — known value at bottom y=1280", "[perspective]") {
+    // depth = (1280 − VP_Y) / range = 2340/2340 = 1.0
+    // Lane0: 360 + (180−360)*1.0 = 180 (identity — no perspective shift)
+    float px = perspective::project_x(180.0f, 1280.0f);
+    CHECK_THAT(px, WithinAbs(180.0, 0.01));
+}
+
+// ── Clamping behaviour ──────────────────────────────────────────────────────
+
+TEST_CASE("perspective::project — depth clamps to 0.01 above vanishing point", "[perspective]") {
+    // At y well above VP (−1060): raw depth < 0 → clamped to 0.01
+    // project(0, y) = 360 + (0−360)*0.01 = 356.4
+    constexpr float far_above = constants::VANISHING_POINT_Y - 500.0f;
+    Vector2 p = perspective::project(0.0f, far_above);
+    CHECK_THAT(p.x, WithinAbs(356.4, 0.01));
+
+    // Right edge: project(720, y) = 360 + (720−360)*0.01 = 363.6
+    Vector2 p2 = perspective::project(720.0f, far_above);
+    CHECK_THAT(p2.x, WithinAbs(363.6, 0.01));
+}
+
+TEST_CASE("perspective::project — depth clamps to 1.5 far below screen", "[perspective]") {
+    // range = SCREEN_H − VP_Y = 2340
+    // depth = 1.5 at y = VP_Y + 1.5*range = −1060 + 3510 = 2450
+    // For y >> 2450, depth clamps to 1.5
+    // project(0, 4000) = 360 + (0−360)*1.5 = −180
+    Vector2 p = perspective::project(0.0f, 4000.0f);
+    CHECK_THAT(p.x, WithinAbs(-180.0, 0.01));
+}
+
+TEST_CASE("perspective::project — depth clamp boundary at exactly 1.5", "[perspective]") {
+    // depth = 1.5 when y = VP_Y + 1.5 * range = −1060 + 3510 = 2450
+    constexpr float range = static_cast<float>(constants::SCREEN_H) - constants::VANISHING_POINT_Y;
+    constexpr float y_boundary = constants::VANISHING_POINT_Y + 1.5f * range;
+
+    // At boundary: project(0, 2450) = 360 + (0−360)*1.5 = −180
+    float px_at_boundary = perspective::project_x(0.0f, y_boundary);
+    CHECK_THAT(px_at_boundary, WithinAbs(-180.0, 0.01));
+
+    // Past boundary: same result (clamped)
+    float px_past = perspective::project_x(0.0f, y_boundary + 200.0f);
+    CHECK_THAT(px_past, WithinAbs(-180.0, 0.01));
+}
+
+// ── Lane convergence ────────────────────────────────────────────────────────
+// All three lanes converge toward x=360 as y decreases.
+
+TEST_CASE("perspective::project — lane convergence toward vanishing point", "[perspective]") {
+    auto lane_spread = [](float y) {
+        float px0 = perspective::project_x(180.0f, y);
+        float px2 = perspective::project_x(540.0f, y);
+        return px2 - px0;  // total horizontal spread
+    };
+
+    float spread_bottom = lane_spread(1280.0f);
+    float spread_mid    = lane_spread(640.0f);
+    float spread_top    = lane_spread(0.0f);
+
+    CAPTURE(spread_bottom, spread_mid, spread_top);
+    CHECK(spread_bottom > spread_mid);
+    CHECK(spread_mid    > spread_top);
+    CHECK(spread_top    > 0.0f);  // never fully converged on-screen
+}
+
+// ── Symmetry ────────────────────────────────────────────────────────────────
+// project_x(360 − d, y) and project_x(360 + d, y) must be equidistant from 360.
+
+TEST_CASE("perspective::project — symmetry about centre line", "[perspective]") {
+    constexpr float center = 360.0f;
+
+    for (float d : {90.0f, 180.0f, 360.0f}) {
+        for (float y : {0.0f, 640.0f, 920.0f, 1280.0f}) {
+            CAPTURE(d, y);
+            float left  = perspective::project_x(center - d, y);
+            float right = perspective::project_x(center + d, y);
+
+            float dist_left  = center - left;
+            float dist_right = right - center;
+            CHECK_THAT(dist_left, WithinAbs(dist_right, 0.01));
+        }
+    }
+}
+
+// ── project_x consistency ───────────────────────────────────────────────────
+// project_x(x, y) must always agree with project(x, y).x.
+
+TEST_CASE("perspective::project_x — consistent with project().x", "[perspective]") {
+    constexpr float vp_y = constants::VANISHING_POINT_Y;
+    for (float x : {0.0f, 180.0f, 360.0f, 540.0f, 720.0f}) {
+        for (float y : {vp_y - 200.0f, vp_y, 0.0f, 640.0f, 1280.0f, 4000.0f}) {
+            CAPTURE(x, y);
+            Vector2 p  = perspective::project(x, y);
+            float   px = perspective::project_x(x, y);
+            CHECK_THAT(px, WithinAbs(p.x, 1e-5));
+        }
+    }
+}
+
+
+// ═════════════════════════════════════════════════════════════════════════════
+// §2  shape_vertices.h — constexpr vertex tables
+// ═════════════════════════════════════════════════════════════════════════════
+
+// ── Circle table ────────────────────────────────────────────────────────────
+
+TEST_CASE("shape_verts::CIRCLE — table size is 24", "[shape_verts]") {
+    CHECK(shape_verts::CIRCLE_SEGMENTS == 24);
+    // Compile-time size verification via sizeof
+    static_assert(sizeof(shape_verts::CIRCLE) / sizeof(shape_verts::V2) == 24);
+}
+
+TEST_CASE("shape_verts::CIRCLE — cardinal points", "[shape_verts]") {
+    // Index 0:   0° → (1, 0)
+    CHECK_THAT(shape_verts::CIRCLE[0].x,  WithinAbs( 1.0, 1e-5));
+    CHECK_THAT(shape_verts::CIRCLE[0].y,  WithinAbs( 0.0, 1e-5));
+
+    // Index 6:  90° → (0, 1)
+    CHECK_THAT(shape_verts::CIRCLE[6].x,  WithinAbs( 0.0, 1e-5));
+    CHECK_THAT(shape_verts::CIRCLE[6].y,  WithinAbs( 1.0, 1e-5));
+
+    // Index 12: 180° → (−1, 0)
+    CHECK_THAT(shape_verts::CIRCLE[12].x, WithinAbs(-1.0, 1e-5));
+    CHECK_THAT(shape_verts::CIRCLE[12].y, WithinAbs( 0.0, 1e-5));
+
+    // Index 18: 270° → (0, −1)
+    CHECK_THAT(shape_verts::CIRCLE[18].x, WithinAbs( 0.0, 1e-5));
+    CHECK_THAT(shape_verts::CIRCLE[18].y, WithinAbs(-1.0, 1e-5));
+}
+
+TEST_CASE("shape_verts::CIRCLE — unit magnitude for all vertices", "[shape_verts]") {
+    for (int i = 0; i < shape_verts::CIRCLE_SEGMENTS; ++i) {
+        CAPTURE(i);
+        float mag_sq = shape_verts::CIRCLE[i].x * shape_verts::CIRCLE[i].x
+                     + shape_verts::CIRCLE[i].y * shape_verts::CIRCLE[i].y;
+        CHECK_THAT(mag_sq, WithinAbs(1.0, 1e-5));
+    }
+}
+
+TEST_CASE("shape_verts::CIRCLE — CCW ordering", "[shape_verts]") {
+    // Consecutive vertices should proceed counter-clockwise (increasing angle
+    // from the positive x-axis).  The cross product of consecutive edge vectors
+    // (in 2D, the z-component) must be positive for CCW winding.
+    for (int i = 0; i < shape_verts::CIRCLE_SEGMENTS; ++i) {
+        int j = (i + 1) % shape_verts::CIRCLE_SEGMENTS;
+        int k = (i + 2) % shape_verts::CIRCLE_SEGMENTS;
+
+        float ax = shape_verts::CIRCLE[j].x - shape_verts::CIRCLE[i].x;
+        float ay = shape_verts::CIRCLE[j].y - shape_verts::CIRCLE[i].y;
+        float bx = shape_verts::CIRCLE[k].x - shape_verts::CIRCLE[j].x;
+        float by = shape_verts::CIRCLE[k].y - shape_verts::CIRCLE[j].y;
+
+        float cross_z = ax * by - ay * bx;
+        CAPTURE(i, j, k, cross_z);
+        CHECK(cross_z > 0.0f);  // positive ⇒ CCW turn
+    }
+}
+
+// ── Hexagon table ───────────────────────────────────────────────────────────
+
+TEST_CASE("shape_verts::HEXAGON — table size is 6", "[shape_verts]") {
+    CHECK(shape_verts::HEX_SEGMENTS == 6);
+    static_assert(sizeof(shape_verts::HEXAGON) / sizeof(shape_verts::V2) == 6);
+}
+
+TEST_CASE("shape_verts::HEXAGON — pointy-top (vertex 0 at top)", "[shape_verts]") {
+    CHECK_THAT(shape_verts::HEXAGON[0].x, WithinAbs( 0.0, 1e-5));
+    CHECK_THAT(shape_verts::HEXAGON[0].y, WithinAbs(-1.0, 1e-5));
+}
+
+TEST_CASE("shape_verts::HEXAGON — unit magnitude for all vertices", "[shape_verts]") {
+    for (int i = 0; i < shape_verts::HEX_SEGMENTS; ++i) {
+        CAPTURE(i);
+        float mag_sq = shape_verts::HEXAGON[i].x * shape_verts::HEXAGON[i].x
+                     + shape_verts::HEXAGON[i].y * shape_verts::HEXAGON[i].y;
+        CHECK_THAT(mag_sq, WithinAbs(1.0, 1e-5));
+    }
+}
+
+TEST_CASE("shape_verts::HEXAGON — top-bottom symmetry", "[shape_verts]") {
+    // Vertex 0 is (0, −1), vertex 3 is (0, +1): mirror about x-axis.
+    CHECK_THAT(shape_verts::HEXAGON[0].x, WithinAbs( shape_verts::HEXAGON[3].x, 1e-5));
+    CHECK_THAT(shape_verts::HEXAGON[0].y, WithinAbs(-shape_verts::HEXAGON[3].y, 1e-5));
+
+    // Vertex 1 (top-right) mirrors vertex 5 (top-left) in x only
+    CHECK_THAT(shape_verts::HEXAGON[1].x, WithinAbs(-shape_verts::HEXAGON[5].x, 1e-5));
+    CHECK_THAT(shape_verts::HEXAGON[1].y, WithinAbs( shape_verts::HEXAGON[5].y, 1e-5));
+
+    // Vertex 2 (bot-right) mirrors vertex 4 (bot-left)
+    CHECK_THAT(shape_verts::HEXAGON[2].x, WithinAbs(-shape_verts::HEXAGON[4].x, 1e-5));
+    CHECK_THAT(shape_verts::HEXAGON[2].y, WithinAbs( shape_verts::HEXAGON[4].y, 1e-5));
+}
+
+// ── Square table ────────────────────────────────────────────────────────────
+
+TEST_CASE("shape_verts::SQUARE — exact corners", "[shape_verts]") {
+    // Expected order: TL, TR, BR, BL
+    CHECK(shape_verts::SQUARE[0].x == -1.0f);
+    CHECK(shape_verts::SQUARE[0].y == -1.0f);
+
+    CHECK(shape_verts::SQUARE[1].x ==  1.0f);
+    CHECK(shape_verts::SQUARE[1].y == -1.0f);
+
+    CHECK(shape_verts::SQUARE[2].x ==  1.0f);
+    CHECK(shape_verts::SQUARE[2].y ==  1.0f);
+
+    CHECK(shape_verts::SQUARE[3].x == -1.0f);
+    CHECK(shape_verts::SQUARE[3].y ==  1.0f);
+}
+
+TEST_CASE("shape_verts::SQUARE — table size is 4", "[shape_verts]") {
+    static_assert(sizeof(shape_verts::SQUARE) / sizeof(shape_verts::V2) == 4);
+}
+
+// ── Triangle table ──────────────────────────────────────────────────────────
+
+TEST_CASE("shape_verts::TRIANGLE — exact vertices", "[shape_verts]") {
+    // Apex, base-left, base-right
+    CHECK(shape_verts::TRIANGLE[0].x ==  0.0f);
+    CHECK(shape_verts::TRIANGLE[0].y == -1.0f);
+
+    CHECK(shape_verts::TRIANGLE[1].x == -1.0f);
+    CHECK(shape_verts::TRIANGLE[1].y ==  1.0f);
+
+    CHECK(shape_verts::TRIANGLE[2].x ==  1.0f);
+    CHECK(shape_verts::TRIANGLE[2].y ==  1.0f);
+}
+
+TEST_CASE("shape_verts::TRIANGLE — table size is 3", "[shape_verts]") {
+    static_assert(sizeof(shape_verts::TRIANGLE) / sizeof(shape_verts::V2) == 3);
+}

--- a/tests/test_perspective.cpp
+++ b/tests/test_perspective.cpp
@@ -481,3 +481,31 @@ TEST_CASE("floor: connector uses depth-scaled half, not flat half", "[floor][reg
     // The correct start matches the actual shape edge
     CHECK_THAT(correct_start, WithinAbs(cy_top + half * d_top, 0.001));
 }
+
+TEST_CASE("floor ring: sub-segment count covers full circle", "[floor][regression]") {
+    // BUG: When drawing a ring with segs < CIRCLE_SEGMENTS (e.g. 12 of 24),
+    // the old code iterated i=0..11 with next=(i+1)%24, only covering
+    // vertices 0-12 (top half). The bottom half was never drawn.
+    //
+    // Fix: map segment indices evenly across the full table:
+    //   idx = (i * CIRCLE_SEGMENTS) / seg
+    //
+    // Verify: for seg=12, the indices should span the full 0..23 range
+    // (every other vertex), not just 0..12.
+
+    constexpr int seg = 12;
+    int min_idx = 999, max_idx = -1;
+    for (int i = 0; i < seg; ++i) {
+        int idx = (i * shape_verts::CIRCLE_SEGMENTS) / seg;
+        if (idx < min_idx) min_idx = idx;
+        if (idx > max_idx) max_idx = idx;
+    }
+    // With even mapping, indices should cover 0, 2, 4, ..., 22
+    CHECK(min_idx == 0);
+    CHECK(max_idx == 22);  // last index before wrapping
+
+    // Also verify the "next" index wraps to 0
+    int last_next = ((seg) * shape_verts::CIRCLE_SEGMENTS) / seg
+                    % shape_verts::CIRCLE_SEGMENTS;
+    CHECK(last_next == 0);  // closes the ring
+}

--- a/tests/test_perspective.cpp
+++ b/tests/test_perspective.cpp
@@ -513,19 +513,26 @@ TEST_CASE("floor ring: sub-segment count covers full circle", "[floor][regressio
 // ═════════════════════════════════════════════════════════════════════════════
 // §4  Winding order regression tests
 // ═════════════════════════════════════════════════════════════════════════════
-// All triangles submitted to rlgl must be CCW (counter-clockwise).
-// CW triangles get back-face culled and are invisible.
-// In screen space (y-down), CCW winding produces a NEGATIVE cross product.
-// These tests verify correct winding for all batched geometry.
+// raylib calls glFrontFace(GL_CCW) — front-facing triangles must have
+// counter-clockwise vertex order.  In screen-space (y-axis points down),
+// the 2D cross product of a CCW triangle is NEGATIVE.
+//
+// GL_CCW = 0x0901 per the OpenGL spec.  We check the cross product sign
+// rather than the constant so the test works without GL headers.
+
+// Expected sign of cross(AB, AC) for a front-facing (CCW) triangle in
+// screen-space where y increases downward.
+constexpr float CCW_SIGN = -1.0f;   // GL_CCW + y-down → negative cross
 
 static float cross2d(float ax, float ay, float bx, float by,
                      float cx, float cy) {
     return (bx - ax) * (cy - ay) - (by - ay) * (cx - ax);
 }
 
+static bool is_ccw(float cross) { return cross * CCW_SIGN > 0.0f; }
+
 TEST_CASE("winding: flat ring triangles are CCW", "[winding][regression]") {
     // Simulate emit_flat_ring for a ring at screen centre.
-    // Both triangles of each segment must have positive cross product (CCW).
     constexpr float px = 360.0f, cy = 500.0f;
     constexpr float outer_r = 20.0f, inner_r = 17.0f;
     constexpr int seg = 12;
@@ -547,12 +554,12 @@ TEST_CASE("winding: flat ring triangles are CCW", "[winding][regression]") {
         // Triangle 1: outer1 → inner1 → outer2 (must be CCW = positive cross)
         float cross1 = cross2d(ox1, oy1, ix1, iy1, ox2, oy2);
         INFO("ring seg=" << i << " tri1 cross=" << cross1);
-        CHECK(cross1 < 0.0f);
+        CHECK(is_ccw(cross1));
 
         // Triangle 2: inner1 → inner2 → outer2 (must be CCW = positive cross)
         float cross2 = cross2d(ix1, iy1, ix2, iy2, ox2, oy2);
         INFO("ring seg=" << i << " tri2 cross=" << cross2);
-        CHECK(cross2 < 0.0f);
+        CHECK(is_ccw(cross2));
     }
 }
 
@@ -576,7 +583,7 @@ TEST_CASE("winding: perspective circle fan triangles are CCW", "[winding][regres
         // Fan triangle: centre → cur → prev
         float cross = cross2d(centre.x, centre.y, cur.x, cur.y, prev.x, prev.y);
         INFO("circle fan i=" << i << " cross=" << cross);
-        CHECK(cross < 0.0f);
+        CHECK(is_ccw(cross));
         prev = cur;
     }
 }
@@ -597,7 +604,7 @@ TEST_CASE("winding: perspective hexagon fan triangles are CCW", "[winding][regre
 
         float cross = cross2d(centre.x, centre.y, cur.x, cur.y, prev.x, prev.y);
         INFO("hex fan i=" << i << " cross=" << cross);
-        CHECK(cross < 0.0f);
+        CHECK(is_ccw(cross));
         prev = cur;
     }
 }
@@ -612,9 +619,9 @@ TEST_CASE("winding: perspective square trapezoid triangles are CCW", "[winding][
                                     cy + shape_verts::SQUARE[i].y * half);
 
     float cross1 = cross2d(v[0].x, v[0].y, v[3].x, v[3].y, v[1].x, v[1].y);
-    CHECK(cross1 < 0.0f);
+    CHECK(is_ccw(cross1));
     float cross2 = cross2d(v[1].x, v[1].y, v[3].x, v[3].y, v[2].x, v[2].y);
-    CHECK(cross2 < 0.0f);
+    CHECK(is_ccw(cross2));
 }
 
 TEST_CASE("winding: perspective triangle shape is CCW", "[winding][regression]") {
@@ -625,7 +632,7 @@ TEST_CASE("winding: perspective triangle shape is CCW", "[winding][regression]")
                                     cy + shape_verts::TRIANGLE[i].y * half);
 
     float cross = cross2d(v[0].x, v[0].y, v[1].x, v[1].y, v[2].x, v[2].y);
-    CHECK(cross < 0.0f);
+    CHECK(is_ccw(cross));
 }
 
 TEST_CASE("winding: perspective rect (obstacle quad) triangles are CCW", "[winding][regression]") {
@@ -641,8 +648,8 @@ TEST_CASE("winding: perspective rect (obstacle quad) triangles are CCW", "[windi
 
     // Triangle 1: TL → BL → TR
     float cross1 = cross2d(tl_x, 300.0f, bl_x, 320.0f, tr_x, 300.0f);
-    CHECK(cross1 < 0.0f);
+    CHECK(is_ccw(cross1));
     // Triangle 2: TR → BL → BR
     float cross2 = cross2d(tr_x, 300.0f, bl_x, 320.0f, br_x, 320.0f);
-    CHECK(cross2 < 0.0f);
+    CHECK(is_ccw(cross2));
 }


### PR DESCRIPTION
## Isometric Perspective Projection

Adds a per-vertex perspective projection that makes the 2D playfield look like a track receding into the distance. Objects near the top of the screen are horizontally compressed toward the centre; objects at the bottom are full-width.

### How it works

Every world-space vertex is individually projected:
```
depth(y) = (y - VP_Y) * INV_RANGE     // ~17° convergence angle
x'     = CENTER + (x - CENTER) * depth
y'     = y                            // unchanged
```

Shapes distort naturally — squares become trapezoids, circles become slightly egg-shaped, lanes converge toward a vanishing point above the screen.

### New files
| File | Purpose |
|---|---|
| `app/shape_vertices.h` | `constexpr` unit vertex tables — zero trig at runtime |
| `app/perspective.h` | `project()`, `project_x()`, `depth()` inline functions |
| `app/perspective.cpp` | Per-vertex draw functions (`draw_shape`, `draw_rect`, etc.) |
| `design-docs/isometric-perspective.md` | Technical spec |
| `tests/test_perspective.cpp` | 30 tests (205 assertions) — math properties + vertex tables |
| `tests/test_level_select_system.cpp` | 20 tests — new coverage for level select |
| `benchmarks/bench_perspective.cpp` | 12 benchmarks — all sub-nanosecond per vertex |

### Key decisions
- **Per-vertex, not post-process** — shapes stay crisp; no UV warp blur
- **Floor shapes drawn flat** at projected positions to avoid double-perspective
- **Pre-cached vertex tables** — `constexpr` cos/sin arrays, zero trig at draw time
- **`INV_RANGE` reciprocal** — multiply instead of divide in hot path
- **`std::clamp()`** — branchless depth clamping
- **HUD/overlays untouched** — only world-space draws are projected

### VP_Y tuning
`VANISHING_POINT_Y = -1060` gives ~17° convergence (top of screen is ~45% width). Easily adjustable — comments in `constants.h` show the angle-to-VP_Y mapping.

### Test results
- **448 tests pass** (1042 assertions), up from 386
- **12 perspective benchmarks** — projection is ~0.22ns per vertex
- Zero warnings under `-Wall -Wextra -Werror`
