### PR TITLE
Autonomous audit loop round 5

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -27,6 +27,11 @@ jobs:
         with:
           lfs: true
 
+      - name: Setup Node.js for native tooling tests
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+
       - name: Export GitHub Actions cache variables
         uses: actions/github-script@v8
         with:
@@ -51,8 +56,7 @@ jobs:
             libxinerama-dev \
             libxcursor-dev \
             libxi-dev \
-            libpulse-dev \
-            catch2
+            libpulse-dev
 
       - name: Setup vcpkg
         run: |

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -37,6 +37,11 @@ jobs:
         with:
           lfs: true
 
+      - name: Setup Node.js for native tooling tests
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+
       - name: Export GitHub Actions cache variables
         uses: actions/github-script@v8
         with:
@@ -127,6 +132,36 @@ jobs:
           upload-artifact: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  ios-bridge-compile-gate:
+    name: iOS ObjC++ compile gate
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: true
+
+      - name: Configure iOS ObjC++ bridge compile check
+        run: |
+          cmake -B build-ios-bridge -S . \
+            -Wno-dev \
+            -DSHAPESHIFTER_IOS_BRIDGE_COMPILE_CHECK=ON \
+            -DCMAKE_SYSTEM_NAME=iOS \
+            -DCMAKE_OSX_SYSROOT=iphonesimulator \
+            -DCMAKE_OSX_ARCHITECTURES=arm64
+
+      - name: Build iOS ObjC++ bridge compile check
+        run: |
+          cmake --build build-ios-bridge --config Release --target shapeshifter_ios_bridge_compile_check_target
+
+      - name: Verify ObjC++ bridge file is in iOS build graph
+        run: |
+          if ! grep -R "haptics_ios_bridge_ios.mm" build-ios-bridge >/dev/null; then
+            echo "::error::ObjC++ haptics bridge source is missing from iOS compile graph"
+            exit 1
+          fi
 
   notarize:
     name: Sign and notarize (macOS)

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           lfs: true
 
+      - name: Setup Node.js for native tooling tests
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+
       - name: Export GitHub Actions cache variables
         uses: actions/github-script@v8
         with:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -49,8 +49,7 @@ jobs:
                     libxinerama-dev \
                     libxcursor-dev \
                     libxi-dev \
-                    libpulse-dev \
-                    catch2
+                    libpulse-dev
 
             - name: Cache CMake build directory
               uses: actions/cache@v5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,29 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 option(SHAPESHIFTER_UNITY_BUILD "Enable unity builds for faster compilation" ON)
 set(CMAKE_UNITY_BUILD ${SHAPESHIFTER_UNITY_BUILD})
 
+option(SHAPESHIFTER_IOS_BRIDGE_COMPILE_CHECK "Compile-only validation of iOS ObjC++ haptics bridge" OFF)
+if(SHAPESHIFTER_IOS_BRIDGE_COMPILE_CHECK)
+    if(NOT APPLE)
+        message(FATAL_ERROR "SHAPESHIFTER_IOS_BRIDGE_COMPILE_CHECK requires an Apple toolchain")
+    endif()
+    enable_language(OBJCXX)
+    add_library(shapeshifter_ios_bridge_compile_check OBJECT
+        app/platform/ios/haptics_ios_bridge_ios.mm
+    )
+    target_include_directories(shapeshifter_ios_bridge_compile_check PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/app
+    )
+    target_compile_features(shapeshifter_ios_bridge_compile_check PRIVATE cxx_std_20)
+    target_compile_options(shapeshifter_ios_bridge_compile_check PRIVATE
+        $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wall -Wextra -Werror>
+        $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+    )
+    add_custom_target(shapeshifter_ios_bridge_compile_check_target
+        DEPENDS shapeshifter_ios_bridge_compile_check
+    )
+    return()
+endif()
+
 # ── Version (major.minor.githash) ────────────────────────────
 execute_process(
     COMMAND git rev-parse --short HEAD
@@ -60,8 +83,11 @@ find_package(magic_enum CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(raylib CONFIG REQUIRED)
 find_path(RAYGUI_INCLUDE_DIR raygui.h REQUIRED)
+include(CTest)
 
-find_package(Catch2 3 CONFIG REQUIRED)
+if(BUILD_TESTING)
+    find_package(Catch2 3 CONFIG REQUIRED)
+endif()
 
 # ── Warnings-as-errors (project targets only) ────────────────
 # Applied via an INTERFACE target so it never leaks into third-party code.
@@ -76,7 +102,10 @@ target_compile_options(shapeshifter_warnings INTERFACE
 
 # Mark third-party include directories as SYSTEM so warnings from their
 # headers are suppressed and cannot be promoted to errors by -Werror.
-set(_system_deps EnTT::EnTT glm::glm magic_enum::magic_enum raylib nlohmann_json::nlohmann_json Catch2::Catch2 Catch2::Catch2WithMain)
+set(_system_deps EnTT::EnTT glm::glm magic_enum::magic_enum raylib nlohmann_json::nlohmann_json)
+if(BUILD_TESTING)
+    list(APPEND _system_deps Catch2::Catch2 Catch2::Catch2WithMain)
+endif()
 foreach(_dep ${_system_deps})
     if(TARGET ${_dep})
         # Resolve alias targets — set_target_properties doesn't work on aliases
@@ -111,6 +140,14 @@ list(FILTER SYSTEM_SOURCES EXCLUDE REGEX "(^|/)input_system\\.cpp$")
 list(FILTER SYSTEM_SOURCES EXCLUDE REGEX "(^|/)song_playback_system\\.cpp$")
 list(FILTER SYSTEM_SOURCES EXCLUDE REGEX "(^|/)camera_system\\.cpp$")
 list(FILTER UI_SOURCES EXCLUDE REGEX "(^|/)raygui_impl\\.cpp$")
+
+# raygui is header-only and requires one implementation owner TU.
+set_source_files_properties(
+    app/ui/screen_controllers/title_screen_controller.cpp
+    PROPERTIES
+        COMPILE_DEFINITIONS RAYGUI_IMPLEMENTATION
+        SKIP_UNITY_BUILD_INCLUSION TRUE
+)
 
 set(SHAPESHIFTER_IOS FALSE)
 if(APPLE)
@@ -450,8 +487,7 @@ if(SHADER_FILES)
 endif()
 
 # ── Tests + Benchmarks ──────────────────────────────────────
-enable_testing()
-
+if(BUILD_TESTING)
 file(GLOB TEST_SOURCES CONFIGURE_DEPENDS tests/*.cpp benchmarks/*.cpp)
 
 # Unity build hazard exclusions (Keaton audit). These test files define
@@ -471,16 +507,6 @@ set_source_files_properties(
     tests/test_shipped_beatmap_lane_run_and_subdivision.cpp
     tests/test_redfoot_testflight_ui.cpp
     PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE
-)
-
-# raygui is header-only and requires one implementation owner TU.
-# Under unity builds we force that TU out of unity batching so
-# RAYGUI_IMPLEMENTATION is scoped to exactly one translation unit.
-set_source_files_properties(
-    app/ui/screen_controllers/title_screen_controller.cpp
-    PROPERTIES
-        COMPILE_DEFINITIONS RAYGUI_IMPLEMENTATION
-        SKIP_UNITY_BUILD_INCLUSION TRUE
 )
 
 add_executable(shapeshifter_tests
@@ -538,7 +564,6 @@ if(EMSCRIPTEN)
 endif()
 
 if(NOT EMSCRIPTEN)
-    include(CTest)
     include(Catch)
     catch_discover_tests(
         shapeshifter_tests
@@ -556,15 +581,25 @@ if(NOT EMSCRIPTEN)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/validate_loop2_content_gates.py --strict
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     )
-    find_program(NODE_EXECUTABLE node REQUIRED)
-    file(GLOB _beatmap_editor_node_test_files CONFIGURE_DEPENDS
-        "${CMAKE_SOURCE_DIR}/tools/beatmap-editor/test/*.test.js"
-    )
-    add_test(
-        NAME beatmap_editor_node_tests
-        COMMAND ${NODE_EXECUTABLE} --test ${_beatmap_editor_node_test_files}
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tools/beatmap-editor
-    )
+    find_program(NODE_EXECUTABLE node)
+    if(NODE_EXECUTABLE)
+        file(GLOB _beatmap_editor_node_test_files CONFIGURE_DEPENDS
+            "${CMAKE_SOURCE_DIR}/tools/beatmap-editor/test/*.test.js"
+        )
+        add_test(
+            NAME beatmap_editor_node_tests
+            COMMAND ${NODE_EXECUTABLE} --test ${_beatmap_editor_node_test_files}
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tools/beatmap-editor
+        )
+        message(STATUS "beatmap_editor_node_tests enabled: ${NODE_EXECUTABLE}")
+    else()
+        add_test(
+            NAME beatmap_editor_node_tests
+            COMMAND ${CMAKE_COMMAND} -E echo "SKIPPED: beatmap_editor_node_tests (node executable not found)"
+        )
+        set_tests_properties(beatmap_editor_node_tests PROPERTIES DISABLED TRUE)
+        message(STATUS "beatmap_editor_node_tests disabled: node executable not found")
+    endif()
 else()
     # Run the Emscripten Catch2 binary under Node. NODERAWFS lets tests read
     # repository/build content files directly instead of preloading game assets.
@@ -579,4 +614,5 @@ else()
         # source-managed UI layout assets resolve the same relative paths.
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     )
+endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -487,6 +487,7 @@ add_executable(shapeshifter_tests
     ${TEST_SOURCES}
     app/systems/camera_system.cpp
     app/systems/song_playback_system.cpp
+    app/systems/input_system.cpp
     app/platform_display.cpp
 )
 target_include_directories(shapeshifter_tests PRIVATE

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ at runtime boundaries, without wrapper abstraction layers.
 - C++20 compiler (Clang 20 recommended)
 - CMake 3.20+
 - [vcpkg](https://vcpkg.io)
+- Node.js 22+ (optional, enables beatmap editor Node test suite during `ctest`)
 
 ### Quick Start
 

--- a/app/components/text.h
+++ b/app/components/text.h
@@ -1,13 +1,11 @@
 #pragma once
 
 #include <cstdint>
-#include <cstdint>
 
-// ── TextAlign ────────────────────────────────────────────────
+// UI/domain-facing text enums used by ECS components.
+// Runtime font resources are owned by TextContext in app/rendering/text_resources.h.
+
 enum class TextAlign : uint8_t { Left, Center, Right };
 
-// ── FontSize ─────────────────────────────────────────────────
 // Named constants for the pre-loaded font sizes.
 enum class FontSize : int { Small = 0, Medium = 1, Large = 2 };
-
-// ── TextContext ──────────────────────────────────────────────

--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -18,7 +18,6 @@
 #include "systems/runtime_systems.h"
 #include "session/test_player_session.h"
 #include "input/input_routing.h"
-#include "components/text.h"
 #include "rendering/text_resources.h"
 #include "util/session_logger.h"
 #include "systems/camera_system.h"
@@ -33,11 +32,18 @@
 #include <raylib.h>
 #include <algorithm>
 #include <string>
+#include <utility>
 
 static constexpr float FIXED_DT  = 1.0f / 60.0f;
 static constexpr float MAX_ACCUM = 0.1f;
 
 namespace {
+
+template <typename T, typename... Args>
+T& reset_ctx_singleton(entt::registry& reg, Args&&... args) {
+    reg.ctx().erase<T>();
+    return reg.ctx().emplace<T>(std::forward<Args>(args)...);
+}
 
 bool load_text_fonts(TextContext& ctx, const char* font_path) {
     if (!FileExists(font_path)) {
@@ -153,30 +159,30 @@ void game_loop_init(entt::registry& reg,
 
     // Text rendering
     {
-        auto& text_ctx = reg.ctx().emplace<TextContext>();
+        auto& text_ctx = reset_ctx_singleton<TextContext>(reg);
         load_default_text_fonts(text_ctx);
     }
 
     // Core singletons
-    reg.ctx().emplace<InputState>();
-    reg.ctx().emplace<entt::dispatcher>();
+    reset_ctx_singleton<InputState>(reg);
+    reset_ctx_singleton<entt::dispatcher>(reg);
     wire_input_dispatcher(reg);
     wire_audio_haptic_dispatcher(reg);
     input_system_init(reg);
-    reg.ctx().emplace<GameState>(GameState{
+    reset_ctx_singleton<GameState>(reg, GameState{
         .phase = GamePhase::Title, .previous_phase = GamePhase::Title,
         .phase_timer = 0.0f, .transition_pending = false,
         .next_phase = GamePhase::Title, .transition_alpha = 0.0f
     });
-    reg.ctx().emplace<ScoreState>();
-    reg.ctx().emplace<LevelSelectState>();
-    reg.ctx().emplace<EnergyState>();
-    reg.ctx().emplace<GameOverState>();
-    reg.ctx().emplace<SongResults>();
-    reg.ctx().emplace<RNGState>();
-    reg.ctx().emplace<TestPlayerState>();
-    reg.ctx().emplace<TestPlayerSessionState>();
-    reg.ctx().emplace<SessionLog>();
+    reset_ctx_singleton<ScoreState>(reg);
+    reset_ctx_singleton<LevelSelectState>(reg);
+    reset_ctx_singleton<EnergyState>(reg);
+    reset_ctx_singleton<GameOverState>(reg);
+    reset_ctx_singleton<SongResults>(reg);
+    reset_ctx_singleton<RNGState>(reg);
+    reset_ctx_singleton<TestPlayerState>(reg);
+    reset_ctx_singleton<TestPlayerSessionState>(reg);
+    reset_ctx_singleton<SessionLog>(reg);
 
     persistence::Paths persistence_paths;
     const auto path_result = persistence::resolve_paths(persistence_paths);
@@ -195,8 +201,8 @@ void game_loop_init(entt::registry& reg,
         if (settings.haptics_enabled) {
             platform::haptics::warmup();
         }
-        reg.ctx().emplace<SettingsState>(settings);
-        reg.ctx().emplace<SettingsPersistence>(settings_persistence);
+        reset_ctx_singleton<SettingsState>(reg, settings);
+        reset_ctx_singleton<SettingsPersistence>(reg, settings_persistence);
     }
 
     // High scores — load from disk; defaults remain if file is missing/corrupt/path-invalid.
@@ -210,8 +216,8 @@ void game_loop_init(entt::registry& reg,
             persistence_state.last_load = path_result;
         }
         log_persistence_result("high score load", persistence_state.last_load);
-        reg.ctx().emplace<HighScoreState>(hs);
-        reg.ctx().emplace<HighScorePersistence>(persistence_state);
+        reset_ctx_singleton<HighScoreState>(reg, hs);
+        reset_ctx_singleton<HighScorePersistence>(reg, persistence_state);
     }
 
     // Cameras + render targets + GPU meshes
@@ -221,9 +227,9 @@ void game_loop_init(entt::registry& reg,
     wire_obstacle_mesh_lifetime(reg);
 
     // UI + beatmap + music
-    reg.ctx().emplace<BeatMap>();
-    reg.ctx().emplace<SongState>();
-    reg.ctx().emplace<MusicContext>();
+    reset_ctx_singleton<BeatMap>(reg);
+    reset_ctx_singleton<SongState>(reg);
+    reset_ctx_singleton<MusicContext>(reg);
 
     // Test player (optional)
     if (test_player_mode) {
@@ -343,4 +349,8 @@ void game_loop_shutdown(entt::registry& reg) {
     platform::haptics::shutdown();
     CloseAudioDevice();
     CloseWindow();
+
+    // Lifecycle contract: shutdown leaves the registry reusable for a fresh
+    // game_loop_init() on the same entt::registry instance.
+    reg = entt::registry{};
 }

--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -15,6 +15,7 @@
 #include "components/obstacle.h"
 #include "components/rng.h"
 #include "systems/all_systems.h"
+#include "systems/game_phase_transition.h"
 #include "systems/runtime_systems.h"
 #include "session/test_player_session.h"
 #include "input/input_routing.h"
@@ -174,6 +175,7 @@ void game_loop_init(entt::registry& reg,
         .phase_timer = 0.0f, .transition_pending = false,
         .next_phase = GamePhase::Title, .transition_alpha = 0.0f
     });
+    enter_phase(reg.ctx().get<GameState>(), GamePhase::Title);
     reset_ctx_singleton<ScoreState>(reg);
     reset_ctx_singleton<LevelSelectState>(reg);
     reset_ctx_singleton<EnergyState>(reg);

--- a/app/game_loop.h
+++ b/app/game_loop.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <entt/entt.hpp>
 
 // Forward-declare to avoid including test_player.h in the header.
@@ -16,7 +17,8 @@ void game_loop_run(entt::registry& reg);
 // Single frame tick (used by Emscripten main loop callback).
 void game_loop_frame(entt::registry& reg, float& accumulator);
 
-// Shutdown: unload GPU resources, close logs, release audio, close window.
+// Shutdown: unload GPU resources, close logs, release audio, close window,
+// and reset registry context/listeners so game_loop_init can be called again.
 void game_loop_shutdown(entt::registry& reg);
 
 // Returns true when the game loop should exit (quit requested or window closed).

--- a/app/rendering/text_resources.h
+++ b/app/rendering/text_resources.h
@@ -2,7 +2,8 @@
 
 #include <raylib.h>
 
-// Runtime text assets kept in registry context.
+// Authoritative runtime text asset state kept in registry context.
+// UI/domain enums remain in app/components/text.h.
 struct TextContext {
     Font font_small{};
     Font font_medium{};

--- a/app/systems/game_phase_transition.cpp
+++ b/app/systems/game_phase_transition.cpp
@@ -1,7 +1,50 @@
 #include "game_phase_transition.h"
 
+#if defined(EMSCRIPTEN)
+#include <emscripten/emscripten.h>
+#endif
+
+#include <string>
+
+namespace {
+
+#if defined(EMSCRIPTEN)
+const char* game_phase_name(GamePhase phase) {
+    switch (phase) {
+        case GamePhase::Title:
+            return "Title";
+        case GamePhase::LevelSelect:
+            return "LevelSelect";
+        case GamePhase::Playing:
+            return "Playing";
+        case GamePhase::Paused:
+            return "Paused";
+        case GamePhase::GameOver:
+            return "GameOver";
+        case GamePhase::SongComplete:
+            return "SongComplete";
+        case GamePhase::Settings:
+            return "Settings";
+        case GamePhase::Tutorial:
+            return "Tutorial";
+        default:
+            return "Unknown";
+    }
+}
+
+void update_web_title(GamePhase phase) {
+    const std::string title = std::string("SHAPESHIFTER [") + game_phase_name(phase) + "]";
+    emscripten_set_window_title(title.c_str());
+}
+#endif
+
+}  // namespace
+
 void enter_phase(GameState& gs, GamePhase next_phase) {
     gs.previous_phase = gs.phase;
     gs.phase = next_phase;
     gs.phase_timer = 0.0f;
+#if defined(EMSCRIPTEN)
+    update_web_title(gs.phase);
+#endif
 }

--- a/app/systems/game_phase_transition.cpp
+++ b/app/systems/game_phase_transition.cpp
@@ -34,7 +34,13 @@ const char* game_phase_name(GamePhase phase) {
 
 void update_web_title(GamePhase phase) {
     const std::string title = std::string("SHAPESHIFTER [") + game_phase_name(phase) + "]";
-    emscripten_set_window_title(title.c_str());
+    EM_ASM(
+        {
+            if (typeof document !== 'undefined') {
+                document.title = UTF8ToString($0);
+            }
+        },
+        title.c_str());
 }
 #endif
 

--- a/app/systems/game_phase_transition.cpp
+++ b/app/systems/game_phase_transition.cpp
@@ -1,6 +1,6 @@
 #include "game_phase_transition.h"
 
-#if defined(EMSCRIPTEN)
+#if defined(__EMSCRIPTEN__)
 #include <emscripten/emscripten.h>
 #endif
 
@@ -8,7 +8,7 @@
 
 namespace {
 
-#if defined(EMSCRIPTEN)
+#if defined(__EMSCRIPTEN__)
 const char* game_phase_name(GamePhase phase) {
     switch (phase) {
         case GamePhase::Title:
@@ -44,7 +44,7 @@ void enter_phase(GameState& gs, GamePhase next_phase) {
     gs.previous_phase = gs.phase;
     gs.phase = next_phase;
     gs.phase_timer = 0.0f;
-#if defined(EMSCRIPTEN)
+#if defined(__EMSCRIPTEN__)
     update_web_title(gs.phase);
 #endif
 }

--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -19,7 +19,19 @@ constexpr unsigned int kGameplayGestureFlags =
     | GESTURE_SWIPE_DOWN;
 
 struct WebInputPolicy {
-    bool prefers_touch = false;
+    // True iff the browser reports the device exposes a touch surface
+    // (navigator.maxTouchPoints > 0). This is a stable, per-session
+    // capability flag — NOT a "prefer touch over mouse" latch. Both
+    // mouse and touch input remain enabled on web so that:
+    //  • iPadOS 13+ Safari (which reports a desktop UA but
+    //    maxTouchPoints>0) still receives touch/swipe gameplay events.
+    //  • Touchscreen laptops/Chromebooks/Surface devices accept touch
+    //    regardless of UA string.
+    //  • A USB/Bluetooth mouse plugged into a touch-capable device is
+    //    not silently ignored for the rest of the session.
+    // Per-frame routing between mouse and touch is handled by the
+    // active_source guard inside input_system.
+    bool touch_capable = false;
 };
 
 } // namespace
@@ -27,11 +39,8 @@ struct WebInputPolicy {
 void input_system_init(entt::registry& reg) {
     auto& policy = reg.ctx().emplace<WebInputPolicy>();
 #if defined(PLATFORM_WEB) && defined(__EMSCRIPTEN__)
-    policy.prefers_touch = (EM_ASM_INT({
-        const ua = navigator.userAgent || "";
-        const mobile = /Android|iPhone|iPad|iPod|webOS|BlackBerry|IEMobile|Opera Mini/i.test(ua);
-        const touchCapable = (navigator.maxTouchPoints || 0) > 0;
-        return mobile && touchCapable ? 1 : 0;
+    policy.touch_capable = (EM_ASM_INT({
+        return ((navigator.maxTouchPoints || 0) > 0) ? 1 : 0;
     }) != 0);
 #else
     (void)policy;
@@ -52,8 +61,11 @@ void input_system(entt::registry& reg, float raw_dt) {
 
 #if defined(PLATFORM_WEB) && defined(__EMSCRIPTEN__)
     const auto& web_policy = reg.ctx().get<WebInputPolicy>();
-    const bool allow_mouse_input = !web_policy.prefers_touch;
-    const bool allow_touch_input = web_policy.prefers_touch;
+    // Mouse is always allowed on web. Touch is allowed whenever the
+    // browser reports a touch surface. The active_source guard below
+    // prevents a single gesture from being routed through both paths.
+    const bool allow_mouse_input = true;
+    const bool allow_touch_input = web_policy.touch_capable;
 #else
     const bool allow_mouse_input = true;
     const bool allow_touch_input = true;

--- a/app/systems/player_input_system.cpp
+++ b/app/systems/player_input_system.cpp
@@ -81,7 +81,11 @@ void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt)
 
     auto view = reg.view<PlayerTag, PlayerShape, ShapeWindow, Lane>();
     for (auto [entity, pshape, swindow, lane] : view.each()) {
-        if (shape_lane >= 0 && lane.current != shape_lane && lane.target != shape_lane) {
+        const bool not_in_shape_lane = (lane.current != shape_lane);
+        const bool conflicting_in_flight_target =
+            (lane.current == shape_lane && lane.target >= 0 && lane.target != shape_lane);
+        if (shape_lane >= 0 && lane.target != shape_lane &&
+            (not_in_shape_lane || conflicting_in_flight_target)) {
             lane.target = shape_lane;
             lane.lerp_t = 0.0f;
             push_haptic(reg, HapticEvent::LaneSwitch);

--- a/app/systems/ui_render_system.cpp
+++ b/app/systems/ui_render_system.cpp
@@ -8,7 +8,6 @@
 #include "../components/rhythm.h"
 #include "../components/game_state.h"
 #include "../components/song_state.h"
-#include "../components/text.h"
 #include "../rendering/text_resources.h"
 #include "../constants.h"
 

--- a/app/ui/generated/game_over_layout.h
+++ b/app/ui/generated/game_over_layout.h
@@ -41,6 +41,18 @@ static inline GameOverLayoutState GameOverLayout_Init(void) {
     return state;
 }
 
+static inline void GameOverLayout_DrawCenteredLabel(Rectangle bounds, const char *text, int text_size) {
+    const int saved_text_size = GuiGetStyle(DEFAULT, TEXT_SIZE);
+    const int saved_label_alignment = GuiGetStyle(LABEL, TEXT_ALIGNMENT);
+
+    GuiSetStyle(DEFAULT, TEXT_SIZE, text_size);
+    GuiSetStyle(LABEL, TEXT_ALIGNMENT, TEXT_ALIGN_CENTER);
+    GuiLabel(bounds, text);
+
+    GuiSetStyle(LABEL, TEXT_ALIGNMENT, saved_label_alignment);
+    GuiSetStyle(DEFAULT, TEXT_SIZE, saved_text_size);
+}
+
 static inline void GameOverLayout_Render(GameOverLayoutState *state) {
     if (!state) return;
     GuiLabel((Rectangle){ state->Anchor01.x + 210, state->Anchor01.y + 440, 300, 60 }, "GAME OVER");

--- a/app/ui/screen_controllers/game_over_screen_controller.cpp
+++ b/app/ui/screen_controllers/game_over_screen_controller.cpp
@@ -1,11 +1,16 @@
 // Game Over screen controller - renders raygui layout and dispatches end-screen choices.
 
 #include "../../components/game_state.h"
+#include "../../components/scoring.h"
+#include "../../components/song_state.h"
 #include "screen_controller_base.h"
+#include "game_over_screen_controller.h"
 #include <entt/entt.hpp>
 
 #include <raygui.h>
 #include "../generated/game_over_layout.h"
+
+#include <cstdio>
 
 namespace {
 
@@ -13,7 +18,40 @@ using GameOverController = RGuiScreenController<GameOverLayoutState,
                                                  &GameOverLayout_Init,
                                                  &GameOverLayout_Render>;
 
+void draw_game_over_value(Vector2 anchor, float x, float y, float w, float h,
+                          const char* text, int text_size) {
+    GameOverLayout_DrawCenteredLabel((Rectangle){anchor.x + x, anchor.y + y, w, h},
+                                     text, text_size);
+}
+
+void draw_game_over_scoreboard(entt::registry& reg, const GameOverLayoutState& state) {
+    const auto& score = reg.ctx().get<ScoreState>();
+
+    char value[32] = {};
+    std::snprintf(value, sizeof(value), "%d", score.score);
+    draw_game_over_value(state.Anchor01, 210, 510, 300, 40, value, 36);
+
+    std::snprintf(value, sizeof(value), "%d", score.high_score);
+    draw_game_over_value(state.Anchor01, 210, 560, 300, 32, value, 24);
+
+    if (const auto* gos = reg.ctx().find<GameOverState>()) {
+        const char* reason = death_cause_text(gos->cause);
+        if (reason && reason[0] != '\0') {
+            draw_game_over_value(state.Anchor01, 110, 640, 500, 40, reason, 22);
+        }
+    }
+}
+
 } // anonymous namespace
+
+const char* death_cause_text(DeathCause cause) {
+    switch (cause) {
+        case DeathCause::EnergyDepleted: return "ENERGY DEPLETED";
+        case DeathCause::MissedABeat:    return "MISSED A BEAT";
+        case DeathCause::None:
+        default:                          return "";
+    }
+}
 
 void init_game_over_screen_ui() {
     // Controller state is registry-owned and initialized lazily in render.
@@ -22,6 +60,7 @@ void init_game_over_screen_ui() {
 void render_game_over_screen_ui(entt::registry& reg) {
     auto& controller = screen_controller<GameOverController>(reg);
     controller.render();
+    draw_game_over_scoreboard(reg, controller.state());
 
     auto& gs = reg.ctx().get<GameState>();
     if (gs.phase_timer <= 0.4f) return;

--- a/app/ui/screen_controllers/game_over_screen_controller.h
+++ b/app/ui/screen_controllers/game_over_screen_controller.h
@@ -2,5 +2,11 @@
 
 #include <entt/entt.hpp>
 
+#include "../../components/song_state.h"
+
 void init_game_over_screen_ui();
 void render_game_over_screen_ui(entt::registry& reg);
+
+// Maps a DeathCause to a short, colorblind-safe, platform-neutral one-line
+// reason string suitable for the Game Over ReasonSlot. Returns "" for None.
+const char* death_cause_text(DeathCause cause);

--- a/app/ui/screen_controllers/level_select_screen_controller.cpp
+++ b/app/ui/screen_controllers/level_select_screen_controller.cpp
@@ -35,17 +35,18 @@ constexpr float DIFF_BTN_H = 50.0f;
 constexpr float DIFF_BTN_GAP = 30.0f;
 constexpr float DIFF_START_X = CARD_X + 50.0f;
 
-Color SELECTED_BG = {40, 40, 60, 255};
-Color UNSELECTED_BG = {20, 20, 30, 255};
-Color SELECTED_BORDER = {100, 150, 255, 255};
-Color UNSELECTED_BORDER = {60, 60, 80, 255};
+// Keep style colors immutable to avoid hidden mutable globals.
+constexpr Color SELECTED_BG = {40, 40, 60, 255};
+constexpr Color UNSELECTED_BG = {20, 20, 30, 255};
+constexpr Color SELECTED_BORDER = {100, 150, 255, 255};
+constexpr Color UNSELECTED_BORDER = {60, 60, 80, 255};
 
 // Difficulty-button active-state emphasis (#469). The selected difficulty
 // is painted *after* GuiButton with a thick border + inset selection bar
 // because raygui's BUTTON style otherwise overdraws any background drawn
 // before GuiButton(). Two non-color cues satisfy A11Y/2.1.3.
-Color DIFF_ACTIVE_BG = {80, 120, 200, 255};
-Color DIFF_ACTIVE_BORDER = {120, 180, 255, 255};
+constexpr Color DIFF_ACTIVE_BG = {80, 120, 200, 255};
+constexpr Color DIFF_ACTIVE_BORDER = {120, 180, 255, 255};
 
 Rectangle level_card_rect(int index) {
     return {CARD_X, CARD_START_Y + static_cast<float>(index) * (CARD_H + CARD_GAP), CARD_W, CARD_H};

--- a/design-docs/game-flow.md
+++ b/design-docs/game-flow.md
@@ -238,21 +238,30 @@ to `GamePhase::Playing`.
   ║┌────────────────────────────────────┐║  ← y = 0.55
   ║│            SETTINGS                │║
   ║│                                    │║
-  ║│   Sound      [■■■■■■■░░░] 70%     │║
+  ║│   Audio Offset                     │║
+  ║│        [ − ]  +12 ms  [ + ]        │║
   ║│                                    │║
-  ║│   Music      [■■■■░░░░░░] 40%     │║
+  ║│   [   HAPTICS: ON   ]              │║
   ║│                                    │║
-  ║│   Haptics    [ ON  ●│ off ]        │║
+  ║│   [   MOTION:  OFF  ]              │║
   ║│                                    │║
-  ║│   ──────────────────────────       │║
-  ║│                                    │║
-  ║│   Reset Tutorial  [ RESET ]        │║
-  ║│                                    │║
-  ║│          [ ✕ CLOSE ]               │║
+  ║│          [  BACK  ]                │║
   ║│                                    │║
   ║└────────────────────────────────────┘║
   ╚══════════════════════════════════════╝
 ```
+
+Shipped controls (source: `content/ui/screens/settings.rgl`):
+
+- **Audio Offset** — ± nudger (`AudioOffsetMinus` / `AudioOffsetDisplay` / `AudioOffsetPlus`); display shows current offset in ms, bound at render time.
+- **Haptics toggle** — single button labeled `HAPTICS: ON` / `HAPTICS: OFF` (state dynamic via `HapticsValue`).
+- **Reduce Motion toggle** — single button labeled `MOTION: ON` / `MOTION: OFF` (state dynamic via `ReduceMotionValue`).
+- **BACK** — close button (label is literally `BACK`, not `CLOSE`).
+
+Not shipped (intentionally absent from this wireframe):
+
+- **Sound / Music volume sliders** — no volume controls exist in `settings.rgl`.
+- **Reset Tutorial [ RESET ]** — `ftue_run_count` / `mark_ftue_complete` plumbing exists in `app/util/settings.h` and `app/util/settings_persistence.h`, but no UI surface ships. If this is still desired, file a separate feature issue rather than implying it ships here.
 
 ---
 

--- a/design-docs/rhythm-design.md
+++ b/design-docs/rhythm-design.md
@@ -85,7 +85,7 @@
 # SECTION 2 — MUSIC DRIVES EVERYTHING
 # ═══════════════════════════════════════════════════
 
-## Aubio Analysis Pipeline
+## Librosa Analysis Pipeline
 
 ```
   ┌─────────────────────────────────────────────────────────────────┐
@@ -93,42 +93,52 @@
   │   Audio file                                                    │
   │       │                                                         │
   │       ▼                                                         │
-  │   aubio melbands  →  40 mel bands per frame (~5ms hop)          │
+  │   librosa onset detection  →  onset events per broad layer     │
   │       │                                                         │
   │       ▼                                                         │
-  │   Split into frequency groups:                                  │
+  │   Split into three broad layer classes (PASS_TO_LAYER):         │
   │                                                                 │
-  │   ┌───────────────┬───────────────┬──────────────────┐         │
-  │   │  LOW          │  MID          │  HIGH            │         │
-  │   │  bands 0–7    │  bands 8–23   │  bands 24–39     │         │
-  │   │  20–300 Hz    │  300 Hz–3 kHz │  3 kHz–20 kHz   │         │
-  │   │  kick / bass  │  snare / gtr  │  hi-hat / cymbal │         │
-  │   └──────┬────────┴──────┬────────┴──────────┬───────┘         │
-  │          │               │                   │                  │
-  │          ▼               ▼                   ▼                  │
-  │       spectral         spectral           spectral              │
-  │         flux             flux               flux                │
-  │          │               │                   │                  │
-  │          ▼               ▼                   ▼                  │
-  │       CIRCLE           SQUARE             TRIANGLE              │
-  │       LANE 0           LANE 1             LANE 2                │
+  │   ┌────────────────┬────────────────┬───────────────────┐      │
+  │   │  PERCUSSIVE    │  FULL-SPECTRUM │  HARMONIC         │      │
+  │   │  bass /        │  spectral flux │  low-mid          │      │
+  │   │  broadband /   │  (catch-all)   │  (sustained tone) │      │
+  │   │  high-mid      │                │                   │      │
+  │   │  e.g. kick,    │  e.g. dense    │  e.g. melody,     │      │
+  │   │  hi-hat (illus)│  mix (illus)   │  pad (illus)      │      │
+  │   └──────┬─────────┴──────┬─────────┴──────────┬────────┘      │
+  │          │                │                    │                │
+  │          ▼                ▼                    ▼                │
+  │       onsets           onsets               onsets              │
+  │          │                │                    │                │
+  │          ▼                ▼                    ▼                │
+  │       TRIANGLE          SQUARE              CIRCLE              │
+  │       LANE 0            LANE 1              LANE 2              │
   │                                                                 │
-  │   Each energy spike = one obstacle spawn candidate.             │
-  │   Snap to beat grid (within 80ms). That's your note.           │
+  │   Each onset = one obstacle spawn candidate.                    │
+  │   Snap to beat grid (within 80ms). That's your note.            │
+  │                                                                 │
+  │   Note: instrument names above are illustrative only. The       │
+  │   pipeline classifies by broad layer, not by raw drum/         │
+  │   instrument identity. Legacy "kick / snare / hi-hat" aliases   │
+  │   are read-only compatibility shims and are stripped from any   │
+  │   newly serialized analysis output.                             │
   │                                                                 │
   └─────────────────────────────────────────────────────────────────┘
 ```
 
 ## The Music Encodes the Level
 
-The shape and lane of every obstacle come directly from which frequency band fired. This is not a design choice — it is a read from the audio. The music writes the level.
+The shape and lane of every obstacle come directly from which broad layer fired the onset. This is not a design choice — it is a read from the audio. The music writes the level. The mapping below is the authoritative `PASS_TO_LAYER` defined in `tools/rhythm_pipeline.py`:
 
 ```
   ┌────────────────────────────────────────────────────────────────┐
-  │  Kick drum at beat 4?   → Circle gate, lane 0 (LEFT)          │
-  │  Snare at beat 6?       → Square gate, lane 1 (CENTER)        │
-  │  Hi-hat at beat 7?      → Triangle gate, lane 2 (RIGHT)       │
-  │  All three at beat 8?   → Dominant band wins                  │
+  │  Percussive onset at beat 4?    → Triangle gate, lane 0 (LEFT) │
+  │  Full-spectrum onset at beat 6? → Square gate,   lane 1 (CTR)  │
+  │  Harmonic onset at beat 7?      → Circle gate,   lane 2 (RIGHT)│
+  │  Multiple layers at beat 8?     → Separate candidates by layer │
+  │                                                                │
+  │  (Instrument names like "kick / snare / hi-hat" are not part   │
+  │   of the public vocabulary — they are illustrative cues only.) │
   └────────────────────────────────────────────────────────────────┘
 ```
 
@@ -152,7 +162,7 @@ The player can hear the beat coming. The timing is legible. What the player cann
 
 ```
   The BPM for a song does not change.
-  aubio tempo gives one fixed value per track.
+  librosa beat tracking gives one fixed value per track.
   Scroll speed, window size, and morph duration all derive from BPM.
   There are no tempo ramps or ritardandos.
 ```
@@ -476,8 +486,8 @@ The player can hear the beat coming. The timing is legible. What the player cann
   │                                                              │
   │  Player must be the matching shape (◯/□/△) in the           │
   │  correct lane when it arrives.                               │
-  │  Shape comes from which mel band fired.                      │
-  │  Lane comes from same band: low=0, mid=1, high=2.            │
+  │  Shape/lane come from the broad layer onset:                 │
+  │  percussive=triangle/0, full-spectrum=square/1, harmonic=◯/2.│
   │                                                              │
   ├──────────────────────────────────────────────────────────────┤
   │  ─────────────────────────────────────────────────────────   │
@@ -488,9 +498,9 @@ The player can hear the beat coming. The timing is legible. What the player cann
   │                                                              │
   │  Passive obstacle — auto-pushes the player one lane in the   │
   │  indicated direction on beat arrival. No player action.      │
-  │  Triggered by HIGH band onsets (hi-hat, cymbal).             │
-  │  Edge pushes (left on Lane 0, right on Lane 2) are no-ops.  │
-  │  Awards 0 points.  (Replaces legacy lane_block.)             │
+  │  Triggered by harmonic-layer onsets (illustrative: cymbal-     │
+  │  like sustain). Edge pushes (left on Lane 0, right on Lane 2) │
+  │  are no-ops. Awards 0 points.  (Replaces legacy lane_block.)  │
   │                                                              │
   ├──────────────────────────────────────────────────────────────┤
   │  low_bar                                                     │
@@ -517,7 +527,8 @@ The player can hear the beat coming. The timing is legible. What the player cann
 
 ```
   EASY:    shape_gate only. Sparse. 2-beat minimum gap.
-           Low/mid onsets only. Learning the shape mechanic.
+           Percussive + harmonic onsets only (full-spectrum
+           catch-all suppressed). Learning the shape mechanic.
 
            Density scales with song intensity section.
 
@@ -545,12 +556,11 @@ The player can hear the beat coming. The timing is legible. What the player cann
   │   yt-dlp  →  WAV file                                       │
   │       │                                                     │
   │       ▼                                                     │
-  │   aubio tempo    →  fixed BPM                               │
-  │   aubio beat     →  beat timestamps                         │
-  │   aubio melbands →  40-band spectral energy per frame       │
+  │   librosa tempo / beat tracking → beat timestamps           │
+  │   librosa STFT + mel features  → broad-layer onset pools    │
   │       │                                                     │
   │       ▼                                                     │
-  │   spectral flux per band group  →  per-band onsets          │
+  │   percussive / harmonic / full-spectrum passes → onsets     │
   │       │                                                     │
   │       ▼                                                     │
   │   snap to beat grid (80ms tolerance)                        │
@@ -595,7 +605,8 @@ The player can hear the beat coming. The timing is legible. What the player cann
 
   Shape gate   Obstacle requiring the player to match its shape in its lane.
 
-               in a direction on beat arrival (replaces legacy Lane Block).
+  Lane push    Passive obstacle that moves the player one lane in a
+               direction on beat arrival (replaces legacy Lane Block).
 
   Proximity    Ring around a shape button that shrinks as the matching
   ring         obstacle approaches. Reaches button size at perfect timing.
@@ -619,10 +630,15 @@ The player can hear the beat coming. The timing is legible. What the player cann
   MISS         Shape mismatch, wrong lane, or late press (>75% off peak).
                Always instant game over. No HP. No second chances.
 
-  Onset        Moment of sudden energy increase in a frequency band.
-               Detected by aubio melbands + spectral flux.
-               Low band → circle. Mid band → square. High band → triangle.
+  Onset        Moment of sudden energy increase detected by librosa
+               on one of the broad layers (percussive / harmonic /
+               full-spectrum). Percussive → triangle / lane 0.
+               Full-spectrum → square / lane 1.
+               Harmonic → circle / lane 2.
 
-  Mel band     One of 40 frequency sub-bands output by aubio melbands.
-               Grouped into low/mid/high for obstacle classification.
+  Layer        One of three broad librosa layer classes used for
+               classification: percussive, harmonic, full-spectrum.
+               Replaces the legacy low/mid/high frequency-band model;
+               raw drum/instrument names (kick/snare/hi-hat) are
+               read-only legacy aliases only.
 ```

--- a/tests/smoke/startup_shutdown_smoke.cpp
+++ b/tests/smoke/startup_shutdown_smoke.cpp
@@ -19,6 +19,7 @@ int parse_nonnegative_int(const char* text, bool& ok) {
 
 int main(int argc, char** argv) {
     int frames = 0;
+    int cycles = 1;
 
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "--frames") == 0 && i + 1 < argc) {
@@ -28,8 +29,15 @@ int main(int argc, char** argv) {
                 std::fprintf(stderr, "Invalid --frames value: %s\n", argv[i]);
                 return 2;
             }
+        } else if (std::strcmp(argv[i], "--cycles") == 0 && i + 1 < argc) {
+            bool ok = false;
+            cycles = parse_nonnegative_int(argv[++i], ok);
+            if (!ok || cycles == 0) {
+                std::fprintf(stderr, "Invalid --cycles value: %s\n", argv[i]);
+                return 2;
+            }
         } else {
-            std::fprintf(stderr, "Usage: %s [--frames N]\n", argv[0]);
+            std::fprintf(stderr, "Usage: %s [--frames N] [--cycles N]\n", argv[0]);
             return 2;
         }
     }
@@ -37,13 +45,15 @@ int main(int argc, char** argv) {
     SetTraceLogLevel(LOG_WARNING);
 
     entt::registry reg;
-    game_loop_init(reg, false, TestPlayerSkill::Pro, "medium");
+    for (int cycle = 0; cycle < cycles; ++cycle) {
+        game_loop_init(reg, false, TestPlayerSkill::Pro, "medium");
 
-    float accumulator = 0.0f;
-    for (int i = 0; i < frames; ++i) {
-        game_loop_frame(reg, accumulator);
+        float accumulator = 0.0f;
+        for (int i = 0; i < frames; ++i) {
+            game_loop_frame(reg, accumulator);
+        }
+
+        game_loop_shutdown(reg);
     }
-
-    game_loop_shutdown(reg);
     return 0;
 }

--- a/tests/test_game_over_screen_controller.cpp
+++ b/tests/test_game_over_screen_controller.cpp
@@ -1,0 +1,68 @@
+// Game Over screen controller tests — issue #498.
+//
+// Verifies that the Game Over screen exposes the run's final score, persisted
+// high score, and a one-line death cause through stable, render-independent
+// surfaces (DeathCause → reason text mapping; ScoreState binding pattern).
+//
+// We deliberately do NOT spin up a raygui surface here: the controller render
+// path requires an active GL context (raygui ↔ raylib). Instead we assert on
+// the values the controller binds to its layout slots, mirroring how
+// song_complete is exercised elsewhere.
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstring>
+
+#include "test_helpers.h"
+#include "ui/screen_controllers/game_over_screen_controller.h"
+#include "components/song_state.h"
+#include "components/scoring.h"
+
+TEST_CASE("game_over: death_cause_text maps every DeathCause to a non-empty platform-neutral string",
+          "[game_over][ui]") {
+    // None → empty (suppresses ReasonSlot rendering).
+    CHECK(std::strlen(death_cause_text(DeathCause::None)) == 0);
+
+    // Real causes must produce a non-empty, ASCII-only one-liner.
+    for (auto cause : { DeathCause::EnergyDepleted, DeathCause::MissedABeat }) {
+        const char* txt = death_cause_text(cause);
+        REQUIRE(txt != nullptr);
+        CHECK(std::strlen(txt) > 0);
+        // Stay short enough to fit ReasonSlot (500px @ 22pt) — sanity bound.
+        CHECK(std::strlen(txt) < 32u);
+    }
+}
+
+TEST_CASE("game_over: distinct DeathCauses produce distinct reasons (#168 coverage)",
+          "[game_over][ui]") {
+    const char* energy = death_cause_text(DeathCause::EnergyDepleted);
+    const char* miss   = death_cause_text(DeathCause::MissedABeat);
+    CHECK(std::strcmp(energy, miss) != 0);
+}
+
+TEST_CASE("game_over: score / high score / cause are visible via registry singletons "
+          "(value-binding contract mirrors song_complete)",
+          "[game_over][ui]") {
+    auto reg = make_registry();
+
+    // Simulate a finished run.
+    auto& score = reg.ctx().get<ScoreState>();
+    score.score      = 12345;
+    score.high_score = 99999;
+
+    auto& gos = reg.ctx().insert_or_assign(GameOverState{});
+    gos.cause = DeathCause::EnergyDepleted;
+
+    auto& gs = reg.ctx().get<GameState>();
+    gs.phase = GamePhase::GameOver;
+    gs.phase_timer = 1.0f;
+
+    // Controller-bound values — these are exactly the fields the
+    // game_over_screen_controller reads to populate the layout slots.
+    const auto& s = reg.ctx().get<ScoreState>();
+    CHECK(s.score      == 12345);
+    CHECK(s.high_score == 99999);
+
+    const auto& g = reg.ctx().get<GameOverState>();
+    CHECK(g.cause == DeathCause::EnergyDepleted);
+    CHECK(std::strlen(death_cause_text(g.cause)) > 0);
+}

--- a/tests/test_phase_transition_canonical.cpp
+++ b/tests/test_phase_transition_canonical.cpp
@@ -10,6 +10,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <regex>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -38,6 +39,110 @@ std::vector<fs::path> sources_under(const fs::path& root) {
     return out;
 }
 
+std::string strip_comments_and_literals(const std::string& source) {
+    std::string sanitized;
+    sanitized.reserve(source.size());
+
+    for (std::size_t i = 0; i < source.size();) {
+        if (i + 1 < source.size() && source[i] == '/' && source[i + 1] == '/') {
+            sanitized.push_back(' ');
+            sanitized.push_back(' ');
+            i += 2;
+            while (i < source.size() && source[i] != '\n') {
+                sanitized.push_back(' ');
+                ++i;
+            }
+            continue;
+        }
+
+        if (i + 1 < source.size() && source[i] == '/' && source[i + 1] == '*') {
+            sanitized.push_back(' ');
+            sanitized.push_back(' ');
+            i += 2;
+            while (i < source.size()) {
+                if (i + 1 < source.size() && source[i] == '*' && source[i + 1] == '/') {
+                    sanitized.push_back(' ');
+                    sanitized.push_back(' ');
+                    i += 2;
+                    break;
+                }
+                sanitized.push_back(source[i] == '\n' ? '\n' : ' ');
+                ++i;
+            }
+            continue;
+        }
+
+        if (source[i] == '"') {
+            sanitized.push_back(' ');
+            ++i;
+            while (i < source.size()) {
+                const char c = source[i];
+                sanitized.push_back(c == '\n' ? '\n' : ' ');
+                ++i;
+                if (c == '\\' && i < source.size()) {
+                    sanitized.push_back(source[i] == '\n' ? '\n' : ' ');
+                    ++i;
+                    continue;
+                }
+                if (c == '"') break;
+            }
+            continue;
+        }
+
+        if (source[i] == '\'') {
+            sanitized.push_back(' ');
+            ++i;
+            while (i < source.size()) {
+                const char c = source[i];
+                sanitized.push_back(c == '\n' ? '\n' : ' ');
+                ++i;
+                if (c == '\\' && i < source.size()) {
+                    sanitized.push_back(source[i] == '\n' ? '\n' : ' ');
+                    ++i;
+                    continue;
+                }
+                if (c == '\'') break;
+            }
+            continue;
+        }
+
+        if (source[i] == 'R' && i + 1 < source.size() && source[i + 1] == '"') {
+            const std::size_t delimiter_start = i + 2;
+            const std::size_t open_paren = source.find('(', delimiter_start);
+            if (open_paren != std::string::npos) {
+                const std::string delimiter = source.substr(delimiter_start, open_paren - delimiter_start);
+                bool delimiter_valid = true;
+                for (const char dc : delimiter) {
+                    if (dc == '\\' || dc == ')' || dc == '(' || dc == ' ' || dc == '\t' || dc == '\n' || dc == '\r') {
+                        delimiter_valid = false;
+                        break;
+                    }
+                }
+                if (delimiter_valid) {
+                    const std::string end_marker = ")" + delimiter + "\"";
+                    const std::size_t close_pos = source.find(end_marker, open_paren + 1);
+                    const std::size_t raw_end = (close_pos == std::string::npos) ? source.size() : close_pos + end_marker.size();
+                    while (i < raw_end && i < source.size()) {
+                        sanitized.push_back(source[i] == '\n' ? '\n' : ' ');
+                        ++i;
+                    }
+                    continue;
+                }
+            }
+        }
+
+        sanitized.push_back(source[i]);
+        ++i;
+    }
+
+    return sanitized;
+}
+
+bool has_direct_enter_phase_call(const std::string& source) {
+    static const std::regex kEnterPhaseCallPattern(R"(\benter_phase\s*\()");
+    return std::regex_search(strip_comments_and_literals(source), kEnterPhaseCallPattern);
+}
+
 // Walk upward from CWD to locate the source root (must contain the app/
 // directory). The test runner may be invoked from build/, build-web/, etc.
 fs::path find_repo_root() {
@@ -62,7 +167,7 @@ TEST_CASE("phase_transition: screen controllers do not call enter_phase directly
     std::vector<std::string> offenders;
     for (const auto& src : sources_under(controllers)) {
         const std::string body = read_file(src);
-        if (body.find("enter_phase(") != std::string::npos) {
+        if (has_direct_enter_phase_call(body)) {
             offenders.push_back(src.string());
         }
     }
@@ -83,7 +188,7 @@ TEST_CASE("phase_transition: input routing does not call enter_phase directly (#
     std::vector<std::string> offenders;
     for (const auto& src : sources_under(input_dir)) {
         const std::string body = read_file(src);
-        if (body.find("enter_phase(") != std::string::npos) {
+        if (has_direct_enter_phase_call(body)) {
             offenders.push_back(src.string());
         }
     }
@@ -92,4 +197,26 @@ TEST_CASE("phase_transition: input routing does not call enter_phase directly (#
          "not call enter_phase() directly. See decisions.md (#482).");
     for (const auto& f : offenders) INFO("offender: " << f);
     REQUIRE(offenders.empty());
+}
+
+TEST_CASE("phase_transition matcher catches whitespace variants and ignores strings/comments",
+          "[phase_transition][architecture]") {
+    const std::string direct_call = R"cpp(
+        void bad(GameState& gs) {
+            enter_phase ( gs, GamePhase::Title );
+        }
+    )cpp";
+    const std::string string_literal_only = R"cpp(
+        const char* text = "enter_phase( should not trigger";
+    )cpp";
+    const std::string comments_only = R"cpp(
+        // enter_phase(gs, GamePhase::Title);
+        /*
+          enter_phase ( gs, GamePhase::Title );
+        */
+    )cpp";
+
+    CHECK(has_direct_enter_phase_call(direct_call));
+    CHECK_FALSE(has_direct_enter_phase_call(string_literal_only));
+    CHECK_FALSE(has_direct_enter_phase_call(comments_only));
 }

--- a/tests/test_player_input_rhythm_extended.cpp
+++ b/tests/test_player_input_rhythm_extended.cpp
@@ -110,6 +110,23 @@ TEST_CASE("player_input_rhythm: shape press does not set stale target when alrea
     CHECK(lane.target == -1);
 }
 
+TEST_CASE("player_input_rhythm: shape press cancels conflicting in-flight lane target",
+          "[player][rhythm]") {
+    auto reg = make_rhythm_registry();
+    auto player = make_rhythm_player(reg);
+    auto& lane = reg.get<Lane>(player);
+    lane.current = 1;
+    lane.target = 2;
+    lane.lerp_t = 0.5f;
+
+    auto btn = make_shape_button(reg, Shape::Square);
+    press_button(reg, btn);
+    run_semantic_input_tick(reg);
+
+    CHECK(lane.target == 1);
+    CHECK(lane.lerp_t == 0.0f);
+}
+
 TEST_CASE("player_input_rhythm: lane change works in rhythm mode", "[player][rhythm]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);

--- a/tests/test_web_input_policy.cpp
+++ b/tests/test_web_input_policy.cpp
@@ -1,0 +1,40 @@
+// Web input policy tests — issue #499.
+//
+// The WebInputPolicy used to latch a one-time "prefers touch" decision from a
+// startup UA regex + maxTouchPoints check. That broke iPadOS 13+ Safari
+// (desktop UA) and any touch-capable laptop with a desktop UA — touch was
+// disabled for the entire session.
+//
+// The new contract:
+//   • On native (non-web), both mouse and touch input are always permitted.
+//   • On web, mouse input is always permitted; touch input is permitted iff
+//     the browser exposes a touch surface (navigator.maxTouchPoints > 0).
+//   • There is no UA regex and no one-time "prefer one source" latch.
+//
+// We can't drive emscripten's EM_ASM_INT from the native test runner, but we
+// CAN assert on the non-web invariant that input_system_init runs cleanly
+// and that input_system continues to honor both sources concurrently with
+// active_source acting as the per-gesture arbiter (covered by the existing
+// pipeline tests for swipe/keyboard routing).
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "test_helpers.h"
+
+TEST_CASE("input_system_init: runs cleanly and leaves both sources enabled on native",
+          "[input][web_policy]") {
+    auto reg = make_registry();
+    // Idempotent: calling init twice must not throw or duplicate context.
+    REQUIRE_NOTHROW(input_system_init(reg));
+    REQUIRE_NOTHROW(input_system_init(reg));
+
+    // On native, no gating. Run a tick — must not crash and must not
+    // synthesize spurious input.
+    auto& input = reg.ctx().get<InputState>();
+    input.touch_down = false;
+    input.touch_up   = false;
+    input.click      = false;
+    REQUIRE_NOTHROW(input_system(reg, 0.016f));
+    CHECK_FALSE(input.touch_down);
+    CHECK_FALSE(input.touch_up);
+}

--- a/tests/test_world_systems.cpp
+++ b/tests/test_world_systems.cpp
@@ -267,6 +267,52 @@ TEST_CASE("game_state: paused to playing on touch", "[gamestate]") {
     CHECK(gs.phase_timer == 0.0f);
 }
 
+TEST_CASE("game_state: paused resume preserves active play session state", "[gamestate][regression]") {
+    auto reg = make_registry();
+    auto& gs = reg.ctx().get<GameState>();
+    gs.phase = GamePhase::Paused;
+
+    auto player = make_player(reg);
+    auto obstacle = reg.create();
+    reg.emplace<ObstacleTag>(obstacle);
+    reg.emplace<WorldTransform>(obstacle, WorldTransform{{0.0f, 123.0f}});
+
+    auto& score = reg.ctx().get<ScoreState>();
+    score.score = 4321;
+
+    auto& energy = reg.ctx().get<EnergyState>();
+    energy.energy = 0.42f;
+    energy.display = 0.37f;
+
+    auto& song = reg.ctx().get<SongState>();
+    song.song_time = 12.5f;
+    song.playing = true;
+    song.restart_music = false;
+
+    auto btn = make_menu_button(reg, MenuActionKind::Confirm);
+    press_button(reg, btn);
+
+    game_state_system(reg, 0.016f);
+
+    CHECK(gs.phase == GamePhase::Playing);
+    CHECK(gs.phase_timer == 0.0f);
+    CHECK(reg.valid(player));
+    CHECK(reg.valid(obstacle));
+    CHECK(score.score == 4321);
+    CHECK(energy.energy == 0.42f);
+    CHECK(energy.display == 0.37f);
+    CHECK(song.song_time == 12.5f);
+    CHECK(song.playing);
+    CHECK_FALSE(song.restart_music);
+
+    int player_count = 0;
+    for (auto e : reg.view<PlayerTag>()) {
+        ++player_count;
+        (void)e;
+    }
+    CHECK(player_count == 1);
+}
+
 TEST_CASE("game_state: title stays title without touch", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();

--- a/tests/wasm_runtime_smoke.cjs
+++ b/tests/wasm_runtime_smoke.cjs
@@ -57,6 +57,19 @@ async function main() {
     return previousHash;
   }
 
+  async function waitForTitlePhase(expectedPhase, timeoutMs) {
+    const started = Date.now();
+    const marker = `[${expectedPhase}]`;
+    while (Date.now() - started < timeoutMs) {
+      const title = await page.title();
+      if (title.includes(marker)) {
+        return true;
+      }
+      await page.waitForTimeout(100);
+    }
+    return false;
+  }
+
   page.on('console', msg => {
     const text = msg.text();
     if (/RuntimeError: Aborted|Aborted\(|abort\(|emscripten_sleep/i.test(text)) {
@@ -91,6 +104,9 @@ async function main() {
     await page.waitForFunction(() => {
       return typeof document.title === 'string' && document.title.includes('SHAPESHIFTER');
     }, undefined, { timeout: 30000 });
+    if (!(await waitForTitlePhase('Title', 3000))) {
+      fatal.push(`missing-title-phase-marker:${await page.title()}`);
+    }
 
     const beforeInput = await page.screenshot();
     const beforeHash = sha256(beforeInput);
@@ -106,6 +122,9 @@ async function main() {
     if (beforeHash === afterStartHash) {
       fatal.push('no-visual-response-after-title-clicks');
     }
+    if (!(await waitForTitlePhase('LevelSelect', 4000))) {
+      fatal.push(`missing-level-select-phase-marker:${await page.title()}`);
+    }
 
     // Once on level select, keyboard navigation should visibly update selection.
     // The title transition above covers the browser click path; using keyboard
@@ -114,6 +133,9 @@ async function main() {
     const afterLevelSelectClickHash = await waitForVisualChange(afterStartHash, 2500);
     if (afterStartHash === afterLevelSelectClickHash) {
       fatal.push('no-visual-response-after-level-select-navigation');
+    }
+    if (!(await waitForTitlePhase('LevelSelect', 1500))) {
+      fatal.push(`unexpected-phase-after-level-select-navigation:${await page.title()}`);
     }
 
     // Start the selected level. The controller intentionally ignores instant
@@ -127,6 +149,9 @@ async function main() {
     }
     if (afterLevelSelectClickHash === afterHash) {
       fatal.push('no-visual-response-after-enter');
+    }
+    if (!(await waitForTitlePhase('Playing', 4500))) {
+      fatal.push(`missing-playing-phase-marker:${await page.title()}`);
     }
   } finally {
     await browser.close();

--- a/tools/rhythm_pipeline.py
+++ b/tools/rhythm_pipeline.py
@@ -41,6 +41,13 @@ DEFAULT_LIBROSA_CONFIG_PATH = Path(__file__).parent / "config" / "rhythm_librosa
 # hihat / melody recognition.
 # ---------------------------------------------------------------------------
 
+# The ``method`` field semantically dispatches the detection envelope:
+#   - "band_flux_*"  : mel-band positive flux envelope, optionally restricted
+#                      to a frequency zone (driven by ``zone``).
+#   - "spectral_flux": full STFT positive spectral flux envelope, computed
+#                      via ``_spectral_flux_onset_envelope``.  This is a
+#                      genuinely independent envelope from the mel-band path
+#                      and must NOT be a duplicate of any band_flux pass.
 ONSET_PASSES = [
     {"name": "percussive_bass",      "method": "band_flux_bass",     "zone": "bass"},
     {"name": "percussive_broadband", "method": "band_flux_full",     "zone": None},
@@ -370,8 +377,18 @@ def _detect_pass_onsets(
     n_mels: int,
     peak_pick_cfg: dict | None = None,
     zone_thresholds: dict | None = None,
+    method: str | None = None,
 ) -> list[float]:
     """Detect onsets for one pass/zone/resolution combination.
+
+    The ``method`` argument dispatches the envelope source:
+
+      * ``"spectral_flux"`` — full STFT positive spectral flux via
+        :func:`_spectral_flux_onset_envelope`.  This is the envelope used by
+        the ``full_spectrum_flux`` pass and is genuinely independent of the
+        mel-band path; it is NOT a duplicate of ``band_flux_full``.
+      * ``"band_flux_*"`` (default) — librosa mel-band positive flux
+        envelope, optionally restricted to a frequency ``zone``.
 
     zone_thresholds (optional): per-zone threshold overrides, e.g.
         {"bass": 0.10, "low_mid": 0.13, "high_mid": 0.15}
@@ -383,8 +400,20 @@ def _detect_pass_onsets(
 
     n_fft = int(resolution["n_fft"])
     hop_length = int(resolution["hop_length"])
-    mel_db = _mel_spectrogram_db(y, sr, n_fft=n_fft, hop_length=hop_length, n_mels=n_mels)
-    onset_env = _flux_envelope(mel_db, zone)
+
+    if method == "spectral_flux":
+        # Full-spectrum STFT flux: an envelope independent from the mel-band
+        # path so the ``full_spectrum_flux`` pass produces a distinct musical
+        # view from ``percussive_broadband`` (issue #491).
+        onset_env = _spectral_flux_onset_envelope(
+            y=y,
+            hop_length=hop_length,
+            n_fft=n_fft,
+            reduce="mean",
+        )
+    else:
+        mel_db = _mel_spectrogram_db(y, sr, n_fft=n_fft, hop_length=hop_length, n_mels=n_mels)
+        onset_env = _flux_envelope(mel_db, zone)
     return _detect_onsets_from_envelope(
         onset_env,
         sr=sr,
@@ -639,6 +668,7 @@ def extract_features(filepath: str, onset_threshold: float, librosa_config: dict
                 n_mels=n_mels,
                 peak_pick_cfg=peak_pick_cfg,
                 zone_thresholds=zone_thresholds_cfg,
+                method=p.get("method"),
             )
             per_resolution.append(
                 {

--- a/tools/test_layer_aware_pipeline.py
+++ b/tools/test_layer_aware_pipeline.py
@@ -678,5 +678,102 @@ class TestLoop1DiagnosticsCoverHarmonicLayer(unittest.TestCase):
                 )
 
 
+class TestFullSpectrumFluxIndependence(unittest.TestCase):
+    """Regression for issue #491.
+
+    The ``full_spectrum_flux`` pass uses an STFT-based spectral flux envelope
+    and must NOT be a deterministic duplicate of ``percussive_broadband``,
+    which uses the mel-band flux path.
+    """
+
+    def _synth_audio(self, sr: int = 22050) -> "tuple[object, int]":
+        import numpy as np
+        rng = np.random.default_rng(0xBEA7)
+        duration = 4.0
+        t = np.arange(int(sr * duration)) / sr
+        y = 0.02 * rng.standard_normal(t.shape).astype("float32")
+        # Broadband percussive transients.
+        for onset in (0.30, 0.95, 1.62, 2.30, 3.05):
+            i = int(onset * sr)
+            n = int(0.05 * sr)
+            env = np.exp(-np.linspace(0, 6, n)).astype("float32")
+            noise = rng.standard_normal(n).astype("float32")
+            if i + n <= len(y):
+                y[i:i + n] += 0.6 * env * noise
+        # Tonal harmonic content (sustained sine bursts) — adds spectral
+        # energy redistribution that STFT flux can see but mel-band positive
+        # flux barely registers as discrete onsets.
+        for onset, freq in ((0.55, 440.0), (1.20, 660.0), (2.70, 523.0)):
+            i = int(onset * sr)
+            n = int(0.30 * sr)
+            env = np.hanning(n).astype("float32")
+            tone = np.sin(2 * np.pi * freq * np.arange(n) / sr).astype("float32")
+            if i + n <= len(y):
+                y[i:i + n] += 0.35 * env * tone
+        return y, sr
+
+    def test_dispatch_method_is_a_parameter(self):
+        import inspect
+        sig = inspect.signature(rp._detect_pass_onsets)
+        self.assertIn(
+            "method", sig.parameters,
+            "_detect_pass_onsets must accept a 'method' kwarg so detection "
+            "can dispatch on ONSET_PASSES[*].method (issue #491)",
+        )
+
+    def test_spectral_flux_envelope_differs_from_mel_band_envelope(self):
+        import numpy as np
+        y, sr = self._synth_audio()
+        n_fft, hop = 2048, 512
+        stft_env = rp._spectral_flux_onset_envelope(
+            y=y, hop_length=hop, n_fft=n_fft, reduce="mean",
+        )
+        mel_db = rp._mel_spectrogram_db(y, sr, n_fft=n_fft, hop_length=hop, n_mels=40)
+        mel_env = rp._flux_envelope(mel_db, None)
+        # Length-align for comparison.
+        n = min(len(stft_env), len(mel_env))
+        a = np.asarray(stft_env[:n], dtype=float)
+        b = np.asarray(mel_env[:n], dtype=float)
+        if a.std() > 0 and b.std() > 0:
+            corr = float(np.corrcoef(a, b)[0, 1])
+        else:
+            corr = 0.0
+        self.assertLess(
+            corr, 0.999,
+            "STFT spectral-flux envelope is essentially identical to the "
+            "mel-band flux envelope; full_spectrum_flux would be a duplicate",
+        )
+
+    def test_full_spectrum_flux_not_equal_to_percussive_broadband(self):
+        y, sr = self._synth_audio()
+        librosa_config = {
+            "onset": {
+                "n_mels": 40,
+                "peak_pick": {},
+                "zone_thresholds": {},
+                "resolutions": [{"n_fft": 2048, "hop_length": 512}],
+            },
+            "beat": {"n_fft": 2048, "hop_length": 512},
+        }
+        # Run only the onset-pass loop logic by calling _detect_pass_onsets
+        # directly for both passes — avoids needing a file on disk.
+        res = {"n_fft": 2048, "hop_length": 512}
+        broadband = rp._detect_pass_onsets(
+            y=y, sr=sr, zone=None, threshold=0.10, resolution=res,
+            n_mels=40, peak_pick_cfg={}, zone_thresholds={},
+            method="band_flux_full",
+        )
+        full_spec = rp._detect_pass_onsets(
+            y=y, sr=sr, zone=None, threshold=0.10, resolution=res,
+            n_mels=40, peak_pick_cfg={}, zone_thresholds={},
+            method="spectral_flux",
+        )
+        self.assertNotEqual(
+            broadband, full_spec,
+            "full_spectrum_flux must produce a distinct detection list from "
+            "percussive_broadband (issue #491)",
+        )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,10 +10,7 @@
     "raylib",
     "raygui",
     "nlohmann-json",
-    {
-      "name": "catch2",
-      "platform": "!linux"
-    }
+    "catch2"
   ],
   "builtin-baseline": "05442024c3fda64320bd25d2251cc9807b84fb6f"
 }


### PR DESCRIPTION
## Summary\n- Fix Round 5 gameplay/session regressions (#486, #487)\n- Harden architecture/tooling/validation gates (#488, #489, #490, #493, #494, #495, #496, #497)\n- Fix rhythm full-spectrum onset detection semantics (#491)\n- Align design docs and UX/input behavior (#492, #498, #499, #500)\n\n## Validation\n- cmake -B build -S . -Wno-dev\n- cmake --build build\n- ./build/shapeshifter_tests\n- ./run.sh test