### PR TITLE
refactor: derive song scroll speed from approach distance

### DIFF
--- a/app/components/song_state.h
+++ b/app/components/song_state.h
@@ -20,7 +20,7 @@ struct SongState {
     // Recalculated from bpm/lead_beats at session init; read-only during play.
     float beat_period     = 0.5f;   // seconds per beat
     float lead_time       = 2.0f;   // total approach window in seconds
-    float scroll_speed    = 520.0f; // pixels per second (APPROACH_DIST / lead_time)
+    float scroll_speed    = constants::APPROACH_DIST / lead_time; // pixels per second
     float window_duration = 0.3f;   // hit-window width in seconds
     float half_window     = 0.15f;  // window_duration / 2
     float morph_duration  = 0.1f;   // shape-morph animation length in seconds

--- a/tests/test_beat_map_validation.cpp
+++ b/tests/test_beat_map_validation.cpp
@@ -492,8 +492,7 @@ TEST_CASE("song_state_compute_derived: scroll_speed calculation", "[rhythm_helpe
     s.lead_beats = 4;
     song_state_compute_derived(s);
 
-    // scroll_speed = APPROACH_DIST / lead_time = 1040 / 2.0 = 520
-    CHECK_THAT(s.scroll_speed, Catch::Matchers::WithinAbs(520.0f, 1.0f));
+    CHECK_THAT(s.scroll_speed, Catch::Matchers::WithinAbs(constants::APPROACH_DIST / 2.0f, 1.0f));
 }
 
 // ── load_validation_constants: path resolution ───────────────

--- a/tests/test_helpers_and_functions.cpp
+++ b/tests/test_helpers_and_functions.cpp
@@ -74,8 +74,7 @@ TEST_CASE("song_state_derived: scroll_speed = APPROACH_DIST / lead_time", "[song
     s.lead_beats = 4;
     song_state_compute_derived(s);
     // lead_time = 4 * 0.5 = 2.0s
-    // scroll_speed = 1040 / 2.0 = 520
-    CHECK_THAT(s.scroll_speed, Catch::Matchers::WithinAbs(520.0f, 0.1f));
+    CHECK_THAT(s.scroll_speed, Catch::Matchers::WithinAbs(constants::APPROACH_DIST / 2.0f, 0.1f));
 }
 
 TEST_CASE("song_state_derived: lead_time = lead_beats * beat_period", "[song_state]") {

--- a/tests/test_rhythm_system.cpp
+++ b/tests/test_rhythm_system.cpp
@@ -177,7 +177,7 @@ TEST_CASE("song_state: derived values at 120 BPM", "[rhythm][songstate]") {
     song_state_compute_derived(state);
     CHECK_THAT(state.beat_period, WithinAbs(0.5f, 0.001f));
     CHECK_THAT(state.lead_time, WithinAbs(2.0f, 0.001f));
-    CHECK_THAT(state.scroll_speed, WithinAbs(520.0f, 1.0f));
+    CHECK_THAT(state.scroll_speed, WithinAbs(constants::APPROACH_DIST / 2.0f, 1.0f));
     CHECK_THAT(state.window_duration, WithinAbs(0.3f, 0.001f));
     CHECK_THAT(state.half_window, WithinAbs(0.15f, 0.001f));
 }


### PR DESCRIPTION
## Summary\n- Replaces SongState's hardcoded default scroll speed with constants::APPROACH_DIST / lead_time.\n- Updates scroll-speed regression expectations to derive from constants::APPROACH_DIST instead of duplicating 520/1040 literals.\n\nFixes #84.\n\n## Verification\n- VCPKG_ROOT=/Users/yashasgujjar/vcpkg cmake -B build -S . -Wno-dev\n- cmake --build build\n- ./build/shapeshifter_tests