### PR TITLE
Use click events for mouse-enabled web input

### DIFF
--- a/app/components/input.h
+++ b/app/components/input.h
@@ -12,6 +12,7 @@ enum class InputSource : uint8_t { None, Mouse, Touch };
 struct InputState {
     bool  touch_down     = false;
     bool  touch_up       = false;
+    bool  click          = false;
     bool  touching       = false;
     bool  quit_requested = false;
 

--- a/app/input/input_state.h
+++ b/app/input/input_state.h
@@ -5,4 +5,5 @@
 inline void clear_input_events(InputState& input) {
     input.touch_down = false;
     input.touch_up   = false;
+    input.click      = false;
 }

--- a/app/input/pointer_input.h
+++ b/app/input/pointer_input.h
@@ -6,7 +6,7 @@
 // Unified pointer-release surface used by UI click handlers.
 // InputState is already normalized to virtual-space coordinates by input_system.
 inline bool pointer_release_position(const InputState& input, Vector2& out_pos) {
-    if (input.touch_up) {
+    if (input.click || input.touch_up) {
         out_pos = {input.end_x, input.end_y};
         return true;
     }

--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -42,6 +42,7 @@ void game_state_system(entt::registry& reg, float dt) {
         if (auto* input = reg.ctx().find<InputState>()) {
             input->touch_down = false;
             input->touch_up = false;
+            input->click = false;
             input->touching = false;
             input->active_source = InputSource::None;
             input->duration = 0.0f;

--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -7,6 +7,9 @@
 #include "../components/game_state.h"
 #include "../constants.h"
 #include <raylib.h>
+#ifdef __EMSCRIPTEN__
+#include <emscripten/emscripten.h>
+#endif
 
 void input_system(entt::registry& reg, float raw_dt) {
     auto& input = reg.ctx().get<InputState>();
@@ -27,38 +30,36 @@ void input_system(entt::registry& reg, float raw_dt) {
     auto to_vx = [&](float wx) { return (wx - st.offset_x) / st.scale; };
     auto to_vy = [&](float wy) { return (wy - st.offset_y) / st.scale; };
 
-    // ── Mouse (desktop) — only when no touch gesture is active ─
-    if (input.active_source != InputSource::Touch &&
-        IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
-        input.touch_down = true;
-        input.touching   = true;
-        input.active_source = InputSource::Mouse;
-        Vector2 pos = GetMousePosition();
-        input.start_x = input.curr_x = to_vx(pos.x);
-        input.start_y = input.curr_y = to_vy(pos.y);
-        input.duration = 0.0f;
-    }
-    const bool mouse_left_down = IsMouseButtonDown(MOUSE_BUTTON_LEFT);
-    if (input.active_source != InputSource::Touch &&
-        input.active_source == InputSource::Mouse &&
-        (IsMouseButtonReleased(MOUSE_BUTTON_LEFT) || (!mouse_left_down && input.touching))) {
-        input.touch_up  = true;
-        input.touching  = false;
+#if defined(PLATFORM_WEB) && defined(__EMSCRIPTEN__)
+    static const bool web_prefers_touch = (EM_ASM_INT({
+        const ua = navigator.userAgent || "";
+        const mobile = /Android|iPhone|iPad|iPod|webOS|BlackBerry|IEMobile|Opera Mini/i.test(ua);
+        const touchCapable = (navigator.maxTouchPoints || 0) > 0;
+        return mobile && touchCapable ? 1 : 0;
+    }) != 0);
+    const bool allow_mouse_input = !web_prefers_touch;
+    const bool allow_touch_input = web_prefers_touch;
+#else
+    const bool allow_mouse_input = true;
+    const bool allow_touch_input = true;
+#endif
+
+    // ── Mouse (desktop) — click-only semantics ─
+    if (allow_mouse_input &&
+        input.active_source != InputSource::Touch &&
+        IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) {
+        input.click      = true;
+        input.touching   = false;
         input.active_source = InputSource::None;
         Vector2 pos = GetMousePosition();
-        input.end_x = to_vx(pos.x);
-        input.end_y = to_vy(pos.y);
-    }
-    if (input.active_source != InputSource::Touch &&
-        mouse_left_down && input.touching &&
-        input.active_source == InputSource::Mouse) {
-        Vector2 pos = GetMousePosition();
-        input.curr_x = to_vx(pos.x);
-        input.curr_y = to_vy(pos.y);
+        input.start_x = input.curr_x = input.end_x = to_vx(pos.x);
+        input.start_y = input.curr_y = input.end_y = to_vy(pos.y);
+        input.duration = 0.0f;
     }
 
     // ── Touch (mobile / web) — only when no mouse gesture is active ─
-    if (input.active_source != InputSource::Mouse &&
+    if (allow_touch_input &&
+        input.active_source != InputSource::Mouse &&
         GetTouchPointCount() > 0) {
         Vector2 tp = GetTouchPosition(0);
         if (!input.touching) {
@@ -72,7 +73,8 @@ void input_system(entt::registry& reg, float raw_dt) {
             input.curr_x = to_vx(tp.x);
             input.curr_y = to_vy(tp.y);
         }
-    } else if (input.active_source != InputSource::Mouse &&
+    } else if (allow_touch_input &&
+               input.active_source != InputSource::Mouse &&
                input.touching && input.active_source == InputSource::Touch) {
         input.touch_up  = true;
         input.touching  = false;
@@ -128,7 +130,10 @@ void input_system(entt::registry& reg, float raw_dt) {
     // Touch/mouse gesture → InputEvent enqueued to dispatcher; delivered to
     // gesture_routing_handle_input via
     // disp.update<InputEvent>() in game_loop_frame (#333).
-    if (input.touch_up) {
+    if (input.click) {
+        disp.enqueue<InputEvent>(InputEvent{InputType::Tap, Direction::Up,
+                                            input.end_x, input.end_y});
+    } else if (input.touch_up) {
         const InputEvent event = input_event_from_raylib_gesture(
             read_detected_raylib_gesture(),
             input.start_y,

--- a/app/ui/screen_controllers/level_select_screen_controller.cpp
+++ b/app/ui/screen_controllers/level_select_screen_controller.cpp
@@ -61,16 +61,10 @@ Rectangle difficulty_button_rect(int index, int selected_level) {
     };
 }
 
-void handle_level_card_pointer_input(entt::registry& reg, LevelSelectState& lss, const InputState& input) {
+void handle_level_card_pointer_input(LevelSelectState& lss, const InputState& input) {
     Vector2 pointer = {};
     const bool released = pointer_release_position(input, pointer);
-    if (!released && !IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) return;
-
-    if (!released) {
-        const Vector2 raw = GetMousePosition();
-        const auto& st = reg.ctx().get<ScreenTransform>();
-        pointer = {(raw.x - st.offset_x) / st.scale, (raw.y - st.offset_y) / st.scale};
-    }
+    if (!released) return;
 
     for (int i = 0; i < LevelSelectState::LEVEL_COUNT; ++i) {
         if (CheckCollisionPointRec(pointer, level_card_rect(i))) {
@@ -91,7 +85,7 @@ void render_level_select_screen_ui(entt::registry& reg) {
     const auto& input = reg.ctx().get<InputState>();
     auto& state = level_select_controller.state();
     auto& gs = reg.ctx().get<GameState>();
-    handle_level_card_pointer_input(reg, lss, input);
+    handle_level_card_pointer_input(lss, input);
     
     int saved_text_size = GuiGetStyle(DEFAULT, TEXT_SIZE);
     

--- a/app/ui/screen_controllers/title_screen_controller.cpp
+++ b/app/ui/screen_controllers/title_screen_controller.cpp
@@ -20,19 +20,6 @@ TitleController title_controller;
 bool read_title_pointer_release(const entt::registry& reg, Vector2& pointer) {
     const auto& input = reg.ctx().get<InputState>();
     if (pointer_release_position(input, pointer)) return true;
-    if (input.touch_down) {
-        pointer = {input.start_x, input.start_y};
-        return true;
-    }
-
-    // Title activation is tolerant to browser stacks that miss release edges:
-    // accept either edge from raylib and map to virtual UI coordinates.
-    if (IsMouseButtonReleased(MOUSE_BUTTON_LEFT) || IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
-        const auto& st = reg.ctx().get<ScreenTransform>();
-        const Vector2 raw = GetMousePosition();
-        pointer = {(raw.x - st.offset_x) / st.scale, (raw.y - st.offset_y) / st.scale};
-        return true;
-    }
     return false;
 }
 


### PR DESCRIPTION
## Summary\n- stop mapping mouse releases to touch down/up edges on mouse-enabled web devices\n- add explicit click signal in input state and route pointer release from click/touch release\n- keep touch gesture flow for touch-first devices\n\n## Validation\n- cmake --build build\n- ./build/shapeshifter_tests '~[bench]'