### PR TITLE
Convert lane_block assets to lane_push_left/lane_push_right

### DIFF
--- a/content/beatmaps/1_stomper_beatmap.json
+++ b/content/beatmaps/1_stomper_beatmap.json
@@ -975,11 +975,8 @@
         },
         {
           "beat": 58,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 60,
@@ -995,19 +992,13 @@
         },
         {
           "beat": 66,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 71,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 74,
@@ -1041,11 +1032,8 @@
         },
         {
           "beat": 86,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 89,
@@ -1073,11 +1061,8 @@
         },
         {
           "beat": 99,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 101,
@@ -1129,11 +1114,8 @@
         },
         {
           "beat": 122,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 124,
@@ -1149,11 +1131,8 @@
         },
         {
           "beat": 130,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 134,
@@ -1199,11 +1178,8 @@
         },
         {
           "beat": 153,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 155,
@@ -1219,11 +1195,8 @@
         },
         {
           "beat": 161,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 165,
@@ -1269,11 +1242,8 @@
         },
         {
           "beat": 183,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 185,
@@ -1289,11 +1259,8 @@
         },
         {
           "beat": 191,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 193,
@@ -1339,11 +1306,8 @@
         },
         {
           "beat": 214,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 217,
@@ -1377,11 +1341,8 @@
         },
         {
           "beat": 229,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 232,
@@ -1427,11 +1388,8 @@
         },
         {
           "beat": 248,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 250,
@@ -1441,27 +1399,18 @@
         },
         {
           "beat": 252,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 256,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 261,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 264,
@@ -1501,11 +1450,8 @@
         },
         {
           "beat": 279,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 281,
@@ -1521,11 +1467,8 @@
         },
         {
           "beat": 289,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 291,
@@ -1709,11 +1652,8 @@
         },
         {
           "beat": 423,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 425,
@@ -1729,11 +1669,8 @@
         },
         {
           "beat": 431,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 436,
@@ -1779,11 +1716,8 @@
         },
         {
           "beat": 455,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 457,
@@ -1799,11 +1733,8 @@
         },
         {
           "beat": 463,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 468,
@@ -2268,11 +2199,8 @@
         },
         {
           "beat": 183,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 185,
@@ -2522,11 +2450,8 @@
         },
         {
           "beat": 291,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 293,
@@ -2536,11 +2461,8 @@
         },
         {
           "beat": 296,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 299,
@@ -2970,11 +2892,8 @@
         },
         {
           "beat": 513,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         }
       ],
       "count": 180

--- a/content/beatmaps/2_drama_beatmap.json
+++ b/content/beatmaps/2_drama_beatmap.json
@@ -801,11 +801,8 @@
         },
         {
           "beat": 93,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 101,
@@ -815,11 +812,8 @@
         },
         {
           "beat": 105,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 112,
@@ -859,11 +853,8 @@
         },
         {
           "beat": 128,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 130,
@@ -873,11 +864,8 @@
         },
         {
           "beat": 133,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 135,
@@ -911,11 +899,8 @@
         },
         {
           "beat": 151,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 157,
@@ -925,11 +910,8 @@
         },
         {
           "beat": 159,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 161,
@@ -939,19 +921,13 @@
         },
         {
           "beat": 166,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 173,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 175,
@@ -967,11 +943,8 @@
         },
         {
           "beat": 180,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 183,
@@ -981,11 +954,8 @@
         },
         {
           "beat": 186,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 188,
@@ -1001,11 +971,8 @@
         },
         {
           "beat": 193,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 197,
@@ -1027,11 +994,8 @@
         },
         {
           "beat": 202,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 205,
@@ -1059,11 +1023,8 @@
         },
         {
           "beat": 214,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 217,
@@ -1079,11 +1040,8 @@
         },
         {
           "beat": 223,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 225,
@@ -1093,11 +1051,8 @@
         },
         {
           "beat": 229,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 233,
@@ -1107,11 +1062,8 @@
         },
         {
           "beat": 235,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 237,
@@ -1121,11 +1073,8 @@
         },
         {
           "beat": 240,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 244,
@@ -1147,11 +1096,8 @@
         },
         {
           "beat": 249,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 252,
@@ -1167,11 +1113,8 @@
         },
         {
           "beat": 258,
-          "kind": "lane_block",
-          "blocked": [
-            1,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 1
         },
         {
           "beat": 260,
@@ -1181,11 +1124,8 @@
         },
         {
           "beat": 263,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 266,
@@ -1195,11 +1135,8 @@
         },
         {
           "beat": 269,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 271,
@@ -1209,11 +1146,8 @@
         },
         {
           "beat": 274,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 279,
@@ -1223,11 +1157,8 @@
         },
         {
           "beat": 283,
-          "kind": "lane_block",
-          "blocked": [
-            1,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 1
         },
         {
           "beat": 286,
@@ -1237,11 +1168,8 @@
         },
         {
           "beat": 290,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 296,
@@ -1263,11 +1191,8 @@
         },
         {
           "beat": 302,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 304,
@@ -1307,11 +1232,8 @@
         },
         {
           "beat": 316,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 320,
@@ -1333,11 +1255,8 @@
         },
         {
           "beat": 326,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 332,
@@ -1347,11 +1266,8 @@
         },
         {
           "beat": 334,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 336,
@@ -1367,19 +1283,13 @@
         },
         {
           "beat": 342,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 349,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 351,
@@ -1389,11 +1299,8 @@
         },
         {
           "beat": 354,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 357,
@@ -1403,11 +1310,8 @@
         },
         {
           "beat": 360,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 362,
@@ -1417,11 +1321,8 @@
         },
         {
           "beat": 365,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 370,
@@ -1431,11 +1332,8 @@
         },
         {
           "beat": 372,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 374,
@@ -1457,11 +1355,8 @@
         },
         {
           "beat": 381,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 387,
@@ -1471,11 +1366,8 @@
         },
         {
           "beat": 389,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 391,
@@ -1497,19 +1389,13 @@
         },
         {
           "beat": 398,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 405,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 407,
@@ -1519,11 +1405,8 @@
         },
         {
           "beat": 410,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 412,
@@ -1533,11 +1416,8 @@
         },
         {
           "beat": 415,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 417,
@@ -1547,11 +1427,8 @@
         },
         {
           "beat": 420,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 424,
@@ -1567,11 +1444,8 @@
         },
         {
           "beat": 427,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 429,
@@ -1581,11 +1455,8 @@
         },
         {
           "beat": 434,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 439,
@@ -1774,11 +1645,8 @@
         },
         {
           "beat": 112,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 115,
@@ -1812,11 +1680,8 @@
         },
         {
           "beat": 128,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 130,
@@ -1826,11 +1691,8 @@
         },
         {
           "beat": 133,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 135,
@@ -1840,11 +1702,8 @@
         },
         {
           "beat": 139,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 142,
@@ -1992,11 +1851,8 @@
         },
         {
           "beat": 202,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 204,
@@ -2024,11 +1880,8 @@
         },
         {
           "beat": 214,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 218,
@@ -2104,11 +1957,8 @@
         },
         {
           "beat": 249,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 251,
@@ -2202,11 +2052,8 @@
         },
         {
           "beat": 290,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 296,
@@ -2228,19 +2075,13 @@
         },
         {
           "beat": 301,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 306,
-          "kind": "lane_block",
-          "blocked": [
-            1,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 1
         },
         {
           "beat": 308,
@@ -2394,11 +2235,8 @@
         },
         {
           "beat": 374,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 378,
@@ -2408,11 +2246,8 @@
         },
         {
           "beat": 380,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 382,
@@ -2434,11 +2269,8 @@
         },
         {
           "beat": 391,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 393,
@@ -2622,11 +2454,8 @@
         },
         {
           "beat": 472,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         }
       ],
       "count": 160

--- a/content/beatmaps/3_mental_corruption_beatmap.json
+++ b/content/beatmaps/3_mental_corruption_beatmap.json
@@ -711,11 +711,8 @@
         },
         {
           "beat": 55,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 58,
@@ -737,11 +734,8 @@
         },
         {
           "beat": 65,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 67,
@@ -895,11 +889,8 @@
         },
         {
           "beat": 161,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 191,
@@ -915,11 +906,8 @@
         },
         {
           "beat": 195,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 199,
@@ -947,11 +935,8 @@
         },
         {
           "beat": 210,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 212,
@@ -979,11 +964,8 @@
         },
         {
           "beat": 227,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 229,
@@ -993,11 +975,8 @@
         },
         {
           "beat": 236,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 238,
@@ -1043,11 +1022,8 @@
         },
         {
           "beat": 253,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 255,
@@ -1153,11 +1129,8 @@
         },
         {
           "beat": 319,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 322,
@@ -1179,11 +1152,8 @@
         },
         {
           "beat": 329,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 331,
@@ -1247,11 +1217,8 @@
         },
         {
           "beat": 377,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 381,
@@ -1273,11 +1240,8 @@
         },
         {
           "beat": 390,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 392,
@@ -1299,11 +1263,8 @@
         },
         {
           "beat": 398,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 400,
@@ -1391,11 +1352,8 @@
         },
         {
           "beat": 456,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 459,
@@ -1411,11 +1369,8 @@
         },
         {
           "beat": 463,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 466,
@@ -1425,11 +1380,8 @@
         },
         {
           "beat": 469,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 471,
@@ -1451,11 +1403,8 @@
         },
         {
           "beat": 476,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 479,
@@ -1471,11 +1420,8 @@
         },
         {
           "beat": 483,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 486,
@@ -1485,11 +1431,8 @@
         },
         {
           "beat": 489,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 531,
@@ -1505,11 +1448,8 @@
         },
         {
           "beat": 535,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 539,
@@ -1525,11 +1465,8 @@
         },
         {
           "beat": 543,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 547,
@@ -1545,11 +1482,8 @@
         },
         {
           "beat": 554,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 557,
@@ -1565,11 +1499,8 @@
         },
         {
           "beat": 561,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         }
       ],
       "count": 146
@@ -1824,11 +1755,8 @@
         },
         {
           "beat": 114,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 118,
@@ -1904,11 +1832,8 @@
         },
         {
           "beat": 161,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 163,
@@ -1930,11 +1855,8 @@
         },
         {
           "beat": 172,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 174,
@@ -2358,11 +2280,8 @@
         },
         {
           "beat": 381,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 383,
@@ -2372,19 +2291,13 @@
         },
         {
           "beat": 385,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 389,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 391,
@@ -2394,11 +2307,8 @@
         },
         {
           "beat": 394,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 396,
@@ -2408,11 +2318,8 @@
         },
         {
           "beat": 398,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 403,
@@ -2518,11 +2425,8 @@
         },
         {
           "beat": 453,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 456,
@@ -2532,11 +2436,8 @@
         },
         {
           "beat": 459,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 461,
@@ -2546,11 +2447,8 @@
         },
         {
           "beat": 463,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 466,
@@ -2560,11 +2458,8 @@
         },
         {
           "beat": 469,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 471,
@@ -2574,11 +2469,8 @@
         },
         {
           "beat": 473,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 476,
@@ -2588,11 +2480,8 @@
         },
         {
           "beat": 479,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 481,
@@ -2602,11 +2491,8 @@
         },
         {
           "beat": 483,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 486,
@@ -2616,11 +2502,8 @@
         },
         {
           "beat": 489,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 491,
@@ -2630,11 +2513,8 @@
         },
         {
           "beat": 493,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 496,
@@ -2644,11 +2524,8 @@
         },
         {
           "beat": 499,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            1
-          ]
+          "kind": "lane_push_right",
+          "lane": 1
         },
         {
           "beat": 501,
@@ -2658,11 +2535,8 @@
         },
         {
           "beat": 504,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_left",
+          "lane": 2
         },
         {
           "beat": 506,
@@ -2678,11 +2552,8 @@
         },
         {
           "beat": 509,
-          "kind": "lane_block",
-          "blocked": [
-            0,
-            2
-          ]
+          "kind": "lane_push_right",
+          "lane": 0
         },
         {
           "beat": 511,

--- a/content/constants.json
+++ b/content/constants.json
@@ -1,5 +1,5 @@
 {
-    "obstacle_kinds": ["shape_gate", "lane_block", "low_bar", "high_bar", "combo_gate", "split_path", "lane_push_left", "lane_push_right"],
+    "obstacle_kinds": ["shape_gate", "low_bar", "high_bar", "combo_gate", "split_path", "lane_push_left", "lane_push_right"],
     "shapes": ["circle", "square", "triangle"],
     "kinds_with_shape": ["shape_gate", "combo_gate", "split_path"],
     "lanes": [0, 1, 2],

--- a/design-docs/beatmap-integration.md
+++ b/design-docs/beatmap-integration.md
@@ -182,7 +182,7 @@ The current obstacle components already match the beatmap schema:
 
 ```
   ObstacleKind::ShapeGate      → "shape_gate"       ✓  already exists
-  ObstacleKind::LaneBlock      → "lane_block"       ✓  legacy (converted to push at runtime)
+  ObstacleKind::LaneBlock      → "lane_block"       ✓  legacy/backward-compatible support
   ObstacleKind::LowBar         → "low_bar"          ✓  already exists
   ObstacleKind::HighBar        → "high_bar"         ✓  already exists
   ObstacleKind::LanePushLeft   → "lane_push_left"   ✓  already exists

--- a/design-docs/beatmap-integration.md
+++ b/design-docs/beatmap-integration.md
@@ -79,9 +79,6 @@
 // shape_gate — most common (~85% of obstacles)
 { "beat": 12, "kind": "shape_gate", "shape": "circle", "lane": 0 }
 
-// lane_block — blocks 2 lanes
-{ "beat": 201, "kind": "lane_block", "blocked": [0, 2] }
-
 // low_bar — jump over
 { "beat": 350, "kind": "low_bar" }
 
@@ -185,14 +182,13 @@ The current obstacle components already match the beatmap schema:
 
 ```
   ObstacleKind::ShapeGate      → "shape_gate"       ✓  already exists
-  ObstacleKind::LaneBlock      → "lane_block"       ✓  already exists
+  ObstacleKind::LaneBlock      → "lane_block"       ✓  legacy (converted to push at runtime)
   ObstacleKind::LowBar         → "low_bar"          ✓  already exists
   ObstacleKind::HighBar        → "high_bar"         ✓  already exists
   ObstacleKind::LanePushLeft   → "lane_push_left"   ✓  already exists
   ObstacleKind::LanePushRight  → "lane_push_right"  ✓  already exists
 
   RequiredShape { shape }    → beatmap "shape" field    ✓
-  BlockedLanes  { mask }     → beatmap "blocked" field  ✓
   RequiredVAction { action } → low_bar/high_bar         ✓
 ```
 

--- a/tools/level_designer.py
+++ b/tools/level_designer.py
@@ -48,9 +48,9 @@ ALL_SHAPES = ["circle", "square", "triangle"]
 # Final section = hardest patterns (the "final fortress").
 SECTION_ROLE = {
     "intro":      {"density": 0.30, "types": ["shape_gate"], "consistent": True},
-    "verse":      {"density": 0.65, "types": ["shape_gate", "lane_block"], "consistent": False},
-    "pre-chorus": {"density": 0.80, "types": ["shape_gate", "lane_block"], "consistent": False},
-    "drop":       {"density": 0.90, "types": ["shape_gate", "lane_block"], "consistent": True},
+    "verse":      {"density": 0.65, "types": ["shape_gate", "lane_push"], "consistent": False},
+    "pre-chorus": {"density": 0.80, "types": ["shape_gate", "lane_push"], "consistent": False},
+    "drop":       {"density": 0.90, "types": ["shape_gate", "lane_push"], "consistent": True},
     "bridge":     {"density": 0.35, "types": ["shape_gate"], "consistent": False},
 }
 
@@ -58,8 +58,8 @@ DIFFICULTY_SCALE = {"easy": 0.55, "medium": 0.80, "hard": 1.20}
 DIFFICULTY_INTRO_REST = {"easy": 8, "medium": 4, "hard": 2}
 DIFFICULTY_KINDS = {
     "easy":   {"shape_gate"},
-    "medium": {"shape_gate", "lane_block"},
-    "hard":   {"shape_gate", "lane_block"},
+    "medium": {"shape_gate", "lane_push"},
+    "hard":   {"shape_gate", "lane_push"},
 }
 
 # Shape palette per section: controls how many shapes are in play.
@@ -115,11 +115,12 @@ def lane_of(obs, fallback=1):
     """What lane does this obstacle put the player in?"""
     if obs["kind"] == "shape_gate":
         return obs.get("lane", 1)
-    elif obs["kind"] == "lane_block":
-        blocked = obs.get("blocked", [])
-        for l in [1, 0, 2]:  # prefer center
-            if l not in blocked:
-                return l
+    elif obs["kind"] in ("lane_push_left", "lane_push_right"):
+        obs_lane = obs.get("lane", 1)
+        if obs["kind"] == "lane_push_left":
+            return max(obs_lane - 1, 0)
+        else:
+            return min(obs_lane + 1, 2)
     return fallback
 
 
@@ -227,7 +228,7 @@ def assign_obstacle(beat_idx, event, gap_to_prev, section_name, difficulty,
     Key insight from research: onset passes determine type, not rotation.
       - kick-only → high_bar (bass thump → slide down)
       - hihat-only → low_bar (percussive pop → jump up)
-      - snare-only or snare+kick → lane_block (transient → dodge)
+      - snare-only or snare+kick → lane_push (transient → dodge)
       - melody or multi-pass → shape_gate (harmonic → match shape)
 
     Gap context (from Liang et al.): short gaps favor same-type obstacles.
@@ -251,7 +252,7 @@ def assign_obstacle(beat_idx, event, gap_to_prev, section_name, difficulty,
     elif has_hihat and not has_kick and not has_snare:
         natural_kind = "low_bar"
     elif has_snare:
-        natural_kind = "lane_block"
+        natural_kind = "lane_push"
     else:
         natural_kind = "shape_gate"
 
@@ -316,8 +317,8 @@ def assign_obstacle(beat_idx, event, gap_to_prev, section_name, difficulty,
         obs["shape"] = shape
         obs["lane"] = lane
 
-    elif natural_kind == "lane_block":
-        # Block lanes that DIDN'T fire; keep player in lane that did
+    elif natural_kind == "lane_push":
+        # Push player toward a musically-appropriate lane
         target_lane = prev_lane  # default: stay put
         if has_kick:
             target_lane = 0
@@ -330,7 +331,21 @@ def assign_obstacle(beat_idx, event, gap_to_prev, section_name, difficulty,
         if abs(target_lane - prev_lane) > 1:
             target_lane = 1  # center is always safe
 
-        obs["blocked"] = [l for l in [0, 1, 2] if l != target_lane]
+        # Place push at prev_lane, pointing toward target
+        if target_lane > prev_lane:
+            obs["kind"] = "lane_push_right"
+            obs["lane"] = prev_lane
+        elif target_lane < prev_lane:
+            obs["kind"] = "lane_push_left"
+            obs["lane"] = prev_lane
+        else:
+            # Already at target; place at player's lane for variety
+            if beat_idx % 2 == 0:
+                obs["kind"] = "lane_push_right"
+                obs["lane"] = prev_lane
+            else:
+                obs["kind"] = "lane_push_left"
+                obs["lane"] = prev_lane
 
     # low_bar and high_bar need no extra fields
 
@@ -386,10 +401,13 @@ def assign_obstacles(selected_beats, event_map, analysis, difficulty):
             # Override to a non-shape type based on passes
             passes = set(event.get("passes", ["flux"])) if event else {"flux"}
             non_shape = sec_kinds - {"shape_gate"}
-            if "lane_block" in non_shape:
-                target_lane = prev_lane
-                obs = {"beat": bi, "kind": "lane_block",
-                       "blocked": [l for l in [0,1,2] if l != target_lane]}
+            if "lane_push" in non_shape:
+                if bi % 2 == 0:
+                    obs = {"beat": bi, "kind": "lane_push_right",
+                           "lane": prev_lane}
+                else:
+                    obs = {"beat": bi, "kind": "lane_push_left",
+                           "lane": prev_lane}
             elif "low_bar" in non_shape and "high_bar" in non_shape:
                 obs = {"beat": bi, "kind": "low_bar" if bi % 2 == 0 else "high_bar"}
             elif "low_bar" in non_shape:

--- a/tools/level_designer.py
+++ b/tools/level_designer.py
@@ -339,8 +339,15 @@ def assign_obstacle(beat_idx, event, gap_to_prev, section_name, difficulty,
             obs["kind"] = "lane_push_left"
             obs["lane"] = prev_lane
         else:
-            # Already at target; place at player's lane for variety
-            if beat_idx % 2 == 0:
+            # Already at target; keep variety without generating
+            # out-of-bounds pushes on edge lanes.
+            if prev_lane == 0:
+                obs["kind"] = "lane_push_right"
+                obs["lane"] = prev_lane
+            elif prev_lane == 2:
+                obs["kind"] = "lane_push_left"
+                obs["lane"] = prev_lane
+            elif beat_idx % 2 == 0:
                 obs["kind"] = "lane_push_right"
                 obs["lane"] = prev_lane
             else:


### PR DESCRIPTION
## Summary

Replace all legacy `lane_block` obstacles with the new push-lane system across beatmaps, tooling, and documentation.

## Changes

| File | What |
|------|------|
| **3 beatmaps** | 127 `lane_block` → `lane_push_left`/`lane_push_right` with `lane` field |
| **constants.json** | Removed `lane_block` from `obstacle_kinds` |
| **level_designer.py** | Generates push-lanes instead of lane_blocks |
| **beatmap-integration.md** | Removed legacy `lane_block` example |

## Conversion rule

Push obstacle placed at a non-target lane, pointing toward the open lane. For `blocked: [0,2]` (center open), alternates between `push_right@0` and `push_left@2`.

## Backward compat

`parse_kind("lane_block")` in `beat_map_loader.cpp` and the `LaneBlock` case in `beat_scheduler_system.cpp` remain for any old files.

## Testing

- All 2091 assertions pass across 551 test cases
- Zero `lane_block` remaining in beatmap JSONs
- `level_designer.py` syntax verified