### PR TITLE
Fix gameplay HUD perfect ring cue

### DIFF
--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
@@ -82,6 +82,20 @@ const HudLayout& resolved_hud_layout(const entt::registry& reg) {
     return fallback;
 }
 
+Color ring_color_for_cue(GameplayHudRingCue cue, const HudLayout& layout) {
+    switch (cue) {
+        case GameplayHudRingCue::Perfect:
+            return layout.ring_perfect;
+        case GameplayHudRingCue::Near:
+            return layout.ring_near;
+        case GameplayHudRingCue::Far:
+            return layout.ring_far;
+        case GameplayHudRingCue::Hidden:
+            break;
+    }
+    return layout.ring_far;
+}
+
 Rectangle shape_slot_bounds(const GameplayHudLayoutState& state, GameplayHudShapeSlot slot) {
     switch (slot) {
         case GameplayHudShapeSlot::Circle:
@@ -137,9 +151,7 @@ void render_shape_buttons(const entt::registry& reg,
     }
 
     auto* song_state = reg.ctx().find<SongState>();
-    float perfect_dist = song_state
-        ? 0.0f
-        : constants::BASE_SCROLL_SPEED * 0.5f;
+    float perfect_dist = gameplay_hud_perfect_distance(song_state);
     float ring_appear_dist = constants::APPROACH_DIST;
     float max_ring_radius = btn_radius * layout.approach_ring_max_radius_scale;
 
@@ -160,18 +172,15 @@ void render_shape_buttons(const entt::registry& reg,
 
         int shape_index = static_cast<int>(button.shape);
         if (shape_index < 0 || shape_index >= static_cast<int>(nearest_dist.size())) continue;
-        if (nearest_dist[shape_index] <= 0.0f || nearest_dist[shape_index] >= ring_appear_dist) continue;
-        float ratio = (nearest_dist[shape_index] - perfect_dist) / (ring_appear_dist - perfect_dist);
-        ratio = Clamp(ratio, 0.0f, 1.0f);
+        const auto cue = gameplay_hud_ring_cue(nearest_dist[shape_index], perfect_dist, ring_appear_dist);
+        if (cue == GameplayHudRingCue::Hidden) continue;
+        float ratio = gameplay_hud_ring_ratio(nearest_dist[shape_index], perfect_dist, ring_appear_dist);
 
         const auto envelope = motion::approach_ring_envelope(ratio, btn_radius,
                                                              max_ring_radius, reduce_motion);
         if (envelope.alpha_scale <= 0.0f) continue;
 
-        Color base = (nearest_dist[shape_index] <= perfect_dist) ? layout.ring_perfect
-                                                                  : ((ratio < 0.3f)
-                                                                         ? layout.ring_near
-                                                                         : layout.ring_far);
+        Color base = ring_color_for_cue(cue, layout);
         Color ring_color = Fade(base, (200.0f / 255.0f) * envelope.alpha_scale);
         DrawCircleLinesV({button.cx, button.cy}, envelope.radius, ring_color);
         DrawCircleLinesV({button.cx, button.cy}, envelope.radius - 1.0f,
@@ -289,6 +298,33 @@ void render_energy_bar(const entt::registry& reg, const EnergyState& energy) {
 }
 
 } // anonymous namespace
+
+float gameplay_hud_perfect_distance(const SongState* song_state) {
+    const float scroll_speed = (song_state && song_state->scroll_speed > 0.0f)
+        ? song_state->scroll_speed
+        : constants::BASE_SCROLL_SPEED;
+    const float morph_duration = (song_state && song_state->morph_duration > 0.0f)
+        ? song_state->morph_duration
+        : constants::MORPH_DURATION;
+    const float half_window = (song_state && song_state->half_window > 0.0f)
+        ? song_state->half_window
+        : 0.15f;
+    return scroll_speed * (morph_duration + half_window);
+}
+
+float gameplay_hud_ring_ratio(float nearest_dist, float perfect_dist, float ring_appear_dist) {
+    const float denom = ring_appear_dist - perfect_dist;
+    if (denom <= 0.0f) return 0.0f;
+    return Clamp((nearest_dist - perfect_dist) / denom, 0.0f, 1.0f);
+}
+
+GameplayHudRingCue gameplay_hud_ring_cue(float nearest_dist, float perfect_dist, float ring_appear_dist) {
+    if (nearest_dist <= 0.0f || nearest_dist >= ring_appear_dist) return GameplayHudRingCue::Hidden;
+    if (nearest_dist <= perfect_dist) return GameplayHudRingCue::Perfect;
+
+    const float ratio = gameplay_hud_ring_ratio(nearest_dist, perfect_dist, ring_appear_dist);
+    return (ratio < 0.3f) ? GameplayHudRingCue::Near : GameplayHudRingCue::Far;
+}
 
 void init_gameplay_hud_screen_ui() {
     // Controller state is registry-owned and initialized lazily in render.

--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.h
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.h
@@ -3,13 +3,24 @@
 #include <raylib.h>
 #include <entt/entt.hpp>
 
+#include "../../components/song_state.h"
+
 enum class GameplayHudShapeSlot {
     Circle = 0,
     Square = 1,
     Triangle = 2
 };
 
+enum class GameplayHudRingCue {
+    Hidden,
+    Far,
+    Near,
+    Perfect
+};
 
+float gameplay_hud_perfect_distance(const SongState* song_state);
+float gameplay_hud_ring_ratio(float nearest_dist, float perfect_dist, float ring_appear_dist);
+GameplayHudRingCue gameplay_hud_ring_cue(float nearest_dist, float perfect_dist, float ring_appear_dist);
 void init_gameplay_hud_screen_ui();
 void render_gameplay_hud_screen_ui(entt::registry& reg);
 Rectangle gameplay_hud_shape_input_bounds(GameplayHudShapeSlot slot);

--- a/tests/test_input_pipeline_behavior.cpp
+++ b/tests/test_input_pipeline_behavior.cpp
@@ -176,6 +176,25 @@ TEST_CASE("pipeline: gameplay HUD shape geometry matches gameplay.rgl slots",
     CHECK(circle_bounds.height == 100.0f);
 }
 
+TEST_CASE("pipeline: gameplay HUD proximity ring progresses through far near perfect",
+          "[input_pipeline][hud]") {
+    SongState song{};
+    song.scroll_speed = 400.0f;
+    song.morph_duration = 0.12f;
+    song.half_window = 0.15f;
+
+    const float perfect_dist = gameplay_hud_perfect_distance(&song);
+    CHECK(perfect_dist > 107.99f);
+    CHECK(perfect_dist < 108.01f);
+
+    const float appear_dist = constants::APPROACH_DIST;
+    const float near_dist = perfect_dist + (appear_dist - perfect_dist) * 0.2f;
+
+    CHECK(gameplay_hud_ring_cue(900.0f, perfect_dist, appear_dist) == GameplayHudRingCue::Far);
+    CHECK(gameplay_hud_ring_cue(near_dist, perfect_dist, appear_dist) == GameplayHudRingCue::Near);
+    CHECK(gameplay_hud_ring_cue(perfect_dist, perfect_dist, appear_dist) == GameplayHudRingCue::Perfect);
+}
+
 TEST_CASE("pipeline: gameplay HUD raygui shape presses ignored outside Playing",
           "[input_pipeline][hud]") {
     auto reg = make_rhythm_registry();


### PR DESCRIPTION
## Summary
- Fixes #659
- Computes the proximity-ring perfect threshold from active SongState timing: scroll_speed * (morph_duration + half_window)
- Adds a pure HUD cue seam covering far, near, and perfect states

## Verification
- VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./build.sh && ./build/shapeshifter_tests