### PR TITLE
Switch rhythm judgment to press-time with 180 BPM cap

### DIFF
--- a/app/components/player.h
+++ b/app/components/player.h
@@ -26,6 +26,7 @@ struct ShapeWindow {
     WindowPhase phase         = WindowPhase::Idle;
     float       window_timer  = 0.0f;
     float       window_start  = 0.0f;
+    float       press_time    = 0.0f;
     float       peak_time     = 0.0f;
     float       window_scale  = 1.0f;
     bool        graded        = false;

--- a/app/components/song_state.h
+++ b/app/components/song_state.h
@@ -19,8 +19,8 @@ struct SongState {
     float beat_period     = 0.5f;   // seconds per beat
     float lead_time       = 2.0f;   // total approach window in seconds
     float scroll_speed    = 520.0f; // pixels per second (APPROACH_DIST / lead_time)
-    float window_duration = 0.8f;   // hit-window width in seconds
-    float half_window     = 0.4f;   // window_duration / 2
+    float window_duration = 0.3f;   // hit-window width in seconds
+    float half_window     = 0.15f;  // window_duration / 2
     float morph_duration  = 0.1f;   // shape-morph animation length in seconds
 
     // ── Per-frame mutable fields ─────────────────────────────────────────────

--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -69,22 +69,19 @@ void collision_system(entt::registry& reg, float /*dt*/) {
             return;
         }
 
-        // In rhythm mode, compute timing grade.
+        // In rhythm mode, compute timing grade from press time.
         if (rhythm_mode && p_window.phase == WindowPhase::Active && song->half_window > 0.0f) {
-            // Grade timing by comparing the player's predicted peak
-            // (center of the Active window) against the obstacle's
-            // scheduled arrival.  peak_time is set at press time as
-            // press + morph_duration + half_window, so a perfectly-
-            // timed tap gives peak_time ≈ arrival_time → pct ≈ 0.
-            // A stale press from a previous beat has peak_time far
-            // from the current obstacle's arrival → Bad.
+            // Grade timing by comparing button-press timestamp against
+            // the obstacle's scheduled arrival.
             auto* beat_info = reg.try_get<BeatInfo>(entity);
             float reference_time = beat_info ? beat_info->arrival_time
-                                             : p_window.peak_time;
-            float pct_from_peak = std::abs(p_window.peak_time - reference_time) / song->half_window;
-            if (pct_from_peak > 1.0f) pct_from_peak = 1.0f;
-            TimingTier tier = compute_timing_tier(pct_from_peak);
-            reg.emplace<TimingGrade>(entity, tier, 1.0f - pct_from_peak);
+                                             : p_window.press_time;
+            float delta_seconds = std::abs(p_window.press_time - reference_time);
+            TimingTier tier = compute_timing_tier_from_delta(delta_seconds);
+            float precision = 1.0f - (delta_seconds / kTimingOkSeconds);
+            if (precision < 0.0f) precision = 0.0f;
+            if (precision > 1.0f) precision = 1.0f;
+            reg.emplace<TimingGrade>(entity, tier, precision);
 
             if (results) {
                 switch (tier) {

--- a/app/systems/player_input_system.cpp
+++ b/app/systems/player_input_system.cpp
@@ -46,6 +46,7 @@ void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt)
         sw.phase = WindowPhase::MorphIn;
         sw.window_timer = 0.0f;
         sw.window_start = song->song_time;
+        sw.press_time = song->song_time;
         sw.peak_time = song->song_time + song->morph_duration + song->half_window;
         ps.morph_t = 0.0f;
         sw.window_scale = 1.0f;
@@ -70,6 +71,7 @@ void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt)
             } else if (phase == WindowPhase::Active && pressed_shape == pshape.current) {
                 swindow.window_timer = 0.0f;
                 swindow.window_start = song->song_time;
+                swindow.press_time = song->song_time;
                 swindow.peak_time = song->song_time + song->half_window;
                 swindow.window_scale = 1.0f;
                 swindow.graded = false;

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -244,7 +244,7 @@ void test_player_system(entt::registry& reg, float dt) {
         bool has_shape = (action.target_shape != Shape::Hexagon);
 
         if (cfg.aim_perfect && has_shape) {
-            float ideal_press = action.arrival_time - song->morph_duration - song->half_window;
+            float ideal_press = action.arrival_time;
             float time_until_ideal = ideal_press - song->song_time;
             if (time_until_ideal > cfg.reaction_min) {
                 action.timer = time_until_ideal;

--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
@@ -144,7 +144,7 @@ void render_shape_buttons(const entt::registry& reg,
 
     auto* song_state = reg.ctx().find<SongState>();
     float perfect_dist = song_state
-        ? song_state->scroll_speed * (song_state->morph_duration + song_state->half_window)
+        ? 0.0f
         : constants::BASE_SCROLL_SPEED * 0.5f;
     float ring_appear_dist = constants::APPROACH_DIST;
     float max_ring_radius = btn_radius * layout.approach_ring_max_radius_scale;

--- a/app/util/rhythm_math.h
+++ b/app/util/rhythm_math.h
@@ -3,6 +3,11 @@
 #include "../components/rhythm.h"
 #include "../constants.h"
 
+constexpr float kTimingBpmCeiling = 180.0f;
+constexpr float kTimingPerfectSeconds = 0.050f;
+constexpr float kTimingGoodSeconds = 0.100f;
+constexpr float kTimingOkSeconds = 0.150f;
+
 // Better timing -> smaller scale -> remaining Active window collapses sooner.
 // collision_system applies this via window_start adjustment (scale < 1.0 path).
 // Spec: rhythm-spec.md §5/§7. BAD is treated as a miss; window is left unchanged.
@@ -27,9 +32,18 @@ inline float timing_multiplier(TimingTier tier) {
 }
 
 inline TimingTier compute_timing_tier(float pct_from_peak) {
-    if (pct_from_peak <= 0.25f) return TimingTier::Perfect;
-    if (pct_from_peak <= 0.50f) return TimingTier::Good;
-    if (pct_from_peak <= 0.75f) return TimingTier::Ok;
+    // Normalized against kTimingOkSeconds:
+    // Perfect <= 50ms, Good <= 100ms, Ok <= 150ms, otherwise Bad.
+    if (pct_from_peak <= (kTimingPerfectSeconds / kTimingOkSeconds)) return TimingTier::Perfect;
+    if (pct_from_peak <= (kTimingGoodSeconds / kTimingOkSeconds)) return TimingTier::Good;
+    if (pct_from_peak <= 1.0f) return TimingTier::Ok;
+    return TimingTier::Bad;
+}
+
+inline TimingTier compute_timing_tier_from_delta(float delta_seconds_abs) {
+    if (delta_seconds_abs <= kTimingPerfectSeconds) return TimingTier::Perfect;
+    if (delta_seconds_abs <= kTimingGoodSeconds) return TimingTier::Good;
+    if (delta_seconds_abs <= kTimingOkSeconds) return TimingTier::Ok;
     return TimingTier::Bad;
 }
 
@@ -39,14 +53,17 @@ inline void song_state_compute_derived(SongState& s) {
 
     s.scroll_speed    = constants::APPROACH_DIST / s.lead_time;
 
-    constexpr float BASE_WINDOW_BEATS = 1.6f;
-    constexpr float MIN_WINDOW        = 0.36f;
     constexpr float BASE_MORPH_BEATS  = 0.2f;
     constexpr float MIN_MORPH         = 0.06f;
+    constexpr float WINDOW_HALF_CEILING = 0.5f * (60.0f / kTimingBpmCeiling);
 
-    float bpm_scale = (s.bpm > 130.0f) ? (130.0f / s.bpm) : 1.0f;
-    s.window_duration = BASE_WINDOW_BEATS * s.beat_period * bpm_scale;
-    if (s.window_duration < MIN_WINDOW) s.window_duration = MIN_WINDOW;
+    // Fixed judgment window policy (press-time grading):
+    // keep active window at +/-150ms while respecting the selected BPM ceiling.
+    float half_window = kTimingOkSeconds;
+    if (half_window > WINDOW_HALF_CEILING) {
+        half_window = WINDOW_HALF_CEILING;
+    }
+    s.window_duration = half_window * 2.0f;
     s.half_window     = s.window_duration / 2.0f;
 
     s.morph_duration  = BASE_MORPH_BEATS * s.beat_period;

--- a/tests/test_beat_map_validation.cpp
+++ b/tests/test_beat_map_validation.cpp
@@ -383,24 +383,24 @@ TEST_CASE("init_song_state: computes derived fields", "[init_song]") {
 
 // ── rhythm helper functions ──────────────────────────────────
 
-TEST_CASE("compute_timing_tier: Perfect for <= 0.25", "[rhythm_helpers]") {
+TEST_CASE("compute_timing_tier: Perfect for <= 0.333", "[rhythm_helpers]") {
     CHECK(compute_timing_tier(0.0f) == TimingTier::Perfect);
-    CHECK(compute_timing_tier(0.25f) == TimingTier::Perfect);
+    CHECK(compute_timing_tier(0.333f) == TimingTier::Perfect);
 }
 
-TEST_CASE("compute_timing_tier: Good for <= 0.50", "[rhythm_helpers]") {
-    CHECK(compute_timing_tier(0.26f) == TimingTier::Good);
-    CHECK(compute_timing_tier(0.50f) == TimingTier::Good);
+TEST_CASE("compute_timing_tier: Good for <= 0.666", "[rhythm_helpers]") {
+    CHECK(compute_timing_tier(0.34f) == TimingTier::Good);
+    CHECK(compute_timing_tier(0.666f) == TimingTier::Good);
 }
 
-TEST_CASE("compute_timing_tier: Ok for <= 0.75", "[rhythm_helpers]") {
-    CHECK(compute_timing_tier(0.51f) == TimingTier::Ok);
-    CHECK(compute_timing_tier(0.75f) == TimingTier::Ok);
+TEST_CASE("compute_timing_tier: Ok for <= 1.0", "[rhythm_helpers]") {
+    CHECK(compute_timing_tier(0.67f) == TimingTier::Ok);
+    CHECK(compute_timing_tier(1.0f) == TimingTier::Ok);
 }
 
-TEST_CASE("compute_timing_tier: Bad for > 0.75", "[rhythm_helpers]") {
-    CHECK(compute_timing_tier(0.76f) == TimingTier::Bad);
-    CHECK(compute_timing_tier(1.0f) == TimingTier::Bad);
+TEST_CASE("compute_timing_tier: Bad for > 1.0", "[rhythm_helpers]") {
+    CHECK(compute_timing_tier(1.01f) == TimingTier::Bad);
+    CHECK(compute_timing_tier(1.5f) == TimingTier::Bad);
 }
 
 TEST_CASE("timing_multiplier: returns correct values", "[rhythm_helpers]") {
@@ -446,9 +446,8 @@ TEST_CASE("song_state_compute_derived: window_duration minimum enforced", "[rhyt
     s.lead_beats = 4;
     song_state_compute_derived(s);
 
-    // window_duration = BASE_WINDOW_BEATS * beat_period = 1.6 * 0.2 = 0.32
-    // But MIN_WINDOW = 0.36, so window_duration should be clamped
-    CHECK(s.window_duration >= 0.36f);
+    // Window is fixed by timing policy to +/-150ms, capped by BPM ceiling.
+    CHECK_THAT(s.window_duration, Catch::Matchers::WithinAbs(0.3f, 0.001f));
 }
 
 TEST_CASE("song_state_compute_derived: morph_duration minimum enforced", "[rhythm_helpers]") {

--- a/tests/test_collision_extended.cpp
+++ b/tests/test_collision_extended.cpp
@@ -66,9 +66,9 @@ TEST_CASE("collision: rhythm mode assigns Perfect for on-time hit", "[collision]
     sw.phase = WindowPhase::Active;
     sw.graded = false;
     sw.window_start = song.song_time;
-    sw.peak_time = song.song_time;
+    sw.press_time = song.song_time;
 
-    // obstacle arrives right at peak_time (perfect)
+    // obstacle arrives right at press_time (perfect)
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<BeatInfo>(obs, 0, song.song_time, song.song_time - song.lead_time);
 
@@ -89,10 +89,10 @@ TEST_CASE("collision: rhythm mode assigns Bad for far-off hit", "[collision][rhy
     sw.phase = WindowPhase::Active;
     sw.graded = false;
     sw.window_start = song.song_time;
-    sw.peak_time = song.song_time + song.half_window;
+    sw.press_time = song.song_time;
 
-    // obstacle arrival time far from peak_time → Bad
-    float bad_arrival = song.song_time + song.half_window * 2.0f;
+    // obstacle arrival time far from press_time -> Bad
+    float bad_arrival = song.song_time + song.half_window * 1.2f;
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<BeatInfo>(obs, 0, bad_arrival, bad_arrival - song.lead_time);
 
@@ -126,6 +126,7 @@ TEST_CASE("collision: rhythm perfect increments perfect_count in SongResults", "
     ps.current = Shape::Circle;
     sw.phase = WindowPhase::Active;
     sw.graded = false;
+    sw.press_time = song.song_time;
 
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<BeatInfo>(obs, 0, song.song_time, song.song_time - song.lead_time);

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -329,11 +329,9 @@ TEST_CASE("collision: BAD timing does not adjust window_start", "[collision][rhy
     sw.window_timer = 0.0f;
     sw.window_start = song.song_time;
 
-    // peak_time doesn't affect grading anymore — timing is based on
-    // BeatInfo.arrival_time.  Set arrival_time far from song_time so
-    // pct_from_peak > 0.75 → BAD (scale = 1.0).
-    sw.peak_time = song.song_time;
-    float bad_arrival = song.song_time - song.half_window * 2.0f;
+    // press_time anchors grading. Set arrival_time far enough so it's BAD.
+    sw.press_time = song.song_time;
+    float bad_arrival = song.song_time - song.half_window * 1.2f;
 
     // Spawn an obstacle at the player's position
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
@@ -365,8 +363,8 @@ TEST_CASE("collision: Perfect timing shrinks window via window_start adjustment"
     sw.window_timer = 0.0f;
     sw.window_start = song.song_time;
 
-    // Set peak_time to right now so the hit is perfect (pct_from_peak = 0)
-    sw.peak_time = song.song_time;
+    // Set press_time to right now so the hit is perfect.
+    sw.press_time = song.song_time;
 
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<BeatInfo>(obs, 0, song.song_time, song.song_time - song.lead_time);

--- a/tests/test_helpers_and_functions.cpp
+++ b/tests/test_helpers_and_functions.cpp
@@ -6,36 +6,36 @@
 
 // ── compute_timing_tier ──────────────────────────────────────
 
-TEST_CASE("timing_tier: perfect zone 0.0-0.25", "[timing]") {
+TEST_CASE("timing_tier: perfect zone 0.0-0.333", "[timing]") {
     CHECK(compute_timing_tier(0.0f)  == TimingTier::Perfect);
-    CHECK(compute_timing_tier(0.25f) == TimingTier::Perfect);
+    CHECK(compute_timing_tier(0.333f) == TimingTier::Perfect);
 }
 
-TEST_CASE("timing_tier: good zone 0.26-0.50", "[timing]") {
-    CHECK(compute_timing_tier(0.26f) == TimingTier::Good);
-    CHECK(compute_timing_tier(0.50f) == TimingTier::Good);
+TEST_CASE("timing_tier: good zone 0.334-0.666", "[timing]") {
+    CHECK(compute_timing_tier(0.34f) == TimingTier::Good);
+    CHECK(compute_timing_tier(0.66f) == TimingTier::Good);
 }
 
-TEST_CASE("timing_tier: ok zone 0.51-0.75", "[timing]") {
-    CHECK(compute_timing_tier(0.51f) == TimingTier::Ok);
-    CHECK(compute_timing_tier(0.75f) == TimingTier::Ok);
+TEST_CASE("timing_tier: ok zone 0.667-1.0", "[timing]") {
+    CHECK(compute_timing_tier(0.67f) == TimingTier::Ok);
+    CHECK(compute_timing_tier(1.0f) == TimingTier::Ok);
 }
 
-TEST_CASE("timing_tier: bad zone 0.76-1.0", "[timing]") {
-    CHECK(compute_timing_tier(0.76f) == TimingTier::Bad);
-    CHECK(compute_timing_tier(1.0f)  == TimingTier::Bad);
+TEST_CASE("timing_tier: bad zone > 1.0", "[timing]") {
+    CHECK(compute_timing_tier(1.01f) == TimingTier::Bad);
+    CHECK(compute_timing_tier(1.5f)  == TimingTier::Bad);
 }
 
-TEST_CASE("timing_tier: boundary at exactly 0.25 is perfect", "[timing]") {
-    CHECK(compute_timing_tier(0.25f) == TimingTier::Perfect);
+TEST_CASE("timing_tier: boundary at exactly 0.333 is perfect", "[timing]") {
+    CHECK(compute_timing_tier(0.333f) == TimingTier::Perfect);
 }
 
-TEST_CASE("timing_tier: boundary at exactly 0.50 is good", "[timing]") {
-    CHECK(compute_timing_tier(0.50f) == TimingTier::Good);
+TEST_CASE("timing_tier: boundary at exactly 0.666 is good", "[timing]") {
+    CHECK(compute_timing_tier(0.666f) == TimingTier::Good);
 }
 
-TEST_CASE("timing_tier: boundary at exactly 0.75 is ok", "[timing]") {
-    CHECK(compute_timing_tier(0.75f) == TimingTier::Ok);
+TEST_CASE("timing_tier: boundary at exactly 1.0 is ok", "[timing]") {
+    CHECK(compute_timing_tier(1.0f) == TimingTier::Ok);
 }
 
 // ── timing_multiplier ────────────────────────────────────────
@@ -119,7 +119,7 @@ TEST_CASE("song_state_derived: lead_time = lead_beats * beat_period", "[song_sta
     CHECK_THAT(s.lead_time, Catch::Matchers::WithinAbs(2.0f, 0.001f));
 }
 
-TEST_CASE("song_state_derived: window_duration scales for high BPM", "[song_state]") {
+TEST_CASE("song_state_derived: window_duration fixed at timing policy", "[song_state]") {
     SongState slow, fast;
     slow.bpm = 100.0f;
     slow.lead_beats = 4;
@@ -127,16 +127,16 @@ TEST_CASE("song_state_derived: window_duration scales for high BPM", "[song_stat
     fast.lead_beats = 4;
     song_state_compute_derived(slow);
     song_state_compute_derived(fast);
-    // Higher BPM → shorter window
-    CHECK(fast.window_duration < slow.window_duration);
+    CHECK_THAT(slow.window_duration, Catch::Matchers::WithinAbs(0.3f, 0.001f));
+    CHECK_THAT(fast.window_duration, Catch::Matchers::WithinAbs(0.3f, 0.001f));
 }
 
-TEST_CASE("song_state_derived: window_duration has minimum floor", "[song_state]") {
+TEST_CASE("song_state_derived: window_duration respects bpm ceiling cap", "[song_state]") {
     SongState s;
     s.bpm = 300.0f;
     s.lead_beats = 2;
     song_state_compute_derived(s);
-    CHECK(s.window_duration >= 0.36f);
+    CHECK(s.window_duration <= (60.0f / 180.0f));
 }
 
 TEST_CASE("song_state_derived: morph_duration has minimum floor", "[song_state]") {
@@ -155,14 +155,12 @@ TEST_CASE("song_state_derived: half_window is half of window_duration", "[song_s
     CHECK_THAT(s.half_window, Catch::Matchers::WithinAbs(s.window_duration / 2.0f, 0.001f));
 }
 
-TEST_CASE("song_state_derived: BPM below 130 has no scale reduction", "[song_state]") {
+TEST_CASE("song_state_derived: fixed window independent of song BPM", "[song_state]") {
     SongState s;
     s.bpm = 100.0f;
     s.lead_beats = 4;
     song_state_compute_derived(s);
-    // At 100 BPM, bpm_scale = 1.0
-    // window_duration = BASE_WINDOW_BEATS * beat_period * 1.0 = 1.6 * 0.6 = 0.96
-    CHECK_THAT(s.window_duration, Catch::Matchers::WithinAbs(1.6f * s.beat_period, 0.001f));
+    CHECK_THAT(s.window_duration, Catch::Matchers::WithinAbs(0.3f, 0.001f));
 }
 
 // ── enum name helpers ────────────────────────────────────────

--- a/tests/test_rhythm_system.cpp
+++ b/tests/test_rhythm_system.cpp
@@ -180,8 +180,8 @@ TEST_CASE("song_state: derived values at 120 BPM", "[rhythm][songstate]") {
     CHECK_THAT(state.beat_period, WithinAbs(0.5f, 0.001f));
     CHECK_THAT(state.lead_time, WithinAbs(2.0f, 0.001f));
     CHECK_THAT(state.scroll_speed, WithinAbs(520.0f, 1.0f));
-    CHECK_THAT(state.window_duration, WithinAbs(0.8f, 0.001f));
-    CHECK_THAT(state.half_window, WithinAbs(0.4f, 0.001f));
+    CHECK_THAT(state.window_duration, WithinAbs(0.3f, 0.001f));
+    CHECK_THAT(state.half_window, WithinAbs(0.15f, 0.001f));
 }
 
 TEST_CASE("song_state: derived values at 80 BPM", "[rhythm][songstate]") {
@@ -191,14 +191,14 @@ TEST_CASE("song_state: derived values at 80 BPM", "[rhythm][songstate]") {
     CHECK_THAT(state.beat_period, WithinAbs(0.75f, 0.001f));
     CHECK_THAT(state.lead_time, WithinAbs(3.0f, 0.001f));
     CHECK_THAT(state.scroll_speed, WithinAbs(346.67f, 1.0f));
-    CHECK_THAT(state.window_duration, WithinAbs(1.2f, 0.001f));
+    CHECK_THAT(state.window_duration, WithinAbs(0.3f, 0.001f));
 }
 
 TEST_CASE("song_state: window duration floor at high BPM", "[rhythm][songstate]") {
     SongState state;
     state.bpm = 300.0f; state.lead_beats = 4;
     song_state_compute_derived(state);
-    CHECK(state.window_duration >= 0.36f);
+    CHECK_THAT(state.window_duration, WithinAbs(0.3f, 0.001f));
 }
 
 TEST_CASE("song_state: init from beat map", "[rhythm][songstate]") {
@@ -417,7 +417,7 @@ TEST_CASE("player_action: button press starts window in rhythm mode", "[rhythm][
     CHECK(sw.target_shape == Shape::Triangle);
 }
 
-TEST_CASE("player_action: peak_time calculated correctly", "[rhythm][action]") {
+TEST_CASE("player_action: press_time recorded correctly", "[rhythm][action]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& song = reg.ctx().get<SongState>();
@@ -426,8 +426,7 @@ TEST_CASE("player_action: peak_time calculated correctly", "[rhythm][action]") {
     press_button(reg, btn);
     player_input_system(reg, 0.016f);
     auto& sw = reg.get<ShapeWindow>(player);
-    float expected_peak = 5.0f + song.morph_duration + song.half_window;
-    CHECK_THAT(sw.peak_time, WithinAbs(expected_peak, 0.001f));
+    CHECK_THAT(sw.press_time, WithinAbs(5.0f, 0.001f));
 }
 
 TEST_CASE("player_action: same shape during active is ignored", "[rhythm][action]") {
@@ -509,7 +508,7 @@ TEST_CASE("collision: MISS drains energy", "[rhythm][collision]") {
     CHECK(energy.flash_timer > 0.0f);
 }
 
-TEST_CASE("collision: timing grade PERFECT at peak", "[rhythm][collision]") {
+TEST_CASE("collision: timing grade PERFECT on press-at-arrival", "[rhythm][collision]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& ps = reg.get<PlayerShape>(player);
@@ -517,9 +516,9 @@ TEST_CASE("collision: timing grade PERFECT at peak", "[rhythm][collision]") {
     auto& song = reg.ctx().get<SongState>();
     ps.current = Shape::Circle;
     sw.phase = WindowPhase::Active;
-    song.song_time = 5.0f; sw.peak_time = 5.0f;
+    song.song_time = 5.0f; sw.press_time = 5.0f;
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
-    // arrival_time == peak_time → pct = 0 → Perfect
+    // arrival_time == press_time -> Perfect
     reg.emplace<BeatInfo>(obs, 0, 5.0f, 5.0f - song.lead_time);
     collision_system(reg, 0.016f);
     REQUIRE(reg.all_of<ScoredTag>(obs));
@@ -527,7 +526,7 @@ TEST_CASE("collision: timing grade PERFECT at peak", "[rhythm][collision]") {
     CHECK(reg.get<TimingGrade>(obs).tier == TimingTier::Perfect);
 }
 
-TEST_CASE("collision: timing grade GOOD at 30pct", "[rhythm][collision]") {
+TEST_CASE("collision: timing grade GOOD at 50pct", "[rhythm][collision]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& ps = reg.get<PlayerShape>(player);
@@ -535,16 +534,16 @@ TEST_CASE("collision: timing grade GOOD at 30pct", "[rhythm][collision]") {
     auto& song = reg.ctx().get<SongState>();
     ps.current = Shape::Circle;
     sw.phase = WindowPhase::Active;
-    song.song_time = 5.0f; sw.peak_time = 5.0f;
+    song.song_time = 5.0f; sw.press_time = 5.0f;
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
-    // arrival_time offset from peak_time by 30% of half_window → Good
-    reg.emplace<BeatInfo>(obs, 0, 5.0f + song.half_window * 0.3f, 0.0f);
+    // arrival_time offset by 50% of half_window (~75ms) -> Good
+    reg.emplace<BeatInfo>(obs, 0, 5.0f + song.half_window * 0.5f, 0.0f);
     collision_system(reg, 0.016f);
     REQUIRE(reg.all_of<TimingGrade>(obs));
     CHECK(reg.get<TimingGrade>(obs).tier == TimingTier::Good);
 }
 
-TEST_CASE("collision: timing grade OK at 60pct", "[rhythm][collision]") {
+TEST_CASE("collision: timing grade OK at 80pct", "[rhythm][collision]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& ps = reg.get<PlayerShape>(player);
@@ -552,16 +551,16 @@ TEST_CASE("collision: timing grade OK at 60pct", "[rhythm][collision]") {
     auto& song = reg.ctx().get<SongState>();
     ps.current = Shape::Circle;
     sw.phase = WindowPhase::Active;
-    song.song_time = 5.0f; sw.peak_time = 5.0f;
+    song.song_time = 5.0f; sw.press_time = 5.0f;
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
-    // arrival_time offset from peak_time by 60% of half_window → Ok
-    reg.emplace<BeatInfo>(obs, 0, 5.0f + song.half_window * 0.6f, 0.0f);
+    // arrival_time offset by 80% of half_window (~120ms) -> Ok
+    reg.emplace<BeatInfo>(obs, 0, 5.0f + song.half_window * 0.8f, 0.0f);
     collision_system(reg, 0.016f);
     REQUIRE(reg.all_of<TimingGrade>(obs));
     CHECK(reg.get<TimingGrade>(obs).tier == TimingTier::Ok);
 }
 
-TEST_CASE("collision: timing grade BAD at 80pct", "[rhythm][collision]") {
+TEST_CASE("collision: timing grade BAD beyond window", "[rhythm][collision]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& ps = reg.get<PlayerShape>(player);
@@ -569,10 +568,10 @@ TEST_CASE("collision: timing grade BAD at 80pct", "[rhythm][collision]") {
     auto& song = reg.ctx().get<SongState>();
     ps.current = Shape::Circle;
     sw.phase = WindowPhase::Active;
-    song.song_time = 5.0f; sw.peak_time = 5.0f;
+    song.song_time = 5.0f; sw.press_time = 5.0f;
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
-    // arrival_time offset from peak_time by 80% of half_window → Bad
-    reg.emplace<BeatInfo>(obs, 0, 5.0f + song.half_window * 0.8f, 0.0f);
+    // arrival_time offset by 120% of half_window (>150ms) -> Bad
+    reg.emplace<BeatInfo>(obs, 0, 5.0f + song.half_window * 1.2f, 0.0f);
     collision_system(reg, 0.016f);
     REQUIRE(reg.all_of<TimingGrade>(obs));
     CHECK(reg.get<TimingGrade>(obs).tier == TimingTier::Bad);
@@ -580,20 +579,17 @@ TEST_CASE("collision: timing grade BAD at 80pct", "[rhythm][collision]") {
 
 TEST_CASE("collision: stale press from previous beat does not get Perfect", "[rhythm][collision]") {
     // Regression: pressing on beat N and cruising through beat N+2 should
-    // NOT award Perfect for beat N+2.  Timing is graded as
-    // abs(peak_time - arrival_time), so a stale peak_time from an earlier
-    // press produces a large pct → Bad.
+    // NOT award Perfect for beat N+2. Timing is graded from button press time.
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
-    // Player pressed Circle at song_time 2.0 (for a beat near 2.0 + morph + half_window)
-    // peak_time = 2.0 + morph_duration(0.1) + half_window(0.4) = 2.5
+    // Player pressed Circle at song_time 2.0.
     ps.current = Shape::Circle;
     sw.phase = WindowPhase::Active;
-    sw.peak_time = 2.0f + song.morph_duration + song.half_window;
+    sw.press_time = 2.0f;
     sw.window_start = 2.0f;
     sw.graded = false;
 
@@ -607,7 +603,7 @@ TEST_CASE("collision: stale press from previous beat does not get Perfect", "[rh
     collision_system(reg, 0.016f);
 
     REQUIRE(reg.all_of<TimingGrade>(obs));
-    // peak_time (2.5) is 1.0s away from arrival (3.5) → pct = 1.0/0.4 = 2.5 → Bad
+    // press_time (2.0) is far from arrival (3.5) -> not Perfect
     CHECK(reg.get<TimingGrade>(obs).tier != TimingTier::Perfect);
 }
 
@@ -619,7 +615,7 @@ TEST_CASE("collision: PERFECT clears obstacle without game over", "[rhythm][coll
     auto& song = reg.ctx().get<SongState>();
     ps.current = Shape::Circle;
     sw.phase = WindowPhase::Active;
-    song.song_time = 5.0f; sw.peak_time = 5.0f;
+    song.song_time = 5.0f; sw.press_time = 5.0f;
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<BeatInfo>(obs, 0, 5.0f, 5.0f - song.lead_time);
     collision_system(reg, 0.016f);
@@ -635,7 +631,7 @@ TEST_CASE("collision: SongResults updated", "[rhythm][collision]") {
     auto& song = reg.ctx().get<SongState>();
     ps.current = Shape::Circle;
     sw.phase = WindowPhase::Active;
-    song.song_time = 5.0f; sw.peak_time = 5.0f;
+    song.song_time = 5.0f; sw.press_time = 5.0f;
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<BeatInfo>(obs, 0, 5.0f, 5.0f - song.lead_time);
     collision_system(reg, 0.016f);
@@ -693,14 +689,13 @@ TEST_CASE("scoring: timing_mult applied to scored obstacle", "[rhythm][scoring]"
 
 TEST_CASE("timing: compute_timing_tier thresholds", "[rhythm][timing]") {
     CHECK(compute_timing_tier(0.0f) == TimingTier::Perfect);
-    CHECK(compute_timing_tier(0.10f) == TimingTier::Perfect);
-    CHECK(compute_timing_tier(0.25f) == TimingTier::Perfect);
-    CHECK(compute_timing_tier(0.26f) == TimingTier::Good);
-    CHECK(compute_timing_tier(0.50f) == TimingTier::Good);
-    CHECK(compute_timing_tier(0.51f) == TimingTier::Ok);
-    CHECK(compute_timing_tier(0.75f) == TimingTier::Ok);
-    CHECK(compute_timing_tier(0.76f) == TimingTier::Bad);
-    CHECK(compute_timing_tier(1.0f) == TimingTier::Bad);
+    CHECK(compute_timing_tier(0.20f) == TimingTier::Perfect);
+    CHECK(compute_timing_tier(0.333f) == TimingTier::Perfect);
+    CHECK(compute_timing_tier(0.34f) == TimingTier::Good);
+    CHECK(compute_timing_tier(0.666f) == TimingTier::Good);
+    CHECK(compute_timing_tier(0.67f) == TimingTier::Ok);
+    CHECK(compute_timing_tier(1.0f) == TimingTier::Ok);
+    CHECK(compute_timing_tier(1.1f) == TimingTier::Bad);
 }
 
 TEST_CASE("timing: timing_multiplier values", "[rhythm][timing]") {
@@ -732,7 +727,7 @@ TEST_CASE("window_scaling: PERFECT grade shortens remaining window", "[rhythm][w
     sw.phase = WindowPhase::Active;
     sw.window_timer = song.window_duration * 0.5f; // halfway through
     song.song_time = 5.0f;
-    sw.peak_time = 5.0f; // PERFECT timing
+    sw.press_time = 5.0f; // PERFECT timing
     sw.window_start = song.song_time - sw.window_timer;
 
     float start_before = sw.window_start;
@@ -763,14 +758,14 @@ TEST_CASE("window_scaling: GOOD grade shortens window slightly", "[rhythm][windo
     sw.phase = WindowPhase::Active;
     sw.window_timer = song.window_duration * 0.4f;
     song.song_time = 5.0f;
-    sw.peak_time = 5.0f;
+    sw.press_time = 5.0f;
     sw.window_start = song.song_time - sw.window_timer;
 
     float start_before = sw.window_start;
     float timer_before = sw.window_timer;
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
-    // arrival offset 30% from peak → Good
-    reg.emplace<BeatInfo>(obs, 0, 5.0f + song.half_window * 0.3f, 0.0f);
+    // arrival offset 50% from press -> Good
+    reg.emplace<BeatInfo>(obs, 0, 5.0f + song.half_window * 0.5f, 0.0f);
     collision_system(reg, 0.016f);
 
     CHECK(sw.graded);
@@ -795,12 +790,12 @@ TEST_CASE("window_scaling: OK grade keeps window unchanged", "[rhythm][window_sc
     sw.window_timer = song.window_duration * 0.3f;
     // Keep window_start consistent with song_time and window_timer
     sw.window_start = song.song_time - sw.window_timer;
-    sw.peak_time = 5.0f;
+    sw.press_time = 5.0f;
 
     float start_before = sw.window_start;
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
-    // arrival offset 60% from peak → Ok
-    reg.emplace<BeatInfo>(obs, 0, 5.0f + song.half_window * 0.6f, 0.0f);
+    // arrival offset 80% from press -> Ok
+    reg.emplace<BeatInfo>(obs, 0, 5.0f + song.half_window * 0.8f, 0.0f);
     collision_system(reg, 0.016f);
 
     CHECK(sw.graded);
@@ -824,12 +819,12 @@ TEST_CASE("window_scaling: BAD grade keeps window unchanged", "[rhythm][window_s
     sw.window_timer = song.window_duration * 0.2f;
     // Keep window_start consistent with song_time and window_timer
     sw.window_start = song.song_time - sw.window_timer;
-    sw.peak_time = 5.0f;
+    sw.press_time = 5.0f;
 
     float start_before = sw.window_start;
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
-    // arrival offset 80% from peak → Bad
-    reg.emplace<BeatInfo>(obs, 0, 5.0f + song.half_window * 0.8f, 0.0f);
+    // arrival offset 120% from press -> Bad
+    reg.emplace<BeatInfo>(obs, 0, 5.0f + song.half_window * 1.2f, 0.0f);
     collision_system(reg, 0.016f);
 
     CHECK(sw.graded);
@@ -851,7 +846,7 @@ TEST_CASE("window_scaling: second obstacle does not re-scale", "[rhythm][window_
     sw.phase = WindowPhase::Active;
     sw.window_timer = song.window_duration * 0.4f;
     song.song_time = 5.0f;
-    sw.peak_time = 5.0f;
+    sw.press_time = 5.0f;
 
     // First obstacle grades PERFECT, jumps timer
     auto obs1 = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);


### PR DESCRIPTION
## Summary
- score rhythm hits from button press timestamp instead of peak time
- enforce fixed ±150ms judgment window under a 180 BPM ceiling
- update test player perfect timing target to press-at-arrival
- align HUD perfect ring timing cue with press-time scoring
- update rhythm/collision tests for new thresholds and window policy

## Validation
- cmake -B build -S . -Wno-dev
- cmake --build build
- ./build/shapeshifter_tests