### PR TITLE
Reserve gameplay scratch queues

### DIFF
--- a/app/components/gameplay_intents.h
+++ b/app/components/gameplay_intents.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 #include "rhythm.h"
@@ -11,6 +12,7 @@ struct PendingEnergyEffects {
     };
 
     std::vector<Event> events;
+    uint32_t capacity_exceeded_count = 0;
 };
 
 struct ScorePopupRequest {
@@ -23,4 +25,5 @@ struct ScorePopupRequest {
 
 struct ScorePopupRequestQueue {
     std::vector<ScorePopupRequest> requests;
+    uint32_t capacity_exceeded_count = 0;
 };

--- a/app/components/system_scratch.h
+++ b/app/components/system_scratch.h
@@ -2,6 +2,7 @@
 
 #include <entt/entt.hpp>
 #include <glm/vec2.hpp>
+#include <cstdint>
 #include <vector>
 
 #include "obstacle.h"
@@ -23,20 +24,26 @@ struct HitRecord {
 struct ScoringSystemScratch {
     std::vector<MissRecord> miss_buf;
     std::vector<HitRecord> hit_buf;
+    uint32_t miss_capacity_exceeded_count = 0;
+    uint32_t hit_capacity_exceeded_count = 0;
 };
 
 struct ObstacleDespawnScratch {
     std::vector<entt::entity> to_destroy;
+    uint32_t capacity_exceeded_count = 0;
 };
 
 struct PopupDisplayScratch {
     std::vector<entt::entity> expired;
+    uint32_t capacity_exceeded_count = 0;
 };
 
 struct ParticleSystemScratch {
     std::vector<entt::entity> expired;
+    uint32_t capacity_exceeded_count = 0;
 };
 
 struct MeshChildCleanupScratch {
     std::vector<entt::entity> stale_children;
+    uint32_t capacity_exceeded_count = 0;
 };

--- a/app/session/play_session.cpp
+++ b/app/session/play_session.cpp
@@ -16,6 +16,7 @@
 #include "../entities/camera_entity.h"
 #include "../entities/player_entity.h"
 #include "../content/level_content_config.h"
+#include "../systems/all_systems.h"
 #include "../systems/game_phase_transition.h"
 #include "../constants.h"
 #include <filesystem>
@@ -77,6 +78,8 @@ void setup_play_session(entt::registry& reg) {
     if (!loaded) {
         TraceLog(LOG_WARNING, "Failed to load beatmap: %s", beatmap_path);
     }
+    runtime_system_scratch_init(reg);
+    runtime_system_scratch_reserve(reg, beatmap.beats.size());
 
     // Wire high score: derive song_id from beatmap filename and set current_key_hash.
     // The key string is built once in a stack buffer (no heap); ensure_entry pre-registers

--- a/app/systems/all_systems.h
+++ b/app/systems/all_systems.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <cstddef>
 #include <entt/entt.hpp>
 #include "../components/game_state.h"
 
 // Phase 0.5: Test player AI (enqueues synthetic input actions)
 void runtime_system_scratch_init(entt::registry& reg);
+void runtime_system_scratch_reserve(entt::registry& reg, std::size_t beat_capacity);
 void test_player_system(entt::registry& reg, float dt);
 
 // Phase 2: Game State

--- a/app/systems/camera_system.cpp
+++ b/app/systems/camera_system.cpp
@@ -258,6 +258,9 @@ void game_camera_system(entt::registry& reg, float /*dt*/) {
         for (auto [entity, mc] : view.each()) {
             auto* parent_wt = reg.try_get<WorldTransform>(mc.parent);
             if (!parent_wt) {
+                if (stale_children.size() >= stale_children.capacity()) {
+                    ++scratch->capacity_exceeded_count;
+                }
                 stale_children.push_back(entity);
                 continue;
             }

--- a/app/systems/obstacle_despawn_system.cpp
+++ b/app/systems/obstacle_despawn_system.cpp
@@ -21,8 +21,13 @@ void obstacle_despawn_system(entt::registry& reg, float /*dt*/) {
 
     auto view = reg.view<ObstacleTag, WorldTransform>();
     for (auto [entity, wt] : view.each()) {
-        if (wt.position.y > constants::DESTROY_Y)
+        if (wt.position.y > constants::DESTROY_Y) {
+            auto& scratch = despawn_scratch_for(reg);
+            if (to_destroy.size() >= to_destroy.capacity()) {
+                ++scratch.capacity_exceeded_count;
+            }
             to_destroy.push_back(entity);
+        }
     }
 
     for (auto e : to_destroy) reg.destroy(e);

--- a/app/systems/particle_system.cpp
+++ b/app/systems/particle_system.cpp
@@ -23,6 +23,10 @@ void particle_system(entt::registry& reg, float dt) {
     for (auto [entity, pdata] : view.each()) {
         pdata.remaining -= dt;
         if (pdata.remaining <= 0.0f) {
+            auto& scratch = particle_scratch_for(reg);
+            if (expired.size() >= expired.capacity()) {
+                ++scratch.capacity_exceeded_count;
+            }
             expired.push_back(entity);
         }
     }

--- a/app/systems/popup_display_system.cpp
+++ b/app/systems/popup_display_system.cpp
@@ -48,6 +48,10 @@ void popup_display_system(entt::registry& reg, float dt) {
         if (alpha_ratio > 1.0f) alpha_ratio = 1.0f;
         pd.a = static_cast<uint8_t>(static_cast<float>(col.a) * alpha_ratio);
         if (popup.remaining <= 0.0f) {
+            auto& scratch = popup_scratch_for(reg);
+            if (expired.size() >= expired.capacity()) {
+                ++scratch.capacity_exceeded_count;
+            }
             expired.push_back(entity);
         }
     }

--- a/app/systems/runtime_system_scratch.cpp
+++ b/app/systems/runtime_system_scratch.cpp
@@ -1,6 +1,20 @@
 #include "all_systems.h"
 #include "../components/gameplay_intents.h"
+#include "../components/rendering.h"
 #include "../components/system_scratch.h"
+
+#include <algorithm>
+#include <cstddef>
+
+namespace {
+
+constexpr std::size_t kMinimumGameplayScratchCapacity = 8;
+
+std::size_t gameplay_capacity(std::size_t beat_capacity) {
+    return std::max(kMinimumGameplayScratchCapacity, beat_capacity);
+}
+
+}  // namespace
 
 void runtime_system_scratch_init(entt::registry& reg) {
     reg.ctx().erase<ScoringSystemScratch>();
@@ -18,4 +32,21 @@ void runtime_system_scratch_init(entt::registry& reg) {
     reg.ctx().emplace<PopupDisplayScratch>();
     reg.ctx().emplace<ParticleSystemScratch>();
     reg.ctx().emplace<MeshChildCleanupScratch>();
+
+    runtime_system_scratch_reserve(reg, 0);
+}
+
+void runtime_system_scratch_reserve(entt::registry& reg, std::size_t beat_capacity) {
+    const std::size_t capacity = gameplay_capacity(beat_capacity);
+    auto& scoring = reg.ctx().get<ScoringSystemScratch>();
+    scoring.miss_buf.reserve(capacity);
+    scoring.hit_buf.reserve(capacity);
+
+    reg.ctx().get<PendingEnergyEffects>().events.reserve(capacity);
+    reg.ctx().get<ScorePopupRequestQueue>().requests.reserve(capacity);
+    reg.ctx().get<ObstacleDespawnScratch>().to_destroy.reserve(capacity);
+    reg.ctx().get<PopupDisplayScratch>().expired.reserve(capacity);
+    reg.ctx().get<ParticleSystemScratch>().expired.reserve(capacity);
+    reg.ctx().get<MeshChildCleanupScratch>().stale_children.reserve(
+        capacity * static_cast<std::size_t>(ObstacleChildren::MAX));
 }

--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -25,6 +25,9 @@ PendingEnergyEffects& pending_energy_for(entt::registry& reg) {
 
 void enqueue_energy_effect(entt::registry& reg, float delta, bool flash = false) {
     auto& pending = pending_energy_for(reg);
+    if (pending.events.size() >= pending.events.capacity()) {
+        ++pending.capacity_exceeded_count;
+    }
     pending.events.push_back(PendingEnergyEffects::Event{delta, flash});
 }
 
@@ -75,6 +78,9 @@ void scoring_system(entt::registry& reg, float dt) {
             if (results) results->miss_count++;
             score.chain_count = 0;
             score.chain_timer = 0.0f;
+            if (miss_buf.size() >= miss_buf.capacity()) {
+                ++scratch.miss_capacity_exceeded_count;
+            }
             miss_buf.push_back({e, true});
         }
 
@@ -85,6 +91,9 @@ void scoring_system(entt::registry& reg, float dt) {
             if (results) results->miss_count++;
             score.chain_count = 0;
             score.chain_timer = 0.0f;
+            if (miss_buf.size() >= miss_buf.capacity()) {
+                ++scratch.miss_capacity_exceeded_count;
+            }
             miss_buf.push_back({e, false});
         }
         // Apply structural removals after iteration — safe.
@@ -114,6 +123,9 @@ void scoring_system(entt::registry& reg, float dt) {
             r.obs      = obs;
             r.has_timing = true;
             r.timing = tg;
+            if (hit_buf.size() >= hit_buf.capacity()) {
+                ++scratch.hit_capacity_exceeded_count;
+            }
             hit_buf.push_back(r);
         }
 
@@ -125,6 +137,9 @@ void scoring_system(entt::registry& reg, float dt) {
             r.popup_xy = wt.position;
             r.obs      = obs;
             r.has_timing = false;
+            if (hit_buf.size() >= hit_buf.capacity()) {
+                ++scratch.hit_capacity_exceeded_count;
+            }
             hit_buf.push_back(r);
         }
 
@@ -179,6 +194,9 @@ void scoring_system(entt::registry& reg, float dt) {
             score.score += points;
 
             // Queue timing/score popup; popup_feedback_system owns spawn/SFX.
+            if (popup_queue.requests.size() >= popup_queue.requests.capacity()) {
+                ++popup_queue.capacity_exceeded_count;
+            }
             popup_queue.requests.push_back({
                 r.popup_xy.x,
                 r.popup_xy.y,
@@ -210,6 +228,9 @@ void scoring_system(entt::registry& reg, float dt) {
         for (auto e : ns_view) {
             HitRecord r;
             r.e = e;
+            if (cleanup_buf.size() >= cleanup_buf.capacity()) {
+                ++scratch.hit_capacity_exceeded_count;
+            }
             cleanup_buf.push_back(r);
         }
         for (auto& r : cleanup_buf) {

--- a/tests/test_scoring_system.cpp
+++ b/tests/test_scoring_system.cpp
@@ -1,5 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
+#include <cstddef>
 #include "test_helpers.h"
+#include "components/system_scratch.h"
 
 TEST_CASE("scoring: distance bonus accumulates", "[scoring]") {
     auto reg = make_registry();
@@ -312,4 +314,34 @@ TEST_CASE("scoring: obstacle/timing points still apply after playback has finish
     scoring_system(reg, 1.0f);
 
     CHECK(score.score >= constants::PTS_SHAPE_GATE);
+}
+
+TEST_CASE("runtime scratch: dense scoring burst stays within reserved capacity", "[scoring][issue557]") {
+    auto reg = make_registry();
+    constexpr int dense_count = 6;
+    runtime_system_scratch_reserve(reg, dense_count);
+
+    auto& scratch = reg.ctx().get<ScoringSystemScratch>();
+    auto& energy = reg.ctx().get<PendingEnergyEffects>();
+    auto& popup_queue = reg.ctx().get<ScorePopupRequestQueue>();
+    const auto hit_capacity = scratch.hit_buf.capacity();
+    const auto energy_capacity = energy.events.capacity();
+    const auto popup_capacity = popup_queue.requests.capacity();
+
+    for (int i = 0; i < dense_count; ++i) {
+        auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y + static_cast<float>(i));
+        reg.emplace<ScoredTag>(obs);
+        reg.emplace<TimingGrade>(obs, TimingTier::Good, 0.5f);
+    }
+
+    scoring_system(reg, 0.0f);
+
+    CHECK(scratch.hit_buf.capacity() == hit_capacity);
+    CHECK(energy.events.capacity() == energy_capacity);
+    CHECK(popup_queue.requests.capacity() == popup_capacity);
+    CHECK(scratch.hit_capacity_exceeded_count == 0);
+    CHECK(energy.capacity_exceeded_count == 0);
+    CHECK(popup_queue.capacity_exceeded_count == 0);
+    CHECK(energy.events.size() == static_cast<std::size_t>(dense_count));
+    CHECK(popup_queue.requests.size() == static_cast<std::size_t>(dense_count));
 }


### PR DESCRIPTION
Closes #557.

## Root cause
Runtime scratch buffers and gameplay intent queues were default-constructed, so the first dense gameplay burst could grow `std::vector` capacity inside scoring, despawn, popup, particle, or mesh-child cleanup hot paths.

## Fix
- Reserve scratch and intent queues at runtime init, then resize the reserve budget from the loaded beatmap at play-session setup.
- Add plain telemetry counters to the scratch/intent data for any hot-path push that reaches capacity.
- Cover a dense scoring burst so hit scratch, pending energy, and popup requests do not grow past their reserved capacity.

## Verification
- `VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./build.sh && ./build/shapeshifter_tests`