### PR TITLE
Fix dependency review trigger

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,7 +1,7 @@
 name: Dependency Review
 
 on:
-  push:
+  pull_request:
     branches: [main]
 
 permissions:


### PR DESCRIPTION
## Summary
- run dependency-review-action on pull_request events so base/head refs are available
- stop triggering dependency review on main pushes where the action fails without PR context

## Validation
- `git diff --check`