### PR TITLE
Fix WASM CI test cwd for redfoot UI layout checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -543,6 +543,8 @@ else()
     add_test(
         NAME shapeshifter_tests_wasm
         COMMAND ${_wasm_test_runner} $<TARGET_FILE:shapeshifter_tests> "~[bench]"
-        WORKING_DIRECTORY $<TARGET_FILE_DIR:shapeshifter_tests>
+        # Match native CI execution context (repo root) so tests that validate
+        # source-managed UI layout assets resolve the same relative paths.
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     )
 endif()


### PR DESCRIPTION
## Root cause
WASM CI runs tests via CTest from build-web, but test_redfoot_testflight_ui.cpp reads content/ui/screens/game_over.rgl via a repo-root-relative path. In WASM that path resolved from build-web, so the file was not found and the test failed.

## Fix
Set shapeshifter_tests_wasm working directory in CMakeLists.txt to the repository source root so WASM test execution context matches native CI.

## Validation
### Failure identified
- Inspected failing main run: CI (WebAssembly) run 25208607787
- Concrete failure:
  - tests/test_redfoot_testflight_ui.cpp:67: FAILED: REQUIRE( restart.has_value() )

### Commands run locally
- export VCPKG_ROOT=/Users/yashasgujjar/vcpkg && ./build.sh
- ./build/shapeshifter_tests "~[bench]" (passed: 767 test cases)
- Attempted CI-equivalent WASM configure/build flow; local Homebrew emscripten layout does not match CI emsdk path expectations (Emscripten.cmake toolchain file not found), so exact local WASM run is environment-limited.

### CI expectation
This change targets the exact failing WASM CTest working-directory mismatch and should restore the main-branch WASM job.