### PR TITLE
Fix rejected music stream cleanup

### DIFF
--- a/app/audio/music_context.h
+++ b/app/audio/music_context.h
@@ -2,6 +2,14 @@
 
 #include <raylib.h>
 
+inline bool music_stream_has_unloadable_resources(const Music& music) {
+    return music.ctxData != nullptr || music.stream.buffer != nullptr;
+}
+
+inline bool music_stream_is_playable(const Music& music) {
+    return IsMusicValid(music) && music.stream.buffer != nullptr;
+}
+
 // Singleton: holds the raylib Music handle and playback state.
 // Cold data — read/written 1-2x per frame by song_playback_system only.
 struct MusicContext {

--- a/app/session/play_session.cpp
+++ b/app/session/play_session.cpp
@@ -119,14 +119,17 @@ void setup_play_session(entt::registry& reg) {
         const char* audio_paths[] = { exe_audio.c_str(), beatmap.song_path.c_str() };
         for (const char* path : audio_paths) {
             Music stream = LoadMusicStream(path);
-            stream.looping = false;
-            if (stream.frameCount > 0) {
+            if (music_stream_is_playable(stream)) {
+                stream.looping = false;
                 music->stream  = stream;
                 music->loaded  = true;
                 music->started = false;
                 SetMusicVolume(music->stream, music->volume);
                 TraceLog(LOG_INFO, "Loaded music: %s", path);
                 break;
+            }
+            if (music_stream_has_unloadable_resources(stream)) {
+                UnloadMusicStream(stream);
             }
         }
     }

--- a/tests/test_music_context.cpp
+++ b/tests/test_music_context.cpp
@@ -1,0 +1,42 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+
+#include "audio/music_context.h"
+
+namespace {
+
+Music make_nominal_music_without_buffer() {
+    Music music{};
+    music.ctxData = reinterpret_cast<void*>(static_cast<std::uintptr_t>(0x1));
+    music.frameCount = 1024;
+    music.stream.sampleRate = 44100;
+    music.stream.sampleSize = 16;
+    music.stream.channels = 2;
+    return music;
+}
+
+} // namespace
+
+TEST_CASE("music context: playable stream requires raylib validity and an audio buffer", "[audio]") {
+    Music music = make_nominal_music_without_buffer();
+
+    CHECK(IsMusicValid(music));
+    CHECK_FALSE(music_stream_is_playable(music));
+
+    music.stream.buffer = reinterpret_cast<decltype(music.stream.buffer)>(static_cast<std::uintptr_t>(0x1));
+
+    CHECK(music_stream_is_playable(music));
+}
+
+TEST_CASE("music context: rejected partial streams are recognized for unload", "[audio]") {
+    Music music{};
+    CHECK_FALSE(music_stream_has_unloadable_resources(music));
+
+    music.ctxData = reinterpret_cast<void*>(static_cast<std::uintptr_t>(0x1));
+    CHECK(music_stream_has_unloadable_resources(music));
+
+    music.ctxData = nullptr;
+    music.stream.buffer = reinterpret_cast<decltype(music.stream.buffer)>(static_cast<std::uintptr_t>(0x1));
+    CHECK(music_stream_has_unloadable_resources(music));
+}


### PR DESCRIPTION
## Summary
- Fixes #651
- Require loaded music streams to pass raylib validity and have an initialized audio buffer before playback
- Unload rejected streams that still own context or audio-buffer resources before trying fallback paths
- Add focused coverage for playable-vs-partial music stream predicates

## Root cause
`setup_play_session` accepted `LoadMusicStream` results when `frameCount > 0`, which could treat a partially initialized stream as loaded and could skip unloading rejected handles before trying the fallback audio path.

## Verification
- `VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./build.sh && ./build/shapeshifter_tests`