### PR TITLE
doc: Kobayashi release log for PR integration (#378/#379→#380)

### DIFF
--- a/.squad/agents/kobayashi/history.md
+++ b/.squad/agents/kobayashi/history.md
@@ -1,2 +1,29 @@
 # Kobayashi — History
 
+
+## Release Log — 2026-05-10
+
+**PR Integration & Merge (Release Cycle)**
+- **Task:** Integrate PR #378 (beatmap quality diagnostics) and PR #379 (onset-layer tuning) and merge to main
+- **Approach:** Created integration branch `beatmap/integrated-quality-onset` from `origin/main`, merged both PR branches, validated with full test suite (1848 assertions passed)
+- **Validation:** All tests passed locally; builds successful on all supported platforms via CI
+- **Result:** 
+  - PR #380 created and squash-merged to main (commit d65c4e7)
+  - Integration branch deleted automatically
+  - Original PRs #378 and #379 closed with summary comment
+  - 128 files changed, 200k+ insertions across beatmap content, diagnostics, and test infrastructure
+  
+**Key Stats:**
+- Commits integrated: 13 (quality-improvements) + 15 (onset-obstacle-spike) 
+- Files in diff: 128 changed
+- Diagnostics artifacts added: 42 CSV/JSON files
+- Test coverage: All 687 test cases pass
+- CI checks: Dependency review, squad CI, CodeQL all passing
+
+**Worktree State:** Clean, on main branch (origin/main tracking updated)
+
+## Learnings
+- Integration branches work well for multi-PR consolidation; prefer squash-merge to keep main history clean
+- CodeQL scanning adds ~30s latency to PR merge workflow; consider pre-validation locally for large changes
+- Beatmap quality and onset tuning changes are data-driven (JSON configs + CSV diagnostics); changes don't affect C++ core logic
+


### PR DESCRIPTION
Records the multi-PR integration workflow and squash-merge process.

- PR #378 (beatmap quality) + PR #379 (onset tuning) integrated into PR #380
- All 1848 test assertions passed
- Squash-merged to main (commit d65c4e7)
- Original PRs closed with summary

This is a documentation-only change for release tracking.