### PR TITLE
Fix local vcpkg CMake cache refresh

### DIFF
--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -108,6 +108,9 @@ Conducted comprehensive audit of `app/ui/*.cpp/.h` root-level files. Confirmed a
 
 ## Learnings
 
+- 2026-04-29: `bash run.sh test` can fail to find EnTT when `build/CMakeCache.txt` was first configured before the vcpkg toolchain was active; `CMAKE_TOOLCHAIN_FILE` cannot be retrofitted into an existing CMake build tree.
+- `build.sh` now verifies `${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake` exists and regenerates only `build/CMakeCache.txt` + `build/CMakeFiles` when the cache lacks vcpkg markers, preserving `build/vcpkg_installed` for CI/local cache reuse.
+- Validation: `bash run.sh test '~[bench]'` passed (775 test cases, 2210 assertions); EnTT resolved from `build/vcpkg_installed/arm64-osx/share/entt`.
 - raygui is now supplied by vcpkg manifest dependency `raygui` (header-only); CMake resolves it via `find_path(RAYGUI_INCLUDE_DIR raygui.h REQUIRED)` and injects it as a SYSTEM include on `shapeshifter_lib`.
 - Removed committed third-party source `app/ui/vendor/raygui.h`; all active UI screen controllers and `app/ui/raygui_impl.cpp` now include `<raygui.h>`.
 - Kept `app/ui/raygui_impl.cpp` as a minimal project-owned integration TU because raygui is header-only and still requires exactly one `#define RAYGUI_IMPLEMENTATION` site.

--- a/.squad/skills/cmake-vcpkg-cache-guard/SKILL.md
+++ b/.squad/skills/cmake-vcpkg-cache-guard/SKILL.md
@@ -1,0 +1,32 @@
+# Skill: CMake vcpkg Cache Guard
+
+## Context
+
+Use this when a CMake project relies on vcpkg manifest packages and local or CI builds fail at `find_package(...)` even though `vcpkg.json` contains the dependency.
+
+## Pattern
+
+`CMAKE_TOOLCHAIN_FILE` is only honored on the first configure of a CMake build tree. Re-running CMake with `-DCMAKE_TOOLCHAIN_FILE=...` against a build directory that was originally configured without vcpkg does not activate the toolchain; it may only record the cache variable.
+
+Guard build scripts against this stale-cache state:
+
+1. Verify `${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake` exists before configuring.
+2. If `build/CMakeCache.txt` exists but lacks vcpkg activation markers such as `VCPKG_INSTALLED_DIR`, remove only:
+   - `build/CMakeCache.txt`
+   - `build/CMakeFiles`
+3. Preserve `build/vcpkg_installed` so restored CI/local package caches are not thrown away.
+4. Re-run CMake with the vcpkg toolchain and manifest install enabled.
+
+## Validation
+
+Check that the regenerated cache contains package directories under `build/vcpkg_installed`, for example:
+
+```bash
+grep -E 'EnTT_DIR|VCPKG_INSTALLED_DIR' build/CMakeCache.txt
+```
+
+Then run the repository build/test path, e.g.:
+
+```bash
+bash run.sh test '~[bench]'
+```

--- a/build.sh
+++ b/build.sh
@@ -13,11 +13,39 @@ if [[ -z "${VCPKG_ROOT:-}" ]]; then
     exit 1
 fi
 
+VCPKG_TOOLCHAIN_FILE="${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+if [[ ! -f "$VCPKG_TOOLCHAIN_FILE" ]]; then
+    echo "Error: vcpkg toolchain file not found: $VCPKG_TOOLCHAIN_FILE" >&2
+    echo "  Check VCPKG_ROOT or install vcpkg: https://vcpkg.io" >&2
+    exit 1
+fi
+
+# CMAKE_TOOLCHAIN_FILE is only honored on the first configure of a build tree.
+# If an older local/CI cache was created before vcpkg was required, re-running
+# cmake cannot activate the toolchain, and find_package() cannot see manifest
+# packages such as EnTT.  Drop just the CMake configure cache while preserving
+# any vcpkg_installed payload that may have been restored from cache.
+if [[ -f build/CMakeCache.txt ]]; then
+    _reset_cmake_cache=false
+
+    if ! grep -q '^CMAKE_TOOLCHAIN_FILE:' build/CMakeCache.txt; then
+        _reset_cmake_cache=true
+    elif ! grep -q '^VCPKG_INSTALLED_DIR:' build/CMakeCache.txt; then
+        _reset_cmake_cache=true
+    fi
+
+    if [[ "$_reset_cmake_cache" == "true" ]]; then
+        echo "Existing build cache was not configured with a vcpkg toolchain; regenerating CMake cache."
+        rm -f build/CMakeCache.txt
+        rm -rf build/CMakeFiles
+    fi
+fi
+
 CMAKE_ARGS=(
     -B build
     -S .
     -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
-    "-DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+    "-DCMAKE_TOOLCHAIN_FILE=${VCPKG_TOOLCHAIN_FILE}"
     "-DVCPKG_OVERLAY_PORTS=${SCRIPT_DIR}/vcpkg-overlay"
 )
 


### PR DESCRIPTION
## Summary
- detect existing CMake build trees that were configured before the vcpkg toolchain was active
- refresh only CMake configure cache files while preserving `build/vcpkg_installed` package caches
- validate `VCPKG_ROOT` points to an actual vcpkg toolchain before configuring

## Validation
- `bash run.sh test '~[bench]'`\n- `git diff --check`