### PR TITLE
Add test-player song matrix selection

### DIFF
--- a/app/content/level_content_config.cpp
+++ b/app/content/level_content_config.cpp
@@ -8,6 +8,7 @@ const LevelInfo LEVELS[LEVEL_COUNT] = {
     {"MENTAL CORRUPTION", "content/beatmaps/3_mental_corruption_beatmap.json"},
 };
 
+const char* const LEVEL_KEYS[LEVEL_COUNT] = {"1_stomper", "2_drama", "3_mental_corruption"};
 const char* const DIFFICULTY_NAMES[DIFFICULTY_COUNT] = {"EASY", "MEDIUM", "HARD"};
 const char* const DIFFICULTY_KEYS[DIFFICULTY_COUNT] = {"easy", "medium", "hard"};
 

--- a/app/content/level_content_config.h
+++ b/app/content/level_content_config.h
@@ -11,6 +11,7 @@ inline constexpr int LEVEL_COUNT = 3;
 inline constexpr int DIFFICULTY_COUNT = 3;
 
 extern const LevelInfo LEVELS[LEVEL_COUNT];
+extern const char* const LEVEL_KEYS[LEVEL_COUNT];
 extern const char* const DIFFICULTY_NAMES[DIFFICULTY_COUNT];
 extern const char* const DIFFICULTY_KEYS[DIFFICULTY_COUNT];
 

--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -139,7 +139,8 @@ void log_persistence_result(const char* operation, const persistence::Result& re
 bool game_loop_init(entt::registry& reg,
                     bool test_player_mode,
                     TestPlayerSkill test_skill,
-                    const char* difficulty) {
+                    const char* difficulty,
+                    int selected_level) {
     // Platform: window + audio
     std::string window_title = std::string("SHAPESHIFTER v") + SHAPESHIFTER_VERSION;
     SetConfigFlags(FLAG_WINDOW_RESIZABLE);
@@ -249,7 +250,7 @@ bool game_loop_init(entt::registry& reg,
 
     // Test player (optional)
     if (test_player_mode) {
-        test_player_init(reg, test_skill, difficulty);
+        test_player_init(reg, test_skill, difficulty, selected_level);
     }
     return true;
 }

--- a/app/game_loop.h
+++ b/app/game_loop.h
@@ -10,7 +10,8 @@ enum class TestPlayerSkill : uint8_t;
 bool game_loop_init(entt::registry& reg,
                     bool test_player_mode = false,
                     TestPlayerSkill test_skill = {},
-                    const char* difficulty = "medium");
+                    const char* difficulty = "medium",
+                    int selected_level = 1);
 
 // Run the game loop (blocks until quit). Handles Emscripten vs native.
 void game_loop_run(entt::registry& reg);

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -1,8 +1,35 @@
 #include "game_loop.h"
 #include "components/test_player.h"
+#include "content/level_content_config.h"
 
 #include <cstdio>
 #include <cstring>
+
+namespace {
+
+int parse_level_arg(const char* value) {
+    if (value[0] >= '1' && value[0] < static_cast<char>('1' + content_config::LEVEL_COUNT)
+        && value[1] == '\0') {
+        return value[0] - '1';
+    }
+    for (int i = 0; i < content_config::LEVEL_COUNT; ++i) {
+        if (std::strcmp(value, content_config::LEVEL_KEYS[i]) == 0 ||
+            std::strcmp(value, content_config::LEVELS[i].title) == 0) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+void print_level_help() {
+    std::fprintf(stderr, "Known levels:");
+    for (int i = 0; i < content_config::LEVEL_COUNT; ++i) {
+        std::fprintf(stderr, " %s", content_config::LEVEL_KEYS[i]);
+    }
+    std::fprintf(stderr, "\n");
+}
+
+}  // namespace
 
 int main(int argc, char* argv[]) {
 
@@ -10,6 +37,7 @@ int main(int argc, char* argv[]) {
     TestPlayerSkill test_skill = TestPlayerSkill::Pro;
     bool test_player_mode = false;
     const char* difficulty = "medium";
+    int selected_level = 1;
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "--test-player") == 0 && i + 1 < argc) {
             test_player_mode = true;
@@ -22,7 +50,7 @@ int main(int argc, char* argv[]) {
                 return 1;
             }
         }
-        if (std::strcmp(argv[i], "--difficulty") == 0 && i + 1 < argc) {
+        else if (std::strcmp(argv[i], "--difficulty") == 0 && i + 1 < argc) {
             ++i;
             if (std::strcmp(argv[i], "easy") == 0 ||
                 std::strcmp(argv[i], "medium") == 0 ||
@@ -33,11 +61,20 @@ int main(int argc, char* argv[]) {
                 return 1;
             }
         }
+        else if (std::strcmp(argv[i], "--level") == 0 && i + 1 < argc) {
+            ++i;
+            selected_level = parse_level_arg(argv[i]);
+            if (selected_level < 0) {
+                std::fprintf(stderr, "Unknown level: %s\n", argv[i]);
+                print_level_help();
+                return 1;
+            }
+        }
     }
 
     // ── Init → Run → Shutdown ────────────────────────────────
     entt::registry reg;
-    const bool initialized = game_loop_init(reg, test_player_mode, test_skill, difficulty);
+    const bool initialized = game_loop_init(reg, test_player_mode, test_skill, difficulty, selected_level);
     if (initialized) {
         game_loop_run(reg);
     }

--- a/app/session/test_player_session.cpp
+++ b/app/session/test_player_session.cpp
@@ -15,15 +15,30 @@ namespace {
 struct TestPlayerSessionSignals {
     bool wired = false;
 };
+
+int valid_level_or_default(int selected_level) {
+    if (selected_level >= 0 && selected_level < content_config::LEVEL_COUNT) {
+        return selected_level;
+    }
+    return 1;
+}
+
+int difficulty_index_or_default(const char* difficulty) {
+    for (int d = 0; d < content_config::DIFFICULTY_COUNT; ++d) {
+        if (std::strcmp(content_config::DIFFICULTY_KEYS[d], difficulty) == 0) {
+            return d;
+        }
+    }
+    return 1;
+}
 }
 
 void test_player_init(entt::registry& reg, TestPlayerSkill skill,
-                      const char* difficulty) {
+                      const char* difficulty,
+                      int selected_level) {
     auto& lss = reg.ctx().get<LevelSelectState>();
-    lss.selected_level = 1;
-    for (int d = 0; d < content_config::DIFFICULTY_COUNT; ++d)
-        if (std::strcmp(content_config::DIFFICULTY_KEYS[d], difficulty) == 0)
-            { lss.selected_difficulty = d; break; }
+    lss.selected_level = valid_level_or_default(selected_level);
+    lss.selected_difficulty = difficulty_index_or_default(difficulty);
 
     auto* session_state = reg.ctx().find<TestPlayerSessionState>();
     if (!session_state) {
@@ -43,8 +58,10 @@ void test_player_init(entt::registry& reg, TestPlayerSkill skill,
     tp_state.rng.seed(seed);
 
     static const char* skill_names[] = { "pro", "good", "bad" };
-    TraceLog(LOG_INFO, "TEST PLAYER: skill=%s",
-             skill_names[static_cast<int>(skill)]);
+    const char* level_key = content_config::LEVEL_KEYS[lss.selected_level];
+    const char* difficulty_key = content_config::DIFFICULTY_KEYS[lss.selected_difficulty];
+    TraceLog(LOG_INFO, "TEST PLAYER: skill=%s level=%s difficulty=%s",
+             skill_names[static_cast<int>(skill)], level_key, difficulty_key);
 
     auto& slog = reg.ctx().get<SessionLog>();
     session_log_close(slog);
@@ -54,11 +71,19 @@ void test_player_init(entt::registry& reg, TestPlayerSkill skill,
     const uint32_t sequence = ++session_state->log_sequence;
     char log_filename[256];
     std::snprintf(log_filename, sizeof(log_filename),
-        "%ssession_%s_rt%010llu_n%04u.log",
+        "%ssession_%s_%s_%s_rt%010llu_n%04u.log",
         GetApplicationDirectory(),
         skill_names[static_cast<int>(skill)],
+        level_key,
+        difficulty_key,
         runtime_millis, sequence);
     session_log_open(slog, log_filename);
+    if (slog.file) {
+        std::fprintf(slog.file, "skill=%s level=%s difficulty=%s seed=%u\n\n",
+                     skill_names[static_cast<int>(skill)], level_key,
+                     difficulty_key, seed);
+        std::fflush(slog.file);
+    }
     TraceLog(LOG_INFO, "SESSION LOG: %s", log_filename);
 
     auto* signals = reg.ctx().find<TestPlayerSessionSignals>();

--- a/app/session/test_player_session.h
+++ b/app/session/test_player_session.h
@@ -14,4 +14,5 @@ struct TestPlayerSessionState {
 };
 
 void test_player_init(entt::registry& reg, TestPlayerSkill skill,
-                      const char* difficulty);
+                      const char* difficulty,
+                      int selected_level = 1);

--- a/run_bad.sh
+++ b/run_bad.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 cd "$(dirname "$0")"
-./run.sh --test-player bad
+export VCPKG_ROOT="${VCPKG_ROOT:-$HOME/vcpkg}"
+./build.sh
+
+levels=(1_stomper 2_drama 3_mental_corruption)
+difficulties=(easy medium hard)
+for level in "${levels[@]}"; do
+  for difficulty in "${difficulties[@]}"; do
+    ./build/shapeshifter --test-player bad --level "$level" --difficulty "$difficulty"
+  done
+done

--- a/run_good.sh
+++ b/run_good.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 cd "$(dirname "$0")"
-./run.sh --test-player good
+export VCPKG_ROOT="${VCPKG_ROOT:-$HOME/vcpkg}"
+./build.sh
+
+levels=(1_stomper 2_drama 3_mental_corruption)
+difficulties=(easy medium hard)
+for level in "${levels[@]}"; do
+  for difficulty in "${difficulties[@]}"; do
+    ./build/shapeshifter --test-player good --level "$level" --difficulty "$difficulty"
+  done
+done

--- a/run_pro.sh
+++ b/run_pro.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 cd "$(dirname "$0")"
-./run.sh --test-player pro
+export VCPKG_ROOT="${VCPKG_ROOT:-$HOME/vcpkg}"
+./build.sh
+
+levels=(1_stomper 2_drama 3_mental_corruption)
+difficulties=(easy medium hard)
+for level in "${levels[@]}"; do
+  for difficulty in "${difficulties[@]}"; do
+    ./build/shapeshifter --test-player pro --level "$level" --difficulty "$difficulty"
+  done
+done

--- a/tools/summarize_test_player_logs.py
+++ b/tools/summarize_test_player_logs.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Summarize and validate SHAPESHIFTER test-player session logs."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+SKILLS = ("pro", "good", "bad")
+LEVELS = ("1_stomper", "2_drama", "3_mental_corruption")
+DIFFICULTIES = ("easy", "medium", "hard")
+
+HEADER_RE = re.compile(r"\bskill=(?P<skill>\w+)\s+level=(?P<level>[\w_]+)\s+difficulty=(?P<difficulty>\w+)")
+FILENAME_RE = re.compile(
+    r"session_(?P<skill>pro|good|bad)_(?P<level>1_stomper|2_drama|3_mental_corruption)"
+    r"_(?P<difficulty>easy|medium|hard)_"
+)
+TIME_RE = re.compile(r"\bT:(?P<time>[0-9]+\.[0-9]+)")
+BEAT_RE = re.compile(r"\bbeat=(?P<beat>-?[0-9]+)")
+SECTION_RE = re.compile(r"\bsection=(?P<section>[\w.-]+)")
+RESULT_RE = re.compile(r"\bresult=(?P<result>MISS|CLEAR)\b")
+TIMING_RE = re.compile(r"\btiming=(?P<timing>[A-Za-z]+)\(")
+
+
+@dataclass
+class LogSummary:
+    path: Path
+    skill: str = "unknown"
+    level: str = "unknown"
+    difficulty: str = "unknown"
+    clears: int = 0
+    misses: int = 0
+    grade_counts: Counter[str] = field(default_factory=Counter)
+    first_failure_time: str = "-"
+    first_failure_section: str = "-"
+    first_failure_beat: str = "-"
+
+    @property
+    def status(self) -> str:
+        return "CLEAR" if self.misses == 0 else "FAIL"
+
+
+def _metadata_from_filename(path: Path) -> tuple[str, str, str] | None:
+    match = FILENAME_RE.search(path.name)
+    if not match:
+        return None
+    return match.group("skill"), match.group("level"), match.group("difficulty")
+
+
+def summarize_log(path: Path) -> LogSummary:
+    summary = LogSummary(path=path)
+    from_name = _metadata_from_filename(path)
+    if from_name:
+        summary.skill, summary.level, summary.difficulty = from_name
+
+    for line in path.read_text(encoding="utf-8").splitlines():
+        header = HEADER_RE.search(line)
+        if header:
+            summary.skill = header.group("skill")
+            summary.level = header.group("level")
+            summary.difficulty = header.group("difficulty")
+            continue
+
+        result = RESULT_RE.search(line)
+        if not result:
+            continue
+
+        if result.group("result") == "MISS":
+            summary.misses += 1
+            if summary.first_failure_time == "-":
+                summary.first_failure_time = _match_or_default(TIME_RE, line, "time")
+                summary.first_failure_section = _match_or_default(SECTION_RE, line, "section")
+                summary.first_failure_beat = _match_or_default(BEAT_RE, line, "beat")
+        else:
+            summary.clears += 1
+            timing = TIMING_RE.search(line)
+            if timing:
+                summary.grade_counts[timing.group("timing")] += 1
+
+    return summary
+
+
+def _match_or_default(pattern: re.Pattern[str], line: str, group: str) -> str:
+    match = pattern.search(line)
+    return match.group(group) if match else "-"
+
+
+def _format_grades(grades: Counter[str]) -> str:
+    if not grades:
+        return "-"
+    return ",".join(f"{grade}:{count}" for grade, count in sorted(grades.items()))
+
+
+def _missing_matrix_entries(summaries: list[LogSummary]) -> list[tuple[str, str, str]]:
+    seen = {(item.skill, item.level, item.difficulty) for item in summaries}
+    return [
+        (skill, level, difficulty)
+        for skill in SKILLS
+        for level in LEVELS
+        for difficulty in DIFFICULTIES
+        if (skill, level, difficulty) not in seen
+    ]
+
+
+def print_summary(summaries: list[LogSummary]) -> None:
+    print("skill level difficulty status clears misses grades first_failure_time first_failure_section first_failure_beat path")
+    for item in sorted(summaries, key=lambda s: (s.skill, s.level, s.difficulty, str(s.path))):
+        print(
+            f"{item.skill} {item.level} {item.difficulty} {item.status} "
+            f"{item.clears} {item.misses} {_format_grades(item.grade_counts)} "
+            f"{item.first_failure_time} {item.first_failure_section} {item.first_failure_beat} {item.path}"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("logs", nargs="+", type=Path, help="session_*.log files to summarize")
+    parser.add_argument(
+        "--expect-matrix",
+        action="store_true",
+        help="fail if the pro/good/bad x shipped-level x easy/medium/hard matrix is incomplete",
+    )
+    args = parser.parse_args(argv)
+
+    summaries = [summarize_log(path) for path in args.logs]
+    print_summary(summaries)
+
+    if args.expect_matrix:
+        missing = _missing_matrix_entries(summaries)
+        if missing:
+            for skill, level, difficulty in missing:
+                print(f"missing matrix log: skill={skill} level={level} difficulty={difficulty}", file=sys.stderr)
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_summarize_test_player_logs.py
+++ b/tools/test_summarize_test_player_logs.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import shutil
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import summarize_test_player_logs as summary  # noqa: E402
+
+
+class TestSummarizeTestPlayerLogs(unittest.TestCase):
+    def setUp(self) -> None:
+        self.base = Path(__file__).resolve().parent / ".test_summarize_test_player_logs"
+        if self.base.exists():
+            shutil.rmtree(self.base)
+        self.base.mkdir(parents=True, exist_ok=True)
+        self.addCleanup(lambda: shutil.rmtree(self.base, ignore_errors=True))
+
+    def _write(self, name: str, text: str) -> Path:
+        path = self.base / name
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def test_summarizes_metadata_grades_and_first_failure(self) -> None:
+        log = self._write(
+            "session_pro_1_stomper_hard_rt0000000001_n0001.log",
+            "\n".join(
+                [
+                    "skill=pro level=1_stomper difficulty=hard seed=1",
+                    "[F:0001 T:001.000] [GAME  ] COLLISION obstacle=1 beat=4 expected=1.000 drift=+0.000s kind=ShapeGate result=CLEAR timing=Perfect(1.00)",
+                    "[F:0002 T:002.000] [GAME  ] COLLISION obstacle=2 beat=8 expected=2.000 drift=+0.250s kind=ShapeGate result=MISS section=chorus",
+                ]
+            ),
+        )
+
+        item = summary.summarize_log(log)
+
+        self.assertEqual(item.skill, "pro")
+        self.assertEqual(item.level, "1_stomper")
+        self.assertEqual(item.difficulty, "hard")
+        self.assertEqual(item.status, "FAIL")
+        self.assertEqual(item.clears, 1)
+        self.assertEqual(item.misses, 1)
+        self.assertEqual(item.grade_counts["Perfect"], 1)
+        self.assertEqual(item.first_failure_time, "002.000")
+        self.assertEqual(item.first_failure_section, "chorus")
+        self.assertEqual(item.first_failure_beat, "8")
+
+    def test_matrix_validator_reports_missing_entries(self) -> None:
+        log = self._write(
+            "session_bad_2_drama_easy_rt0000000001_n0001.log",
+            "skill=bad level=2_drama difficulty=easy seed=1\n",
+        )
+
+        missing = summary._missing_matrix_entries([summary.summarize_log(log)])
+
+        self.assertEqual(len(missing), 26)
+        self.assertNotIn(("bad", "2_drama", "easy"), missing)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- Fixes #656
- Adds `--level` selection for test-player mode and carries level/difficulty into session log filenames and headers
- Updates pro/good/bad runners to build once, then run every shipped song across easy/medium/hard
- Adds a test-player session log summarizer with optional full-matrix validation

## Verification
- `VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./build.sh && ./build/shapeshifter_tests && python3 -m unittest discover -s tools -p 'test_*.py'`\n- `python3 tools/summarize_test_player_logs.py <sample session log>`