### PR TITLE
Fix WASM persistence durability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,9 +351,11 @@ if(EMSCRIPTEN)
         -sASYNCIFY
         -sALLOW_MEMORY_GROWTH=1
         -sDYNAMIC_EXECUTION=0
+        -sFORCE_FILESYSTEM=1
         # The browser frame loop is registered with emscripten_set_main_loop();
         # keep the Emscripten runtime alive for that long-running callback.
         -sNO_EXIT_RUNTIME=1
+        -lidbfs.js
         --shell-file ${_shell_html}
     )
     # Use LINK_FLAGS (raw string) for --preload-file so CMake forwards the flag

--- a/app/util/high_score_persistence.cpp
+++ b/app/util/high_score_persistence.cpp
@@ -176,6 +176,11 @@ bool high_score_state_from_json(const nlohmann::json& obj, HighScoreState& state
 }  // namespace
 
 persistence::Result load_high_scores(HighScoreState& state, const std::filesystem::path& path) {
+    const auto prepare_result = persistence::prepare_for_persistence_read(path);
+    if (!prepare_result.ok()) {
+        return prepare_result;
+    }
+
     std::error_code ec;
     const bool exists = std::filesystem::exists(path, ec);
     if (ec) {
@@ -223,7 +228,10 @@ persistence::Result save_high_scores(const HighScoreState& state, const std::fil
         return persistence::Result{persistence::Status::FileWriteFailed, {}};
     }
     file.close();
-    return persistence::Result{};
+    if (!file.good()) {
+        return persistence::Result{persistence::Status::FileWriteFailed, {}};
+    }
+    return persistence::flush_persistence_writes(path);
 }
 
 void update_if_higher(HighScoreState& state, int32_t new_score) {

--- a/app/util/persistence_policy.cpp
+++ b/app/util/persistence_policy.cpp
@@ -1,9 +1,15 @@
 #include "persistence_policy.h"
 
 #include <cstdlib>
+#include <string>
+#include <string_view>
 #include <system_error>
 
 #include <raylib.h>
+
+#if defined(__EMSCRIPTEN__)
+    #include <emscripten/emscripten.h>
+#endif
 
 #ifndef _WIN32
     #include <pwd.h>
@@ -16,6 +22,77 @@
 
 namespace persistence {
 namespace {
+
+#if defined(__EMSCRIPTEN__)
+constexpr const char* kWebPersistenceMount = "/persistent";
+constexpr const char* kWebPersistenceRoot = "/persistent/shapeshifter";
+
+Result sync_web_filesystem(const bool populate, const Status failure_status) {
+    int sync_done = 0;
+    int sync_failed = 0;
+    EM_ASM(
+        {
+            FS.syncfs($0 != 0, function(err) {
+                HEAP32[$1 >> 2] = err ? 1 : 0;
+                HEAP32[$2 >> 2] = 1;
+            });
+        },
+        populate ? 1 : 0,
+        &sync_failed,
+        &sync_done);
+
+    while (sync_done == 0) {
+        emscripten_sleep(1);
+    }
+
+    return sync_failed != 0 ? Result{failure_status, std::make_error_code(std::errc::io_error)} : Result{};
+}
+
+Result ensure_web_persistence_ready() {
+    static bool initialized = false;
+    static Result init_result{};
+
+    if (initialized) {
+        return init_result;
+    }
+
+    const int mount_status = EM_ASM_INT(
+        {
+            if (typeof FS === 'undefined' || typeof IDBFS === 'undefined') {
+                return 1;
+            }
+            try {
+                if (!FS.analyzePath(UTF8ToString($0)).exists) {
+                    FS.mkdir(UTF8ToString($0));
+                }
+                if (!Module.shapeshifterPersistenceMounted) {
+                    FS.mount(IDBFS, {}, UTF8ToString($0));
+                    Module.shapeshifterPersistenceMounted = true;
+                }
+                return 0;
+            } catch (e) {
+                console.error('SHAPESHIFTER persistence mount failed', e);
+                return 1;
+            }
+        },
+        kWebPersistenceMount);
+    if (mount_status != 0) {
+        init_result = Result{Status::PathUnavailable, std::make_error_code(std::errc::io_error)};
+        initialized = true;
+        return init_result;
+    }
+
+    init_result = sync_web_filesystem(true, Status::FileReadFailed);
+    initialized = true;
+    return init_result;
+}
+
+bool path_uses_web_persistence(const std::filesystem::path& path) {
+    const std::string normalized = path.lexically_normal().generic_string();
+    constexpr std::string_view root{kWebPersistenceRoot};
+    return normalized == root || normalized.rfind(std::string(root) + "/", 0) == 0;
+}
+#endif
 
 std::error_code ensure_directory_exists(const std::filesystem::path& dir) {
     if (dir.empty()) return {};
@@ -35,7 +112,7 @@ std::filesystem::path resolve_root_dir(const std::filesystem::path& root_overrid
     if (appdata) return std::filesystem::path(appdata) / "shapeshifter";
     return {};
 #elif defined(__EMSCRIPTEN__)
-    return std::filesystem::path(".");
+    return std::filesystem::path(kWebPersistenceRoot);
 #else
     const char* home = std::getenv("HOME");
     if (!home) {
@@ -55,6 +132,15 @@ std::filesystem::path resolve_root_dir(const std::filesystem::path& root_overrid
 }  // namespace
 
 Result resolve_paths(Paths& out_paths, const std::filesystem::path& root_override) {
+#if defined(__EMSCRIPTEN__)
+    if (root_override.empty()) {
+        const auto web_result = ensure_web_persistence_ready();
+        if (!web_result.ok()) {
+            return web_result;
+        }
+    }
+#endif
+
     const auto root_dir = resolve_root_dir(root_override);
     if (root_dir.empty()) {
         return Result{Status::PathUnavailable, {}};
@@ -69,6 +155,34 @@ Result resolve_paths(Paths& out_paths, const std::filesystem::path& root_overrid
     out_paths.settings_file = root_dir / "settings.json";
     out_paths.high_scores_file = root_dir / "high_scores.json";
     return Result{};
+}
+
+Result prepare_for_persistence_read(const std::filesystem::path& path) {
+#if defined(__EMSCRIPTEN__)
+    if (!path_uses_web_persistence(path)) {
+        return Result{};
+    }
+    return ensure_web_persistence_ready();
+#else
+    (void)path;
+    return Result{};
+#endif
+}
+
+Result flush_persistence_writes(const std::filesystem::path& path) {
+#if defined(__EMSCRIPTEN__)
+    if (!path_uses_web_persistence(path)) {
+        return Result{};
+    }
+    const auto web_result = ensure_web_persistence_ready();
+    if (!web_result.ok()) {
+        return web_result;
+    }
+    return sync_web_filesystem(false, Status::FileWriteFailed);
+#else
+    (void)path;
+    return Result{};
+#endif
 }
 
 const char* status_name(const Status status) {

--- a/app/util/persistence_policy.h
+++ b/app/util/persistence_policy.h
@@ -33,6 +33,9 @@ struct Paths {
 
 Result resolve_paths(Paths& out_paths, const std::filesystem::path& root_override = {});
 
+Result prepare_for_persistence_read(const std::filesystem::path& path);
+Result flush_persistence_writes(const std::filesystem::path& path);
+
 const char* status_name(Status status);
 
 }  // namespace persistence

--- a/app/util/settings_persistence.cpp
+++ b/app/util/settings_persistence.cpp
@@ -106,6 +106,11 @@ bool settings_from_json(const nlohmann::json& obj, SettingsState& state) {
 }
 
 persistence::Result load_settings(SettingsState& state, const std::filesystem::path& path) {
+    const auto prepare_result = persistence::prepare_for_persistence_read(path);
+    if (!prepare_result.ok()) {
+        return prepare_result;
+    }
+
     std::error_code ec;
     const bool exists = std::filesystem::exists(path, ec);
     if (ec) {
@@ -152,7 +157,11 @@ persistence::Result save_settings(const SettingsState& state, const std::filesys
     if (!file.good()) {
         return persistence::Result{persistence::Status::FileWriteFailed, {}};
     }
-    return persistence::Result{};
+    file.close();
+    if (!file.good()) {
+        return persistence::Result{persistence::Status::FileWriteFailed, {}};
+    }
+    return persistence::flush_persistence_writes(path);
 }
 
 void mark_dirty_and_save(SettingsPersistence& persistence_state, const SettingsState& state) {

--- a/tests/test_settings_persistence.cpp
+++ b/tests/test_settings_persistence.cpp
@@ -300,6 +300,12 @@ TEST_CASE("Persistence paths: one shared policy resolves both settings and high-
     std::filesystem::remove_all(paths.root_dir);
 }
 
+TEST_CASE("Persistence sync seams skip paths outside the web persistence root", "[settings]") {
+    const std::filesystem::path current_dir_file = "settings_current_dir_tmp.json";
+    CHECK(persistence::prepare_for_persistence_read(current_dir_file).ok());
+    CHECK(persistence::flush_persistence_writes(current_dir_file).ok());
+}
+
 TEST_CASE("Settings persistence helper: file path resolution reports failure without CWD fallback", "[settings]") {
     const auto root = std::filesystem::path("test_settings_path_resolution_failure");
     const auto blocked_root = root / "blocked_root";

--- a/tests/test_wasm_beforeunload_lifecycle.cpp
+++ b/tests/test_wasm_beforeunload_lifecycle.cpp
@@ -69,10 +69,28 @@ TEST_CASE("wasm lifecycle: visibilitychange callback pauses active play",
 }
 
 TEST_CASE("wasm smoke phase title markers are compile-gated",
-          "[lifecycle][architecture]") {
+           "[lifecycle][architecture]") {
     const fs::path root = find_repo_root();
     const std::string phase_source = read_file(root / "app" / "systems" / "game_phase_transition.cpp");
 
     CHECK(phase_source.find("SHAPESHIFTER [") != std::string::npos);
     CHECK(phase_source.find("__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)") != std::string::npos);
+}
+
+TEST_CASE("wasm persistence uses explicit IDBFS policy and save flush hooks", "[persistence][architecture]") {
+    const fs::path root = find_repo_root();
+    const std::string cmake_source = read_file(root / "CMakeLists.txt");
+    const std::string policy_source = read_file(root / "app" / "util" / "persistence_policy.cpp");
+    const std::string settings_source = read_file(root / "app" / "util" / "settings_persistence.cpp");
+    const std::string high_score_source = read_file(root / "app" / "util" / "high_score_persistence.cpp");
+
+    CHECK(cmake_source.find("-sFORCE_FILESYSTEM=1") != std::string::npos);
+    CHECK(cmake_source.find("-lidbfs.js") != std::string::npos);
+    CHECK(policy_source.find("FS.mount(IDBFS") != std::string::npos);
+    CHECK(policy_source.find("FS.syncfs") != std::string::npos);
+    CHECK(policy_source.find("\"/persistent/shapeshifter\"") != std::string::npos);
+    CHECK(settings_source.find("persistence::prepare_for_persistence_read(path)") != std::string::npos);
+    CHECK(settings_source.find("persistence::flush_persistence_writes(path)") != std::string::npos);
+    CHECK(high_score_source.find("persistence::prepare_for_persistence_read(path)") != std::string::npos);
+    CHECK(high_score_source.find("persistence::flush_persistence_writes(path)") != std::string::npos);
 }


### PR DESCRIPTION
## Summary
- mount an explicit IDBFS-backed `/persistent/shapeshifter` root for web persistence
- sync IDBFS before policy-based loads and after successful settings/high-score saves
- link Emscripten filesystem/IDBFS support and add regression coverage for the persistence contract

Root cause: the web persistence policy resolved saves to volatile Emscripten storage and never flushed browser storage, so settings/high scores appeared saved only until reload.

Closes #646

## Validation
- `VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./build.sh && ./build/shapeshifter_tests`
- `EMSCRIPTEN_ROOT=/opt/homebrew/opt/emscripten/libexec VCPKG_ROOT=/Users/yashasgujjar/vcpkg emcmake cmake -G Ninja -B build-web -S . -DCMAKE_BUILD_TYPE=Release -Wno-dev "-DCMAKE_TOOLCHAIN_FILE=/Users/yashasgujjar/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DVCPKG_OVERLAY_PORTS=$(pwd)/vcpkg-overlay" "-DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=/opt/homebrew/opt/emscripten/libexec/cmake/Modules/Platform/Emscripten.cmake" -DVCPKG_TARGET_TRIPLET=wasm32-emscripten -DSHAPESHIFTER_WASM_SMOKE_MARKERS=ON && cmake --build build-web -- -j$(sysctl -n hw.ncpu) && (cd build-web && ctest --verbose --output-on-failure)`