### PR TITLE
Make chain scoring multiplicative

### DIFF
--- a/app/constants.h
+++ b/app/constants.h
@@ -39,7 +39,8 @@ constexpr int   PTS_LANE_BLOCK    = 100;
 constexpr int   PTS_COMBO_GATE    = 200;
 constexpr int   PTS_SPLIT_PATH    = 300;
 constexpr int   PTS_PER_SECOND    = 10;
-constexpr int   CHAIN_BONUS[5]    = { 0, 0, 50, 100, 200 };
+constexpr float CHAIN_MULT_STEP    = 0.05f;
+constexpr int32_t CHAIN_MULT_BONUS_STEPS_CAP = 20;
 
 // ── Rhythm Constants ──────────────────────────────
 constexpr float APPROACH_DIST      = 1040.0f;  // |PLAYER_Y - SPAWN_Y|

--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -11,6 +11,7 @@
 #include "../components/rhythm.h"
 #include "../util/rhythm_math.h"
 #include "../constants.h"
+#include <algorithm>
 #include <cmath>
 
 namespace {
@@ -30,6 +31,14 @@ void enqueue_energy_effect(entt::registry& reg, float delta, bool flash = false)
 
 ScorePopupRequestQueue& popup_queue_for(entt::registry& reg) {
     return reg.ctx().get<ScorePopupRequestQueue>();
+}
+
+float chain_multiplier_for_count(int32_t chain_count) {
+    if (chain_count <= 1) {
+        return 1.0f;
+    }
+    const int32_t bonus_steps = std::min(chain_count - 1, constants::CHAIN_MULT_BONUS_STEPS_CAP);
+    return 1.0f + constants::CHAIN_MULT_STEP * static_cast<float>(bonus_steps);
 }
 
 }  // namespace
@@ -160,17 +169,12 @@ void scoring_system(entt::registry& reg, float dt) {
                 }
             }
 
-            int points = static_cast<int>(
-                std::floor(r.obs.base_points * timing_mult));
-
-            // Chain bonus
+            // Chain multiplier
             score.chain_count++;
             score.chain_timer = 0.0f;
-            if (score.chain_count >= 2 && score.chain_count <= 4) {
-                points += constants::CHAIN_BONUS[score.chain_count];
-            } else if (score.chain_count >= 5) {
-                points += constants::CHAIN_BONUS[4] + (score.chain_count - 4) * 100;
-            }
+            const float chain_mult = chain_multiplier_for_count(score.chain_count);
+            int points = static_cast<int>(
+                std::floor(static_cast<float>(r.obs.base_points) * timing_mult * chain_mult));
 
             if (results && score.chain_count > results->max_chain) {
                 results->max_chain = score.chain_count;

--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
@@ -350,6 +350,26 @@ void render_gameplay_hud_screen_ui(entt::registry& reg) {
         GuiSetAlpha(0.7f);
         GuiLabel(Rectangle{ 80, 50, 200, 30 }, high_score_text);
         GuiSetAlpha(1.0f);
+
+        if (score->chain_count >= 2) {
+            const bool meaningful_chain = score->chain_count >= 5;
+            char chain_text[32];
+            std::snprintf(chain_text, sizeof(chain_text), meaningful_chain ? "CHAIN %d!" : "CHAIN %d",
+                          score->chain_count);
+            if (meaningful_chain) {
+                const auto* settings = reg.ctx().find<SettingsState>();
+                const bool reduce_motion = settings && settings->reduce_motion;
+                const auto* song = reg.ctx().find<SongState>();
+                const float pulse_time = (song && song->playing) ? song->song_time : static_cast<float>(GetTime());
+                const float pulse = reduce_motion ? 0.5f : (0.5f + 0.5f * std::sin(pulse_time * 8.0f));
+                DrawRectangleLinesEx(Rectangle{76, 82, 138, 28}, 2.0f,
+                                     Fade({100, 255, 180, 255}, 0.20f + 0.20f * pulse));
+            }
+            GuiSetStyle(DEFAULT, TEXT_SIZE, meaningful_chain ? 20 : 18);
+            GuiSetAlpha(meaningful_chain ? 0.95f : 0.70f);
+            GuiLabel(Rectangle{ 80, 80, 160, 32 }, chain_text);
+            GuiSetAlpha(1.0f);
+        }
     }
 
     render_shape_buttons(reg, hud_layout, state);

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -107,8 +107,8 @@ namespace constants {
     constexpr int   PTS_COMBO_GATE    = 200;
     constexpr int   PTS_SPLIT_PATH    = 300;
     constexpr int   PTS_PER_SECOND    = 10;       // distance bonus
-    constexpr int   CHAIN_BONUS[5]    = { 0, 0, 50, 100, 200 };
-    //               chain:             0  1   2    3     4  (5+ = +100/ea)
+    constexpr float CHAIN_MULT_STEP    = 0.05f;
+    constexpr int32_t CHAIN_MULT_BONUS_STEPS_CAP = 20; // caps at 2.0x
 
     // ── Difficulty Timeline ───────────────────────────
     constexpr float SPEED_RAMP_RATE   = 0.011f;   // multiplier/sec → ×3.0 at 180s

--- a/design-docs/game.md
+++ b/design-docs/game.md
@@ -122,14 +122,15 @@ When an obstacle requires TWO actions (e.g., switch to ● AND swipe left), the 
 ## Scoring
 
 ### Points Per Obstacle
-- `floor(base_points × timing_multiplier) + chain_flat_bonus`
+- `floor(base_points × timing_multiplier × chain_multiplier)`
 - Timing multiplier comes from the beat-distance grade (Perfect/Good/Ok/Bad). See `rhythm-design.md`.
 
 ### Chain
 - Each consecutive non-miss timing grade (Perfect, Good, Ok, or Bad) grows the chain.
 - Bad awards reduced points and drains small energy. Miss resets the chain.
 - Chain resets on any MISS.
-- Chain contributes a bounded flat bonus so consistent rhythm is rewarded over isolated hits.
+- Chain contributes `chain_multiplier = 1.0 + 0.05 × min(chain_count - 1, 20)`, capped at 2.0× from chain 21 onward, so consistent rhythm scales every obstacle instead of adding a small flat bonus.
+- Good Shape Gate comparison: chain 1 = 200, chain 5 = 240, chain 10 = 290, chain 20 = 390. Perfect Shape Gate comparison: chain 1 = 300, chain 5 = 360, chain 10 = 435, chain 20 = 585.
 
 ### Distance Bonus
 - +10 points per second survived (passive income).

--- a/design-docs/rhythm-design.md
+++ b/design-docs/rhythm-design.md
@@ -344,7 +344,7 @@ The player can hear the beat coming. The timing is legible. What the player cann
   │  Thresholds are fixed milliseconds in shipped code.         │
   │  Lower Window Scale means the active shape window collapses │
   │  sooner after that scored press.                            │
-  │  Score = floor(base_points × timing_multiplier) + chain_flat_bonus. │
+  │  Score = floor(base_points × timing_multiplier × chain_multiplier). │
   │                                                             │
   └─────────────────────────────────────────────────────────────┘
 ```
@@ -355,7 +355,8 @@ The player can hear the beat coming. The timing is legible. What the player cann
   Each consecutive non-miss timing grade (PERFECT, GOOD, OK, or BAD)
   grows the chain. BAD awards reduced points and drains small energy;
   MISS resets the chain.
-  Score = floor(base_pts × timing_multiplier) + chain_flat_bonus
+  Score = floor(base_pts × timing_multiplier × chain_multiplier)
+  chain_multiplier = 1.0 + 0.05 × min(chain_count - 1, 20), capped at 2.0×.
 
   Chain resets on any MISS.
 

--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -134,9 +134,10 @@ constexpr float WINDOW_SCALE_OK      = 1.00f;  // OK hit      → no change (def
 constexpr float MORPH_DURATION = 0.12f;
 
 // ── Scoring ──────────────────────────────────────────────────────────
-// Points are computed dynamically: base_points × timing_multiplier.
+// Points are computed dynamically: base_points × timing_multiplier × chain_multiplier.
 // No fixed PTS_PERFECT/PTS_GOOD/PTS_OK constants.
-constexpr int   CHAIN_BONUS[5]   = { 0, 0, 50, 100, 200 }; // indexed by chain length (clamped to 4)
+constexpr float CHAIN_MULT_STEP = 0.05f;
+constexpr int32_t CHAIN_MULT_BONUS_STEPS_CAP = 20; // caps at 2.0x from chain 21 onward
 ```
 
 ---
@@ -312,7 +313,7 @@ struct SongResults {
            ↓
   ┌─ SCORING ──────────────────────────────────────────────────┐
   │ scoring_system                                 [MOD]       │
-  │   → reads TimingGrade, computes pts + flat chain bonus      │
+  │   → reads TimingGrade, computes pts with chain multiplier   │
   │   → updates SongResults counters                           │
   │   → spawns grade popup VFX                                 │
   │                                                            │

--- a/tests/test_scoring_system.cpp
+++ b/tests/test_scoring_system.cpp
@@ -1,6 +1,22 @@
 #include <catch2/catch_test_macros.hpp>
 #include "test_helpers.h"
 
+namespace {
+
+int score_good_shape_gate(entt::registry& reg) {
+    auto& score = reg.ctx().get<ScoreState>();
+    const int before = score.score;
+
+    auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
+    reg.emplace<ScoredTag>(obs);
+    reg.emplace<TimingGrade>(obs, TimingTier::Good, 0.0f);
+    scoring_system(reg, 0.0f);
+
+    return score.score - before;
+}
+
+}  // namespace
+
 TEST_CASE("scoring: distance bonus accumulates", "[scoring]") {
     auto reg = make_registry();
 
@@ -27,7 +43,7 @@ TEST_CASE("scoring: scored obstacle awards points", "[scoring]") {
     CHECK(score.score >= constants::PTS_SHAPE_GATE);
 }
 
-TEST_CASE("scoring: chain bonus increases points", "[scoring]") {
+TEST_CASE("scoring: chain multiplier increases points", "[scoring]") {
     auto reg = make_registry();
 
     // Score 3 obstacles in a row
@@ -42,7 +58,7 @@ TEST_CASE("scoring: chain bonus increases points", "[scoring]") {
 
     auto& score = reg.ctx().get<ScoreState>();
     CHECK(score.chain_count == 3);
-    // Total should be more than 3x base due to chain bonuses
+    // Total should be more than 3x base due to the chain multiplier.
     int base_only = 3 * constants::PTS_SHAPE_GATE;
     CHECK(score.score > base_only);
 }
@@ -123,7 +139,7 @@ TEST_CASE("scoring: not in Playing phase skips processing", "[scoring]") {
     CHECK(reg.ctx().get<ScoreState>().score == 0);
 }
 
-TEST_CASE("scoring: chain bonus 5+ gives extended bonus", "[scoring]") {
+TEST_CASE("scoring: chain multiplier 5+ gives extended value", "[scoring]") {
     auto reg = make_registry();
 
     // Score 5 obstacles in a row (chain_count 1..5)
@@ -138,9 +154,54 @@ TEST_CASE("scoring: chain bonus 5+ gives extended bonus", "[scoring]") {
 
     auto& score = reg.ctx().get<ScoreState>();
     CHECK(score.chain_count == 5);
-    // 5th obstacle: base + CHAIN_BONUS[4] + (5-4)*100 = 200 + 200 + 100 = 500
-    // Total for 5 obstacles should be significantly more than 5*200
+    // Total for 5 obstacles should exceed base-only scoring due to the chain multiplier.
     CHECK(score.score > 5 * constants::PTS_SHAPE_GATE);
+}
+
+TEST_CASE("scoring: chain multiplier economy scales at design checkpoints (#206)", "[scoring]") {
+    auto reg = make_registry();
+
+    int chain_1_points = 0;
+    int chain_5_points = 0;
+    int chain_10_points = 0;
+    int chain_20_points = 0;
+
+    for (int chain = 1; chain <= 20; ++chain) {
+        const int points = score_good_shape_gate(reg);
+        if (chain == 1) chain_1_points = points;
+        if (chain == 5) chain_5_points = points;
+        if (chain == 10) chain_10_points = points;
+        if (chain == 20) chain_20_points = points;
+    }
+
+    CHECK(chain_1_points == 200);
+    CHECK(chain_5_points == 240);
+    CHECK(chain_10_points == 290);
+    CHECK(chain_20_points == 390);
+    CHECK(chain_1_points < chain_5_points);
+    CHECK(chain_5_points < chain_10_points);
+    CHECK(chain_10_points < chain_20_points);
+}
+
+TEST_CASE("scoring: breaking a 10-chain loses meaningful next-hit value (#206)", "[scoring]") {
+    auto reg = make_registry();
+
+    for (int i = 0; i < 9; ++i) {
+        (void)score_good_shape_gate(reg);
+    }
+    const int chained_tenth_hit = score_good_shape_gate(reg);
+
+    auto miss = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
+    reg.emplace<ScoredTag>(miss);
+    reg.emplace<MissTag>(miss);
+    scoring_system(reg, 0.0f);
+    REQUIRE(reg.ctx().get<ScoreState>().chain_count == 0);
+
+    const int isolated_after_break = score_good_shape_gate(reg);
+
+    CHECK(chained_tenth_hit == 290);
+    CHECK(isolated_after_break == 200);
+    CHECK(chained_tenth_hit >= isolated_after_break + 90);
 }
 
 TEST_CASE("scoring: obstacle entity cleaned up after scoring", "[scoring]") {


### PR DESCRIPTION
## Summary
- Replaces flat chain bonuses with a 5% per-chain-step multiplier capped at 2.0x.
- Adds scoring regression coverage for chain checkpoints and 10-chain break value.
- Adds in-game HUD chain copy/glow at meaningful chains and updates scoring docs.

Fixes #206.

## Verification
- VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./build.sh
- ./build/shapeshifter_tests