### PR TITLE
Resolve round 13 ECS and timing doc issues

### DIFF
--- a/app/components/rendering.h
+++ b/app/components/rendering.h
@@ -30,7 +30,10 @@ struct ScreenTransform {
 };
 
 [[nodiscard]] inline glm::vec2 screen_to_virtual(const glm::vec2& screen_pos,
-                                                 const ScreenTransform& st) noexcept {
+                                                  const ScreenTransform& st) noexcept {
+    if (st.scale <= 0.0f) {
+        return screen_pos;
+    }
     return {
         (screen_pos.x - st.offset_x) / st.scale,
         (screen_pos.y - st.offset_y) / st.scale
@@ -45,24 +48,24 @@ enum class MeshType : uint8_t { Shape, Slab, Quad };
 
 struct ModelTransform {
     glm::mat4 mat{1.0f};
-    Color     tint{};
+    Color     tint{255, 255, 255, 255};
     uint8_t   mesh_index = 0;  // index into ShapeMeshes.shapes[] for Shape type
-    MeshType  mesh_type;
+    MeshType  mesh_type = MeshType::Shape;
 };
 
 // Visual mesh child of a logical entity (e.g., obstacle slabs, ghost shapes).
 // Created at spawn time by game object factories. game_camera_system reads
 // parent WorldTransform + child offsets to compute ModelTransform each frame.
 struct MeshChild {
-    entt::entity parent;
-    float x;             // absolute X position in game coords
-    float z_offset;      // offset from parent WorldTransform.position.y (scroll axis)
-    float width;         // slab width (game coords)
-    float depth;         // slab depth (game coords)
-    float height;        // slab height (game coords)
-    Color tint;
+    entt::entity parent = entt::null;
+    float x = 0.0f;             // absolute X position in game coords
+    float z_offset = 0.0f;      // offset from parent WorldTransform.position.y (scroll axis)
+    float width = 0.0f;         // slab width (game coords)
+    float depth = 0.0f;         // slab depth (game coords)
+    float height = 0.0f;        // slab height (game coords)
+    Color tint{255, 255, 255, 255};
     uint8_t mesh_index = 0;  // index into ShapeMeshes.shapes[] for Shape type
-    MeshType mesh_type;
+    MeshType mesh_type = MeshType::Shape;
 };
 
 // ── Mesh-child ownership ─────────────────────────────────────────────────────
@@ -71,7 +74,7 @@ struct MeshChild {
 // scanning the entire MeshChild pool.
 struct ObstacleChildren {
     static constexpr int MAX = 8;
-    entt::entity children[MAX];
+    entt::entity children[MAX]{};
     int count = 0;
 };
 

--- a/app/components/rendering.h
+++ b/app/components/rendering.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cassert>
 #include <cstdint>
+#include <cmath>
 #include <entt/entt.hpp>
 #include <glm/mat4x4.hpp>
 #include <glm/vec2.hpp>
@@ -31,12 +33,12 @@ struct ScreenTransform {
 
 [[nodiscard]] inline glm::vec2 screen_to_virtual(const glm::vec2& screen_pos,
                                                   const ScreenTransform& st) noexcept {
-    if (st.scale <= 0.0f) {
-        return screen_pos;
-    }
+    assert(std::isfinite(st.scale));
+    assert(st.scale > 0.0f);
+    const float inv_scale = 1.0f / st.scale;
     return {
-        (screen_pos.x - st.offset_x) / st.scale,
-        (screen_pos.y - st.offset_y) / st.scale
+        (screen_pos.x - st.offset_x) * inv_scale,
+        (screen_pos.y - st.offset_y) * inv_scale
     };
 }
 

--- a/app/components/song_state.h
+++ b/app/components/song_state.h
@@ -53,7 +53,6 @@ struct EnergyState {
 enum class DeathCause : uint8_t {
     None = 0,
     EnergyDepleted = 1,
-    MissedABeat    = 2,
 };
 
 struct GameOverState {

--- a/app/entities/obstacle_entity.cpp
+++ b/app/entities/obstacle_entity.cpp
@@ -8,7 +8,9 @@
 entt::entity spawn_obstacle(entt::registry& reg, const ObstacleSpawnParams& params,
                              const BeatInfo* beat_info) {
     auto e = reg.create();
-    reg.emplace<MotionVelocity>(e, MotionVelocity{{0.0f, params.speed}});
+    if (!beat_info) {
+        reg.emplace<MotionVelocity>(e, MotionVelocity{{0.0f, params.speed}});
+    }
     reg.emplace<WorldTransform>(e, WorldTransform{{params.x, params.y}});
     reg.emplace<DrawLayer>(e, Layer::Game);
     reg.emplace<TagWorldPass>(e);

--- a/app/entities/obstacle_entity.cpp
+++ b/app/entities/obstacle_entity.cpp
@@ -5,19 +5,13 @@
 #include "obstacle_render_entity.h"
 #include "../constants.h"
 
-entt::entity spawn_obstacle(entt::registry& reg, const ObstacleSpawnParams& params,
-                             const BeatInfo* beat_info) {
+namespace {
+
+entt::entity spawn_obstacle_base(entt::registry& reg, const ObstacleSpawnParams& params) {
     auto e = reg.create();
-    if (!beat_info) {
-        reg.emplace<MotionVelocity>(e, MotionVelocity{{0.0f, params.speed}});
-    }
     reg.emplace<WorldTransform>(e, WorldTransform{{params.x, params.y}});
     reg.emplace<DrawLayer>(e, Layer::Game);
     reg.emplace<TagWorldPass>(e);
-
-    if (beat_info) {
-        reg.emplace<BeatInfo>(e, *beat_info);
-    }
 
     switch (params.kind) {
         case ObstacleKind::ShapeGate: {
@@ -57,8 +51,28 @@ entt::entity spawn_obstacle(entt::registry& reg, const ObstacleSpawnParams& para
         }
     }
 
+    return e;
+}
+
+void finish_obstacle(entt::registry& reg, entt::entity e) {
     spawn_obstacle_meshes(reg, e);
     reg.emplace<ObstacleTag>(e);
+}
+
+} // namespace
+
+entt::entity spawn_obstacle(entt::registry& reg, const ObstacleSpawnParams& params) {
+    auto e = spawn_obstacle_base(reg, params);
+    reg.emplace<MotionVelocity>(e, MotionVelocity{{0.0f, params.speed}});
+    finish_obstacle(reg, e);
+    return e;
+}
+
+entt::entity spawn_rhythm_obstacle(entt::registry& reg, const ObstacleSpawnParams& params,
+                                   const BeatInfo& beat_info) {
+    auto e = spawn_obstacle_base(reg, params);
+    reg.emplace<BeatInfo>(e, beat_info);
+    finish_obstacle(reg, e);
 
     return e;
 }

--- a/app/entities/obstacle_entity.h
+++ b/app/entities/obstacle_entity.h
@@ -18,8 +18,8 @@ struct ObstacleSpawnParams {
 };
 
 // Creates and fully configures an obstacle entity:
-//   ObstacleTag + MotionVelocity + DrawLayer + kind-specific components
-//   + BeatInfo (if beat_info != nullptr) + mesh child entities.
+//   ObstacleTag + DrawLayer + kind-specific components + mesh child entities.
+//   Rhythm obstacles get BeatInfo; non-rhythm obstacles get MotionVelocity.
 // Owns the complete component bundle contract for obstacles.
 entt::entity spawn_obstacle(entt::registry& reg, const ObstacleSpawnParams& params,
                              const BeatInfo* beat_info = nullptr);

--- a/app/entities/obstacle_entity.h
+++ b/app/entities/obstacle_entity.h
@@ -19,7 +19,12 @@ struct ObstacleSpawnParams {
 
 // Creates and fully configures an obstacle entity:
 //   ObstacleTag + DrawLayer + kind-specific components + mesh child entities.
-//   Rhythm obstacles get BeatInfo; non-rhythm obstacles get MotionVelocity.
+//   Non-rhythm obstacles get MotionVelocity.
 // Owns the complete component bundle contract for obstacles.
-entt::entity spawn_obstacle(entt::registry& reg, const ObstacleSpawnParams& params,
-                             const BeatInfo* beat_info = nullptr);
+entt::entity spawn_obstacle(entt::registry& reg, const ObstacleSpawnParams& params);
+
+// Creates a song-time-authoritative rhythm obstacle:
+//   ObstacleTag + BeatInfo + DrawLayer + kind-specific components + mesh children.
+// Rhythm obstacles intentionally do not get MotionVelocity.
+entt::entity spawn_rhythm_obstacle(entt::registry& reg, const ObstacleSpawnParams& params,
+                                   const BeatInfo& beat_info);

--- a/app/platform_display.cpp
+++ b/app/platform_display.cpp
@@ -2,11 +2,12 @@
 #include "game_loop.h"
 #include "components/game_state.h"
 
+#include <algorithm>
+
 #ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
 #include <emscripten/html5.h>
 #include <rlgl.h>
-#include <algorithm>
 
 void platform_get_display_size(float& out_w, float& out_h) {
     double css_w = 0.0, css_h = 0.0;
@@ -142,8 +143,8 @@ void platform_run_loop(entt::registry& reg) {
 #else // Native
 
 void platform_get_display_size(float& out_w, float& out_h) {
-    out_w = static_cast<float>(GetScreenWidth());
-    out_h = static_cast<float>(GetScreenHeight());
+    out_w = std::max(1.0f, static_cast<float>(GetScreenWidth()));
+    out_h = std::max(1.0f, static_cast<float>(GetScreenHeight()));
 }
 
 void platform_pre_blit() {

--- a/app/systems/beat_scheduler_system.cpp
+++ b/app/systems/beat_scheduler_system.cpp
@@ -77,7 +77,7 @@ void beat_scheduler_system(entt::registry& reg, float /*dt*/) {
         }
 
         const BeatInfo bi{entry.beat_index, calibrated_arrival_time, effective_spawn_time};
-        spawn_obstacle(reg, {
+        spawn_rhythm_obstacle(reg, {
             entry.kind,
             x_pos,
             start_y,
@@ -85,7 +85,7 @@ void beat_scheduler_system(entt::registry& reg, float /*dt*/) {
             entry.blocked_mask,
             entry.lane,
             song->scroll_speed
-        }, &bi);
+        }, bi);
 
         song->next_spawn_idx++;
     }

--- a/app/systems/camera_system.cpp
+++ b/app/systems/camera_system.cpp
@@ -321,8 +321,9 @@ void game_camera_system(entt::registry& reg, float /*dt*/) {
         float pulse = 0.0f;
         if (song && song->playing && song->beat_period > 0.0f && song->current_beat >= 0) {
             float beat_time = song->offset + static_cast<float>(song->current_beat) * song->beat_period;
-            if (map && !map->beat_times.empty()) {
-                beat_time = map->beat_times[static_cast<size_t>(song->current_beat)];
+            const auto beat_index = static_cast<size_t>(song->current_beat);
+            if (map && beat_index < map->beat_times.size()) {
+                beat_time = map->beat_times[beat_index];
             }
             float time_since_beat = song->song_time - beat_time;
             float pulse_t = Clamp(time_since_beat / constants::FLOOR_PULSE_DECAY, 0.0f, 1.0f);

--- a/app/systems/motion_system.cpp
+++ b/app/systems/motion_system.cpp
@@ -4,7 +4,8 @@
 #include "../components/rhythm.h"
 
 void motion_system(entt::registry& reg, float dt) {
-    // WorldTransform+MotionVelocity entities (obstacles, popups, particles, player).
+    // MotionVelocity is the ownership marker for dt-integrated movement.
+    // Song-time-authoritative rhythm obstacles have BeatInfo instead.
     auto motion_view = reg.view<WorldTransform, MotionVelocity>();
     for (auto [entity_id, transform, velocity] : motion_view.each()) {
         (void)entity_id;

--- a/app/systems/motion_system.cpp
+++ b/app/systems/motion_system.cpp
@@ -5,8 +5,7 @@
 
 void motion_system(entt::registry& reg, float dt) {
     // WorldTransform+MotionVelocity entities (obstacles, popups, particles, player).
-    // Excludes BeatInfo entities (position derived from song_time in scroll_system).
-    auto motion_view = reg.view<WorldTransform, MotionVelocity>(entt::exclude<BeatInfo>);
+    auto motion_view = reg.view<WorldTransform, MotionVelocity>();
     for (auto [entity_id, transform, velocity] : motion_view.each()) {
         (void)entity_id;
         transform.position.x += velocity.value.x * dt;

--- a/app/systems/popup_display_system.cpp
+++ b/app/systems/popup_display_system.cpp
@@ -52,32 +52,6 @@ void popup_display_system(entt::registry& reg, float dt) {
         }
     }
 
-    auto expire_only_view = reg.view<ScorePopup>(entt::exclude<PopupDisplay, Color>);
-    for (auto [entity, popup] : expire_only_view.each()) {
-        popup.remaining -= dt;
-        if (popup.remaining <= 0.0f) {
-            expired.push_back(entity);
-        }
-    }
-
-    auto popup_only_view = reg.view<ScorePopup, PopupDisplay>(entt::exclude<Color>);
-    for (auto [entity, popup, pd] : popup_only_view.each()) {
-        (void)pd;
-        popup.remaining -= dt;
-        if (popup.remaining <= 0.0f) {
-            expired.push_back(entity);
-        }
-    }
-
-    auto color_only_view = reg.view<ScorePopup, Color>(entt::exclude<PopupDisplay>);
-    for (auto [entity, popup, col] : color_only_view.each()) {
-        (void)col;
-        popup.remaining -= dt;
-        if (popup.remaining <= 0.0f) {
-            expired.push_back(entity);
-        }
-    }
-
     for (auto entity : expired) {
         reg.destroy(entity);
     }

--- a/app/ui/screen_controllers/game_over_screen_controller.cpp
+++ b/app/ui/screen_controllers/game_over_screen_controller.cpp
@@ -73,7 +73,6 @@ void draw_game_over_scoreboard(entt::registry& reg, const GameOverLayoutState& s
 const char* death_cause_text(DeathCause cause) {
     switch (cause) {
         case DeathCause::EnergyDepleted: return "ENERGY DEPLETED";
-        case DeathCause::MissedABeat:    return "MISSED A BEAT";
         case DeathCause::None:
         default:                          return "";
     }

--- a/design-docs/rhythm-design.md
+++ b/design-docs/rhythm-design.md
@@ -336,12 +336,14 @@ The player can hear the beat coming. The timing is legible. What the player cann
   │                                                             │
   │    |input - t_peak|   Grade      Multiplier  Window Scale  │
   │   ─────────────────   ────────   ──────────  ────────────  │
-  │       ≤ 50 ms         PERFECT     × 1.50      × 1.50       │
-  │       ≤ 100 ms        GOOD        × 1.00      × 1.00       │
-  │       ≤ 150 ms        OK          × 0.50      × 0.75       │
-  │       > 150 ms        BAD         × 0.25      × 0.50       │
+  │       ≤ 50 ms         PERFECT     × 1.50      × 0.50       │
+  │       ≤ 100 ms        GOOD        × 1.00      × 0.75       │
+  │       ≤ 150 ms        OK          × 0.50      × 1.00       │
+  │       > 150 ms        BAD         × 0.25      × 1.00       │
   │                                                             │
   │  Thresholds are fixed milliseconds in shipped code.         │
+  │  Lower Window Scale means the active shape window collapses │
+  │  sooner after that scored press.                            │
   │  Score = floor(base_points × timing_multiplier) + chain_flat_bonus. │
   │                                                             │
   └─────────────────────────────────────────────────────────────┘

--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -122,7 +122,8 @@ regression gate.
 constexpr float WINDOW_PERFECT   = 0.050f;  // ±50ms  → PERFECT
 constexpr float WINDOW_GOOD      = 0.100f;  // ±100ms → GOOD
 constexpr float WINDOW_OK        = 0.150f;  // ±150ms → OK
-constexpr float WINDOW_BAD       = 0.200f;  // ±200ms → BAD timing tier
+// BAD is any scored press beyond OK timing; the active shape window,
+// not a separate 200ms constant, bounds whether the hit can score.
 
 // ── Window scale factors (applied to remaining window on early hit) ──
 constexpr float WINDOW_SCALE_PERFECT = 0.50f;  // PERFECT hit → halve remaining window

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -380,7 +380,7 @@ TEST_CASE("beat_scheduler: obstacles spawn with overshoot compensation", "[beat_
     }
 }
 
-TEST_CASE("beat_scheduler: obstacles have velocity matching scroll_speed", "[beat_scheduler]") {
+TEST_CASE("beat_scheduler: rhythm obstacles omit MotionVelocity", "[beat_scheduler]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     auto& map = reg.ctx().get<BeatMap>();
@@ -391,10 +391,11 @@ TEST_CASE("beat_scheduler: obstacles have velocity matching scroll_speed", "[bea
 
     beat_scheduler_system(reg, 0.016f);
 
-    auto view = reg.view<ObstacleTag, MotionVelocity>();
-    for (auto [e, vel] : view.each()) {
-        CHECK(vel.value.y == song.scroll_speed);
-        CHECK(vel.value.x == 0.0f);
+    auto view = reg.view<ObstacleTag, BeatInfo>();
+    REQUIRE(std::distance(view.begin(), view.end()) == 1);
+    for (auto [e, info] : view.each()) {
+        (void)info;
+        CHECK_FALSE(reg.all_of<MotionVelocity>(e));
     }
 }
 

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -397,6 +397,8 @@ TEST_CASE("beat_scheduler: rhythm obstacles omit MotionVelocity", "[beat_schedul
         (void)info;
         CHECK_FALSE(reg.all_of<MotionVelocity>(e));
     }
+    auto invalid_view = reg.view<ObstacleTag, BeatInfo, MotionVelocity>();
+    CHECK(std::distance(invalid_view.begin(), invalid_view.end()) == 0);
 }
 
 TEST_CASE("beat_scheduler: ShapeGate Circle has blue color", "[beat_scheduler]") {

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -23,6 +23,38 @@ TEST_CASE("components: MotionVelocity defaults to zero vector", "[components][tr
     CHECK(velocity.value.y == 0.0f);
 }
 
+TEST_CASE("components: rendering components are safely default constructible",
+          "[components][rendering]") {
+    ModelTransform model{};
+    CHECK(model.tint.r == 255);
+    CHECK(model.tint.g == 255);
+    CHECK(model.tint.b == 255);
+    CHECK(model.tint.a == 255);
+    CHECK(model.mesh_index == uint8_t{0});
+    CHECK(model.mesh_type == MeshType::Shape);
+
+    MeshChild child{};
+    const bool parent_is_null = child.parent == entt::null;
+    CHECK(parent_is_null);
+    CHECK(child.x == 0.0f);
+    CHECK(child.z_offset == 0.0f);
+    CHECK(child.width == 0.0f);
+    CHECK(child.depth == 0.0f);
+    CHECK(child.height == 0.0f);
+    CHECK(child.tint.r == 255);
+    CHECK(child.tint.g == 255);
+    CHECK(child.tint.b == 255);
+    CHECK(child.tint.a == 255);
+    CHECK(child.mesh_index == uint8_t{0});
+    CHECK(child.mesh_type == MeshType::Shape);
+
+    ObstacleChildren children{};
+    CHECK(children.count == 0);
+    for (const auto entity : children.children) {
+        CHECK(entity == entt::entity{});
+    }
+}
+
 TEST_CASE("components: UIPosition is distinct screen-space placement", "[components][transform][ui]") {
     UIPosition position{};
     CHECK(position.value.x == 0.0f);

--- a/tests/test_game_over_screen_controller.cpp
+++ b/tests/test_game_over_screen_controller.cpp
@@ -46,26 +46,19 @@ struct ScopedGameOverHooks {
 
 } // namespace
 
-TEST_CASE("game_over: death_cause_text maps every DeathCause to a non-empty platform-neutral string",
+TEST_CASE("game_over: death_cause_text maps terminal causes to platform-neutral strings",
           "[game_over][ui]") {
     // None → empty (suppresses ReasonSlot rendering).
     CHECK(std::strlen(death_cause_text(DeathCause::None)) == 0);
 
     // Real causes must produce a non-empty, ASCII-only one-liner.
-    for (auto cause : { DeathCause::EnergyDepleted, DeathCause::MissedABeat }) {
+    for (auto cause : { DeathCause::EnergyDepleted }) {
         const char* txt = death_cause_text(cause);
         REQUIRE(txt != nullptr);
         CHECK(std::strlen(txt) > 0);
         // Stay short enough to fit ReasonSlot (500px @ 22pt) — sanity bound.
         CHECK(std::strlen(txt) < 32u);
     }
-}
-
-TEST_CASE("game_over: distinct DeathCauses produce distinct reasons (#168 coverage)",
-          "[game_over][ui]") {
-    const char* energy = death_cause_text(DeathCause::EnergyDepleted);
-    const char* miss   = death_cause_text(DeathCause::MissedABeat);
-    CHECK(std::strcmp(energy, miss) != 0);
 }
 
 TEST_CASE("game_over: score / high score / cause are visible via registry singletons "
@@ -106,7 +99,7 @@ TEST_CASE("game_over: render binds score/high-score/reason into scoreboard draw 
     score.high_score = 92653;
 
     auto& gos = reg.ctx().get<GameOverState>();
-    gos.cause = DeathCause::MissedABeat;
+    gos.cause = DeathCause::EnergyDepleted;
 
     auto& gs = reg.ctx().get<GameState>();
     gs.phase = GamePhase::GameOver;
@@ -116,7 +109,7 @@ TEST_CASE("game_over: render binds score/high-score/reason into scoreboard draw 
 
     CHECK(has_bound_text("31415"));
     CHECK(has_bound_text("92653"));
-    CHECK(has_bound_text("MISSED A BEAT"));
+    CHECK(has_bound_text("ENERGY DEPLETED"));
 }
 
 TEST_CASE("game_over: render binds new-best badge and previous score", "[game_over][ui]") {

--- a/tests/test_ndc_viewport.cpp
+++ b/tests/test_ndc_viewport.cpp
@@ -2,6 +2,7 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include "test_helpers.h"
 #include <algorithm>
+#include <cmath>
 // ─────────────────────────────────────────────────────────────────────────────
 // NDC Viewport Constants
 // All *_N constants must lie in [0, 1] and must round-trip to the intended
@@ -220,6 +221,8 @@ TEST_CASE("ndc: zone boundary constant is 0.80", "[ndc]") {
 namespace {
 // Pure mirror of the letterbox math in compute_screen_transform.
 ScreenTransform make_screen_transform(float win_w, float win_h) {
+    win_w = std::max(1.0f, win_w);
+    win_h = std::max(1.0f, win_h);
     float scale = std::min(
         win_w / static_cast<float>(constants::SCREEN_W),
         win_h / static_cast<float>(constants::SCREEN_H));
@@ -250,7 +253,7 @@ TEST_CASE("screen_transform: letterbox math is idempotent (#241)",
 }
 
 TEST_CASE("screen_transform: letterbox math produces correct pillarbox offsets (#241)",
-          "[screen_transform][regression]") {
+           "[screen_transform][regression]") {
     // 1280×1280 window: scale = min(1280/720, 1280/1280) = 1.0;
     // dst_w = 720, offset_x = (1280-720)/2 = 280; dst_h = 1280, offset_y = 0.
     ScreenTransform st = make_screen_transform(1280.0f, 1280.0f);
@@ -258,4 +261,14 @@ TEST_CASE("screen_transform: letterbox math produces correct pillarbox offsets (
     CHECK_THAT(st.scale,    WithinAbs(1.0f,  1e-5f));
     CHECK_THAT(st.offset_x, WithinAbs(280.0f, 1e-5f));
     CHECK_THAT(st.offset_y, WithinAbs(0.0f,  1e-5f));
+}
+
+TEST_CASE("screen_transform: zero-sized display keeps finite virtual coordinates",
+          "[screen_transform][regression]") {
+    ScreenTransform st = make_screen_transform(0.0f, 0.0f);
+
+    CHECK(st.scale > 0.0f);
+    const auto pos = screen_to_virtual({10.0f, 20.0f}, st);
+    CHECK(std::isfinite(pos.x));
+    CHECK(std::isfinite(pos.y));
 }

--- a/tests/test_obstacle_archetypes.cpp
+++ b/tests/test_obstacle_archetypes.cpp
@@ -71,7 +71,7 @@ TEST_CASE("entity: ObstacleTag is emplaced after obstacle metadata", "[archetype
     reg.on_construct<ObstacleTag>().connect<&probe_obstacle_tag_construct>();
     BeatInfo beat_info{7, 1.5f, 0.25f};
 
-    spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f, Shape::Circle}, &beat_info);
+    spawn_rhythm_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f, Shape::Circle}, beat_info);
 
     CHECK(probe.saw_obstacle);
     CHECK(probe.saw_beat_info);
@@ -276,7 +276,7 @@ TEST_CASE("entity: ShapeGate position x/y propagated from input", "[archetype]")
 TEST_CASE("entity: BeatInfo emplaced when provided", "[archetype]") {
     entt::registry reg;
     const BeatInfo bi{5, 1.5f, 1.0f};
-    auto e = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f}, &bi);
+    auto e = spawn_rhythm_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f}, bi);
 
     REQUIRE(reg.all_of<BeatInfo>(e));
     CHECK_FALSE(reg.all_of<MotionVelocity>(e));

--- a/tests/test_obstacle_archetypes.cpp
+++ b/tests/test_obstacle_archetypes.cpp
@@ -279,6 +279,7 @@ TEST_CASE("entity: BeatInfo emplaced when provided", "[archetype]") {
     auto e = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f}, &bi);
 
     REQUIRE(reg.all_of<BeatInfo>(e));
+    CHECK_FALSE(reg.all_of<MotionVelocity>(e));
     CHECK(reg.get<BeatInfo>(e).beat_index == 5);
     CHECK(reg.get<BeatInfo>(e).arrival_time == 1.5f);
     CHECK(reg.get<BeatInfo>(e).spawn_time == 1.0f);
@@ -289,4 +290,5 @@ TEST_CASE("entity: no BeatInfo when not provided", "[archetype]") {
     auto e = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f});
 
     CHECK_FALSE(reg.all_of<BeatInfo>(e));
+    CHECK(reg.all_of<MotionVelocity>(e));
 }

--- a/tests/test_popup_display_system.cpp
+++ b/tests/test_popup_display_system.cpp
@@ -210,53 +210,6 @@ TEST_CASE("popup_display_system: works without ScorePopup component (#251)",
     CHECK(std::strcmp(pd.text, "OK") == 0);
 }
 
-TEST_CASE("popup_display_system: ScorePopup expires without render components",
-          "[popup_display]") {
-    entt::registry reg;
-    runtime_system_scratch_init(reg);
-    auto e = reg.create();
-    ScorePopup popup{};
-    popup.remaining = 0.01f;
-    popup.max_time = 1.0f;
-    reg.emplace<ScorePopup>(e, popup);
-
-    popup_display_system(reg, 0.02f);
-
-    CHECK_FALSE(reg.valid(e));
-}
-
-TEST_CASE("popup_display_system: ScorePopup+PopupDisplay expires without Color",
-          "[popup_display]") {
-    entt::registry reg;
-    runtime_system_scratch_init(reg);
-    auto e = reg.create();
-    ScorePopup popup{};
-    popup.remaining = 0.01f;
-    popup.max_time = 1.0f;
-    reg.emplace<ScorePopup>(e, popup);
-    reg.emplace<PopupDisplay>(e);
-
-    popup_display_system(reg, 0.02f);
-
-    CHECK_FALSE(reg.valid(e));
-}
-
-TEST_CASE("popup_display_system: ScorePopup+Color expires without PopupDisplay",
-          "[popup_display]") {
-    entt::registry reg;
-    runtime_system_scratch_init(reg);
-    auto e = reg.create();
-    ScorePopup popup{};
-    popup.remaining = 0.01f;
-    popup.max_time = 1.0f;
-    reg.emplace<ScorePopup>(e, popup);
-    reg.emplace<Color>(e, Color{255, 255, 255, 255});
-
-    popup_display_system(reg, 0.02f);
-
-    CHECK_FALSE(reg.valid(e));
-}
-
 TEST_CASE("popup_display_system: expired popups are destroyed",
           "[popup_display]") {
     entt::registry reg;
@@ -265,6 +218,18 @@ TEST_CASE("popup_display_system: expired popups are destroyed",
     popup_display_system(reg, 0.016f);
 
     CHECK_FALSE(reg.valid(e));
+}
+
+TEST_CASE("spawn_score_popup: creates the full popup display archetype",
+          "[popup_display][archetype]") {
+    entt::registry reg;
+    auto e = spawn_score_popup(reg, {100.0f, 200.0f, 50, TimingTier::Good});
+
+    REQUIRE(reg.all_of<ScorePopup, PopupDisplay, Color, MotionVelocity,
+                       WorldTransform, DrawLayer, TagHUDPass>(e));
+    CHECK(reg.get<ScorePopup>(e).has_timing_tier);
+    CHECK(reg.get<ScorePopup>(e).timing_tier == TimingTier::Good);
+    CHECK(std::strcmp(reg.get<PopupDisplay>(e).text, "GOOD") == 0);
 }
 
 TEST_CASE("init_popup_display: formats grade text + font size from ScorePopup (#251)",

--- a/tests/test_redfoot_testflight_ui.cpp
+++ b/tests/test_redfoot_testflight_ui.cpp
@@ -144,7 +144,7 @@ TEST_CASE("redfoot/#168: energy depletion falls back to ENERGY DEPLETED",
     CHECK(gos.cause == DeathCause::EnergyDepleted);
 }
 
-TEST_CASE("redfoot/#168: energy depletion overwrites stale non-terminal cause",
+TEST_CASE("redfoot/#168: energy depletion writes terminal cause",
            "[ui][redfoot][game_over][wiring]") {
     entt::registry reg;
     reg.ctx().emplace<GameState>().phase = GamePhase::Playing;
@@ -153,7 +153,7 @@ TEST_CASE("redfoot/#168: energy depletion overwrites stale non-terminal cause",
     auto& song = reg.ctx().emplace<SongState>();
     song.playing = true;
     auto& gos = reg.ctx().emplace<GameOverState>();
-    gos.cause = DeathCause::MissedABeat;
+    gos.cause = DeathCause::None;
     energy.energy = 0.0f;
 
     game_state_system(reg, 0.016f);

--- a/tests/test_rhythm_system.cpp
+++ b/tests/test_rhythm_system.cpp
@@ -297,17 +297,18 @@ TEST_CASE("beat_scheduler: spawns multiple when time catches up", "[rhythm][sche
     CHECK(reg.view<ObstacleTag>().size() == 2);
 }
 
-TEST_CASE("beat_scheduler: scroll speed matches song state", "[rhythm][scheduler]") {
+TEST_CASE("beat_scheduler: rhythm obstacles use BeatInfo without MotionVelocity", "[rhythm][scheduler]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     auto& map = reg.ctx().get<BeatMap>();
     map.beats.push_back({4, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
     song.playing = true; song.song_time = 0.1f;
     beat_scheduler_system(reg, 0.016f);
-    auto obs_view = reg.view<ObstacleTag, MotionVelocity>();
+    auto obs_view = reg.view<ObstacleTag, BeatInfo>();
     REQUIRE(std::distance(obs_view.begin(), obs_view.end()) == 1);
-    for (auto [e, vel] : obs_view.each()) {
-        CHECK_THAT(vel.value.y, WithinAbs(song.scroll_speed, 0.1f));
+    for (auto [e, info] : obs_view.each()) {
+        (void)info;
+        CHECK_FALSE(reg.all_of<MotionVelocity>(e));
     }
 }
 

--- a/tests/test_rhythm_system.cpp
+++ b/tests/test_rhythm_system.cpp
@@ -310,6 +310,8 @@ TEST_CASE("beat_scheduler: rhythm obstacles use BeatInfo without MotionVelocity"
         (void)info;
         CHECK_FALSE(reg.all_of<MotionVelocity>(e));
     }
+    auto invalid_view = reg.view<ObstacleTag, BeatInfo, MotionVelocity>();
+    CHECK(std::distance(invalid_view.begin(), invalid_view.end()) == 0);
 }
 
 TEST_CASE("beat_scheduler: spawns lane_block with blocked mask", "[rhythm][scheduler]") {

--- a/tests/test_world_systems.cpp
+++ b/tests/test_world_systems.cpp
@@ -46,19 +46,18 @@ TEST_CASE("motion: WorldTransform+MotionVelocity entity moves by velocity * dt",
     CHECK(wt.position.y == 220.0f);
 }
 
-TEST_CASE("motion: WorldTransform+MotionVelocity entity with BeatInfo is excluded", "[motion]") {
-    // BeatInfo entities have their position derived from song_time in scroll_system;
-    // motion_system must not double-integrate their position.
+TEST_CASE("motion: BeatInfo alone does not make an entity movable", "[motion]") {
+    // Rhythm obstacles are song-time authoritative and should not carry
+    // MotionVelocity. BeatInfo by itself is ignored by motion_system.
     auto reg = make_registry();
     auto e = reg.create();
     reg.emplace<WorldTransform>(e, WorldTransform{{100.0f, 200.0f}});
-    reg.emplace<MotionVelocity>(e, MotionVelocity{{10.0f, 20.0f}});
     reg.emplace<BeatInfo>(e, BeatInfo{0, 0.0f, 0.0f});  // marks entity as beat-authoritative
 
     motion_system(reg, 1.0f);
 
     const auto& wt = reg.get<WorldTransform>(e);
-    CHECK(wt.position.x == 100.0f);  // unchanged — motion_system skips BeatInfo entities
+    CHECK(wt.position.x == 100.0f);
     CHECK(wt.position.y == 200.0f);
 }
 


### PR DESCRIPTION
## Summary
- clamp native display dimensions and guard screen_to_virtual against non-positive scale
- guard camera floor pulse beat_time lookup against out-of-range beat indices
- make rendering components safely default-initialized
- keep MotionVelocity off BeatInfo rhythm obstacles and simplify motion_system
- remove impossible partial-popup hot-path scans and tests
- remove stale MissedABeat copy and align timing docs with runtime tiers/window scales

## Validation
- cmake -B build-round13 -S . -Wno-dev -DCMAKE_TOOLCHAIN_FILE=/Users/yashasgujjar/vcpkg/scripts/buildsystems/vcpkg.cmake
- cmake --build build-round13
- ./build-round13/shapeshifter_tests
- python3 -m unittest discover -s tools -p 'test_*.py'
- python3 tools/validate_loop2_content_gates.py --strict
- python3 tools/validate_max_beat_gap.py
- python3 tools/validate_difficulty_ramp.py
- git diff --check

Closes #647
Closes #649
Closes #650
Closes #652
Closes #653
Closes #657
Closes #658
Closes #660