### PR TITLE
Guard legacy beat-grid beatmap API

### DIFF
--- a/tools/level_designer.py
+++ b/tools/level_designer.py
@@ -1274,11 +1274,11 @@ def shape_gate_clusters(obstacles):
 # ═══════════════════════════════════════════════════════════════
 
 def select_beats(analysis, difficulty):
-    """Select which beats will have obstacles.
+    """Diagnostics-only legacy beat-grid selector.
 
-    Key insight: repeated sections reuse the same relative beat pattern.
-    The first verse defines the pattern; subsequent verses replay it.
-    This gives players the "second time = mastery" feeling.
+    Shipping beatmap generation uses segment-focus onset selection instead.
+    This legacy selector is retained for diagnostics that compare historical
+    beat-grid behavior against the onset-only authoring path.
     """
     beats = analysis["beats"]
     events = analysis["events"]
@@ -2773,7 +2773,7 @@ def design_level_onset_motif(analysis, difficulty, cleanup_enabled=True):
 
 def assign_obstacle(beat_idx, event, gap_to_prev, section_name, difficulty,
                     prev_lane, prev_shapes, allowed_kinds, rng, shape_state):
-    """Assign obstacle type from beat-local context only (no onset pass mapping)."""
+    """Diagnostics-only legacy beat-grid obstacle assignment."""
     natural_kind = "shape_gate"
     # Respect difficulty restrictions
     if natural_kind not in allowed_kinds:
@@ -3304,7 +3304,7 @@ def clean_level(obstacles, difficulty, boundary_beats):
 
 
 def fill_max_gaps(obstacles, difficulty, analysis):
-    """Insert shape gates so consecutive authored beats stay under max-gap."""
+    """Diagnostics-only legacy filler for beat-grid obstacle gaps."""
     del analysis
     max_diff = MAX_BEAT_DIFF.get(difficulty)
     if not max_diff or len(obstacles) < 2:
@@ -3965,8 +3965,21 @@ def _ensure_obstacle_class_floor(obstacles, selected_events, onset_class, floor_
 SAME_SHAPE_CLUSTER_CHAIN_CAP = {"medium": 3, "hard": 3}
 
 
-def build_beatmap(analysis, difficulties, cleanup_enabled=True, experimental_onset_timing=True):
+def build_beatmap(
+    analysis,
+    difficulties,
+    cleanup_enabled=True,
+    experimental_onset_timing=True,
+    *,
+    allow_diagnostics_legacy_grid=False,
+):
     """Build the full beatmap JSON."""
+    if not experimental_onset_timing and not allow_diagnostics_legacy_grid:
+        raise ValueError(
+            "build_beatmap legacy beat-grid generation is diagnostics-only; "
+            "pass allow_diagnostics_legacy_grid=True for explicit debug output."
+        )
+
     beats = analysis["beats"]
     if not beats:
         raise ValueError("analysis.beats is required and must not be empty")

--- a/tools/test_level_designer_onset_spike.py
+++ b/tools/test_level_designer_onset_spike.py
@@ -118,6 +118,48 @@ class TestExperimentalOnsetTiming(unittest.TestCase):
             self.assertIn("onset_time_sec", obs)
             self.assertIn("beat_time_sec", obs)
 
+    def test_build_beatmap_rejects_legacy_grid_without_diagnostics_flag(self):
+        with self.assertRaisesRegex(ValueError, "diagnostics-only"):
+            ld.build_beatmap(
+                _analysis_fixture(),
+                ["easy"],
+                experimental_onset_timing=False,
+            )
+
+        beatmap = ld.build_beatmap(
+            _analysis_fixture(),
+            ["easy"],
+            experimental_onset_timing=False,
+            allow_diagnostics_legacy_grid=True,
+        )
+        self.assertGreater(beatmap["difficulties"]["easy"]["count"], 0)
+
+    def test_shipped_generation_does_not_call_legacy_grid_functions(self):
+        blockers = (
+            mock.patch.object(ld, "select_beats", side_effect=AssertionError("legacy select_beats called")),
+            mock.patch.object(ld, "assign_obstacle", side_effect=AssertionError("legacy assign_obstacle called")),
+            mock.patch.object(ld, "fill_max_gaps", side_effect=AssertionError("legacy fill_max_gaps called")),
+        )
+        with blockers[0] as select_mock, blockers[1] as assign_mock, blockers[2] as fill_mock:
+            beatmap = ld.build_beatmap(_varied_fixture(), ["easy", "medium", "hard"])
+
+        self.assertGreater(beatmap["difficulties"]["easy"]["count"], 0)
+        select_mock.assert_not_called()
+        assign_mock.assert_not_called()
+        fill_mock.assert_not_called()
+
+    def test_shipped_obstacles_have_public_onset_provenance(self):
+        beatmap = ld.build_beatmap(_varied_fixture(), ["easy", "medium", "hard"])
+        public_classes = set(ld.ONSET_CLASS_TO_OBSTACLE)
+        for diff in ("easy", "medium", "hard"):
+            beats = beatmap["difficulties"][diff]["beats"]
+            self.assertGreater(len(beats), 0)
+            for obs in beats:
+                self.assertEqual(obs.get("timing_source"), "onset")
+                self.assertIsInstance(obs.get("source_event_idx"), int)
+                self.assertIsInstance(obs.get("onset_time_sec"), (int, float))
+                self.assertIn(obs.get("onset_class"), public_classes)
+
     def test_experimental_mode_uses_onset_time_when_available(self):
         beatmap = ld.build_beatmap(
             _analysis_fixture(),


### PR DESCRIPTION
Fixes #645

## Root cause
The CLI rejected --legacy-beat-grid for beatmap output, but callers could still invoke build_beatmap(..., experimental_onset_timing=False) directly and trigger the legacy beat-grid selector/assigner/filler path.

## Changes
- Reject legacy beat-grid build_beatmap calls unless allow_diagnostics_legacy_grid=True is passed explicitly.
- Mark select_beats, assign_obstacle, and fill_max_gaps as diagnostics-only legacy helpers.
- Add tests proving shipped generation does not call legacy helpers and emits onset provenance for every generated obstacle.

## Verification
- python3 -m unittest tools.test_level_designer_onset_spike
- python3 -m unittest discover -s tools -p 'test*.py'\n- VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./build.sh && ./build/shapeshifter_tests