### PR TITLE
Fix WASM service worker asset caching

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -96,7 +96,7 @@ jobs:
           mkdir -p build/ci
           ctest --test-dir build -N \
             | sed -nE 's/^ *Test *#[0-9]+: (.*)$/\1/p' \
-            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_difficulty_ramp|validate_max_beat_gap|validate_no_simultaneous_shape_gates|beatmap_editor_node_tests|startup_shutdown_smoke)$' \
+            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_difficulty_ramp|validate_max_beat_gap|validate_no_simultaneous_shape_gates|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
             | sort -u > build/ci/ctest-nonbench-catch.txt
           ./build/shapeshifter_tests --list-tests "~[bench]" --verbosity quiet \
             | sort -u > build/ci/catch-nonbench.txt
@@ -104,7 +104,7 @@ jobs:
           ./build/shapeshifter_tests "~[bench]"
           xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24" \
             ctest --test-dir build --output-on-failure -R "^startup_shutdown_smoke$"
-          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_difficulty_ramp|validate_max_beat_gap|validate_no_simultaneous_shape_gates|beatmap_editor_node_tests)$"
+          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_difficulty_ramp|validate_max_beat_gap|validate_no_simultaneous_shape_gates|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
 
       - name: Upload artifact
         if: success()

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -98,14 +98,14 @@ jobs:
           mkdir -p build/ci
           ctest --test-dir build -N \
             | sed -nE 's/^ *Test *#[0-9]+: (.*)$/\1/p' \
-            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_difficulty_ramp|validate_max_beat_gap|validate_no_simultaneous_shape_gates|beatmap_editor_node_tests|startup_shutdown_smoke)$' \
+            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_difficulty_ramp|validate_max_beat_gap|validate_no_simultaneous_shape_gates|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
             | sort -u > build/ci/ctest-nonbench-catch.txt
           ./build/shapeshifter_tests --list-tests "~[bench]" --verbosity quiet \
             | sort -u > build/ci/catch-nonbench.txt
           diff -u build/ci/ctest-nonbench-catch.txt build/ci/catch-nonbench.txt
           ./build/shapeshifter_tests "~[bench]"
           ctest --test-dir build --output-on-failure -R "^startup_shutdown_smoke$"
-          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_difficulty_ramp|validate_max_beat_gap|validate_no_simultaneous_shape_gates|beatmap_editor_node_tests)$"
+          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_difficulty_ramp|validate_max_beat_gap|validate_no_simultaneous_shape_gates|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
 
       - name: Upload artifact
         if: success()

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -91,7 +91,7 @@ jobs:
           mkdir -p build/ci
           ctest --test-dir build -N \
             | sed -nE 's/^ *Test *#[0-9]+: (.*)$/\1/p' \
-            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_difficulty_ramp|validate_max_beat_gap|validate_no_simultaneous_shape_gates|beatmap_editor_node_tests|startup_shutdown_smoke)$' \
+            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_difficulty_ramp|validate_max_beat_gap|validate_no_simultaneous_shape_gates|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
             | tr -d '\r' \
             | sort -u > build/ci/ctest-nonbench-catch.txt
           ./build/shapeshifter_tests.exe --list-tests "~[bench]" --verbosity quiet \
@@ -100,7 +100,7 @@ jobs:
           diff -u build/ci/ctest-nonbench-catch.txt build/ci/catch-nonbench.txt
           ./build/shapeshifter_tests.exe "~[bench]"
           ctest --test-dir build --output-on-failure -R "^startup_shutdown_smoke$"
-          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_difficulty_ramp|validate_max_beat_gap|validate_no_simultaneous_shape_gates|beatmap_editor_node_tests)$"
+          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_difficulty_ramp|validate_max_beat_gap|validate_no_simultaneous_shape_gates|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
         shell: bash
 
       - name: Upload artifact

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -622,6 +622,11 @@ if(NOT EMSCRIPTEN)
             COMMAND ${NODE_EXECUTABLE} --test ${_beatmap_editor_node_test_files}
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tools/beatmap-editor
         )
+        add_test(
+            NAME service_worker_cache_policy_node_tests
+            COMMAND ${NODE_EXECUTABLE} --test ${CMAKE_SOURCE_DIR}/tests/service_worker_cache_policy.test.cjs
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        )
         message(STATUS "beatmap_editor_node_tests enabled: ${NODE_EXECUTABLE}")
     else()
         add_test(

--- a/app/sw.js
+++ b/app/sw.js
@@ -2,6 +2,16 @@ const CACHE_PREFIX = 'shapeshifter-';
 const CACHE_NAME = CACHE_PREFIX + '@GIT_COMMIT_HASH@';
 const ASSETS_TO_CACHE = ['index.js', 'index.wasm', 'index.data'];
 
+function isBuildAssetRequest(request) {
+  if (request.method !== 'GET') return false;
+
+  const url = new URL(request.url);
+  if (url.origin !== self.location.origin) return false;
+
+  const filename = url.pathname.split('/').pop();
+  return ASSETS_TO_CACHE.includes(filename);
+}
+
 self.addEventListener('install', e => {
   self.skipWaiting();
 });
@@ -19,19 +29,21 @@ self.addEventListener('activate', e => {
 });
 
 self.addEventListener('fetch', e => {
-  const url = new URL(e.request.url);
-  const filename = url.pathname.split('/').pop();
-  if (!ASSETS_TO_CACHE.includes(filename)) return;
+  if (!isBuildAssetRequest(e.request)) return;
 
   e.respondWith(
     caches.open(CACHE_NAME).then(cache =>
-      cache.match(e.request).then(cached => {
-        if (cached) return cached;
-        return fetch(e.request).then(resp => {
-          if (resp.ok) cache.put(e.request, resp.clone());
-          return resp;
-        });
-      })
-    ).catch(() => new Response('Offline', { status: 503 }))
+      fetch(new Request(e.request, { cache: 'no-store' })).then(resp => {
+        if (resp.ok) {
+          e.waitUntil(cache.put(e.request, resp.clone()));
+        }
+        return resp;
+      }).catch(() =>
+        cache.match(e.request).then(cached => {
+          if (cached) return cached;
+          return new Response('Offline', { status: 503 });
+        })
+      )
+    )
   );
 });

--- a/tests/service_worker_cache_policy.test.cjs
+++ b/tests/service_worker_cache_policy.test.cjs
@@ -1,0 +1,121 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const test = require('node:test');
+const vm = require('node:vm');
+
+function createServiceWorkerHarness(fetchImpl) {
+  const listeners = new Map();
+  const cachedResponses = new Map();
+  const cache = {
+    async match(request) {
+      return cachedResponses.get(request.url);
+    },
+    async put(request, response) {
+      cachedResponses.set(request.url, response);
+    },
+  };
+  const context = {
+    URL,
+    Request,
+    Response,
+    caches: {
+      async keys() {
+        return [];
+      },
+      async open() {
+        return cache;
+      },
+      async delete() {
+        return true;
+      },
+    },
+    clients: {
+      async claim() {},
+    },
+    fetch: fetchImpl,
+    self: {
+      location: new URL('https://example.test/game/'),
+      skipWaiting() {},
+      addEventListener(type, handler) {
+        listeners.set(type, handler);
+      },
+    },
+  };
+
+  vm.createContext(context);
+  vm.runInContext(fs.readFileSync('app/sw.js', 'utf8'), context);
+
+  return { listeners, cachedResponses };
+}
+
+async function dispatchFetch(listeners, request) {
+  let responsePromise;
+  const waitUntilPromises = [];
+  listeners.get('fetch')({
+    request,
+    respondWith(promise) {
+      responsePromise = Promise.resolve(promise);
+    },
+    waitUntil(promise) {
+      waitUntilPromises.push(Promise.resolve(promise));
+    },
+  });
+
+  assert.ok(responsePromise, 'service worker should handle build asset fetches');
+  const response = await responsePromise;
+  await Promise.all(waitUntilPromises);
+  return response;
+}
+
+test('build assets use network response before stale cache entries', async () => {
+  const { listeners, cachedResponses } = createServiceWorkerHarness(async request => {
+    assert.equal(request.cache, 'no-store');
+    return new Response('fresh wasm', { status: 200 });
+  });
+  const request = new Request('https://example.test/game/index.wasm');
+  cachedResponses.set(request.url, new Response('stale wasm', { status: 200 }));
+
+  const response = await dispatchFetch(listeners, request);
+
+  assert.equal(await response.text(), 'fresh wasm');
+  assert.equal(await cachedResponses.get(request.url).clone().text(), 'fresh wasm');
+});
+
+test('build assets fall back to cache when network is unavailable', async () => {
+  const { listeners, cachedResponses } = createServiceWorkerHarness(async () => {
+    throw new Error('network unavailable');
+  });
+  const request = new Request('https://example.test/game/index.data');
+  cachedResponses.set(request.url, new Response('cached data', { status: 200 }));
+
+  const response = await dispatchFetch(listeners, request);
+
+  assert.equal(await response.text(), 'cached data');
+});
+
+test('missing network and cache returns explicit offline response', async () => {
+  const { listeners } = createServiceWorkerHarness(async () => {
+    throw new Error('network unavailable');
+  });
+  const request = new Request('https://example.test/game/index.js');
+
+  const response = await dispatchFetch(listeners, request);
+
+  assert.equal(response.status, 503);
+  assert.equal(await response.text(), 'Offline');
+});
+
+test('non-build assets are ignored by the service worker fetch handler', () => {
+  const { listeners } = createServiceWorkerHarness(async () => new Response('unused'));
+  let handled = false;
+
+  listeners.get('fetch')({
+    request: new Request('https://example.test/game/cover.png'),
+    respondWith() {
+      handled = true;
+    },
+    waitUntil() {},
+  });
+
+  assert.equal(handled, false);
+});


### PR DESCRIPTION
## Summary
- Fixes #596
- Switches generated WASM build assets to network-first fetches with no-store requests
- Keeps cached index.js/index.wasm/index.data responses as the explicit offline fallback
- Adds a Node regression test for stale-cache, offline fallback, and non-build asset bypass behavior

## Root cause
The service worker returned cached build assets before attempting the network, and the cache name only changed with @GIT_COMMIT_HASH@. Same-commit rebuilds or deploy transitions could therefore keep serving stale index.js/index.wasm/index.data from the service-worker cache.

## Verification
- `VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./build.sh && ./build/shapeshifter_tests && ctest --test-dir build --output-on-failure -R service_worker_cache_policy_node_tests`