### PR TITLE
Fix keyboard shape lane shortcuts

### DIFF
--- a/app/input/keyboard_shape_mapping.h
+++ b/app/input/keyboard_shape_mapping.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "../components/player.h"
+
+#include <cstdint>
+
+enum class KeyboardShapeSlot : uint8_t {
+    Left,
+    Center,
+    Right,
+};
+
+inline constexpr Shape shape_for_keyboard_slot(KeyboardShapeSlot slot) noexcept {
+    switch (slot) {
+        case KeyboardShapeSlot::Left:   return Shape::Triangle;
+        case KeyboardShapeSlot::Center: return Shape::Square;
+        case KeyboardShapeSlot::Right:  return Shape::Circle;
+    }
+    return Shape::Square;
+}

--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -1,5 +1,6 @@
 #include "all_systems.h"
 #include "web_input_policy.h"
+#include "../input/keyboard_shape_mapping.h"
 #include "../components/input.h"
 #include "../components/input_events.h"
 #include "../components/rendering.h"
@@ -148,16 +149,22 @@ void input_system(entt::registry& reg, float raw_dt) {
     // Keyboard shape-button presses: encode semantic payload directly — no
     // entity lookup needed (#273).
     if (IsKeyPressed(KEY_ONE) || IsKeyPressed(KEY_Z)) {
-        disp.enqueue<ButtonPressEvent>({ButtonPressKind::Shape, Shape::Circle,
-                                       MenuActionKind::Confirm, 0});
+        disp.enqueue<ButtonPressEvent>({ButtonPressKind::Shape,
+                                        shape_for_keyboard_slot(KeyboardShapeSlot::Left),
+                                        MenuActionKind::Confirm,
+                                        0});
     }
     if (IsKeyPressed(KEY_TWO) || IsKeyPressed(KEY_X)) {
-        disp.enqueue<ButtonPressEvent>({ButtonPressKind::Shape, Shape::Square,
-                                       MenuActionKind::Confirm, 0});
+        disp.enqueue<ButtonPressEvent>({ButtonPressKind::Shape,
+                                        shape_for_keyboard_slot(KeyboardShapeSlot::Center),
+                                        MenuActionKind::Confirm,
+                                        0});
     }
     if (IsKeyPressed(KEY_THREE) || IsKeyPressed(KEY_C)) {
-        disp.enqueue<ButtonPressEvent>({ButtonPressKind::Shape, Shape::Triangle,
-                                       MenuActionKind::Confirm, 0});
+        disp.enqueue<ButtonPressEvent>({ButtonPressKind::Shape,
+                                        shape_for_keyboard_slot(KeyboardShapeSlot::Right),
+                                        MenuActionKind::Confirm,
+                                        0});
     }
     if (IsKeyPressed(KEY_ENTER) || IsKeyPressed(KEY_SPACE)) {
         disp.enqueue<ButtonPressEvent>({ButtonPressKind::Menu, Shape::Circle,

--- a/design-docs/game.md
+++ b/design-docs/game.md
@@ -54,6 +54,8 @@ The screen is divided into two zones:
 
   The currently active shape button is highlighted/glowing. Tapping a button immediately shifts the player to that shape.
 
+- **Keyboard fallback** mirrors lane layout for shipped beatmaps: `Z`/`1` selects the left-lane shape, `X`/`2` selects center, and `C`/`3` selects right.
+
 ### Lanes
 
 3 lanes: left, center, right. Player starts in center.

--- a/tests/test_input_pipeline_behavior.cpp
+++ b/tests/test_input_pipeline_behavior.cpp
@@ -21,12 +21,21 @@
 //   - Event replay: second pipeline tick resets lane.lerp_t (symptom: #213 bug)
 
 #include <catch2/catch_test_macros.hpp>
+#include "input/keyboard_shape_mapping.h"
 #include "test_helpers.h"
 #include "ui/screen_controllers/gameplay_hud_screen_controller.h"
+#include "util/shape_lane_mapping.h"
 
 // Runs the fixed-tick input path.
 static void run_pipeline(entt::registry& reg, float dt = 0.016f) {
     game_state_system(reg, dt);
+}
+
+TEST_CASE("pipeline: keyboard shape shortcuts follow left-center-right lanes",
+          "[input_pipeline][keyboard][issue662]") {
+    CHECK(lane_for_shape(shape_for_keyboard_slot(KeyboardShapeSlot::Left)) == 0);
+    CHECK(lane_for_shape(shape_for_keyboard_slot(KeyboardShapeSlot::Center)) == 1);
+    CHECK(lane_for_shape(shape_for_keyboard_slot(KeyboardShapeSlot::Right)) == 2);
 }
 
 // ── Swipe → lane change ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Map keyboard shape shortcuts by lane position: Z/1 left, X/2 center, C/3 right.
- Add a regression test tying keyboard slots to the shipped shape-lane mapping.
- Document the keyboard fallback layout in the game design docs.

Fixes #662

## Verification
- VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./build.sh
- ./build/shapeshifter_tests