### PR TITLE
Cache popup text width

### DIFF
--- a/app/components/scoring.h
+++ b/app/components/scoring.h
@@ -27,10 +27,12 @@ struct ScorePopup {
     float      max_time        = 0.0f;
 };
 
-// Pre-computed popup display data. Computed by popup_display_system,
-// consumed by ui_render_system (just draws text at position with color).
+// Pre-computed popup display data. Static text/color are initialized at spawn;
+// ui_render_system lazily caches the text width once the active font is known.
 struct PopupDisplay {
     char     text[16] = {};
     FontSize font_size = FontSize::Small;
     uint8_t  r = 255, g = 255, b = 255, a = 255;
+    float    text_half_width = 0.0f;
+    int      measured_font_base_size = -1;
 };

--- a/app/systems/ui_render_system.cpp
+++ b/app/systems/ui_render_system.cpp
@@ -65,8 +65,12 @@ void ui_render_system(entt::registry& reg, float /*alpha*/) {
             const Font& font = popup_font_for_size(text_ctx, pd.font_size);
             const float font_size = static_cast<float>(font.baseSize);
             const float spacing = 1.0f;
-            const Vector2 size = MeasureTextEx(font, pd.text, font_size, spacing);
-            DrawTextEx(font, pd.text, {sp.x - size.x / 2.0f, sp.y},
+            if (pd.measured_font_base_size != font.baseSize) {
+                const Vector2 size = MeasureTextEx(font, pd.text, font_size, spacing);
+                pd.text_half_width = size.x / 2.0f;
+                pd.measured_font_base_size = font.baseSize;
+            }
+            DrawTextEx(font, pd.text, {sp.x - pd.text_half_width, sp.y},
                        font_size, spacing, {pd.r, pd.g, pd.b, pd.a});
         }
     }

--- a/tests/test_popup_display_system.cpp
+++ b/tests/test_popup_display_system.cpp
@@ -247,6 +247,8 @@ TEST_CASE("init_popup_display: formats grade text + font size from ScorePopup (#
     CHECK(pd.g == 20);
     CHECK(pd.b == 30);
     CHECK(pd.a == 200);
+    CHECK(pd.text_half_width == 0.0f);
+    CHECK(pd.measured_font_base_size == -1);
 }
 
 TEST_CASE("init_popup_display: nullopt tier formats numeric value (#251)",
@@ -260,6 +262,8 @@ TEST_CASE("init_popup_display: nullopt tier formats numeric value (#251)",
 
     CHECK(std::strcmp(pd.text, "4242") == 0);
     CHECK(pd.font_size == FontSize::Small);
+    CHECK(pd.text_half_width == 0.0f);
+    CHECK(pd.measured_font_base_size == -1);
 }
 
 // ── spawn_score_popup: entity factory contract (#349) ─────────────────────────


### PR DESCRIPTION
## Summary\n- Cache popup text half-width on PopupDisplay after the active font is known\n- Reuse the cached half-width for popup alignment instead of measuring every UI frame\n- Assert init_popup_display leaves width cache fields in their unmeasured state\n\n## Verification\n- `VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./build.sh && ./build/shapeshifter_tests`\n\nCloses #655