### PR TITLE
Fix TestFlight obstacle mesh lifecycle issues

### DIFF
--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -155,3 +155,12 @@ Removed runtime override entirely from `title_screen_controller.cpp`. Updated `c
 - Pattern documented for future single-header library implementations
 
 **Orchestration log:** `.squad/orchestration-log/2026-04-29T08:05:08Z-hockney.md`
+
+## 2026-04-29 — TestFlight Persistence hardening (#297, #298)
+
+- Added shared persistence policy (`app/util/persistence_policy.*`) that resolves one canonical root + file paths for settings/high scores and returns structured `persistence::Result` status.
+- iOS path contract is explicit: `HOME/Library/Application Support/shapeshifter` (no silent CWD fallback). Path/directory failures now surface as `PathUnavailable` / `DirectoryCreateFailed`.
+- Upgraded settings/high-score load/save APIs from `bool` to structured result enums (`MissingFile`, `CorruptData`, `FileOpenFailed`, etc.) and propagated results through startup and save call sites.
+- Added save observability and retry state (`last_load`, `last_save`, `dirty`) on persistence ctx structs; game-state high-score save now preserves dirty state on failure.
+- Validation: `cmake --build build-ralph --target shapeshifter_tests && ./build-ralph/shapeshifter_tests "[settings],[high_score]" --reporter compact` → pass (174 assertions / 37 tests).
+- 2026-04-29: Restored pre-split energy semantics by applying ordered pending energy events with clamp-after-each-step in energy_system; added mixed same-tick boundary regression coverage.

--- a/.squad/agents/mcmanus/history.md
+++ b/.squad/agents/mcmanus/history.md
@@ -221,3 +221,10 @@ Next: Await merge approval.
 - Shifted **popup spawn + popup SFX** behind a dedicated bridge: `scoring_system` now emits `ScorePopupRequestQueue` intents; new `popup_feedback_system` owns `spawn_score_popup` + `audio_push(SFX::ScorePopup)`.
 - Centralized **miss death-cause attribution** in `scoring_system` MissTag processing (first-cause-wins), removing direct `GameOverState::cause` writes from `collision_system` and `miss_detection_system`.
 - Moved **energy-zero → GameOver transition ownership** to `game_state_system` (state-machine owner). `enter_game_over` now owns setting `SongState.finished/playing` on death.
+
+### 2026-04-29 — #281 setup_play_session ownership split (surgical)
+
+- Extracted player spawn call from `setup_play_session()` into focused helper `spawn_session_player(entt::registry&)`.
+- Isolated runtime Playing HUD button spawning behind `spawn_playing_shape_buttons(entt::registry&)` and phase mutation behind `enter_playing_phase(GameState&)`.
+- Added regression coverage for end-screen restart path: GameOver restart now explicitly validated across two ticks (choice tick + transition tick) to ensure fresh play-session setup.
+- Validation: `cmake --build build-ralph --target shapeshifter_tests`, `./build-ralph/shapeshifter_tests "[gamestate]"`, `./build-ralph/shapeshifter_tests "[play_session]"`, and full `./build-ralph/shapeshifter_tests` all pass.

--- a/.squad/agents/mcmanus/history.md
+++ b/.squad/agents/mcmanus/history.md
@@ -214,3 +214,10 @@ Next: Await merge approval.
 **Status:** Decision captured and merged into team decisions.
 
 **Related:** `mcmanus-popup-entity-factory.md` merged into `.squad/decisions.md`
+
+### 2026-04-29 — Gameplay boundary cluster (#276/#278/#279/#282)
+
+- Shifted **energy writes** behind a single-writer boundary: `scoring_system` now accumulates `PendingEnergyEffects` intent; `energy_system` is the only system that mutates `EnergyState` (`energy`, `flash_timer`).
+- Shifted **popup spawn + popup SFX** behind a dedicated bridge: `scoring_system` now emits `ScorePopupRequestQueue` intents; new `popup_feedback_system` owns `spawn_score_popup` + `audio_push(SFX::ScorePopup)`.
+- Centralized **miss death-cause attribution** in `scoring_system` MissTag processing (first-cause-wins), removing direct `GameOverState::cause` writes from `collision_system` and `miss_detection_system`.
+- Moved **energy-zero → GameOver transition ownership** to `game_state_system` (state-machine owner). `enter_game_over` now owns setting `SongState.finished/playing` on death.

--- a/.squad/agents/mcmanus/history.md
+++ b/.squad/agents/mcmanus/history.md
@@ -228,3 +228,13 @@ Next: Await merge approval.
 - Isolated runtime Playing HUD button spawning behind `spawn_playing_shape_buttons(entt::registry&)` and phase mutation behind `enter_playing_phase(GameState&)`.
 - Added regression coverage for end-screen restart path: GameOver restart now explicitly validated across two ticks (choice tick + transition tick) to ensure fresh play-session setup.
 - Validation: `cmake --build build-ralph --target shapeshifter_tests`, `./build-ralph/shapeshifter_tests "[gamestate]"`, `./build-ralph/shapeshifter_tests "[play_session]"`, and full `./build-ralph/shapeshifter_tests` all pass.
+
+### 2026-04-29 — #277 game_state boundary extraction (surgical)
+
+- Extracted terminal-phase side effects out of `game_state_system.cpp` into `game_state_enter_terminal_phase(...)` (`app/systems/game_state_terminal_phase_system.cpp`).
+  - High-score compare/update/persist now lives outside the core state-machine file.
+  - Terminal feedback (Crash SFX, DeathCrash/NewHighScore haptics with `SettingsState` gating) moved with it.
+- Isolated end-screen transition loop behind `game_state_end_screen_system(...)` (`app/systems/game_state_end_screen_system.cpp`) and called it from `game_state_system`.
+- Isolated menu/end-screen input mapping behind focused routing boundary `game_state_handle_end_screen_press(...)` (`app/input/game_state_end_screen_routing.cpp`), invoked by `game_state_handle_press`.
+- Preserved behavior and timing guards (`0.4s` end-screen input, `0.5s` SongComplete choice application).
+- Validation: `cmake --build build-ralph --target shapeshifter_tests`; `./build-ralph/shapeshifter_tests "[gamestate]"`; `"[haptic]"`; `"[high_score]"`; `"[redfoot]"`; full `./build-ralph/shapeshifter_tests` (pass, exit 0).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ endforeach()
 file(GLOB SYSTEM_SOURCES CONFIGURE_DEPENDS app/systems/*.cpp)
 file(GLOB AUDIO_SOURCES CONFIGURE_DEPENDS app/audio/*.cpp)
 file(GLOB UTIL_SOURCES CONFIGURE_DEPENDS app/util/*.cpp)
+file(GLOB PLATFORM_SOURCES CONFIGURE_DEPENDS app/platform/*.cpp app/platform/ios/*.cpp)
 file(GLOB UI_SOURCES CONFIGURE_DEPENDS app/ui/*.cpp)
 file(GLOB UI_SCREEN_CONTROLLER_SOURCES CONFIGURE_DEPENDS app/ui/screen_controllers/*.cpp)
 file(GLOB INPUT_SOURCES CONFIGURE_DEPENDS app/input/*.cpp)
@@ -111,7 +112,22 @@ list(FILTER UI_SOURCES EXCLUDE REGEX "(^|/)text_renderer\\.cpp$")
 list(FILTER UI_SOURCES EXCLUDE REGEX "(^|/)raygui_impl\\.cpp$")
 list(FILTER UTIL_SOURCES EXCLUDE REGEX "(^|/)file_logger\\.cpp$")
 
-add_library(shapeshifter_lib STATIC ${SYSTEM_SOURCES} ${AUDIO_SOURCES} ${UTIL_SOURCES} ${UI_SOURCES} ${UI_SCREEN_CONTROLLER_SOURCES} ${INPUT_SOURCES} ${SESSION_SOURCES} ${ENTITY_SOURCES})
+set(SHAPESHIFTER_IOS FALSE)
+if(APPLE)
+    if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+        set(SHAPESHIFTER_IOS TRUE)
+    elseif(DEFINED CMAKE_OSX_SYSROOT AND CMAKE_OSX_SYSROOT MATCHES "iphoneos|iphonesimulator")
+        set(SHAPESHIFTER_IOS TRUE)
+    endif()
+endif()
+
+if(SHAPESHIFTER_IOS)
+    enable_language(OBJCXX)
+    list(FILTER PLATFORM_SOURCES EXCLUDE REGEX "(^|/)haptics_ios_bridge_stub\\.cpp$")
+    list(APPEND PLATFORM_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/app/platform/ios/haptics_ios_bridge_ios.mm")
+endif()
+
+add_library(shapeshifter_lib STATIC ${SYSTEM_SOURCES} ${AUDIO_SOURCES} ${UTIL_SOURCES} ${PLATFORM_SOURCES} ${UI_SOURCES} ${UI_SCREEN_CONTROLLER_SOURCES} ${INPUT_SOURCES} ${SESSION_SOURCES} ${ENTITY_SOURCES})
 target_include_directories(shapeshifter_lib PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/app
     ${CMAKE_BINARY_DIR}/generated
@@ -125,6 +141,12 @@ target_link_libraries(shapeshifter_lib PUBLIC
     nlohmann_json::nlohmann_json
     raylib
 )
+if(SHAPESHIFTER_IOS)
+    target_link_libraries(shapeshifter_lib PUBLIC
+        "-framework Foundation"
+        "-framework UIKit"
+    )
+endif()
 target_link_libraries(shapeshifter_lib PRIVATE shapeshifter_warnings)
 
 # ── Platform capability flags ────────────────────────────────
@@ -138,6 +160,8 @@ elseif(EMSCRIPTEN)
     target_compile_definitions(shapeshifter_lib PUBLIC PLATFORM_WEB PLATFORM_HAS_KEYBOARD)
     # JSON/settings loaders use C++ try/catch for recoverable parse failures.
     target_compile_options(shapeshifter_lib PUBLIC -fexceptions)
+elseif(SHAPESHIFTER_IOS)
+    target_compile_definitions(shapeshifter_lib PUBLIC PLATFORM_IOS)
 endif()
 
 # Suppress MSVC CRT deprecation warnings for standard C functions (fopen, etc.)

--- a/app/components/gameplay_intents.h
+++ b/app/components/gameplay_intents.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include "rhythm.h"
+
+struct PendingEnergyEffects {
+    struct Event {
+        float delta = 0.0f;
+        bool  flash = false;
+    };
+
+    std::vector<Event> events;
+
+    // Legacy compatibility for direct test setup; new gameplay writes events.
+    float delta = 0.0f;
+    bool  flash = false;
+};
+
+struct ScorePopupRequest {
+    float                    x = 0.0f;
+    float                    y = 0.0f;
+    int                      points = 0;
+    std::optional<TimingTier> timing_tier = std::nullopt;
+};
+
+struct ScorePopupRequestQueue {
+    std::vector<ScorePopupRequest> requests;
+};

--- a/app/components/high_score.h
+++ b/app/components/high_score.h
@@ -5,6 +5,8 @@
 #include <string>
 #include <entt/entt.hpp>
 
+#include "../util/persistence_policy.h"
+
 // Compact fixed-size high-score table.
 // Max entries: LEVEL_COUNT x DIFFICULTY_COUNT = 9.
 // Flat array storage -- no heap nodes, O(N) linear scan (faster than
@@ -30,4 +32,7 @@ struct HighScoreState {
 
 struct HighScorePersistence {
     std::string path;
+    persistence::Result last_load{};
+    persistence::Result last_save{};
+    bool dirty{false};
 };

--- a/app/entities/obstacle_render_entity.cpp
+++ b/app/entities/obstacle_render_entity.cpp
@@ -15,6 +15,28 @@ bool obstacle_model_lifecycle_wired(entt::registry& reg) {
     auto* state = reg.ctx().find<ObstacleModelLifecycleState>();
     return state && state->wired;
 }
+
+struct PendingEntity {
+    entt::registry& reg;
+    entt::entity entity;
+    bool active = true;
+
+    PendingEntity(entt::registry& registry, entt::entity created)
+        : reg(registry), entity(created) {}
+
+    PendingEntity(const PendingEntity&) = delete;
+    PendingEntity& operator=(const PendingEntity&) = delete;
+
+    ~PendingEntity() {
+        if (active && reg.valid(entity)) {
+            reg.destroy(entity);
+        }
+    }
+
+    void release() {
+        active = false;
+    }
+};
 }
 
 static void append_child(entt::registry& reg, entt::entity parent, entt::entity child) {
@@ -25,24 +47,40 @@ static void append_child(entt::registry& reg, entt::entity parent, entt::entity 
     children.children[children.count++] = child;
 }
 
+// ObstacleChildren::MAX is the hard cap for mesh children owned by one
+// logical obstacle. Factory helpers reserve a slot before reg.create() so an
+// overflow cannot leave an unregistered MeshChild entity behind.
+static void require_child_capacity(entt::registry& reg, entt::entity parent) {
+    auto& children = reg.get_or_emplace<ObstacleChildren>(parent);
+    if (children.count >= ObstacleChildren::MAX) {
+        throw std::logic_error("ObstacleChildren capacity exceeded");
+    }
+}
+
 static entt::entity add_slab_child(entt::registry& reg, entt::entity parent,
                                    float x, float w, float d, float h, Color tint) {
+    require_child_capacity(reg, parent);
     auto e = reg.create();
+    PendingEntity pending{reg, e};
     reg.emplace<MeshChild>(e, MeshChild{parent, x, 0.0f, w, d, h, tint, MeshType::Slab, 0});
     reg.emplace<TagWorldPass>(e);
     append_child(reg, parent, e);
+    pending.release();
     return e;
 }
 
 static entt::entity add_shape_child(entt::registry& reg, entt::entity parent,
                                      Shape shape, float cx, float z_offset,
                                      float size, Color tint) {
+    require_child_capacity(reg, parent);
     int idx = static_cast<int>(shape);
     auto e = reg.create();
+    PendingEntity pending{reg, e};
     reg.emplace<MeshChild>(e, MeshChild{parent, cx, z_offset, size, 0, 0, tint,
                                         MeshType::Shape, idx});
     reg.emplace<TagWorldPass>(e);
     append_child(reg, parent, e);
+    pending.release();
     return e;
 }
 

--- a/app/entities/obstacle_render_entity.cpp
+++ b/app/entities/obstacle_render_entity.cpp
@@ -4,6 +4,7 @@
 #include "../components/rendering.h"
 #include "../constants.h"
 #include <raymath.h>
+#include <cstdint>
 #include <stdexcept>
 
 namespace {
@@ -14,6 +15,29 @@ struct ObstacleModelLifecycleState {
 bool obstacle_model_lifecycle_wired(entt::registry& reg) {
     auto* state = reg.ctx().find<ObstacleModelLifecycleState>();
     return state && state->wired;
+}
+
+int checked_shape_mesh_index(Shape shape) {
+    switch (shape) {
+        case Shape::Circle:
+            return 0;
+        case Shape::Square:
+            return 1;
+        case Shape::Triangle:
+            return 2;
+        case Shape::Hexagon:
+            return 3;
+    }
+
+    throw std::logic_error("Invalid RequiredShape shape");
+}
+
+int checked_lane_index(int8_t lane) {
+    const int lane_index = static_cast<int>(lane);
+    if (lane_index < 0 || lane_index >= constants::LANE_COUNT) {
+        throw std::logic_error("Invalid RequiredLane lane");
+    }
+    return lane_index;
 }
 
 struct PendingEntity {
@@ -70,14 +94,13 @@ static entt::entity add_slab_child(entt::registry& reg, entt::entity parent,
 }
 
 static entt::entity add_shape_child(entt::registry& reg, entt::entity parent,
-                                     Shape shape, float cx, float z_offset,
+                                     int mesh_index, float cx, float z_offset,
                                      float size, Color tint) {
     require_child_capacity(reg, parent);
-    int idx = static_cast<int>(shape);
     auto e = reg.create();
     PendingEntity pending{reg, e};
-    reg.emplace<MeshChild>(e, MeshChild{parent, cx, z_offset, size, 0, 0, tint,
-                                        MeshType::Shape, idx});
+    reg.emplace<MeshChild>(e, MeshChild{parent, cx, z_offset, size, 0.0f, 0.0f, tint,
+                                        MeshType::Shape, mesh_index});
     reg.emplace<TagWorldPass>(e);
     append_child(reg, parent, e);
     pending.release();
@@ -107,21 +130,25 @@ void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical) {
         case ObstacleKind::ShapeGate: {
             if (!pos_ptr) break;
             const auto& pos = *pos_ptr;
+            auto* req = reg.try_get<RequiredShape>(logical);
+            int mesh_index = 0;
+            if (req) {
+                mesh_index = checked_shape_mesh_index(req->shape);
+            }
             add_slab_child(reg, logical, 0, pos.x-50, dsz.h,
                            constants::OBSTACLE_3D_HEIGHT, col);
             add_slab_child(reg, logical, pos.x+50,
                 constants::SCREEN_W-pos.x-50, dsz.h,
                 constants::OBSTACLE_3D_HEIGHT, col);
-            auto* req = reg.try_get<RequiredShape>(logical);
             if (req)
-                add_shape_child(reg, logical, req->shape, pos.x, dsz.h/2,
+                add_shape_child(reg, logical, mesh_index, pos.x, dsz.h/2,
                                 40, {col.r, col.g, col.b, 120});
             break;
         }
         case ObstacleKind::LaneBlock: {
             auto* blocked = reg.try_get<BlockedLanes>(logical);
             if (blocked)
-                for (int i = 0; i < 3; ++i)
+                for (int i = 0; i < constants::LANE_COUNT; ++i)
                     if ((blocked->mask >> i) & 1)
                         add_slab_child(reg, logical, constants::LANE_X[i]-dsz.w/2,
                                        dsz.w, dsz.h, constants::OBSTACLE_3D_HEIGHT, col);
@@ -129,32 +156,44 @@ void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical) {
         }
         case ObstacleKind::ComboGate: {
             auto* blocked = reg.try_get<BlockedLanes>(logical);
+            auto* req = reg.try_get<RequiredShape>(logical);
+            int mesh_index = 0;
+            if (req) {
+                mesh_index = checked_shape_mesh_index(req->shape);
+            }
             if (blocked)
-                for (int i = 0; i < 3; ++i)
+                for (int i = 0; i < constants::LANE_COUNT; ++i)
                     if ((blocked->mask >> i) & 1)
                         add_slab_child(reg, logical, constants::LANE_X[i]-120,
                                        240.0f, dsz.h, constants::OBSTACLE_3D_HEIGHT, col);
-            auto* req = reg.try_get<RequiredShape>(logical);
             if (req) {
                 int open = 1;
                 if (blocked)
-                    for (int i = 0; i < 3; ++i)
+                    for (int i = 0; i < constants::LANE_COUNT; ++i)
                         if (!((blocked->mask >> i) & 1)) { open = i; break; }
-                add_shape_child(reg, logical, req->shape, constants::LANE_X[open],
-                                dsz.h/2, 30, {255, 255, 255, 180});
+                add_shape_child(reg, logical, mesh_index, constants::LANE_X[open],
+                                 dsz.h/2, 30, {255, 255, 255, 180});
             }
             break;
         }
         case ObstacleKind::SplitPath: {
             auto* rlane = reg.try_get<RequiredLane>(logical);
-            for (int i = 0; i < 3; ++i)
-                if (!rlane || i != rlane->lane)
+            int lane_index = 0;
+            if (rlane) {
+                lane_index = checked_lane_index(rlane->lane);
+            }
+            auto* req = reg.try_get<RequiredShape>(logical);
+            int mesh_index = 0;
+            if (req) {
+                mesh_index = checked_shape_mesh_index(req->shape);
+            }
+            for (int i = 0; i < constants::LANE_COUNT; ++i)
+                if (!rlane || i != lane_index)
                     add_slab_child(reg, logical, constants::LANE_X[i]-120,
                                    240.0f, dsz.h, constants::OBSTACLE_3D_HEIGHT, col);
-            auto* req = reg.try_get<RequiredShape>(logical);
             if (req && rlane)
-                add_shape_child(reg, logical, req->shape,
-                                constants::LANE_X[rlane->lane],
+                add_shape_child(reg, logical, mesh_index,
+                                constants::LANE_X[lane_index],
                                 dsz.h/2, 30, {255, 255, 255, 180});
             break;
         }

--- a/app/entities/obstacle_render_entity.cpp
+++ b/app/entities/obstacle_render_entity.cpp
@@ -8,6 +8,10 @@
 #include <stdexcept>
 
 namespace {
+struct ObstacleMeshLifetimeState {
+    bool wired = false;
+};
+
 struct ObstacleModelLifecycleState {
     bool wired = false;
 };
@@ -61,6 +65,27 @@ struct PendingEntity {
         active = false;
     }
 };
+}
+
+void on_obstacle_destroy(entt::registry& reg, entt::entity parent);
+
+void wire_obstacle_mesh_lifetime(entt::registry& reg) {
+    auto* state = reg.ctx().find<ObstacleMeshLifetimeState>();
+    if (!state) {
+        state = &reg.ctx().emplace<ObstacleMeshLifetimeState>();
+    }
+    if (state->wired) return;
+
+    reg.storage<ObstacleChildren>();
+    reg.on_destroy<ObstacleChildren>().connect<&on_obstacle_destroy>();
+    state->wired = true;
+}
+
+void unwire_obstacle_mesh_lifetime(entt::registry& reg) {
+    reg.on_destroy<ObstacleChildren>().disconnect<&on_obstacle_destroy>();
+    if (auto* state = reg.ctx().find<ObstacleMeshLifetimeState>()) {
+        state->wired = false;
+    }
 }
 
 static void append_child(entt::registry& reg, entt::entity parent, entt::entity child) {
@@ -121,6 +146,8 @@ static bool bar_height_for(ObstacleKind kind, float& height) {
 }
 
 void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical) {
+    wire_obstacle_mesh_lifetime(reg);
+
     auto& obs = reg.get<Obstacle>(logical);
     const auto* pos_ptr = reg.try_get<Position>(logical);
     auto& col = reg.get<Color>(logical);

--- a/app/entities/obstacle_render_entity.h
+++ b/app/entities/obstacle_render_entity.h
@@ -9,10 +9,14 @@ void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical);
 
 void build_obstacle_model(entt::registry& reg, entt::entity logical);
 
+// Centralized mesh-child lifetime wiring. Safe to call more than once.
+void wire_obstacle_mesh_lifetime(entt::registry& reg);
+void unwire_obstacle_mesh_lifetime(entt::registry& reg);
+
 void on_obstacle_model_destroy(entt::registry& reg, entt::entity entity);
 void wire_obstacle_model_lifecycle(entt::registry& reg);
 void unwire_obstacle_model_lifecycle(entt::registry& reg);
 
-// EnTT on_destroy listener: destroys all MeshChild entities referencing parent.
-// Connect with: reg.on_destroy<ObstacleTag>().connect<&on_obstacle_destroy>();
+// EnTT listener: destroys MeshChild entities recorded by ObstacleChildren.
+// Prefer wire_obstacle_mesh_lifetime() over connecting this directly.
 void on_obstacle_destroy(entt::registry& reg, entt::entity parent);

--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -24,6 +24,7 @@
 #include "systems/camera_system.h"
 #include "entities/obstacle_render_entity.h"
 #include "platform_display.h"
+#include "util/persistence_policy.h"
 #include "util/settings_persistence.h"
 #include "components/high_score.h"
 #include "util/high_score_persistence.h"
@@ -34,6 +35,34 @@
 
 static constexpr float FIXED_DT  = 1.0f / 60.0f;
 static constexpr float MAX_ACCUM = 0.1f;
+
+namespace {
+
+void log_persistence_result(const char* operation, const persistence::Result& result) {
+    switch (result.status) {
+        case persistence::Status::Success:
+            TraceLog(LOG_INFO, "%s: success", operation);
+            break;
+        case persistence::Status::MissingFile:
+            TraceLog(LOG_INFO, "%s: missing file (defaults in use)", operation);
+            break;
+        case persistence::Status::CorruptData:
+            TraceLog(LOG_WARNING, "%s: corrupt data (defaults in use)", operation);
+            break;
+        default:
+            if (result.error) {
+                TraceLog(LOG_WARNING, "%s: %s (%s)", operation,
+                         persistence::status_name(result.status),
+                         result.error.message().c_str());
+            } else {
+                TraceLog(LOG_WARNING, "%s: %s", operation,
+                         persistence::status_name(result.status));
+            }
+            break;
+    }
+}
+
+}  // namespace
 
 // ── Init ────────────────────────────────────────────────────────────────────
 
@@ -85,20 +114,37 @@ void game_loop_init(entt::registry& reg,
     reg.ctx().emplace<SongResults>();
     reg.ctx().emplace<RNGState>();
 
-    // Settings — load from disk; default values apply when no file exists.
+    persistence::Paths persistence_paths;
+    const auto path_result = persistence::resolve_paths(persistence_paths);
+
+    // Settings — load from disk; defaults remain if file is missing/corrupt/path-invalid.
     {
         SettingsState settings;
-        settings::load_settings(settings, settings::get_settings_file_path());
+        SettingsPersistence settings_persistence;
+        if (path_result.ok()) {
+            settings_persistence.path = persistence_paths.settings_file.string();
+            settings_persistence.last_load = settings::load_settings(settings, persistence_paths.settings_file);
+        } else {
+            settings_persistence.last_load = path_result;
+        }
+        log_persistence_result("settings load", settings_persistence.last_load);
         reg.ctx().emplace<SettingsState>(settings);
+        reg.ctx().emplace<SettingsPersistence>(settings_persistence);
     }
 
-    // High scores — load from disk; default values apply when no file exists.
+    // High scores — load from disk; defaults remain if file is missing/corrupt/path-invalid.
     {
-        const auto high_scores_path = high_score::get_high_scores_file_path();
         HighScoreState hs;
-        high_score::load_high_scores(hs, high_scores_path);
+        HighScorePersistence persistence_state;
+        if (path_result.ok()) {
+            persistence_state.path = persistence_paths.high_scores_file.string();
+            persistence_state.last_load = high_score::load_high_scores(hs, persistence_paths.high_scores_file);
+        } else {
+            persistence_state.last_load = path_result;
+        }
+        log_persistence_result("high score load", persistence_state.last_load);
         reg.ctx().emplace<HighScoreState>(hs);
-        reg.ctx().emplace<HighScorePersistence>(HighScorePersistence{high_scores_path.string()});
+        reg.ctx().emplace<HighScorePersistence>(persistence_state);
     }
 
     // Cameras + render targets + GPU meshes
@@ -142,6 +188,8 @@ static void tick_fixed_systems(entt::registry& reg, float dt) {
     collision_system(reg, dt);
     miss_detection_system(reg, dt);
     scoring_system(reg, dt);
+    // Scoring enqueues popup intents; popup_feedback_system owns popup spawn/SFX.
+    popup_feedback_system(reg, dt);
     energy_system(reg, dt);
     particle_system(reg, dt);
     obstacle_despawn_system(reg, dt);

--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -104,13 +104,8 @@ void game_loop_init(entt::registry& reg,
     // Cameras + render targets + GPU meshes
     camera::init(reg);
 
-    // MeshChild auto-cleanup: destroy children when parent obstacle is destroyed.
-    // Prime ObstacleChildren pool BEFORE connecting on_destroy<ObstacleTag>.
-    // EnTT destroy() iterates pools in reverse insertion order; priming first
-    // ensures ObstacleChildren has a lower index so it's removed last — i.e.,
-    // it's still readable when on_obstacle_destroy fires for ObstacleTag.
-    reg.storage<ObstacleChildren>();
-    reg.on_destroy<ObstacleTag>().connect<&on_obstacle_destroy>();
+    // MeshChild auto-cleanup: destroy children when parent ownership is removed.
+    wire_obstacle_mesh_lifetime(reg);
     wire_obstacle_model_lifecycle(reg);
 
     // UI + beatmap + music
@@ -235,7 +230,7 @@ void game_loop_run(entt::registry& reg) {
 void game_loop_shutdown(entt::registry& reg) {
     // Disconnect all destroy/construct listeners before clearing entities
     unwire_input_dispatcher(reg);
-    reg.on_destroy<ObstacleTag>().disconnect<&on_obstacle_destroy>();
+    unwire_obstacle_mesh_lifetime(reg);
     reg.on_construct<ObstacleTag>().disconnect<&session_log_on_obstacle_spawn>();
     reg.on_construct<ScoredTag>().disconnect<&session_log_on_scored>();
 

--- a/app/input/game_state_end_screen_routing.cpp
+++ b/app/input/game_state_end_screen_routing.cpp
@@ -1,0 +1,34 @@
+#include "input_routing.h"
+#include "../components/game_state.h"
+#include "../components/input_events.h"
+#include "../components/haptics.h"
+#include "../util/haptic_queue.h"
+#include "../util/settings.h"
+
+bool game_state_handle_end_screen_press(entt::registry& reg, const ButtonPressEvent& evt) {
+    auto& gs = reg.ctx().get<GameState>();
+    if ((gs.phase != GamePhase::GameOver && gs.phase != GamePhase::SongComplete) ||
+        gs.phase_timer <= 0.4f) {
+        return false;
+    }
+
+    auto* hq = reg.ctx().find<HapticQueue>();
+    auto* st = reg.ctx().find<SettingsState>();
+    if (hq) {
+        const bool haptics_on = !st || st->haptics_enabled;
+        if (evt.menu_action == MenuActionKind::Restart) {
+            haptic_push(*hq, haptics_on, HapticEvent::RetryTap);
+        } else {
+            haptic_push(*hq, haptics_on, HapticEvent::UIButtonTap);
+        }
+    }
+
+    if (evt.menu_action == MenuActionKind::Restart) {
+        gs.end_choice = EndScreenChoice::Restart;
+    } else if (evt.menu_action == MenuActionKind::GoLevelSelect) {
+        gs.end_choice = EndScreenChoice::LevelSelect;
+    } else if (evt.menu_action == MenuActionKind::GoMainMenu) {
+        gs.end_choice = EndScreenChoice::MainMenu;
+    }
+    return true;
+}

--- a/app/input/game_state_routing.cpp
+++ b/app/input/game_state_routing.cpp
@@ -36,25 +36,7 @@ void game_state_handle_press(entt::registry& reg, const ButtonPressEvent& evt) {
         return;
     }
 
-    if ((gs.phase == GamePhase::GameOver || gs.phase == GamePhase::SongComplete)
-        && gs.phase_timer > 0.4f) {
-        {
-            auto* hq = reg.ctx().find<HapticQueue>();
-            auto* st = reg.ctx().find<SettingsState>();
-            if (hq) {
-                bool haptics_on = !st || st->haptics_enabled;
-                if (evt.menu_action == MenuActionKind::Restart)
-                    haptic_push(*hq, haptics_on, HapticEvent::RetryTap);
-                else
-                    haptic_push(*hq, haptics_on, HapticEvent::UIButtonTap);
-            }
-        }
-        if (evt.menu_action == MenuActionKind::Restart)
-            gs.end_choice = EndScreenChoice::Restart;
-        else if (evt.menu_action == MenuActionKind::GoLevelSelect)
-            gs.end_choice = EndScreenChoice::LevelSelect;
-        else if (evt.menu_action == MenuActionKind::GoMainMenu)
-            gs.end_choice = EndScreenChoice::MainMenu;
+    if (game_state_handle_end_screen_press(reg, evt)) {
         return;
     }
 

--- a/app/input/input_routing.h
+++ b/app/input/input_routing.h
@@ -13,6 +13,7 @@ void hit_test_handle_input(entt::registry& reg, const InputEvent& evt);
 // Tier-2 semantic listeners: semantic events -> game/player state.
 void game_state_handle_go(entt::registry& reg, const GoEvent& evt);
 void game_state_handle_press(entt::registry& reg, const ButtonPressEvent& evt);
+bool game_state_handle_end_screen_press(entt::registry& reg, const ButtonPressEvent& evt);
 void player_input_handle_go(entt::registry& reg, const GoEvent& evt);
 void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt);
 

--- a/app/platform/haptics_backend.cpp
+++ b/app/platform/haptics_backend.cpp
@@ -1,0 +1,60 @@
+#include "haptics_backend.h"
+
+#include "ios/haptics_ios_bridge.h"
+
+#include <magic_enum/magic_enum.hpp>
+#include <raylib.h>
+
+namespace platform::haptics {
+namespace {
+
+void trace_haptic_event(const char* prefix, HapticEvent event) {
+    const auto event_name = magic_enum::enum_name(event);
+    if (event_name.empty()) {
+        TraceLog(LOG_DEBUG, "%sUnknown", prefix);
+        return;
+    }
+    TraceLog(LOG_DEBUG, "%s%.*s", prefix, static_cast<int>(event_name.size()), event_name.data());
+}
+
+}  // namespace
+
+TriggerPattern pattern_for_event(HapticEvent event) noexcept {
+    switch (event) {
+        case HapticEvent::LaneSwitch:
+        case HapticEvent::UIButtonTap:
+            return {ImpactStyle::Light, 1};
+        case HapticEvent::ShapeShift:
+        case HapticEvent::JumpLand:
+        case HapticEvent::Burnout1_5x:
+        case HapticEvent::RetryTap:
+            return {ImpactStyle::Light, 1};
+        case HapticEvent::Burnout2_0x:
+        case HapticEvent::Burnout3_0x:
+        case HapticEvent::NewHighScore:
+            return {ImpactStyle::Medium, 1};
+        case HapticEvent::Burnout4_0x:
+        case HapticEvent::NearMiss:
+            return {ImpactStyle::Heavy, 1};
+        case HapticEvent::Burnout5_0x:
+            return {ImpactStyle::Heavy, 3};
+        case HapticEvent::DeathCrash:
+            return {ImpactStyle::Heavy, 2};
+        default:
+            return {ImpactStyle::Light, 1};
+    }
+}
+
+void trigger(HapticEvent event) noexcept {
+#if defined(PLATFORM_IOS)
+    if (platform::ios::haptics_ios_available()) {
+        platform::ios::haptics_ios_trigger(event);
+        return;
+    }
+    trace_haptic_event("HAPTIC [iOS-stub]: ", event);
+#else
+    trace_haptic_event("HAPTIC: ", event);
+#endif
+}
+
+}  // namespace platform::haptics

--- a/app/platform/haptics_backend.h
+++ b/app/platform/haptics_backend.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "../components/haptics.h"
+
+namespace platform::haptics {
+
+enum class ImpactStyle : unsigned char {
+    Light = 0,
+    Medium,
+    Heavy,
+};
+
+struct TriggerPattern {
+    ImpactStyle style = ImpactStyle::Light;
+    int pulse_count = 1;
+};
+
+TriggerPattern pattern_for_event(HapticEvent event) noexcept;
+void trigger(HapticEvent event) noexcept;
+
+}  // namespace platform::haptics

--- a/app/platform/ios/haptics_ios_bridge.h
+++ b/app/platform/ios/haptics_ios_bridge.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "../../components/haptics.h"
+
+namespace platform::ios {
+
+bool haptics_ios_available() noexcept;
+void haptics_ios_trigger(HapticEvent event) noexcept;
+
+}  // namespace platform::ios

--- a/app/platform/ios/haptics_ios_bridge_ios.mm
+++ b/app/platform/ios/haptics_ios_bridge_ios.mm
@@ -1,0 +1,68 @@
+#import "haptics_ios_bridge.h"
+
+#import "../haptics_backend.h"
+
+#import <UIKit/UIKit.h>
+
+namespace platform::ios {
+namespace {
+
+UIImpactFeedbackStyle to_ios_style(platform::haptics::ImpactStyle style) {
+    switch (style) {
+        case platform::haptics::ImpactStyle::Light:
+            return UIImpactFeedbackStyleLight;
+        case platform::haptics::ImpactStyle::Medium:
+            return UIImpactFeedbackStyleMedium;
+        case platform::haptics::ImpactStyle::Heavy:
+            return UIImpactFeedbackStyleHeavy;
+        default:
+            return UIImpactFeedbackStyleLight;
+    }
+}
+
+UIImpactFeedbackGenerator* generator_for_style(platform::haptics::ImpactStyle style) {
+    static UIImpactFeedbackGenerator* light = nil;
+    static UIImpactFeedbackGenerator* medium = nil;
+    static UIImpactFeedbackGenerator* heavy = nil;
+
+    UIImpactFeedbackGenerator** slot = nullptr;
+    switch (style) {
+        case platform::haptics::ImpactStyle::Light:
+            slot = &light;
+            break;
+        case platform::haptics::ImpactStyle::Medium:
+            slot = &medium;
+            break;
+        case platform::haptics::ImpactStyle::Heavy:
+            slot = &heavy;
+            break;
+        default:
+            slot = &light;
+            break;
+    }
+
+    if (*slot == nil) {
+        *slot = [[UIImpactFeedbackGenerator alloc] initWithStyle:to_ios_style(style)];
+    }
+    return *slot;
+}
+
+}  // namespace
+
+bool haptics_ios_available() noexcept {
+    return true;
+}
+
+void haptics_ios_trigger(HapticEvent event) noexcept {
+    @autoreleasepool {
+        const auto pattern = platform::haptics::pattern_for_event(event);
+        const int pulses = (pattern.pulse_count > 0) ? pattern.pulse_count : 1;
+        for (int i = 0; i < pulses; ++i) {
+            UIImpactFeedbackGenerator* generator = generator_for_style(pattern.style);
+            [generator prepare];
+            [generator impactOccurred];
+        }
+    }
+}
+
+}  // namespace platform::ios

--- a/app/platform/ios/haptics_ios_bridge_stub.cpp
+++ b/app/platform/ios/haptics_ios_bridge_stub.cpp
@@ -1,0 +1,11 @@
+#include "haptics_ios_bridge.h"
+
+namespace platform::ios {
+
+bool haptics_ios_available() noexcept {
+    return false;
+}
+
+void haptics_ios_trigger(HapticEvent) noexcept {}
+
+}  // namespace platform::ios

--- a/app/session/play_session.cpp
+++ b/app/session/play_session.cpp
@@ -22,6 +22,44 @@
 #include <filesystem>
 #include <raylib.h>
 
+namespace {
+
+// Session setup owns when a player is spawned; player_entity owns how.
+void spawn_session_player(entt::registry& reg) {
+    create_player_entity(reg);
+}
+
+// Session setup owns the runtime "shape button" HUD population for Playing.
+void spawn_playing_shape_buttons(entt::registry& reg) {
+    float btn_w       = constants::BUTTON_W_N  * constants::SCREEN_W;
+    float btn_h       = constants::BUTTON_H_N  * constants::SCREEN_H;
+    float btn_spacing = constants::BUTTON_SPACING_N * constants::SCREEN_W;
+    float btn_y       = constants::BUTTON_Y_N  * constants::SCREEN_H;
+    float btn_area_x  = (constants::SCREEN_W - 3.0f * btn_w - 2.0f * btn_spacing) / 2.0f;
+    float btn_cy      = btn_y + btn_h / 2.0f;
+    float btn_radius  = btn_w / 2.8f;
+    float hit_radius  = btn_radius * 1.4f;
+
+    Shape shapes[3] = { Shape::Circle, Shape::Square, Shape::Triangle };
+    for (int i = 0; i < 3; ++i) {
+        float btn_cx = btn_area_x + static_cast<float>(i) * (btn_w + btn_spacing) + btn_w / 2.0f;
+        auto btn = reg.create();
+        reg.emplace<ShapeButtonTag>(btn);
+        reg.emplace<UIPosition>(btn, Vector2{btn_cx, btn_cy});
+        reg.emplace<HitCircle>(btn, hit_radius);
+        reg.emplace<ShapeButtonData>(btn, shapes[i]);
+        reg.emplace<ActiveInPhase>(btn, GamePhaseBit::Playing);
+    }
+}
+
+void enter_playing_phase(GameState& gs) {
+    gs.previous_phase = gs.phase;
+    gs.phase = GamePhase::Playing;
+    gs.phase_timer = 0.0f;
+}
+
+} // namespace
+
 void setup_play_session(entt::registry& reg) {
     reg.clear();
     spawn_game_camera(reg);
@@ -141,34 +179,10 @@ void setup_play_session(entt::registry& reg) {
         score.high_score = high_score::get_current_high_score(*hs);
     }
 
-    create_player_entity(reg);
-
-    // ── Spawn shape button UI entities ──────────────────────────
-    {
-        float btn_w       = constants::BUTTON_W_N  * constants::SCREEN_W;
-        float btn_h       = constants::BUTTON_H_N  * constants::SCREEN_H;
-        float btn_spacing = constants::BUTTON_SPACING_N * constants::SCREEN_W;
-        float btn_y       = constants::BUTTON_Y_N  * constants::SCREEN_H;
-        float btn_area_x  = (constants::SCREEN_W - 3.0f * btn_w - 2.0f * btn_spacing) / 2.0f;
-        float btn_cy      = btn_y + btn_h / 2.0f;
-        float btn_radius  = btn_w / 2.8f;
-        float hit_radius  = btn_radius * 1.4f;
-
-        Shape shapes[3] = { Shape::Circle, Shape::Square, Shape::Triangle };
-        for (int i = 0; i < 3; ++i) {
-            float btn_cx = btn_area_x + static_cast<float>(i) * (btn_w + btn_spacing) + btn_w / 2.0f;
-            auto btn = reg.create();
-            reg.emplace<ShapeButtonTag>(btn);
-            reg.emplace<UIPosition>(btn, Vector2{btn_cx, btn_cy});
-            reg.emplace<HitCircle>(btn, hit_radius);
-            reg.emplace<ShapeButtonData>(btn, shapes[i]);
-            reg.emplace<ActiveInPhase>(btn, GamePhaseBit::Playing);
-        }
-    }
+    spawn_session_player(reg);
+    spawn_playing_shape_buttons(reg);
 
     // Transition game state
     auto& gs = reg.ctx().get<GameState>();
-    gs.previous_phase = gs.phase;
-    gs.phase = GamePhase::Playing;
-    gs.phase_timer = 0.0f;
+    enter_playing_phase(gs);
 }

--- a/app/systems/all_systems.h
+++ b/app/systems/all_systems.h
@@ -26,6 +26,7 @@ void scroll_system(entt::registry& reg, float dt);
 void collision_system(entt::registry& reg, float dt);
 void miss_detection_system(entt::registry& reg, float dt);
 void scoring_system(entt::registry& reg, float dt);
+void popup_feedback_system(entt::registry& reg, float dt);
 
 // Phase 5.5: Energy
 void energy_system(entt::registry& reg, float dt);

--- a/app/systems/all_systems.h
+++ b/app/systems/all_systems.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <entt/entt.hpp>
+#include "../components/game_state.h"
 
 // Phase 0: Raw input (polls raylib input)
 void input_system(entt::registry& reg, float raw_dt);
@@ -10,6 +11,8 @@ void test_player_system(entt::registry& reg, float dt);
 
 // Phase 2: Game State
 void game_state_system(entt::registry& reg, float dt);
+void game_state_enter_terminal_phase(entt::registry& reg, GamePhase phase);
+void game_state_end_screen_system(entt::registry& reg, float dt);
 
 // Phase 3: Rhythm Engine
 void song_playback_system(entt::registry& reg, float dt);

--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -54,14 +54,12 @@ void collision_system(entt::registry& reg, float /*dt*/) {
 
     auto* song    = reg.ctx().find<SongState>();
     auto* results = reg.ctx().find<SongResults>();
-    auto* gos     = reg.ctx().find<GameOverState>();  // #309: hoisted above resolve lambda
     bool rhythm_mode = (song != nullptr);
 
     // resolve: tag entity as scored (cleared) or missed.
     // kind is passed by the caller — no try_get needed since each per-kind
     // loop already holds the Obstacle component.
-    auto resolve = [&](entt::entity entity, float obs_z, bool cleared,
-                       ObstacleKind kind) {
+    auto resolve = [&](entt::entity entity, float obs_z, bool cleared) {
         if (!player_in_timing_window(p_transform, p_vstate, obs_z)) return;
 
         if (cleared) {
@@ -113,12 +111,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
             }
             reg.emplace<ScoredTag>(entity);
         } else {
-            // MISS — tag and record cause; energy drain handled by scoring_system.
-            // Tag the cause of death for the UI (does not override a prior cause)
-            if (gos && gos->cause == DeathCause::None) {
-                bool is_bar = (kind == ObstacleKind::LowBar || kind == ObstacleKind::HighBar);
-                gos->cause = is_bar ? DeathCause::HitABar : DeathCause::MissedABeat;
-            }
+            // MISS — tag only; scoring_system owns energy drain and death-cause attribution.
             reg.emplace<MissTag>(entity);
             reg.emplace<ScoredTag>(entity);
         }
@@ -129,52 +122,52 @@ void collision_system(entt::registry& reg, float /*dt*/) {
 
     // ShapeGate: RequiredShape only (no BlockedLanes, no RequiredLane)
     {
-        auto view = reg.view<ObstacleTag, Position, Obstacle, RequiredShape>(
+        auto view = reg.view<ObstacleTag, Position, RequiredShape>(
             entt::exclude<ScoredTag, BlockedLanes, RequiredLane>);
-        for (auto [e, pos, obs, req] : view.each()) {
+        for (auto [e, pos, req] : view.each()) {
             bool shape_match = (p_shape.current == req.shape) && (p_shape.current != Shape::Hexagon);
             bool lane_match  = player_overlaps_lane(p_transform, pos);
-            resolve(e, pos.y, shape_match && lane_match, obs.kind);
+            resolve(e, pos.y, shape_match && lane_match);
         }
     }
 
     // LaneBlock: BlockedLanes only (no RequiredShape)
     {
-        auto view = reg.view<ObstacleTag, Position, Obstacle, BlockedLanes>(
+        auto view = reg.view<ObstacleTag, Position, BlockedLanes>(
             entt::exclude<ScoredTag, RequiredShape>);
-        for (auto [e, pos, obs, blocked] : view.each()) {
-            resolve(e, pos.y, !((blocked.mask >> p_lane.current) & 1), obs.kind);
+        for (auto [e, pos, blocked] : view.each()) {
+            resolve(e, pos.y, !((blocked.mask >> p_lane.current) & 1));
         }
     }
 
     // LowBar / HighBar: RequiredVAction
     {
-        auto view = reg.view<ObstacleTag, ObstacleScrollZ, Obstacle, RequiredVAction>(
+        auto view = reg.view<ObstacleTag, ObstacleScrollZ, RequiredVAction>(
             entt::exclude<ScoredTag>);
-        for (auto [e, oz, obs, req_v] : view.each()) {
-            resolve(e, oz.z, p_vstate.mode == req_v.action, obs.kind);
+        for (auto [e, oz, req_v] : view.each()) {
+            resolve(e, oz.z, p_vstate.mode == req_v.action);
         }
     }
 
     // ComboGate: RequiredShape + BlockedLanes (no RequiredLane)
     {
-        auto view = reg.view<ObstacleTag, Position, Obstacle, RequiredShape, BlockedLanes>(
+        auto view = reg.view<ObstacleTag, Position, RequiredShape, BlockedLanes>(
             entt::exclude<ScoredTag, RequiredLane>);
-        for (auto [e, pos, obs, req, blocked] : view.each()) {
+        for (auto [e, pos, req, blocked] : view.each()) {
             bool shape_ok = (p_shape.current == req.shape) && (p_shape.current != Shape::Hexagon);
             bool lane_ok  = !((blocked.mask >> p_lane.current) & 1);
-            resolve(e, pos.y, shape_ok && lane_ok, obs.kind);
+            resolve(e, pos.y, shape_ok && lane_ok);
         }
     }
 
     // SplitPath: RequiredShape + RequiredLane
     {
-        auto view = reg.view<ObstacleTag, Position, Obstacle, RequiredShape, RequiredLane>(
+        auto view = reg.view<ObstacleTag, Position, RequiredShape, RequiredLane>(
             entt::exclude<ScoredTag>);
-        for (auto [e, pos, obs, req, rlane] : view.each()) {
+        for (auto [e, pos, req, rlane] : view.each()) {
             bool shape_ok = (p_shape.current == req.shape) && (p_shape.current != Shape::Hexagon);
             bool lane_ok  = (p_lane.current == rlane.lane);
-            resolve(e, pos.y, shape_ok && lane_ok, obs.kind);
+            resolve(e, pos.y, shape_ok && lane_ok);
         }
     }
 

--- a/app/systems/energy_system.cpp
+++ b/app/systems/energy_system.cpp
@@ -1,5 +1,6 @@
 #include "all_systems.h"
 #include "../components/game_state.h"
+#include "../components/gameplay_intents.h"
 #include "../components/rhythm.h"
 #include "../constants.h"
 #include <raymath.h>
@@ -10,26 +11,31 @@ void energy_system(entt::registry& reg, float dt) {
     auto* energy = reg.ctx().find<EnergyState>();
     if (!energy) return;
 
-    auto* song = reg.ctx().find<SongState>();
-    if (!song || !song->playing) return;
+    auto apply_clamped_delta = [&](float delta) {
+        energy->energy = Clamp(energy->energy + delta, 0.0f, constants::ENERGY_MAX);
+        if (energy->energy < 1e-6f) energy->energy = 0.0f;
+    };
 
-    // Depletion check
-    if (energy->energy <= 0.0f) {
-        auto& gs = reg.ctx().get<GameState>();
-        gs.transition_pending = true;
-        gs.next_phase = GamePhase::GameOver;
-        // Fallback cause: if nothing more specific was recorded by a
-        // collision (e.g. energy decayed through some non-collision path
-        // in future systems), surface "ENERGY DEPLETED" rather than
-        // showing a blank reason.
-        if (auto* gos = reg.ctx().find<GameOverState>()) {
-            if (gos->cause == DeathCause::None) {
-                gos->cause = DeathCause::EnergyDepleted;
+    // Apply deferred gameplay energy effects (single writer boundary).
+    if (auto* pending = reg.ctx().find<PendingEnergyEffects>()) {
+        // Preserve per-event clamp semantics (legacy scoring order: misses first, then hits).
+        for (const auto& effect : pending->events) {
+            apply_clamped_delta(effect.delta);
+            if (effect.flash) {
+                energy->flash_timer = constants::ENERGY_FLASH_DURATION;
             }
         }
-        song->finished = true;
-        song->playing  = false;
-        return;
+        pending->events.clear();
+
+        // Compatibility path for direct tests still setting aggregate fields.
+        if (pending->delta != 0.0f) {
+            apply_clamped_delta(pending->delta);
+            pending->delta = 0.0f;
+        }
+        if (pending->flash) {
+            energy->flash_timer = constants::ENERGY_FLASH_DURATION;
+            pending->flash = false;
+        }
     }
 
     // Smooth display toward actual energy

--- a/app/systems/game_state_end_screen_system.cpp
+++ b/app/systems/game_state_end_screen_system.cpp
@@ -1,0 +1,28 @@
+#include "all_systems.h"
+#include "../components/game_state.h"
+
+namespace {
+
+GamePhase resolve_end_screen_phase(EndScreenChoice choice) {
+    if (choice == EndScreenChoice::Restart) return GamePhase::Playing;
+    if (choice == EndScreenChoice::LevelSelect) return GamePhase::LevelSelect;
+    return GamePhase::Title;
+}
+
+}  // namespace
+
+void game_state_end_screen_system(entt::registry& reg, float /*dt*/) {
+    auto& gs = reg.ctx().get<GameState>();
+    const bool game_over_ready =
+        gs.phase == GamePhase::GameOver && gs.phase_timer > 0.4f;
+    const bool song_complete_ready =
+        gs.phase == GamePhase::SongComplete && gs.phase_timer > 0.5f;
+    if (!(game_over_ready || song_complete_ready) ||
+        gs.end_choice == EndScreenChoice::None) {
+        return;
+    }
+
+    gs.transition_pending = true;
+    gs.next_phase = resolve_end_screen_phase(gs.end_choice);
+    gs.end_choice = EndScreenChoice::None;
+}

--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -2,91 +2,8 @@
 #include "../session/play_session.h"
 #include "../components/game_state.h"
 #include "../util/obstacle_counter.h"
-#include "../components/input.h"
 #include "../components/input_events.h"
-#include "../components/scoring.h"
-#include "../audio/audio_queue.h"
-#include "../components/haptics.h"
-#include "../util/haptic_queue.h"
-#include "../util/settings.h"
 #include "../components/rhythm.h"
-#include "../components/high_score.h"
-#include "../util/high_score_persistence.h"
-#include "../constants.h"
-
-static void enter_game_over(entt::registry& reg) {
-    auto& score = reg.ctx().get<ScoreState>();
-    bool is_new_high_score = (score.score > score.high_score);
-    if (is_new_high_score) {
-        score.high_score = score.score;
-        if (auto* hs = reg.ctx().find<HighScoreState>()) {
-            high_score::update_if_higher(*hs, score.score);
-            if (auto* hp = reg.ctx().find<HighScorePersistence>()) {
-                hp->dirty = true;
-                if (hp->path.empty()) {
-                    hp->last_save = persistence::Result{persistence::Status::PathUnavailable, {}};
-                } else {
-                    hp->last_save = high_score::save_high_scores(*hs, hp->path);
-                    if (hp->last_save.ok()) hp->dirty = false;
-                }
-            }
-        }
-    }
-    audio_push(reg.ctx().get<AudioQueue>(), SFX::Crash);
-
-    {
-        auto* hq = reg.ctx().find<HapticQueue>();
-        auto* st = reg.ctx().find<SettingsState>();
-        if (hq) {
-            bool haptics_on = !st || st->haptics_enabled;
-            haptic_push(*hq, haptics_on, HapticEvent::DeathCrash);
-            if (is_new_high_score) haptic_push(*hq, haptics_on, HapticEvent::NewHighScore);
-        }
-    }
-
-    auto& gs = reg.ctx().get<GameState>();
-    gs.previous_phase = gs.phase;
-    gs.phase = GamePhase::GameOver;
-    gs.phase_timer = 0.0f;
-
-    if (auto* song = reg.ctx().find<SongState>()) {
-        song->finished = true;
-        song->playing = false;
-    }
-}
-
-static void enter_song_complete(entt::registry& reg) {
-    auto& score = reg.ctx().get<ScoreState>();
-    bool is_new_high_score = (score.score > score.high_score);
-    if (is_new_high_score) {
-        score.high_score = score.score;
-        if (auto* hs = reg.ctx().find<HighScoreState>()) {
-            high_score::update_if_higher(*hs, score.score);
-            if (auto* hp = reg.ctx().find<HighScorePersistence>()) {
-                hp->dirty = true;
-                if (hp->path.empty()) {
-                    hp->last_save = persistence::Result{persistence::Status::PathUnavailable, {}};
-                } else {
-                    hp->last_save = high_score::save_high_scores(*hs, hp->path);
-                    if (hp->last_save.ok()) hp->dirty = false;
-                }
-            }
-        }
-    }
-
-    {
-        auto* hq = reg.ctx().find<HapticQueue>();
-        auto* st = reg.ctx().find<SettingsState>();
-        if (hq && is_new_high_score) {
-            haptic_push(*hq, !st || st->haptics_enabled, HapticEvent::NewHighScore);
-        }
-    }
-
-    auto& gs = reg.ctx().get<GameState>();
-    gs.previous_phase = gs.phase;
-    gs.phase = GamePhase::SongComplete;
-    gs.phase_timer = 0.0f;
-}
 
 void game_state_system(entt::registry& reg, float dt) {
     auto& gs = reg.ctx().get<GameState>();
@@ -121,10 +38,10 @@ void game_state_system(entt::registry& reg, float dt) {
         switch (gs.next_phase) {
             case GamePhase::Playing:      setup_play_session(reg);  break;
             case GamePhase::GameOver:
-                enter_game_over(reg);
+                game_state_enter_terminal_phase(reg, GamePhase::GameOver);
                 break;
             case GamePhase::SongComplete:
-                enter_song_complete(reg);
+                game_state_enter_terminal_phase(reg, GamePhase::SongComplete);
                 break;
             case GamePhase::Paused:
                 gs.previous_phase = gs.phase;
@@ -169,18 +86,6 @@ void game_state_system(entt::registry& reg, float dt) {
         }
     }
 
-    // GameOver → button choice (after brief delay)
-    if (gs.phase == GamePhase::GameOver && gs.phase_timer > 0.4f && gs.end_choice != EndScreenChoice::None) {
-        gs.transition_pending = true;
-        if (gs.end_choice == EndScreenChoice::Restart)
-            gs.next_phase = GamePhase::Playing;
-        else if (gs.end_choice == EndScreenChoice::LevelSelect)
-            gs.next_phase = GamePhase::LevelSelect;
-        else
-            gs.next_phase = GamePhase::Title;
-        gs.end_choice = EndScreenChoice::None;
-    }
-
     // Playing → SongComplete when song finishes (all obstacles cleared)
     if (gs.phase == GamePhase::Playing) {
         auto* energy = reg.ctx().find<EnergyState>();
@@ -206,15 +111,5 @@ void game_state_system(entt::registry& reg, float dt) {
         }
     }
 
-    // SongComplete → button choice (after brief delay)
-    if (gs.phase == GamePhase::SongComplete && gs.phase_timer > 0.5f && gs.end_choice != EndScreenChoice::None) {
-        gs.transition_pending = true;
-        if (gs.end_choice == EndScreenChoice::Restart)
-            gs.next_phase = GamePhase::Playing;
-        else if (gs.end_choice == EndScreenChoice::LevelSelect)
-            gs.next_phase = GamePhase::LevelSelect;
-        else
-            gs.next_phase = GamePhase::Title;
-        gs.end_choice = EndScreenChoice::None;
-    }
+    game_state_end_screen_system(reg, dt);
 }

--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -22,7 +22,13 @@ static void enter_game_over(entt::registry& reg) {
         if (auto* hs = reg.ctx().find<HighScoreState>()) {
             high_score::update_if_higher(*hs, score.score);
             if (auto* hp = reg.ctx().find<HighScorePersistence>()) {
-                if (!hp->path.empty()) high_score::save_high_scores(*hs, hp->path);
+                hp->dirty = true;
+                if (hp->path.empty()) {
+                    hp->last_save = persistence::Result{persistence::Status::PathUnavailable, {}};
+                } else {
+                    hp->last_save = high_score::save_high_scores(*hs, hp->path);
+                    if (hp->last_save.ok()) hp->dirty = false;
+                }
             }
         }
     }
@@ -42,6 +48,11 @@ static void enter_game_over(entt::registry& reg) {
     gs.previous_phase = gs.phase;
     gs.phase = GamePhase::GameOver;
     gs.phase_timer = 0.0f;
+
+    if (auto* song = reg.ctx().find<SongState>()) {
+        song->finished = true;
+        song->playing = false;
+    }
 }
 
 static void enter_song_complete(entt::registry& reg) {
@@ -52,7 +63,13 @@ static void enter_song_complete(entt::registry& reg) {
         if (auto* hs = reg.ctx().find<HighScoreState>()) {
             high_score::update_if_higher(*hs, score.score);
             if (auto* hp = reg.ctx().find<HighScorePersistence>()) {
-                if (!hp->path.empty()) high_score::save_high_scores(*hs, hp->path);
+                hp->dirty = true;
+                if (hp->path.empty()) {
+                    hp->last_save = persistence::Result{persistence::Status::PathUnavailable, {}};
+                } else {
+                    hp->last_save = high_score::save_high_scores(*hs, hp->path);
+                    if (hp->last_save.ok()) hp->dirty = false;
+                }
             }
         }
     }
@@ -166,7 +183,19 @@ void game_state_system(entt::registry& reg, float dt) {
 
     // Playing → SongComplete when song finishes (all obstacles cleared)
     if (gs.phase == GamePhase::Playing) {
+        auto* energy = reg.ctx().find<EnergyState>();
         auto* song = reg.ctx().find<SongState>();
+        if (energy && song && song->playing && energy->energy <= 0.0f) {
+            if (auto* gos = reg.ctx().find<GameOverState>()) {
+                if (gos->cause == DeathCause::None) {
+                    gos->cause = DeathCause::EnergyDepleted;
+                }
+            }
+            gs.transition_pending = true;
+            gs.next_phase = GamePhase::GameOver;
+            return;
+        }
+
         if (song && song->finished) {
             // Wait until all obstacle entities have been destroyed (O(1) counter).
             auto* oc = reg.ctx().find<ObstacleCounter>();

--- a/app/systems/game_state_terminal_phase_system.cpp
+++ b/app/systems/game_state_terminal_phase_system.cpp
@@ -1,0 +1,70 @@
+#include "all_systems.h"
+#include "../audio/audio_queue.h"
+#include "../audio/audio_types.h"
+#include "../components/haptics.h"
+#include "../components/high_score.h"
+#include "../components/rhythm.h"
+#include "../components/scoring.h"
+#include "../util/haptic_queue.h"
+#include "../util/high_score_persistence.h"
+#include "../util/settings.h"
+
+namespace {
+
+bool update_and_persist_high_score(entt::registry& reg) {
+    auto& score = reg.ctx().get<ScoreState>();
+    const bool is_new_high_score = (score.score > score.high_score);
+    if (!is_new_high_score) return false;
+
+    score.high_score = score.score;
+    if (auto* hs = reg.ctx().find<HighScoreState>()) {
+        high_score::update_if_higher(*hs, score.score);
+        if (auto* hp = reg.ctx().find<HighScorePersistence>()) {
+            hp->dirty = true;
+            if (hp->path.empty()) {
+                hp->last_save = persistence::Result{persistence::Status::PathUnavailable, {}};
+            } else {
+                hp->last_save = high_score::save_high_scores(*hs, hp->path);
+                if (hp->last_save.ok()) hp->dirty = false;
+            }
+        }
+    }
+    return true;
+}
+
+void emit_terminal_feedback(entt::registry& reg, GamePhase phase, bool is_new_high_score) {
+    if (phase == GamePhase::GameOver) {
+        audio_push(reg.ctx().get<AudioQueue>(), SFX::Crash);
+    }
+
+    auto* hq = reg.ctx().find<HapticQueue>();
+    auto* st = reg.ctx().find<SettingsState>();
+    if (!hq) return;
+
+    const bool haptics_on = !st || st->haptics_enabled;
+    if (phase == GamePhase::GameOver) {
+        haptic_push(*hq, haptics_on, HapticEvent::DeathCrash);
+    }
+    if (is_new_high_score) {
+        haptic_push(*hq, haptics_on, HapticEvent::NewHighScore);
+    }
+}
+
+}  // namespace
+
+void game_state_enter_terminal_phase(entt::registry& reg, GamePhase phase) {
+    const bool is_new_high_score = update_and_persist_high_score(reg);
+    emit_terminal_feedback(reg, phase, is_new_high_score);
+
+    auto& gs = reg.ctx().get<GameState>();
+    gs.previous_phase = gs.phase;
+    gs.phase = phase;
+    gs.phase_timer = 0.0f;
+
+    if (phase == GamePhase::GameOver) {
+        if (auto* song = reg.ctx().find<SongState>()) {
+            song->finished = true;
+            song->playing = false;
+        }
+    }
+}

--- a/app/systems/haptic_system.cpp
+++ b/app/systems/haptic_system.cpp
@@ -1,43 +1,14 @@
 #include "all_systems.h"
 #include "../components/haptics.h"
+#include "../platform/haptics_backend.h"
 #include "../util/haptic_queue.h"
-#include "../util/settings.h"
-#include <magic_enum/magic_enum.hpp>
-#include <raylib.h>
-
-// ── Platform notes ────────────────────────────────────────────────────────────
-// Desktop / WASM: no platform vibration API — events are logged at DEBUG level
-//   so they remain deterministic and observable in tests without real hardware.
-// iOS: TODO(Hockney) — add UIImpactFeedbackGenerator bridge in a platform .mm
-//   file and call it from the #if defined(PLATFORM_IOS) block below.
-//   Do NOT add a silent fallback; unsupported platforms must be explicit here.
-// ─────────────────────────────────────────────────────────────────────────────
-
-static void trace_haptic_event(const char* prefix, HapticEvent e) {
-    const auto event_name = magic_enum::enum_name(e);
-    if (event_name.empty()) {
-        TraceLog(LOG_DEBUG, "%sUnknown", prefix);
-        return;
-    }
-    TraceLog(LOG_DEBUG, "%s%.*s", prefix, static_cast<int>(event_name.size()), event_name.data());
-}
 
 void haptic_system(entt::registry& reg) {
     auto* hq = reg.ctx().find<HapticQueue>();
     if (!hq || hq->count == 0) return;
 
     for (int i = 0; i < hq->count; ++i) {
-        HapticEvent e = hq->queue[i];
-
-#if defined(PLATFORM_IOS)
-        // TODO(Hockney): call UIImpactFeedbackGenerator bridge here.
-        // Example: haptic_ios_trigger(e);
-        // Until implemented, log only — do NOT silently swallow the event.
-        trace_haptic_event("HAPTIC [iOS-stub]: ", e);
-#else
-        // Desktop / WASM: log only — no platform vibration API available.
-        trace_haptic_event("HAPTIC: ", e);
-#endif
+        platform::haptics::trigger(hq->queue[i]);
     }
 
     haptic_clear(*hq);

--- a/app/systems/miss_detection_system.cpp
+++ b/app/systems/miss_detection_system.cpp
@@ -2,7 +2,6 @@
 #include "../components/obstacle.h"
 #include "../components/transform.h"
 #include "../components/game_state.h"
-#include "../components/song_state.h"
 #include "../constants.h"
 
 // Pure tagger: marks unscored obstacles that have scrolled past DESTROY_Y.
@@ -11,30 +10,19 @@
 void miss_detection_system(entt::registry& reg, float /*dt*/) {
     if (reg.ctx().get<GameState>().phase != GamePhase::Playing) return;
 
-    auto* gos = reg.ctx().find<GameOverState>();  // #309: hoisted above loop
-
-    auto model_view = reg.view<ObstacleTag, Obstacle, ObstacleScrollZ>(entt::exclude<ScoredTag>);
-    for (auto [entity, obs, oz] : model_view.each()) {
+    auto model_view = reg.view<ObstacleTag, ObstacleScrollZ>(entt::exclude<ScoredTag>);
+    for (auto [entity, oz] : model_view.each()) {
         if (oz.z <= constants::DESTROY_Y) continue;
 
         reg.emplace<MissTag>(entity);
         reg.emplace<ScoredTag>(entity);
-
-        if (gos && gos->cause == DeathCause::None) {
-            gos->cause = DeathCause::HitABar;
-        }
     }
 
-    auto view = reg.view<ObstacleTag, Obstacle, Position>(entt::exclude<ScoredTag>);
-    for (auto [entity, obs, pos] : view.each()) {
+    auto view = reg.view<ObstacleTag, Position>(entt::exclude<ScoredTag>);
+    for (auto [entity, pos] : view.each()) {
         if (pos.y <= constants::DESTROY_Y) continue;
 
         reg.emplace<MissTag>(entity);
         reg.emplace<ScoredTag>(entity);
-
-        // Set death-cause for the UI (does not override a prior cause).
-        if (gos && gos->cause == DeathCause::None) {
-            gos->cause = DeathCause::MissedABeat;
-        }
     }
 }

--- a/app/systems/popup_feedback_system.cpp
+++ b/app/systems/popup_feedback_system.cpp
@@ -1,0 +1,20 @@
+#include "all_systems.h"
+
+#include "../audio/audio_queue.h"
+#include "../components/game_state.h"
+#include "../components/gameplay_intents.h"
+#include "../entities/popup_entity.h"
+
+void popup_feedback_system(entt::registry& reg, float /*dt*/) {
+    if (reg.ctx().get<GameState>().phase != GamePhase::Playing) return;
+
+    auto* queue = reg.ctx().find<ScorePopupRequestQueue>();
+    if (!queue || queue->requests.empty()) return;
+
+    auto& audio = reg.ctx().get<AudioQueue>();
+    for (const auto& request : queue->requests) {
+        spawn_score_popup(reg, {request.x, request.y, request.points, request.timing_tier});
+        audio_push(audio, SFX::ScorePopup);
+    }
+    queue->requests.clear();
+}

--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -1,11 +1,10 @@
 #include "all_systems.h"
-#include "../entities/popup_entity.h"
 #include "../components/game_state.h"
 #include "../components/scoring.h"
 #include "../components/obstacle.h"
+#include "../components/gameplay_intents.h"
 #include "../components/transform.h"
 #include "../components/rendering.h"
-#include "../audio/audio_queue.h"
 #include "../components/haptics.h"
 #include "../util/settings.h"
 #include "../components/rhythm.h"
@@ -31,7 +30,7 @@ struct HitRecord {
 
 struct ScoringSystemScratch {
     std::vector<MissRecord> miss_buf;
-    std::vector<HitRecord> hit_buf;
+    std::vector<HitRecord>  hit_buf;
 };
 
 ScoringSystemScratch& scoring_scratch_for(entt::registry& reg) {
@@ -39,6 +38,25 @@ ScoringSystemScratch& scoring_scratch_for(entt::registry& reg) {
         return *scratch;
     }
     return reg.ctx().emplace<ScoringSystemScratch>();
+}
+
+PendingEnergyEffects& pending_energy_for(entt::registry& reg) {
+    if (auto* pending = reg.ctx().find<PendingEnergyEffects>()) {
+        return *pending;
+    }
+    return reg.ctx().emplace<PendingEnergyEffects>();
+}
+
+void enqueue_energy_effect(entt::registry& reg, float delta, bool flash = false) {
+    auto& pending = pending_energy_for(reg);
+    pending.events.push_back(PendingEnergyEffects::Event{delta, flash});
+}
+
+ScorePopupRequestQueue& popup_queue_for(entt::registry& reg) {
+    if (auto* queue = reg.ctx().find<ScorePopupRequestQueue>()) {
+        return *queue;
+    }
+    return reg.ctx().emplace<ScorePopupRequestQueue>();
 }
 
 }  // namespace
@@ -60,8 +78,10 @@ void scoring_system(entt::registry& reg, float dt) {
         score.chain_count = 0;
     }
 
-    auto* energy  = reg.ctx().find<EnergyState>();   // #309: hoisted above loop
     auto* results = reg.ctx().find<SongResults>();   // #309: hoisted above loop
+    auto* gos     = reg.ctx().find<GameOverState>();
+
+    auto& popup_queue = popup_queue_for(reg);
 
     // ── Miss pass ────────────────────────────────────────────────────────────
     // Structural view: only entities carrying MissTag.
@@ -77,14 +97,15 @@ void scoring_system(entt::registry& reg, float dt) {
 
         auto miss_view = reg.view<ObstacleTag, ScoredTag, MissTag, Obstacle>();
         for (auto e : miss_view) {
-            if (energy) {
-                energy->energy -= constants::ENERGY_DRAIN_MISS;
-                if (energy->energy < 1e-6f) energy->energy = 0.0f;
-                energy->flash_timer = constants::ENERGY_FLASH_DURATION;
-            }
+            enqueue_energy_effect(reg, -constants::ENERGY_DRAIN_MISS, true);
             if (results) results->miss_count++;
             score.chain_count = 0;
             score.chain_timer = 0.0f;
+            const auto kind = miss_view.get<Obstacle>(e).kind;
+            if (gos && gos->cause == DeathCause::None) {
+                const bool is_bar = (kind == ObstacleKind::LowBar || kind == ObstacleKind::HighBar);
+                gos->cause = is_bar ? DeathCause::HitABar : DeathCause::MissedABeat;
+            }
             miss_buf.push_back({e, reg.any_of<TimingGrade>(e)});
         }
         // Apply structural removals after iteration — safe.
@@ -142,24 +163,21 @@ void scoring_system(entt::registry& reg, float dt) {
             float timing_mult  = r.has_timing ? timing_multiplier(r.timing.tier) : 1.0f;
 
             // Energy adjustment based on timing
-            if (r.has_timing && energy) {
+            if (r.has_timing) {
                 switch (r.timing.tier) {
                     case TimingTier::Perfect:
-                        energy->energy += constants::ENERGY_RECOVER_PERFECT;
+                        enqueue_energy_effect(reg, constants::ENERGY_RECOVER_PERFECT);
                         break;
                     case TimingTier::Good:
-                        energy->energy += constants::ENERGY_RECOVER_GOOD;
+                        enqueue_energy_effect(reg, constants::ENERGY_RECOVER_GOOD);
                         break;
                     case TimingTier::Ok:
-                        energy->energy += constants::ENERGY_RECOVER_OK;
+                        enqueue_energy_effect(reg, constants::ENERGY_RECOVER_OK);
                         break;
                     case TimingTier::Bad:
-                        energy->energy -= constants::ENERGY_DRAIN_BAD;
-                        energy->flash_timer = constants::ENERGY_FLASH_DURATION;
+                        enqueue_energy_effect(reg, -constants::ENERGY_DRAIN_BAD, true);
                         break;
                 }
-                if (energy->energy < 0.0f) energy->energy = 0.0f;
-                if (energy->energy > constants::ENERGY_MAX) energy->energy = constants::ENERGY_MAX;
             }
 
             int points = static_cast<int>(
@@ -180,11 +198,10 @@ void scoring_system(entt::registry& reg, float dt) {
 
             score.score += points;
 
-            // Spawn timing/score popup via entity factory (#349).
+            // Queue timing/score popup; popup_feedback_system owns spawn/SFX.
             std::optional<TimingTier> tt = r.has_timing
                 ? std::make_optional(r.timing.tier) : std::nullopt;
-            spawn_score_popup(reg, {r.pos.x, r.pos.y, points, tt});
-            audio_push(reg.ctx().get<AudioQueue>(), SFX::ScorePopup);
+            popup_queue.requests.push_back({r.pos.x, r.pos.y, points, tt});
 
             // Structural removals after all reads — safe.
             reg.remove<Obstacle>(r.e);

--- a/app/util/fs_utils.h
+++ b/app/util/fs_utils.h
@@ -5,13 +5,23 @@
 
 namespace fs_utils {
 
+struct EnsureDirectoryResult {
+    bool ok{true};
+    std::error_code error{};
+};
+
 // Create all directories on the path, succeeding silently if they already
 // exist.  Returns true on success or when the path is empty.
-inline bool ensure_directory(const std::filesystem::path& dir) {
-    if (dir.empty()) return true;
+inline EnsureDirectoryResult ensure_directory_result(const std::filesystem::path& dir) {
+    if (dir.empty()) return EnsureDirectoryResult{};
     std::error_code ec;
     std::filesystem::create_directories(dir, ec);
-    return !ec;
+    if (ec) return EnsureDirectoryResult{false, ec};
+    return EnsureDirectoryResult{};
+}
+
+inline bool ensure_directory(const std::filesystem::path& dir) {
+    return ensure_directory_result(dir).ok;
 }
 
 } // namespace fs_utils

--- a/app/util/high_score_persistence.cpp
+++ b/app/util/high_score_persistence.cpp
@@ -1,6 +1,6 @@
 #include "high_score_persistence.h"
-#include "settings_persistence.h"
 #include "fs_utils.h"
+#include "persistence_policy.h"
 #include <nlohmann/json.hpp>
 #include <fstream>
 #include <filesystem>
@@ -12,11 +12,23 @@
 namespace high_score {
 
 std::filesystem::path get_high_scores_dir() {
-    return settings::get_settings_dir();
+    persistence::Paths paths;
+    const auto result = persistence::resolve_paths(paths);
+    return result.ok() ? paths.root_dir : std::filesystem::path{};
 }
 
-std::filesystem::path get_high_scores_file_path() {
-    return get_high_scores_dir() / "high_scores.json";
+persistence::Result get_high_scores_file_path(
+    std::filesystem::path& out_path,
+    const std::filesystem::path& root_override) {
+    persistence::Paths paths;
+    const auto result = persistence::resolve_paths(paths, root_override);
+    if (!result.ok()) {
+        out_path.clear();
+        return result;
+    }
+
+    out_path = paths.high_scores_file;
+    return persistence::Result{};
 }
 
 int32_t make_key_str(char* buf, int32_t cap, const char* song_id, const char* difficulty) {
@@ -153,44 +165,55 @@ bool high_score_state_from_json(const nlohmann::json& obj, HighScoreState& state
 
 }  // namespace
 
-bool load_high_scores(HighScoreState& state, const std::filesystem::path& path) {
+persistence::Result load_high_scores(HighScoreState& state, const std::filesystem::path& path) {
     std::error_code ec;
-    if (!std::filesystem::exists(path, ec) || ec) {
-        return false;
+    const bool exists = std::filesystem::exists(path, ec);
+    if (ec) {
+        return persistence::Result{persistence::Status::FileReadFailed, ec};
+    }
+    if (!exists) {
+        return persistence::Result{persistence::Status::MissingFile, {}};
     }
 
     try {
         std::ifstream file(path);
         if (!file.is_open()) {
-            return false;
+            return persistence::Result{persistence::Status::FileOpenFailed, {}};
         }
 
         nlohmann::json obj;
         file >> obj;
-        return high_score_state_from_json(obj, state);
+        if (file.bad()) {
+            return persistence::Result{persistence::Status::FileReadFailed, {}};
+        }
+        if (!high_score_state_from_json(obj, state)) {
+            return persistence::Result{persistence::Status::CorruptData, {}};
+        }
+        return persistence::Result{};
     } catch (const nlohmann::json::exception&) {
-        return false;
+        return persistence::Result{persistence::Status::CorruptData, {}};
     }
 }
 
-bool save_high_scores(const HighScoreState& state, const std::filesystem::path& path) {
-    if (!fs_utils::ensure_directory(path.parent_path())) {
-        return false;
+persistence::Result save_high_scores(const HighScoreState& state, const std::filesystem::path& path) {
+    const auto ensure = fs_utils::ensure_directory_result(path.parent_path());
+    if (!ensure.ok) {
+        return persistence::Result{persistence::Status::DirectoryCreateFailed, ensure.error};
     }
 
     std::ofstream file(path);
     if (!file.is_open()) {
-        return false;
+        return persistence::Result{persistence::Status::FileOpenFailed, {}};
     }
 
     nlohmann::json obj = high_score_state_to_json(state);
     file << obj.dump(2);
     file.flush();
     if (!file.good()) {
-        return false;
+        return persistence::Result{persistence::Status::FileWriteFailed, {}};
     }
     file.close();
-    return true;
+    return persistence::Result{};
 }
 
 void update_if_higher(HighScoreState& state, int32_t new_score) {

--- a/app/util/high_score_persistence.h
+++ b/app/util/high_score_persistence.h
@@ -6,18 +6,21 @@
 namespace high_score {
 
 // Load high scores from JSON file.
-// If file doesn't exist or parsing fails, returns false and leaves state unchanged.
-bool load_high_scores(HighScoreState& state, const std::filesystem::path& path);
+// Distinguishes missing/corrupt/path errors via structured status.
+persistence::Result load_high_scores(HighScoreState& state, const std::filesystem::path& path);
 
 // Save high scores to JSON file.
-// Returns false if write fails.
-bool save_high_scores(const HighScoreState& state, const std::filesystem::path& path);
+// Distinguishes path/open/write failures via structured status.
+persistence::Result save_high_scores(const HighScoreState& state, const std::filesystem::path& path);
 
 // Get platform-specific high scores directory (same as settings dir).
 std::filesystem::path get_high_scores_dir();
 
-// Get full high scores file path (dir/high_scores.json)
-std::filesystem::path get_high_scores_file_path();
+// Resolve full high scores file path.
+// Returns structured failure and clears out_path when resolution fails.
+persistence::Result get_high_scores_file_path(
+    std::filesystem::path& out_path,
+    const std::filesystem::path& root_override = {});
 
 // Update the stored score for state.current_key_hash if new_score is strictly higher.
 // Negative new_score is clamped to 0. No-op if current_key_hash is zero.

--- a/app/util/persistence_policy.cpp
+++ b/app/util/persistence_policy.cpp
@@ -1,0 +1,79 @@
+#include "persistence_policy.h"
+
+#include "fs_utils.h"
+
+#include <cstdlib>
+
+#ifndef _WIN32
+    #include <pwd.h>
+    #include <unistd.h>
+#endif
+
+#if defined(__APPLE__)
+    #include <TargetConditionals.h>
+#endif
+
+namespace persistence {
+namespace {
+
+std::filesystem::path resolve_root_dir(const std::filesystem::path& root_override) {
+    if (!root_override.empty()) {
+        return root_override;
+    }
+
+#ifdef _WIN32
+    const char* appdata = std::getenv("APPDATA");
+    if (appdata) return std::filesystem::path(appdata) / "shapeshifter";
+    return {};
+#elif defined(__EMSCRIPTEN__)
+    return std::filesystem::path(".");
+#else
+    const char* home = std::getenv("HOME");
+    if (!home) {
+        const passwd* pw = getpwuid(getuid());
+        if (pw) home = pw->pw_dir;
+    }
+    if (!home) return {};
+
+#if defined(__APPLE__) && defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
+    return std::filesystem::path(home) / "Library" / "Application Support" / "shapeshifter";
+#else
+    return std::filesystem::path(home) / ".shapeshifter";
+#endif
+#endif
+}
+
+}  // namespace
+
+Result resolve_paths(Paths& out_paths, const std::filesystem::path& root_override) {
+    const auto root_dir = resolve_root_dir(root_override);
+    if (root_dir.empty()) {
+        return Result{Status::PathUnavailable, {}};
+    }
+
+    const auto ensure = fs_utils::ensure_directory_result(root_dir);
+    if (!ensure.ok) {
+        return Result{Status::DirectoryCreateFailed, ensure.error};
+    }
+
+    out_paths.root_dir = root_dir;
+    out_paths.settings_file = root_dir / "settings.json";
+    out_paths.high_scores_file = root_dir / "high_scores.json";
+    return Result{};
+}
+
+const char* status_name(const Status status) {
+    switch (status) {
+        case Status::Success: return "success";
+        case Status::MissingFile: return "missing_file";
+        case Status::CorruptData: return "corrupt_data";
+        case Status::PathUnavailable: return "path_unavailable";
+        case Status::DirectoryCreateFailed: return "directory_create_failed";
+        case Status::FileOpenFailed: return "file_open_failed";
+        case Status::FileReadFailed: return "file_read_failed";
+        case Status::FileWriteFailed: return "file_write_failed";
+    }
+    return "unknown";
+}
+
+}  // namespace persistence

--- a/app/util/persistence_policy.h
+++ b/app/util/persistence_policy.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <filesystem>
+#include <system_error>
+
+namespace persistence {
+
+enum class Status {
+    Success,
+    MissingFile,
+    CorruptData,
+    PathUnavailable,
+    DirectoryCreateFailed,
+    FileOpenFailed,
+    FileReadFailed,
+    FileWriteFailed
+};
+
+struct Result {
+    Status status{Status::Success};
+    std::error_code error{};
+
+    [[nodiscard]] bool ok() const {
+        return status == Status::Success;
+    }
+};
+
+struct Paths {
+    std::filesystem::path root_dir;
+    std::filesystem::path settings_file;
+    std::filesystem::path high_scores_file;
+};
+
+Result resolve_paths(Paths& out_paths, const std::filesystem::path& root_override = {});
+
+const char* status_name(Status status);
+
+}  // namespace persistence

--- a/app/util/settings.h
+++ b/app/util/settings.h
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include <string>
 
+#include "persistence_policy.h"
+
 // Settings state singleton (lives in registry context)
 struct SettingsState {
     static constexpr int16_t MIN_AUDIO_OFFSET_MS = -250;
@@ -28,4 +30,7 @@ struct SettingsState {
 
 struct SettingsPersistence {
     std::string path;
+    persistence::Result last_load{};
+    persistence::Result last_save{};
+    bool dirty{false};
 };

--- a/app/util/settings_persistence.cpp
+++ b/app/util/settings_persistence.cpp
@@ -1,25 +1,14 @@
 #include "settings_persistence.h"
 #include "fs_utils.h"
+#include "persistence_policy.h"
 #include <fstream>
-#include <cstdlib>
 #include <algorithm>
 #include <cstdint>
 #include <limits>
-#include <system_error>
-
-#ifndef _WIN32
-    #include <pwd.h>
-    #include <unistd.h>
-#endif
 
 namespace settings {
 
 namespace {
-
-std::filesystem::path create_or_fallback(const std::filesystem::path& dir) {
-    if (fs_utils::ensure_directory(dir)) return dir;
-    return std::filesystem::path(".");
-}
 
 bool json_integer_to_i64(const nlohmann::json& value, std::int64_t& out) {
     if (!value.is_number_integer()) return false;
@@ -37,29 +26,23 @@ bool json_integer_to_i64(const nlohmann::json& value, std::int64_t& out) {
 }  // namespace
 
 std::filesystem::path get_settings_dir() {
-    #ifdef _WIN32
-        const char* appdata = std::getenv("APPDATA");
-        if (appdata) {
-            return create_or_fallback(std::filesystem::path(appdata) / "shapeshifter");
-        }
-    #elif defined(__EMSCRIPTEN__)
-        return create_or_fallback(std::filesystem::path("."));
-    #else
-        const char* home = std::getenv("HOME");
-        if (!home) {
-            const passwd* pw = getpwuid(getuid());
-            if (pw) home = pw->pw_dir;
-        }
-        if (home) {
-            return create_or_fallback(std::filesystem::path(home) / ".shapeshifter");
-        }
-    #endif
-    // Fallback to current directory if no home found
-    return std::filesystem::path(".");
+    persistence::Paths paths;
+    const auto result = persistence::resolve_paths(paths);
+    return result.ok() ? paths.root_dir : std::filesystem::path{};
 }
 
-std::filesystem::path get_settings_file_path() {
-    return get_settings_dir() / "settings.json";
+persistence::Result get_settings_file_path(
+    std::filesystem::path& out_path,
+    const std::filesystem::path& root_override) {
+    persistence::Paths paths;
+    const auto result = persistence::resolve_paths(paths, root_override);
+    if (!result.ok()) {
+        out_path.clear();
+        return result;
+    }
+
+    out_path = paths.settings_file;
+    return persistence::Result{};
 }
 
 nlohmann::json settings_to_json(const SettingsState& state) {
@@ -112,43 +95,54 @@ bool settings_from_json(const nlohmann::json& obj, SettingsState& state) {
     return true;
 }
 
-bool load_settings(SettingsState& state, const std::filesystem::path& path) {
+persistence::Result load_settings(SettingsState& state, const std::filesystem::path& path) {
     std::error_code ec;
-    if (!std::filesystem::exists(path, ec) || ec) {
-        return false;
+    const bool exists = std::filesystem::exists(path, ec);
+    if (ec) {
+        return persistence::Result{persistence::Status::FileReadFailed, ec};
+    }
+    if (!exists) {
+        return persistence::Result{persistence::Status::MissingFile, {}};
     }
 
     try {
         std::ifstream file(path);
         if (!file.is_open()) {
-            return false;
+            return persistence::Result{persistence::Status::FileOpenFailed, {}};
         }
 
         nlohmann::json obj;
         file >> obj;
-        return settings_from_json(obj, state);
+        if (file.bad()) {
+            return persistence::Result{persistence::Status::FileReadFailed, {}};
+        }
+        if (!settings_from_json(obj, state)) {
+            return persistence::Result{persistence::Status::CorruptData, {}};
+        }
+        return persistence::Result{};
     } catch (const nlohmann::json::exception&) {
-        return false;
+        return persistence::Result{persistence::Status::CorruptData, {}};
     }
 }
 
-bool save_settings(const SettingsState& state, const std::filesystem::path& path) {
-    if (!fs_utils::ensure_directory(path.parent_path())) {
-        return false;
+persistence::Result save_settings(const SettingsState& state, const std::filesystem::path& path) {
+    const auto ensure = fs_utils::ensure_directory_result(path.parent_path());
+    if (!ensure.ok) {
+        return persistence::Result{persistence::Status::DirectoryCreateFailed, ensure.error};
     }
 
     std::ofstream file(path);
     if (!file.is_open()) {
-        return false;
+        return persistence::Result{persistence::Status::FileOpenFailed, {}};
     }
 
     nlohmann::json obj = settings_to_json(state);
     file << obj.dump(2);
     file.flush();
     if (!file.good()) {
-        return false;
+        return persistence::Result{persistence::Status::FileWriteFailed, {}};
     }
-    return true;
+    return persistence::Result{};
 }
 
 void clamp_audio_offset(SettingsState& state) {

--- a/app/util/settings_persistence.h
+++ b/app/util/settings_persistence.h
@@ -7,21 +7,23 @@
 namespace settings {
 
 // Load settings from JSON file (platform-aware path).
-// If file doesn't exist or parsing fails, returns false.
+// Distinguishes missing/corrupt/path errors via structured status.
 // Settings are clamped to valid ranges.
-bool load_settings(SettingsState& state, const std::filesystem::path& path);
+persistence::Result load_settings(SettingsState& state, const std::filesystem::path& path);
 
 // Save settings to JSON file (platform-aware path).
-// Returns false if write fails.
-bool save_settings(const SettingsState& state, const std::filesystem::path& path);
+// Distinguishes path/open/write failures via structured status.
+persistence::Result save_settings(const SettingsState& state, const std::filesystem::path& path);
 
 // Get platform-specific settings directory.
-// On desktop: ~/.shapeshifter or %APPDATA%\shapeshifter
-// On web/mobile where a home directory is unavailable, falls back to ".".
+// Returns empty path when resolution fails.
 std::filesystem::path get_settings_dir();
 
-// Get full settings file path (dir/settings.json)
-std::filesystem::path get_settings_file_path();
+// Resolve full settings file path.
+// Returns structured failure and clears out_path when resolution fails.
+persistence::Result get_settings_file_path(
+    std::filesystem::path& out_path,
+    const std::filesystem::path& root_override = {});
 
 // Convert SettingsState to JSON
 nlohmann::json settings_to_json(const SettingsState& state);

--- a/tests/test_collision_extended.cpp
+++ b/tests/test_collision_extended.cpp
@@ -14,6 +14,7 @@ TEST_CASE("collision: Hexagon shape never matches shape gate", "[collision]") {
 
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     auto& gs = reg.ctx().get<GameState>();
     CHECK_FALSE(gs.transition_pending);
@@ -42,6 +43,7 @@ TEST_CASE("collision: Hexagon fails even when matching gate shape", "[collision]
     collision_system(reg, 0.016f);
     // Hexagon should NEVER clear shape gates
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     // Hexagon should NEVER clear shape gates
     auto& gs = reg.ctx().get<GameState>();
@@ -108,6 +110,7 @@ TEST_CASE("collision: rhythm miss increments miss_count in SongResults", "[colli
 
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     auto& results = reg.ctx().get<SongResults>();
     CHECK(results.miss_count == 1);
@@ -141,6 +144,7 @@ TEST_CASE("collision: multiple misses accumulate in miss_count", "[collision][rh
     make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     // Reset game over for second collision
     auto& gs = reg.ctx().get<GameState>();
@@ -151,9 +155,29 @@ TEST_CASE("collision: multiple misses accumulate in miss_count", "[collision][rh
     make_shape_gate(reg, Shape::Triangle, constants::PLAYER_Y);
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     auto& results = reg.ctx().get<SongResults>();
     CHECK(results.miss_count == 2);
+}
+
+TEST_CASE("collision: first miss cause is preserved across later misses", "[collision][issue282]") {
+    auto reg = make_rhythm_registry();
+    make_rhythm_player(reg);
+    auto& gos = reg.ctx().get<GameOverState>();
+
+    make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
+    collision_system(reg, 0.016f);
+    scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
+    REQUIRE(gos.cause == DeathCause::MissedABeat);
+
+    make_vertical_bar(reg, ObstacleKind::LowBar, constants::PLAYER_Y);
+    collision_system(reg, 0.016f);
+    scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
+
+    CHECK(gos.cause == DeathCause::MissedABeat);
 }
 
 // ── collision_system: combo gate edge cases ──────────────────
@@ -169,6 +193,7 @@ TEST_CASE("collision: combo gate requires both shape AND open lane", "[collision
 
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
     auto& energy = reg.ctx().get<EnergyState>();
@@ -230,6 +255,7 @@ TEST_CASE("collision: low bar fails when sliding", "[collision]") {
 
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
     auto& energy = reg.ctx().get<EnergyState>();
@@ -245,6 +271,7 @@ TEST_CASE("collision: high bar fails when jumping", "[collision]") {
 
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
     auto& energy = reg.ctx().get<EnergyState>();

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -24,6 +24,7 @@ TEST_CASE("collision: shape gate drains energy with wrong shape", "[collision]")
     CHECK(reg.all_of<MissTag>(obs));
 
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     auto& gs = reg.ctx().get<GameState>();
     CHECK_FALSE(gs.transition_pending);
@@ -51,6 +52,7 @@ TEST_CASE("collision: lane block drains energy when player in blocked lane", "[c
 
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
     auto& energy = reg.ctx().get<EnergyState>();
@@ -76,6 +78,7 @@ TEST_CASE("collision: low bar drains energy when grounded", "[collision]") {
 
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
     auto& energy = reg.ctx().get<EnergyState>();
@@ -101,6 +104,7 @@ TEST_CASE("collision: high bar drains energy when grounded", "[collision]") {
 
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
     auto& energy = reg.ctx().get<EnergyState>();
@@ -188,6 +192,7 @@ TEST_CASE("collision: combo gate fails with wrong shape", "[collision]") {
 
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
     auto& energy = reg.ctx().get<EnergyState>();
@@ -203,6 +208,7 @@ TEST_CASE("collision: combo gate fails when lane is blocked", "[collision]") {
 
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
     auto& energy = reg.ctx().get<EnergyState>();
@@ -230,6 +236,7 @@ TEST_CASE("collision: split path fails with wrong shape", "[collision]") {
 
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
     auto& energy = reg.ctx().get<EnergyState>();
@@ -245,6 +252,7 @@ TEST_CASE("collision: split path fails with wrong lane", "[collision]") {
 
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
     auto& energy = reg.ctx().get<EnergyState>();
@@ -281,6 +289,7 @@ TEST_CASE("collision: low bar drains energy when sliding", "[collision]") {
 
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
     auto& energy = reg.ctx().get<EnergyState>();
@@ -296,6 +305,7 @@ TEST_CASE("collision: high bar drains energy when jumping", "[collision]") {
 
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
     auto& energy = reg.ctx().get<EnergyState>();

--- a/tests/test_death_model_unified.cpp
+++ b/tests/test_death_model_unified.cpp
@@ -17,15 +17,14 @@ TEST_CASE("death_model: one miss drains energy without immediate GameOver", "[de
     CHECK(reg.all_of<ScoredTag>(obstacle));
 
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK(reg.ctx().get<SongResults>().miss_count == 1);
     CHECK_THAT(energy.energy,
                Catch::Matchers::WithinAbs(constants::ENERGY_MAX - constants::ENERGY_DRAIN_MISS,
                                             0.0001f));
-    CHECK(energy.flash_timer == constants::ENERGY_FLASH_DURATION);
+    CHECK(energy.flash_timer > 0.0f);
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
-
-    energy_system(reg, 0.016f);
 
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
 }
@@ -58,15 +57,16 @@ TEST_CASE("death_model: GameOver is deferred to energy depletion", "[death_model
     make_shape_gate(reg, Shape::Triangle, constants::PLAYER_Y);
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK(energy.energy == 0.0f);
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
 
-    energy_system(reg, 0.016f);
+    game_state_system(reg, 0.016f);
+    game_state_system(reg, 0.016f);
 
     const auto& state = reg.ctx().get<GameState>();
-    CHECK(state.transition_pending);
-    CHECK(state.next_phase == GamePhase::GameOver);
+    CHECK(state.phase == GamePhase::GameOver);
     CHECK_FALSE(reg.ctx().get<SongState>().playing);
 }
 
@@ -81,6 +81,7 @@ TEST_CASE("death_model: timing recovery can preserve survival margin", "[death_m
     reg.emplace<ScoredTag>(scored);
     reg.emplace<TimingGrade>(scored, TimingTier::Perfect, 1.0f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK_THAT(energy.energy,
                Catch::Matchers::WithinAbs(0.15f + constants::ENERGY_RECOVER_PERFECT, 0.0001f));
@@ -149,14 +150,13 @@ TEST_CASE("death_model: collision clamps depleted energy before GameOver transit
     make_shape_gate(reg, Shape::Triangle, constants::PLAYER_Y);
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK(energy.energy == 0.0f);
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
 
-    energy_system(reg, 0.016f);
-
+    game_state_system(reg, 0.016f);
     CHECK(reg.ctx().get<GameState>().transition_pending);
-    CHECK(reg.ctx().get<GameState>().next_phase == GamePhase::GameOver);
 }
 
 TEST_CASE("death_model: scroll-past miss drains energy without directly requesting GameOver", "[death_model]") {
@@ -180,15 +180,14 @@ TEST_CASE("death_model: scroll-past miss drains energy without directly requesti
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
 
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK(energy.energy == 0.0f);
     CHECK(reg.ctx().get<SongResults>().miss_count == 1);
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
 
-    energy_system(reg, 0.016f);
-
+    game_state_system(reg, 0.016f);
     CHECK(reg.ctx().get<GameState>().transition_pending);
-    CHECK(reg.ctx().get<GameState>().next_phase == GamePhase::GameOver);
 }
 
 // Regression: a scroll-past miss that depletes energy to 0 triggers GameOver
@@ -206,14 +205,13 @@ TEST_CASE("death_model: scroll-past fatal miss triggers GameOver same frame", "[
 
     miss_detection_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK(energy.energy == 0.0f);
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
 
-    energy_system(reg, 0.016f);
-
+    game_state_system(reg, 0.016f);
     CHECK(reg.ctx().get<GameState>().transition_pending);
-    CHECK(reg.ctx().get<GameState>().next_phase == GamePhase::GameOver);
 }
 
 // Regression: a scroll-past miss must not double-drain (energy delta = exactly
@@ -231,6 +229,7 @@ TEST_CASE("death_model: scroll-past miss does not double-drain", "[death_model]"
 
     miss_detection_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK(reg.ctx().get<SongResults>().miss_count == 1);
     CHECK_THAT(energy.energy,
@@ -255,6 +254,7 @@ TEST_CASE("death_model: LanePush scroll-past does not produce MissTag", "[death_
 
     miss_detection_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK_FALSE(reg.all_of<MissTag>(obstacle));
     CHECK_THAT(energy.energy, Catch::Matchers::WithinAbs(initial_energy, 0.0001f));

--- a/tests/test_energy_system.cpp
+++ b/tests/test_energy_system.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include "test_helpers.h"
+#include "components/gameplay_intents.h"
 
 // ── energy_system ────────────────────────────────────────────
 
@@ -28,40 +29,63 @@ TEST_CASE("energy: no action when energy is positive", "[energy]") {
     CHECK(reg.ctx().get<SongState>().playing);
 }
 
-TEST_CASE("energy: triggers game over when energy reaches zero", "[energy]") {
+TEST_CASE("energy: pending miss drain is applied by energy_system", "[energy]") {
+    auto reg = make_rhythm_registry();
+    auto& energy = reg.ctx().get<EnergyState>();
+    energy.energy = 0.8f;
+    auto& pending = reg.ctx().emplace<PendingEnergyEffects>();
+    pending.delta = -constants::ENERGY_DRAIN_MISS;
+    pending.flash = true;
+
+    energy_system(reg, 0.016f);
+
+    CHECK_THAT(energy.energy, Catch::Matchers::WithinAbs(0.8f - constants::ENERGY_DRAIN_MISS, 0.0001f));
+    CHECK(energy.flash_timer > 0.0f);
+    CHECK(energy.flash_timer < constants::ENERGY_FLASH_DURATION);
+    CHECK(pending.delta == 0.0f);
+    CHECK_FALSE(pending.flash);
+}
+
+TEST_CASE("energy: pending perfect recovery is applied by energy_system", "[energy]") {
+    auto reg = make_rhythm_registry();
+    auto& energy = reg.ctx().get<EnergyState>();
+    energy.energy = 0.2f;
+    auto& pending = reg.ctx().emplace<PendingEnergyEffects>();
+    pending.delta = constants::ENERGY_RECOVER_PERFECT;
+
+    energy_system(reg, 0.016f);
+
+    CHECK_THAT(energy.energy,
+               Catch::Matchers::WithinAbs(0.2f + constants::ENERGY_RECOVER_PERFECT, 0.0001f));
+    CHECK(pending.delta == 0.0f);
+}
+
+TEST_CASE("energy: pending events clamp each step in order", "[energy]") {
+    auto reg = make_rhythm_registry();
+    auto& energy = reg.ctx().get<EnergyState>();
+    energy.energy = 0.0f;
+    auto& pending = reg.ctx().emplace<PendingEnergyEffects>();
+    pending.events.push_back({-constants::ENERGY_DRAIN_MISS, true});
+    pending.events.push_back({constants::ENERGY_RECOVER_PERFECT, false});
+
+    energy_system(reg, 0.016f);
+
+    CHECK_THAT(energy.energy, Catch::Matchers::WithinAbs(constants::ENERGY_RECOVER_PERFECT, 0.0001f));
+    CHECK(energy.flash_timer > 0.0f);
+    CHECK(pending.events.empty());
+}
+
+TEST_CASE("energy: game_state triggers game over when energy reaches zero", "[energy]") {
     auto reg = make_rhythm_registry();
     auto& energy = reg.ctx().get<EnergyState>();
     energy.energy = 0.0f;
 
-    energy_system(reg, 0.016f);
+    game_state_system(reg, 0.016f);
 
     auto& gs = reg.ctx().get<GameState>();
     CHECK(gs.transition_pending);
     CHECK(gs.next_phase == GamePhase::GameOver);
-}
-
-TEST_CASE("energy: stops song playback when energy depleted", "[energy]") {
-    auto reg = make_rhythm_registry();
-    auto& energy = reg.ctx().get<EnergyState>();
-    energy.energy = 0.0f;
-
-    energy_system(reg, 0.016f);
-
-    auto& song = reg.ctx().get<SongState>();
-    CHECK(song.finished);
-    CHECK_FALSE(song.playing);
-}
-
-TEST_CASE("energy: negative energy also triggers game over", "[energy]") {
-    auto reg = make_rhythm_registry();
-    auto& energy = reg.ctx().get<EnergyState>();
-    energy.energy = -0.5f;
-
-    energy_system(reg, 0.016f);
-
-    auto& gs = reg.ctx().get<GameState>();
-    CHECK(gs.transition_pending);
-    CHECK(gs.next_phase == GamePhase::GameOver);
+    CHECK(reg.ctx().get<GameOverState>().cause == DeathCause::EnergyDepleted);
 }
 
 TEST_CASE("energy: no action when SongState not present", "[energy]") {
@@ -112,7 +136,7 @@ TEST_CASE("energy: small positive energy does not trigger game over", "[energy]"
     auto& energy = reg.ctx().get<EnergyState>();
     energy.energy = 0.01f;
 
-    energy_system(reg, 0.016f);
+    game_state_system(reg, 0.016f);
 
     auto& gs = reg.ctx().get<GameState>();
     CHECK_FALSE(gs.transition_pending);
@@ -141,6 +165,19 @@ TEST_CASE("energy: flash timer decrements", "[energy]") {
 
     CHECK(energy.flash_timer < 0.2f);
     CHECK(energy.flash_timer > 0.0f);
+}
+
+TEST_CASE("energy: enter_game_over owns song stop", "[energy][gamestate]") {
+    auto reg = make_rhythm_registry();
+    auto& gs = reg.ctx().get<GameState>();
+    gs.transition_pending = true;
+    gs.next_phase = GamePhase::GameOver;
+
+    game_state_system(reg, 0.016f);
+
+    auto& song = reg.ctx().get<SongState>();
+    CHECK(song.finished);
+    CHECK_FALSE(song.playing);
 }
 
 TEST_CASE("energy: flash timer clamps to zero", "[energy]") {

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -245,6 +245,37 @@ TEST_CASE("game_state: game_over main_menu button triggers title", "[gamestate]"
     CHECK(gs.next_phase == GamePhase::Title);
 }
 
+TEST_CASE("game_state: game_over restart enters fresh play session on next tick", "[gamestate][play_session]") {
+    auto reg = make_registry();
+    auto& gs = reg.ctx().get<GameState>();
+    gs.phase = GamePhase::GameOver;
+    gs.phase_timer = 0.5f;
+    gs.end_choice = EndScreenChoice::Restart;
+
+    auto stale = reg.create();
+    reg.emplace<ObstacleTag>(stale);
+    reg.emplace<Position>(stale, 0.0f, 0.0f);
+    reg.ctx().get<ScoreState>().score = 3210;
+
+    game_state_system(reg, 0.016f);
+    REQUIRE(gs.transition_pending);
+    REQUIRE(gs.next_phase == GamePhase::Playing);
+
+    game_state_system(reg, 0.016f);
+
+    CHECK_FALSE(gs.transition_pending);
+    CHECK(gs.phase == GamePhase::Playing);
+    CHECK_FALSE(reg.valid(stale));
+    CHECK_FALSE(reg.view<PlayerTag>().empty());
+    int shape_button_count = 0;
+    for (auto entity : reg.view<ShapeButtonTag>()) {
+        ++shape_button_count;
+        (void)entity;
+    }
+    CHECK(shape_button_count == 3);
+    CHECK(reg.ctx().get<ScoreState>().score == 0);
+}
+
 TEST_CASE("game_state: title position tap triggers level_select", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();

--- a/tests/test_haptics_backend.cpp
+++ b/tests/test_haptics_backend.cpp
@@ -1,0 +1,24 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "components/haptics.h"
+#include "platform/haptics_backend.h"
+
+TEST_CASE("haptics backend maps burst patterns for heavy events", "[haptic]") {
+    const auto death = platform::haptics::pattern_for_event(HapticEvent::DeathCrash);
+    CHECK(death.style == platform::haptics::ImpactStyle::Heavy);
+    CHECK(death.pulse_count == 2);
+
+    const auto burnout = platform::haptics::pattern_for_event(HapticEvent::Burnout5_0x);
+    CHECK(burnout.style == platform::haptics::ImpactStyle::Heavy);
+    CHECK(burnout.pulse_count == 3);
+}
+
+TEST_CASE("haptics backend maps light and medium events deterministically", "[haptic]") {
+    const auto lane = platform::haptics::pattern_for_event(HapticEvent::LaneSwitch);
+    CHECK(lane.style == platform::haptics::ImpactStyle::Light);
+    CHECK(lane.pulse_count == 1);
+
+    const auto score = platform::haptics::pattern_for_event(HapticEvent::NewHighScore);
+    CHECK(score.style == platform::haptics::ImpactStyle::Medium);
+    CHECK(score.pulse_count == 1);
+}

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -19,16 +19,14 @@
 #include "components/high_score.h"
 #include "components/rng.h"
 #include "constants.h"
+#include "entities/obstacle_render_entity.h"
 #include "systems/all_systems.h"
 #include "input/input_routing.h"
 
 // Sets up a registry with all singletons in their default state
 inline entt::registry make_registry() {
     entt::registry reg;
-    // Prime ObstacleChildren pool before wire_obstacle_counter creates the ObstacleTag
-    // pool. EnTT::destroy() iterates pools in reverse insertion order; ObstacleChildren
-    // must have a lower index so it is still accessible when on_obstacle_destroy fires.
-    reg.storage<ObstacleChildren>();
+    wire_obstacle_mesh_lifetime(reg);
     reg.ctx().emplace<InputState>();
     reg.ctx().emplace<entt::dispatcher>();
     wire_input_dispatcher(reg);

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <filesystem>
+#include <fstream>
 
 #include "components/high_score.h"
 #include "entities/camera_entity.h"
@@ -88,7 +89,7 @@ TEST_CASE("High score integration: new song-complete high score persists",
     CHECK(high_score::get_score(high_scores, "song_001|easy") == 2500);
 
     HighScoreState loaded;
-    REQUIRE(high_score::load_high_scores(loaded, file));
+    REQUIRE(high_score::load_high_scores(loaded, file).ok());
     CHECK(high_score::get_score(loaded, "song_001|easy") == 2500);
 
     remove_path(file);
@@ -123,6 +124,43 @@ TEST_CASE("High score integration: lower game-over score does not overwrite pers
     remove_path(file);
 }
 
+TEST_CASE("High score integration: failed save keeps dirty state for retry",
+          "[high_score][gamestate]") {
+    const auto root = std::filesystem::path("test_high_score_retry_state");
+    const auto blocked_parent = root / "blocked_parent";
+    const auto blocked_file = blocked_parent / "high_scores.json";
+    remove_path(root);
+    std::filesystem::create_directories(root);
+    {
+        std::ofstream out(blocked_parent);
+        REQUIRE(out.is_open());
+        out << "file blocks directory creation";
+    }
+
+    auto reg = make_registry();
+    reg.ctx().get<HighScorePersistence>().path = blocked_file.string();
+    auto& high_scores = reg.ctx().get<HighScoreState>();
+    high_score::ensure_entry(high_scores, "song_001|easy");
+    high_scores.current_key_hash = high_score::make_key_hash("song_001", "easy");
+    high_score::set_score(high_scores, "song_001|easy", 1000);
+
+    auto& score = reg.ctx().get<ScoreState>();
+    score.high_score = 1000;
+    score.score = 2500;
+
+    auto& gs = reg.ctx().get<GameState>();
+    gs.transition_pending = true;
+    gs.next_phase = GamePhase::SongComplete;
+
+    game_state_system(reg, 0.016f);
+
+    const auto& persistence_state = reg.ctx().get<HighScorePersistence>();
+    CHECK(persistence_state.dirty);
+    CHECK(persistence_state.last_save.status == persistence::Status::DirectoryCreateFailed);
+
+    remove_path(root);
+}
+
 TEST_CASE("High score bootstrap: persistence path is populated for save call sites",
           "[high_score][gamestate][issue-302]") {
     const auto file = temp_high_score_path("shapeshifter_issue_302_high_scores_bootstrap.json");
@@ -130,11 +168,11 @@ TEST_CASE("High score bootstrap: persistence path is populated for save call sit
 
     HighScoreState seeded;
     high_score::set_score(seeded, "song_001|easy", 1000);
-    REQUIRE(high_score::save_high_scores(seeded, file));
+    REQUIRE(high_score::save_high_scores(seeded, file).ok());
 
     auto reg = make_registry();
     HighScoreState loaded_at_bootstrap;
-    high_score::load_high_scores(loaded_at_bootstrap, file);
+    CHECK(high_score::load_high_scores(loaded_at_bootstrap, file).ok());
     reg.ctx().get<HighScoreState>() = loaded_at_bootstrap;
     reg.ctx().get<HighScorePersistence>() = HighScorePersistence{file.string()};
     reg.ctx().get<GameState>() = GameState{
@@ -155,7 +193,7 @@ TEST_CASE("High score bootstrap: persistence path is populated for save call sit
     game_state_system(reg, 0.016f);
 
     HighScoreState loaded;
-    REQUIRE(high_score::load_high_scores(loaded, file));
+    REQUIRE(high_score::load_high_scores(loaded, file).ok());
     CHECK(high_score::get_score(loaded, "song_001|easy") == 2500);
 
     remove_path(file);

--- a/tests/test_high_score_persistence.cpp
+++ b/tests/test_high_score_persistence.cpp
@@ -106,10 +106,10 @@ TEST_CASE("High score persistence: round-trips score map", "[high_score]") {
     high_score::set_score(original, "song_001|hard", 2000);
     high_score::set_score(original, "song_002|easy", 1500);
 
-    REQUIRE(high_score::save_high_scores(original, file));
+    REQUIRE(high_score::save_high_scores(original, file).ok());
 
     HighScoreState loaded;
-    REQUIRE(high_score::load_high_scores(loaded, file));
+    REQUIRE(high_score::load_high_scores(loaded, file).ok());
     CHECK(high_score::get_score(loaded, "song_001|easy") == high_score::get_score(original, "song_001|easy"));
     CHECK(high_score::get_score(loaded, "song_001|hard") == high_score::get_score(original, "song_001|hard"));
     CHECK(high_score::get_score(loaded, "song_002|easy") == high_score::get_score(original, "song_002|easy"));
@@ -124,10 +124,10 @@ TEST_CASE("High score persistence: supports current-directory files", "[high_sco
     HighScoreState original;
     high_score::set_score(original, "song_001|easy", 2000);
 
-    REQUIRE(high_score::save_high_scores(original, file));
+    REQUIRE(high_score::save_high_scores(original, file).ok());
 
     HighScoreState loaded;
-    REQUIRE(high_score::load_high_scores(loaded, file));
+    REQUIRE(high_score::load_high_scores(loaded, file).ok());
     CHECK(high_score::get_score(loaded, "song_001|easy") == 2000);
 
     remove_path(file);
@@ -140,7 +140,8 @@ TEST_CASE("High score persistence: missing file returns false and preserves stat
     HighScoreState state;
     high_score::set_score(state, "song_001|easy", 500);
 
-    CHECK_FALSE(high_score::load_high_scores(state, file));
+    const auto result = high_score::load_high_scores(state, file);
+    CHECK(result.status == persistence::Status::MissingFile);
     CHECK(high_score::get_score(state, "song_001|easy") == 500);
 }
 
@@ -158,7 +159,8 @@ TEST_CASE("High score persistence: malformed JSON preserves state", "[high_score
     HighScoreState state;
     high_score::set_score(state, "song_001|easy", 500);
 
-    CHECK_FALSE(high_score::load_high_scores(state, file));
+    const auto result = high_score::load_high_scores(state, file);
+    CHECK(result.status == persistence::Status::CorruptData);
     CHECK(high_score::get_score(state, "song_001|easy") == 500);
 
     remove_path(dir);
@@ -178,7 +180,7 @@ TEST_CASE("High score persistence: invalid schema preserves state", "[high_score
     HighScoreState state;
     high_score::set_score(state, "song_001|easy", 500);
 
-    CHECK_FALSE(high_score::load_high_scores(state, file));
+    CHECK(high_score::load_high_scores(state, file).status == persistence::Status::CorruptData);
     CHECK(high_score::get_score(state, "song_001|easy") == 500);
 
     {
@@ -186,7 +188,7 @@ TEST_CASE("High score persistence: invalid schema preserves state", "[high_score
         out << R"({"scores":{"song_001|easy":"not_a_number"}})";
     }
 
-    CHECK_FALSE(high_score::load_high_scores(state, file));
+    CHECK(high_score::load_high_scores(state, file).status == persistence::Status::CorruptData);
     CHECK(high_score::get_score(state, "song_001|easy") == 500);
 
     remove_path(dir);
@@ -204,7 +206,7 @@ TEST_CASE("High score persistence: clamps negative and oversized scores", "[high
     }
 
     HighScoreState state;
-    REQUIRE(high_score::load_high_scores(state, file));
+    REQUIRE(high_score::load_high_scores(state, file).ok());
     CHECK(high_score::get_score(state, "negative|easy") == 0);
     CHECK(high_score::get_score(state, "huge|hard") == std::numeric_limits<int32_t>::max());
 
@@ -218,17 +220,57 @@ TEST_CASE("High score persistence: load preserves current active key", "[high_sc
 
     HighScoreState original;
     high_score::set_score(original, "song_001|easy", 1000);
-    REQUIRE(high_score::save_high_scores(original, file));
+    REQUIRE(high_score::save_high_scores(original, file).ok());
 
     HighScoreState loaded;
     // Simulate a session already active on song_002|hard before the load.
     const auto pre_load_hash = high_score::make_key_hash("song_002", "hard");
     loaded.current_key_hash = pre_load_hash;
-    REQUIRE(high_score::load_high_scores(loaded, file));
+    REQUIRE(high_score::load_high_scores(loaded, file).ok());
 
     // Load must not clobber the in-progress session key.
     CHECK(loaded.current_key_hash == pre_load_hash);
     CHECK(high_score::get_score(loaded, "song_001|easy") == 1000);
 
     remove_path(dir);
+}
+
+TEST_CASE("High score persistence: save reports unwritable parent path", "[high_score]") {
+    const auto root = std::filesystem::path("test_high_score_unwritable_parent");
+    const auto not_a_dir = root / "not_a_directory";
+    const auto file = not_a_dir / "high_scores.json";
+
+    remove_path(root);
+    std::filesystem::create_directories(root);
+    {
+        std::ofstream out(not_a_dir);
+        REQUIRE(out.is_open());
+        out << "file blocks directory creation";
+    }
+
+    HighScoreState state;
+    high_score::set_score(state, "song_001|easy", 1000);
+    const auto result = high_score::save_high_scores(state, file);
+    CHECK(result.status == persistence::Status::DirectoryCreateFailed);
+
+    remove_path(root);
+}
+
+TEST_CASE("High score helper: file path resolution reports failure without CWD fallback", "[high_score]") {
+    const auto root = std::filesystem::path("test_high_score_path_resolution_failure");
+    const auto blocked_root = root / "blocked_root";
+    remove_path(root);
+    std::filesystem::create_directories(root);
+    {
+        std::ofstream out(blocked_root);
+        REQUIRE(out.is_open());
+        out << "file blocks directory creation";
+    }
+
+    std::filesystem::path file_path = "seed_should_clear.json";
+    const auto result = high_score::get_high_scores_file_path(file_path, blocked_root);
+    CHECK(result.status == persistence::Status::DirectoryCreateFailed);
+    CHECK(file_path.empty());
+
+    remove_path(root);
 }

--- a/tests/test_obstacle_archetypes.cpp
+++ b/tests/test_obstacle_archetypes.cpp
@@ -100,8 +100,7 @@ TEST_CASE("entity: obstacle roots and mesh children declare world render pass", 
 
 TEST_CASE("entity: obstacle mesh overflow does not create orphan MeshChild", "[archetype][render][cleanup]") {
     entt::registry reg;
-    reg.storage<ObstacleChildren>();
-    reg.on_destroy<ObstacleTag>().connect<&on_obstacle_destroy>();
+    wire_obstacle_mesh_lifetime(reg);
 
     auto parent = reg.create();
     reg.emplace<Position>(parent, 360.0f, -120.0f);
@@ -125,6 +124,31 @@ TEST_CASE("entity: obstacle mesh overflow does not create orphan MeshChild", "[a
     CHECK_THROWS_AS(spawn_obstacle_meshes(reg, parent), std::logic_error);
     CHECK(count_mesh_children(reg) == ObstacleChildren::MAX);
     CHECK(reg.get<ObstacleChildren>(parent).count == ObstacleChildren::MAX);
+
+    reg.destroy(parent);
+
+    CHECK(count_mesh_children(reg) == 0);
+}
+
+TEST_CASE("entity: obstacle mesh lifetime is wired by the factory", "[archetype][render][cleanup]") {
+    entt::registry reg;
+    auto parent = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f, Shape::Circle});
+
+    REQUIRE(count_mesh_children(reg) > 0);
+
+    reg.destroy(parent);
+
+    CHECK(count_mesh_children(reg) == 0);
+}
+
+TEST_CASE("entity: direct mesh factory cleanup does not depend on ObstacleTag order", "[archetype][render][cleanup]") {
+    entt::registry reg;
+    auto parent = make_mesh_factory_obstacle(reg, ObstacleKind::ShapeGate);
+    reg.emplace<RequiredShape>(parent, Shape::Circle);
+    reg.emplace<ObstacleTag>(parent);
+
+    spawn_obstacle_meshes(reg, parent);
+    REQUIRE(count_mesh_children(reg) > 0);
 
     reg.destroy(parent);
 

--- a/tests/test_obstacle_archetypes.cpp
+++ b/tests/test_obstacle_archetypes.cpp
@@ -1,6 +1,9 @@
 #include <catch2/catch_test_macros.hpp>
 #include "test_helpers.h"
 #include "entities/obstacle_entity.h"
+#include "entities/obstacle_render_entity.h"
+
+#include <stdexcept>
 
 // spawn_obstacle: entity bundle contract tests.
 // Calls the entity factory directly, independent of beat_scheduler_system.
@@ -16,6 +19,15 @@ void probe_obstacle_tag_construct(entt::registry& reg, entt::entity entity) {
     if (!probe) return;
     probe->saw_obstacle = reg.all_of<Obstacle>(entity);
     probe->saw_beat_info = reg.all_of<BeatInfo>(entity);
+}
+
+int count_mesh_children(entt::registry& reg) {
+    int count = 0;
+    auto view = reg.view<MeshChild>();
+    for ([[maybe_unused]] auto entity : view) {
+        ++count;
+    }
+    return count;
 }
 }
 
@@ -68,6 +80,39 @@ TEST_CASE("entity: obstacle roots and mesh children declare world render pass", 
     auto low_bar = spawn_obstacle(reg, {ObstacleKind::LowBar, 360.0f, -120.0f});
     CHECK(reg.all_of<TagWorldPass>(low_bar));
     CHECK(reg.all_of<WorldTransform>(low_bar));
+}
+
+TEST_CASE("entity: obstacle mesh overflow does not create orphan MeshChild", "[archetype][render][cleanup]") {
+    entt::registry reg;
+    reg.storage<ObstacleChildren>();
+    reg.on_destroy<ObstacleTag>().connect<&on_obstacle_destroy>();
+
+    auto parent = reg.create();
+    reg.emplace<Position>(parent, 360.0f, -120.0f);
+    reg.emplace<Obstacle>(parent, ObstacleKind::ShapeGate, int16_t{constants::PTS_SHAPE_GATE});
+    reg.emplace<DrawSize>(parent, constants::SCREEN_W_F, 80.0f);
+    reg.emplace<Color>(parent, Color{80, 200, 255, 255});
+    reg.emplace<RequiredShape>(parent, Shape::Circle);
+
+    auto& children = reg.emplace<ObstacleChildren>(parent);
+    for (int i = 0; i < ObstacleChildren::MAX; ++i) {
+        auto child = reg.create();
+        reg.emplace<MeshChild>(child, MeshChild{
+            parent, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f,
+            Color{255, 255, 255, 255}, MeshType::Slab, 0
+        });
+        children.children[children.count++] = child;
+    }
+    reg.emplace<ObstacleTag>(parent);
+
+    CHECK(count_mesh_children(reg) == ObstacleChildren::MAX);
+    CHECK_THROWS_AS(spawn_obstacle_meshes(reg, parent), std::logic_error);
+    CHECK(count_mesh_children(reg) == ObstacleChildren::MAX);
+    CHECK(reg.get<ObstacleChildren>(parent).count == ObstacleChildren::MAX);
+
+    reg.destroy(parent);
+
+    CHECK(count_mesh_children(reg) == 0);
 }
 
 TEST_CASE("entity: ShapeGate Square - red color", "[archetype]") {

--- a/tests/test_obstacle_archetypes.cpp
+++ b/tests/test_obstacle_archetypes.cpp
@@ -29,6 +29,22 @@ int count_mesh_children(entt::registry& reg) {
     }
     return count;
 }
+
+entt::entity make_mesh_factory_obstacle(entt::registry& reg, ObstacleKind kind) {
+    auto parent = reg.create();
+    reg.emplace<Position>(parent, constants::LANE_X[1], -120.0f);
+    reg.emplace<Obstacle>(parent, kind, int16_t{0});
+    reg.emplace<DrawSize>(parent, constants::SCREEN_W_F, 80.0f);
+    reg.emplace<Color>(parent, Color{255, 255, 255, 255});
+    return parent;
+}
+
+void check_no_mesh_children(entt::registry& reg, entt::entity parent) {
+    CHECK(count_mesh_children(reg) == 0);
+    if (auto* children = reg.try_get<ObstacleChildren>(parent)) {
+        CHECK(children->count == 0);
+    }
+}
 }
 
 TEST_CASE("entity: ShapeGate Circle - correct components and color", "[archetype]") {
@@ -113,6 +129,61 @@ TEST_CASE("entity: obstacle mesh overflow does not create orphan MeshChild", "[a
     reg.destroy(parent);
 
     CHECK(count_mesh_children(reg) == 0);
+}
+
+TEST_CASE("entity: mesh factory rejects invalid RequiredShape before children", "[archetype][render][validation]") {
+    const Shape invalid_shape = static_cast<Shape>(255);
+
+    SECTION("ShapeGate") {
+        entt::registry reg;
+        auto parent = make_mesh_factory_obstacle(reg, ObstacleKind::ShapeGate);
+        reg.emplace<RequiredShape>(parent, invalid_shape);
+
+        CHECK_THROWS_AS(spawn_obstacle_meshes(reg, parent), std::logic_error);
+        check_no_mesh_children(reg, parent);
+    }
+
+    SECTION("ComboGate") {
+        entt::registry reg;
+        auto parent = make_mesh_factory_obstacle(reg, ObstacleKind::ComboGate);
+        reg.emplace<RequiredShape>(parent, invalid_shape);
+        reg.emplace<BlockedLanes>(parent, uint8_t{0b101});
+
+        CHECK_THROWS_AS(spawn_obstacle_meshes(reg, parent), std::logic_error);
+        check_no_mesh_children(reg, parent);
+    }
+
+    SECTION("SplitPath") {
+        entt::registry reg;
+        auto parent = make_mesh_factory_obstacle(reg, ObstacleKind::SplitPath);
+        reg.emplace<RequiredShape>(parent, invalid_shape);
+        reg.emplace<RequiredLane>(parent, int8_t{1});
+
+        CHECK_THROWS_AS(spawn_obstacle_meshes(reg, parent), std::logic_error);
+        check_no_mesh_children(reg, parent);
+    }
+}
+
+TEST_CASE("entity: mesh factory rejects invalid RequiredLane before children", "[archetype][render][validation]") {
+    SECTION("negative lane") {
+        entt::registry reg;
+        auto parent = make_mesh_factory_obstacle(reg, ObstacleKind::SplitPath);
+        reg.emplace<RequiredShape>(parent, Shape::Square);
+        reg.emplace<RequiredLane>(parent, int8_t{-1});
+
+        CHECK_THROWS_AS(spawn_obstacle_meshes(reg, parent), std::logic_error);
+        check_no_mesh_children(reg, parent);
+    }
+
+    SECTION("lane beyond lane table") {
+        entt::registry reg;
+        auto parent = make_mesh_factory_obstacle(reg, ObstacleKind::SplitPath);
+        reg.emplace<RequiredShape>(parent, Shape::Square);
+        reg.emplace<RequiredLane>(parent, int8_t{3});
+
+        CHECK_THROWS_AS(spawn_obstacle_meshes(reg, parent), std::logic_error);
+        check_no_mesh_children(reg, parent);
+    }
 }
 
 TEST_CASE("entity: ShapeGate Square - red color", "[archetype]") {

--- a/tests/test_pr43_regression.cpp
+++ b/tests/test_pr43_regression.cpp
@@ -140,12 +140,10 @@ TEST_CASE("MeshChild: height stores OBSTACLE_3D_HEIGHT for ShapeGate side slabs"
 }
 
 // ═══════════════════════════════════════════════════════════════════════
-// Theme 6 – on_obstacle_destroy must only destroy children whose parent
+// Theme 6 – obstacle mesh lifetime must only destroy children whose parent
 //           is the entity being destroyed, not other obstacles' children.
-// on_obstacle_destroy uses ObstacleChildren for O(N) lookup.
-// The production fix must prime the ObstacleChildren pool before connecting
-// on_destroy<ObstacleTag>, so the pool's insertion index is lower than
-// ObstacleTag's; EnTT destroy() iterates pools in reverse insertion order.
+// The cleanup listener follows ObstacleChildren ownership directly, so it does
+// not depend on ObstacleTag pool insertion order.
 // ═══════════════════════════════════════════════════════════════════════
 
 // Helper: create an obstacle with an ObstacleChildren list.
@@ -161,19 +159,13 @@ static entt::entity make_obstacle(entt::registry& reg,
     return obs;
 }
 
-// Helper: set up the registry with on_obstacle_destroy wired.
-// make_registry() already primes the ObstacleChildren pool before wire_obstacle_counter
-// creates the ObstacleTag pool, guaranteeing that ObstacleChildren has a lower insertion
-// index. EnTT destroy() iterates pools in reverse order, so ObstacleChildren is removed
-// LAST — still accessible when on_obstacle_destroy fires for ObstacleTag.
+// Helper: set up the registry with centralized obstacle mesh lifetime wiring.
 static entt::registry make_obs_registry() {
-    auto reg = make_registry();
-    reg.on_destroy<ObstacleTag>().connect<&on_obstacle_destroy>();
-    return reg;
+    return make_registry();
 }
 
-TEST_CASE("on_obstacle_destroy: only removes the destroyed parent's children",
-          "[obstacle][cleanup][pr43]") {
+TEST_CASE("obstacle mesh lifetime: only removes the destroyed parent's children",
+           "[obstacle][cleanup][pr43]") {
     auto reg = make_obs_registry();
 
     auto childA1 = reg.create();
@@ -191,8 +183,8 @@ TEST_CASE("on_obstacle_destroy: only removes the destroyed parent's children",
     CHECK(reg.valid(childB));
 }
 
-TEST_CASE("on_obstacle_destroy: all children of destroyed parent removed",
-          "[obstacle][cleanup][pr43]") {
+TEST_CASE("obstacle mesh lifetime: all children of destroyed parent removed",
+           "[obstacle][cleanup][pr43]") {
     auto reg = make_obs_registry();
 
     const int NUM_CHILDREN = 4;

--- a/tests/test_redfoot_testflight_ui.cpp
+++ b/tests/test_redfoot_testflight_ui.cpp
@@ -3,7 +3,7 @@
 //
 // These tests now focus on runtime-live coverage only:
 //   * Schema/content checks that remain relevant to current UI flows.
-//   * Wiring checks that collision and energy systems set GameOverState.cause.
+//   * Wiring checks that scoring and game_state systems set GameOverState.cause.
 
 #include <catch2/catch_test_macros.hpp>
 #include <entt/entity/registry.hpp>
@@ -66,7 +66,7 @@ TEST_CASE("redfoot/#168: existing game_over buttons keep their original position
     CHECK(menu   ->value("action", "") == "main_menu");
 }
 
-// ── Wiring: collision sets DeathCause for misses and bar hits ───────────────
+// ── Wiring: scoring sets DeathCause for misses and bar hits ──────────────────
 
 namespace {
 // Spawn a player aligned with an obstacle so the collision system's
@@ -106,6 +106,7 @@ TEST_CASE("redfoot/#168: collision flags HitABar when a bar passes ungraded",
     entt::registry reg;
     reg.ctx().emplace<GameState>().phase = GamePhase::Playing;
     reg.ctx().emplace<EnergyState>();
+    reg.ctx().emplace<ScoreState>();
     reg.ctx().emplace<SongResults>();
     reg.ctx().emplace<GameOverState>();
 
@@ -114,6 +115,7 @@ TEST_CASE("redfoot/#168: collision flags HitABar when a bar passes ungraded",
     reg.emplace<RequiredVAction>(bar, VMode::Jumping);
 
     collision_system(reg, 0.016f);
+    scoring_system(reg, 0.016f);
 
     auto& gos = reg.ctx().get<GameOverState>();
     CHECK(gos.cause == DeathCause::HitABar);
@@ -124,6 +126,7 @@ TEST_CASE("redfoot/#168: collision flags MissedABeat for a missed shape gate",
     entt::registry reg;
     reg.ctx().emplace<GameState>().phase = GamePhase::Playing;
     reg.ctx().emplace<EnergyState>();
+    reg.ctx().emplace<ScoreState>();
     reg.ctx().emplace<SongResults>();
     reg.ctx().emplace<GameOverState>();
 
@@ -132,6 +135,7 @@ TEST_CASE("redfoot/#168: collision flags MissedABeat for a missed shape gate",
     reg.emplace<RequiredShape>(gate, Shape::Circle);
 
     collision_system(reg, 0.016f);
+    scoring_system(reg, 0.016f);
 
     auto& gos = reg.ctx().get<GameOverState>();
     CHECK(gos.cause == DeathCause::MissedABeat);
@@ -141,13 +145,14 @@ TEST_CASE("redfoot/#168: energy depletion falls back to ENERGY DEPLETED",
           "[ui][redfoot][game_over][wiring]") {
     entt::registry reg;
     reg.ctx().emplace<GameState>().phase = GamePhase::Playing;
+    reg.ctx().emplace<entt::dispatcher>();
     auto& energy = reg.ctx().emplace<EnergyState>();
     auto& song = reg.ctx().emplace<SongState>();
     song.playing = true;
     reg.ctx().emplace<GameOverState>();  // cause stays None
     energy.energy = 0.0f;
 
-    energy_system(reg, 0.016f);
+    game_state_system(reg, 0.016f);
 
     auto& gos = reg.ctx().get<GameOverState>();
     CHECK(gos.cause == DeathCause::EnergyDepleted);
@@ -157,6 +162,7 @@ TEST_CASE("redfoot/#168: energy depletion does not overwrite a specific cause",
           "[ui][redfoot][game_over][wiring]") {
     entt::registry reg;
     reg.ctx().emplace<GameState>().phase = GamePhase::Playing;
+    reg.ctx().emplace<entt::dispatcher>();
     auto& energy = reg.ctx().emplace<EnergyState>();
     auto& song = reg.ctx().emplace<SongState>();
     song.playing = true;
@@ -164,7 +170,7 @@ TEST_CASE("redfoot/#168: energy depletion does not overwrite a specific cause",
     gos.cause = DeathCause::HitABar;
     energy.energy = 0.0f;
 
-    energy_system(reg, 0.016f);
+    game_state_system(reg, 0.016f);
 
     CHECK(gos.cause == DeathCause::HitABar);  // preserved, not clobbered
 }

--- a/tests/test_rhythm_system.cpp
+++ b/tests/test_rhythm_system.cpp
@@ -487,6 +487,7 @@ TEST_CASE("collision: hexagon fails shape gates — drains energy", "[rhythm][co
     make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
     auto& gs = reg.ctx().get<GameState>();
     CHECK_FALSE(gs.transition_pending);
     auto& energy = reg.ctx().get<EnergyState>();
@@ -502,6 +503,7 @@ TEST_CASE("collision: MISS drains energy", "[rhythm][collision]") {
     make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
     auto& gs = reg.ctx().get<GameState>();
     CHECK_FALSE(gs.transition_pending);
     auto& energy = reg.ctx().get<EnergyState>();
@@ -644,10 +646,10 @@ TEST_CASE("collision: SongResults updated", "[rhythm][collision]") {
 
 // Energy System
 
-TEST_CASE("energy_system: triggers game over at 0 energy", "[rhythm][energy]") {
+TEST_CASE("game_state: triggers game over at 0 energy", "[rhythm][energy]") {
     auto reg = make_rhythm_registry();
     reg.ctx().get<EnergyState>().energy = 0.0f;
-    energy_system(reg, 0.016f);
+    game_state_system(reg, 0.016f);
     CHECK(reg.ctx().get<GameState>().transition_pending);
     CHECK(reg.ctx().get<GameState>().next_phase == GamePhase::GameOver);
 }
@@ -659,10 +661,11 @@ TEST_CASE("energy_system: does nothing when energy is positive", "[rhythm][energ
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
 }
 
-TEST_CASE("energy_system: marks song finished on depletion", "[rhythm][energy]") {
+TEST_CASE("game_state: enter_game_over marks song finished on depletion", "[rhythm][energy]") {
     auto reg = make_rhythm_registry();
     reg.ctx().get<EnergyState>().energy = 0.0f;
-    energy_system(reg, 0.016f);
+    game_state_system(reg, 0.016f);
+    game_state_system(reg, 0.016f);
     auto& song = reg.ctx().get<SongState>();
     CHECK(song.finished);
     CHECK_FALSE(song.playing);

--- a/tests/test_scoring_extended.cpp
+++ b/tests/test_scoring_extended.cpp
@@ -11,6 +11,8 @@ TEST_CASE("scoring: perfect timing multiplier gives 1.5x base", "[scoring][rhyth
     reg.emplace<TimingGrade>(obs, TimingTier::Perfect, 1.0f);
 
     scoring_system(reg, 0.016f);
+    popup_feedback_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     auto& score = reg.ctx().get<ScoreState>();
     // 200 * 1.5 * 1.0 = 300, plus distance bonus and chain
@@ -24,6 +26,8 @@ TEST_CASE("scoring: bad timing multiplier gives 0.25x base", "[scoring][rhythm]"
     reg.emplace<TimingGrade>(obs, TimingTier::Bad, 0.0f);
 
     scoring_system(reg, 0.016f);
+    popup_feedback_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     auto& score = reg.ctx().get<ScoreState>();
     // 200 * 0.25 * 1.0 = 50, plus distance bonus
@@ -38,6 +42,8 @@ TEST_CASE("scoring: perfect timing and base points combine correctly", "[scoring
     reg.emplace<TimingGrade>(obs, TimingTier::Perfect, 1.0f);
 
     scoring_system(reg, 0.016f);
+    popup_feedback_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     auto& score = reg.ctx().get<ScoreState>();
     // 200 * 1.5 (perfect) = 300, plus distance bonus
@@ -51,6 +57,8 @@ TEST_CASE("scoring: SongResults tracks max_chain", "[scoring]") {
         auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y + float(i));
         reg.emplace<ScoredTag>(obs);
         scoring_system(reg, 0.016f);
+    popup_feedback_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
     }
 
     auto& results = reg.ctx().get<SongResults>();
@@ -64,6 +72,8 @@ TEST_CASE("scoring: TimingGrade removed from entity after scoring", "[scoring]")
     reg.emplace<TimingGrade>(obs, TimingTier::Good, 0.5f);
 
     scoring_system(reg, 0.016f);
+    popup_feedback_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK_FALSE(reg.all_of<TimingGrade>(obs));
 }
@@ -75,6 +85,8 @@ TEST_CASE("scoring: popup timing_tier set for graded obstacles", "[scoring][rhyt
     reg.emplace<TimingGrade>(obs, TimingTier::Good, 0.5f);
 
     scoring_system(reg, 0.016f);
+    popup_feedback_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     auto popup_view = reg.view<ScorePopup>();
     for (auto [e, popup] : popup_view.each()) {
@@ -89,6 +101,8 @@ TEST_CASE("scoring: popup timing_tier is nullopt for ungraded obstacles", "[scor
     // No TimingGrade
 
     scoring_system(reg, 0.016f);
+    popup_feedback_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     auto popup_view = reg.view<ScorePopup>();
     for (auto [e, popup] : popup_view.each()) {
@@ -105,6 +119,8 @@ TEST_CASE("scoring: multiple obstacles scored in single frame", "[scoring]") {
     reg.emplace<ScoredTag>(obs2);
 
     scoring_system(reg, 0.016f);
+    popup_feedback_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     auto popup_view = reg.view<ScorePopup>();
     int popup_count = 0;
@@ -124,6 +140,8 @@ TEST_CASE("scoring: miss-tagged obstacles do not award score and reset chain", "
 
     int score_before = score.score;
     scoring_system(reg, 0.016f);
+    popup_feedback_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK(score.chain_count == 0);
     CHECK(score.chain_timer == 0.0f);
@@ -131,6 +149,26 @@ TEST_CASE("scoring: miss-tagged obstacles do not award score and reset chain", "
     CHECK_FALSE(reg.all_of<Obstacle>(obs));
     CHECK_FALSE(reg.all_of<ScoredTag>(obs));
     CHECK_FALSE(reg.all_of<MissTag>(obs));
+}
+
+TEST_CASE("scoring: mixed miss and perfect at zero preserves per-event clamp ordering", "[scoring][energy]") {
+    auto reg = make_registry();
+    auto& energy = reg.ctx().get<EnergyState>();
+    energy.energy = 0.0f;
+
+    auto miss = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
+    reg.emplace<ScoredTag>(miss);
+    reg.emplace<MissTag>(miss);
+
+    auto hit = make_shape_gate(reg, Shape::Square, constants::PLAYER_Y + 1.0f);
+    reg.emplace<ScoredTag>(hit);
+    reg.emplace<TimingGrade>(hit, TimingTier::Perfect, 1.0f);
+
+    scoring_system(reg, 0.016f);
+    popup_feedback_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
+
+    CHECK_THAT(energy.energy, Catch::Matchers::WithinAbs(constants::ENERGY_RECOVER_PERFECT, 0.0001f));
 }
 
 // ── LanePush exclusion from chain and popup ──────────────────────────────────
@@ -154,6 +192,8 @@ TEST_CASE("scoring: LanePush excluded from chain and popup", "[scoring][lane_pus
     int chain_before = score.chain_count;
 
     scoring_system(reg, 0.016f);
+    popup_feedback_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK(score.chain_count == chain_before);
 
@@ -185,6 +225,8 @@ TEST_CASE("scoring: LanePushRight excluded from chain and popup", "[scoring][lan
     int chain_before = score.chain_count;
 
     scoring_system(reg, 0.016f);
+    popup_feedback_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK(score.chain_count == chain_before);
 

--- a/tests/test_scoring_system.cpp
+++ b/tests/test_scoring_system.cpp
@@ -5,6 +5,8 @@ TEST_CASE("scoring: distance bonus accumulates", "[scoring]") {
     auto reg = make_registry();
 
     scoring_system(reg, 1.0f);
+    popup_feedback_system(reg, 1.0f);
+    energy_system(reg, 1.0f);
 
     auto& score = reg.ctx().get<ScoreState>();
     CHECK(score.score >= constants::PTS_PER_SECOND);
@@ -17,6 +19,8 @@ TEST_CASE("scoring: scored obstacle awards points", "[scoring]") {
     reg.emplace<ScoredTag>(obs);
 
     scoring_system(reg, 0.016f);
+    popup_feedback_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     auto& score = reg.ctx().get<ScoreState>();
     CHECK(score.score >= constants::PTS_SHAPE_GATE);
@@ -30,6 +34,8 @@ TEST_CASE("scoring: chain bonus increases points", "[scoring]") {
         auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y + float(i));
         reg.emplace<ScoredTag>(obs);
         scoring_system(reg, 0.016f);
+    popup_feedback_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
     }
 
     auto& score = reg.ctx().get<ScoreState>();
@@ -45,10 +51,14 @@ TEST_CASE("scoring: chain resets after timeout", "[scoring]") {
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<ScoredTag>(obs);
     scoring_system(reg, 0.016f);
+    popup_feedback_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
     CHECK(reg.ctx().get<ScoreState>().chain_count == 1);
 
     // Wait > 2 seconds
     scoring_system(reg, 2.5f);
+    popup_feedback_system(reg, 2.5f);
+    energy_system(reg, 2.5f);
 
     CHECK(reg.ctx().get<ScoreState>().chain_count == 0);
 }
@@ -59,6 +69,8 @@ TEST_CASE("scoring: popup entity spawned on score", "[scoring]") {
     reg.emplace<ScoredTag>(obs);
 
     scoring_system(reg, 0.016f);
+    popup_feedback_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     auto popup_view = reg.view<ScorePopup>();
     int popup_count = 0;
@@ -79,6 +91,8 @@ TEST_CASE("scoring: SFX pushed on score", "[scoring]") {
     reg.emplace<ScoredTag>(obs);
 
     scoring_system(reg, 0.016f);
+    popup_feedback_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK(reg.ctx().get<AudioQueue>().count > 0);
 }
@@ -90,6 +104,8 @@ TEST_CASE("scoring: displayed_score rolls up toward score", "[scoring]") {
     score.displayed_score = 0;
 
     scoring_system(reg, 0.1f);
+    popup_feedback_system(reg, 0.1f);
+    energy_system(reg, 0.1f);
 
     CHECK(score.displayed_score > 0);
     CHECK(score.displayed_score <= score.score);
@@ -100,6 +116,8 @@ TEST_CASE("scoring: not in Playing phase skips processing", "[scoring]") {
     reg.ctx().get<GameState>().phase = GamePhase::GameOver;
 
     scoring_system(reg, 1.0f);
+    popup_feedback_system(reg, 1.0f);
+    energy_system(reg, 1.0f);
 
     CHECK(reg.ctx().get<ScoreState>().score == 0);
 }
@@ -112,6 +130,8 @@ TEST_CASE("scoring: chain bonus 5+ gives extended bonus", "[scoring]") {
         auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y + float(i));
         reg.emplace<ScoredTag>(obs);
         scoring_system(reg, 0.016f);
+    popup_feedback_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
     }
 
     auto& score = reg.ctx().get<ScoreState>();
@@ -127,6 +147,8 @@ TEST_CASE("scoring: obstacle entity cleaned up after scoring", "[scoring]") {
     reg.emplace<ScoredTag>(obs);
 
     scoring_system(reg, 0.016f);
+    popup_feedback_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     // Obstacle and ScoredTag components should be removed
     CHECK_FALSE(reg.all_of<Obstacle>(obs));
@@ -143,6 +165,8 @@ TEST_CASE("scoring: displayed_score does not overshoot score", "[scoring]") {
 
     // Very large dt that would normally overshoot
     scoring_system(reg, 10.0f);
+    popup_feedback_system(reg, 10.0f);
+    energy_system(reg, 10.0f);
 
     // displayed_score should not exceed score (capped)
     // Note: score increases by dt * PTS_PER_SECOND too
@@ -155,6 +179,8 @@ TEST_CASE("scoring: distance_traveled accumulates from scroll speed", "[scoring]
     song.scroll_speed = 400.0f;
 
     scoring_system(reg, 1.0f);
+    popup_feedback_system(reg, 1.0f);
+    energy_system(reg, 1.0f);
 
     CHECK(reg.ctx().get<ScoreState>().distance_traveled == 400.0f);
 }
@@ -165,7 +191,9 @@ TEST_CASE("scoring: no-penalty — on-beat gate scores at base points", "[scorin
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<ScoredTag>(obs);
 
-    scoring_system(reg, 0.0f);  // dt=0 excludes distance bonus for exact assertion
+    scoring_system(reg, 0.0f);
+    popup_feedback_system(reg, 0.0f);
+    energy_system(reg, 0.0f);  // dt=0 excludes distance bonus for exact assertion
 
     auto& score = reg.ctx().get<ScoreState>();
     CHECK(score.score == constants::PTS_SHAPE_GATE);
@@ -177,6 +205,8 @@ TEST_CASE("scoring: popup entity has full factory contract", "[scoring][popup_en
     reg.emplace<ScoredTag>(obs);
 
     scoring_system(reg, 0.016f);
+    popup_feedback_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     auto popup_view = reg.view<ScorePopup>();
     int count = 0;
@@ -205,6 +235,8 @@ TEST_CASE("scoring: LanePush emits no popup", "[scoring][lane_push]") {
     reg.emplace<ScoredTag>(lp);
 
     scoring_system(reg, 0.016f);
+    popup_feedback_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK(reg.view<ScorePopup>().size() == 0);
 }

--- a/tests/test_settings_persistence.cpp
+++ b/tests/test_settings_persistence.cpp
@@ -170,14 +170,14 @@ TEST_CASE("Settings persistence: round-trip save and load", "[settings]") {
     original.reduce_motion = true;
     original.ftue_run_count = 1;
 
-    bool save_result = settings::save_settings(original, test_file);
-    CHECK(save_result == true);
+    const auto save_result = settings::save_settings(original, test_file);
+    CHECK(save_result.status == persistence::Status::Success);
     CHECK(std::filesystem::exists(test_file));
 
     // Load and verify
     SettingsState loaded;
-    bool load_result = settings::load_settings(loaded, test_file);
-    CHECK(load_result == true);
+    const auto load_result = settings::load_settings(loaded, test_file);
+    CHECK(load_result.status == persistence::Status::Success);
     CHECK(loaded.audio_offset_ms == -75);
     CHECK(loaded.haptics_enabled == false);
     CHECK(loaded.reduce_motion == true);
@@ -194,11 +194,11 @@ TEST_CASE("Settings persistence: save_settings supports current-directory files"
     SettingsState state;
     state.audio_offset_ms = 20;
 
-    CHECK(settings::save_settings(state, test_file));
+    CHECK(settings::save_settings(state, test_file).ok());
     CHECK(std::filesystem::exists(test_file));
 
     SettingsState loaded;
-    CHECK(settings::load_settings(loaded, test_file));
+    CHECK(settings::load_settings(loaded, test_file).ok());
     CHECK(loaded.audio_offset_ms == 20);
 
     std::filesystem::remove(test_file);
@@ -208,8 +208,8 @@ TEST_CASE("Settings persistence: load_settings returns false for missing file", 
     std::filesystem::path nonexistent = "nonexistent_file_xyz.json";
     SettingsState state;
 
-    bool result = settings::load_settings(state, nonexistent);
-    CHECK(result == false);
+    const auto result = settings::load_settings(state, nonexistent);
+    CHECK(result.status == persistence::Status::MissingFile);
 }
 
 TEST_CASE("Settings persistence: load_settings handles malformed JSON", "[settings]") {
@@ -224,9 +224,75 @@ TEST_CASE("Settings persistence: load_settings handles malformed JSON", "[settin
     out.close();
 
     SettingsState state;
-    bool result = settings::load_settings(state, test_file);
-    CHECK(result == false);
+    const auto result = settings::load_settings(state, test_file);
+    CHECK(result.status == persistence::Status::CorruptData);
 
     // Cleanup
     std::filesystem::remove_all(test_dir);
+}
+
+TEST_CASE("Settings persistence: save_settings reports unwritable parent path", "[settings]") {
+    std::filesystem::path root = "test_settings_unwritable_parent";
+    std::filesystem::path not_a_dir = root / "not_a_directory";
+    std::filesystem::path target = not_a_dir / "settings.json";
+
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root);
+    {
+        std::ofstream out(not_a_dir);
+        REQUIRE(out.is_open());
+        out << "file blocks directory creation";
+    }
+
+    SettingsState state;
+    const auto result = settings::save_settings(state, target);
+    CHECK(result.status == persistence::Status::DirectoryCreateFailed);
+
+    std::filesystem::remove_all(root);
+}
+
+TEST_CASE("Persistence paths: one shared policy resolves both settings and high-score files", "[settings]") {
+    persistence::Paths paths;
+    const auto result = persistence::resolve_paths(paths, "test_persistence_policy_root");
+    REQUIRE(result.ok());
+    CHECK(paths.settings_file == paths.root_dir / "settings.json");
+    CHECK(paths.high_scores_file == paths.root_dir / "high_scores.json");
+    std::filesystem::remove_all(paths.root_dir);
+}
+
+TEST_CASE("Settings persistence helper: file path resolution reports failure without CWD fallback", "[settings]") {
+    const auto root = std::filesystem::path("test_settings_path_resolution_failure");
+    const auto blocked_root = root / "blocked_root";
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root);
+    {
+        std::ofstream out(blocked_root);
+        REQUIRE(out.is_open());
+        out << "file blocks directory creation";
+    }
+
+    std::filesystem::path file_path = "seed_should_clear.json";
+    const auto result = settings::get_settings_file_path(file_path, blocked_root);
+    CHECK(result.status == persistence::Status::DirectoryCreateFailed);
+    CHECK(file_path.empty());
+
+    std::filesystem::remove_all(root);
+}
+
+TEST_CASE("Persistence paths: directory creation failure is observable", "[settings]") {
+    const auto root = std::filesystem::path("test_persistence_policy_failure");
+    const auto blocked_root = root / "blocked_root";
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root);
+    {
+        std::ofstream out(blocked_root);
+        REQUIRE(out.is_open());
+        out << "file blocks directory creation";
+    }
+
+    persistence::Paths paths;
+    const auto result = persistence::resolve_paths(paths, blocked_root);
+    CHECK(result.status == persistence::Status::DirectoryCreateFailed);
+
+    std::filesystem::remove_all(root);
 }


### PR DESCRIPTION
## Summary
- preflight ObstacleChildren capacity before creating MeshChild entities so overflow cannot orphan child rows
- validate RequiredShape and RequiredLane payloads before emitting render mesh indices or indexing lane coordinates
- centralize obstacle MeshChild lifetime wiring through ObstacleChildren ownership and auto-wire the factory path
- add structured persistence path/result handling for settings and high scores without silent CWD fallback
- split energy, popup feedback, and death-cause side effects behind focused gameplay intent/system boundaries
- extract play-session setup helpers for player spawn, gameplay HUD buttons, and Playing phase entry
- add explicit platform haptics backend with iOS bridge surface and desktop/WASM stub behavior
- split terminal game-state high-score, feedback, and end-screen routing/resolution into focused systems

## Issues
Fixes #294
Fixes #295
Fixes #296
Fixes #276
Fixes #278
Fixes #279
Fixes #282
Fixes #297
Fixes #298
Fixes #281
Fixes #236
Fixes #277

## Validation
- `cmake -B build-ralph -S . -Wno-dev -DCMAKE_TOOLCHAIN_FILE="$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake"`
- `cmake --build build-ralph -j4`
- `./build-ralph/shapeshifter_tests "[archetype]"`
- `./build-ralph/shapeshifter_tests "[cleanup]"`
- `./build-ralph/shapeshifter_tests "[pr43]"`
- `./build-ralph/shapeshifter_tests "[settings],[high_score]"`
- `./build-ralph/shapeshifter_tests "[energy],[scoring],[collision],[gamestate]"`
- `./build-ralph/shapeshifter_tests "[ui][redfoot][game_over][wiring]"`
- `./build-ralph/shapeshifter_tests "[death_model]"`
- `./build-ralph/shapeshifter_tests "[gamestate]"`
- `./build-ralph/shapeshifter_tests "[play_session]"`
- `./build-ralph/shapeshifter_tests "[haptic]"`
- `./build-ralph/shapeshifter_tests "[high_score]"`
- `./build-ralph/shapeshifter_tests "[redfoot]"`
- `./build-ralph/shapeshifter_tests`
- `git diff --check`
