### PR TITLE
Keep chains through musical rests

### DIFF
--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -46,11 +46,8 @@ void scoring_system(entt::registry& reg, float dt) {
         score.score += static_cast<int>(dt * constants::PTS_PER_SECOND);
     }
 
-    // Chain timer
+    // Track rest duration for diagnostics/feedback, but only misses break chain.
     score.chain_timer += dt;
-    if (score.chain_timer > 2.0f) {
-        score.chain_count = 0;
-    }
 
     auto* results = reg.ctx().find<SongResults>();   // #309: hoisted above loop
 

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -276,7 +276,7 @@ struct ScoreState {
     int32_t  displayed_score;    // for smooth scroll-up animation
     int32_t  high_score;         // persisted across sessions
     int32_t  chain_count;        // consecutive obstacles cleared
-    float    chain_timer;        // seconds since last clear — chain breaks if > threshold
+    float    chain_timer;        // seconds since last clear, retained across rests
     float    distance_traveled;  // total pixels scrolled (for distance bonus)
 };
 

--- a/design-docs/game.md
+++ b/design-docs/game.md
@@ -128,7 +128,7 @@ When an obstacle requires TWO actions (e.g., switch to ● AND swipe left), the 
 ### Chain
 - Each consecutive non-miss timing grade (Perfect, Good, Ok, or Bad) grows the chain.
 - Bad awards reduced points and drains small energy. Miss resets the chain.
-- Chain resets on any MISS.
+- Chain persists through authored musical rests; only a MISS resets it.
 - Chain contributes a bounded flat bonus so consistent rhythm is rewarded over isolated hits.
 
 ### Distance Bonus

--- a/tests/test_scoring_system.cpp
+++ b/tests/test_scoring_system.cpp
@@ -47,7 +47,7 @@ TEST_CASE("scoring: chain bonus increases points", "[scoring]") {
     CHECK(score.score > base_only);
 }
 
-TEST_CASE("scoring: chain resets after timeout", "[scoring]") {
+TEST_CASE("scoring: chain persists across authored rests until miss (#100)", "[scoring][issue100]") {
     auto reg = make_registry();
 
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
@@ -58,10 +58,20 @@ TEST_CASE("scoring: chain resets after timeout", "[scoring]") {
     energy_system(reg, 0.016f);
     CHECK(reg.ctx().get<ScoreState>().chain_count == 1);
 
-    // Wait > 2 seconds
+    // Musical rests should not silently break a clean chain.
     scoring_system(reg, 2.5f);
     popup_feedback_system(reg, 2.5f);
     energy_system(reg, 2.5f);
+
+    CHECK(reg.ctx().get<ScoreState>().chain_count == 1);
+
+    auto miss = make_shape_gate(reg, Shape::Square, constants::PLAYER_Y);
+    reg.emplace<ScoredTag>(miss);
+    reg.emplace<MissTag>(miss);
+
+    scoring_system(reg, 0.016f);
+    popup_feedback_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
 
     CHECK(reg.ctx().get<ScoreState>().chain_count == 0);
 }


### PR DESCRIPTION
## Summary
- Fixes #100
- Removes the silent 2s chain timeout so authored musical rests preserve a clean chain
- Keeps misses as the explicit chain reset path and updates scoring docs/architecture notes
- Adds regression coverage for rest-gap persistence followed by miss reset

## Root cause
`scoring_system` reset `ScoreState::chain_count` whenever `chain_timer` exceeded 2 seconds, even though the design docs define MISS as the chain reset event. Rest-heavy chart sections could therefore break the chain without player error or feedback.

## Verification
- `VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./build.sh && ./build/shapeshifter_tests`