### PR TITLE
Reject missing shape-bearing beatmap entries

### DIFF
--- a/app/util/beat_map_loader.cpp
+++ b/app/util/beat_map_loader.cpp
@@ -23,6 +23,12 @@ int lane_bit_count(const uint8_t mask) {
     }
     return count;
 }
+
+bool kind_requires_shape(const ObstacleKind kind) {
+    return kind == ObstacleKind::ShapeGate ||
+           kind == ObstacleKind::ComboGate ||
+           kind == ObstacleKind::SplitPath;
+}
 } // namespace
 
 static bool try_load_constants_from(const std::string& path, ValidationConstants& vc) {
@@ -176,6 +182,12 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
                 continue;
             }
             entry.shape = *shape_opt;
+        } else if (kind_requires_shape(entry.kind)) {
+            errors.push_back({entry.beat_index,
+                "Missing required shape for obstacle kind '" + kind_str + "' at beat "
+                    + std::to_string(entry.beat_index)});
+            parse_ok = false;
+            continue;
         }
 
         entry.lane = static_cast<int8_t>(b.value("lane", 1));
@@ -429,9 +441,7 @@ bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors,
         }
 
         // Rule 6: different-shape gates must be >= min_shape_change_gap beats apart
-        bool has_shape = (entry.kind == ObstacleKind::ShapeGate ||
-                          entry.kind == ObstacleKind::ComboGate ||
-                          entry.kind == ObstacleKind::SplitPath);
+        bool has_shape = kind_requires_shape(entry.kind);
         if (has_shape && prev_had_shape &&
             entry.shape != prev_shape &&
             (entry.beat_index - prev_shape_beat) < vc.min_shape_change_gap) {

--- a/tests/test_beat_map_parser_unknown_fields.cpp
+++ b/tests/test_beat_map_parser_unknown_fields.cpp
@@ -101,10 +101,12 @@ TEST_CASE("parse: all valid kinds parse without errors", "[parse][kind]") {
     for (const auto& kind : valid_kinds) {
         BeatMap map;
         std::vector<BeatMapError> errors;
+        const bool requires_shape = kind == "shape_gate" || kind == "combo_gate" || kind == "split_path";
+        const std::string shape = requires_shape ? R"(, "shape": "circle")" : "";
         std::string json = R"({
             "bpm": 120, "offset": 0.0, "lead_beats": 4, "duration_sec": 60.0,
             "beats": [
-                { "beat": 4, "kind": ")" + kind + R"(", "lane": 1 }
+                { "beat": 4, "kind": ")" + kind + R"(", "lane": 1)" + shape + R"( }
             ]
         })";
         INFO("Testing kind: " << kind);

--- a/tests/test_beat_map_validation.cpp
+++ b/tests/test_beat_map_validation.cpp
@@ -615,6 +615,49 @@ TEST_CASE("parse: beat without time_sec falls back to beat_times", "[parse][beat
     CHECK_THAT(map.beats[0].time_sec, Catch::Matchers::WithinAbs(1.4f, 0.001f));
 }
 
+TEST_CASE("parse: shape-bearing obstacles require explicit shape", "[parse][shape][issue224]") {
+    const char* shape_bearing_kinds[] = {"shape_gate", "combo_gate", "split_path"};
+
+    for (const char* kind : shape_bearing_kinds) {
+        BeatMap map;
+        std::vector<BeatMapError> errors;
+        const std::string blocked = std::string(kind) == "combo_gate" ? R"(, "blocked": [1])" : "";
+        const std::string json = std::string(R"({
+            "song_id": "missing_shape_test",
+            "bpm": 120,
+            "offset": 0.0,
+            "lead_beats": 4,
+            "duration_sec": 60.0,
+            "beats": [
+                { "beat": 2, "kind": ")") + kind + R"(")" + blocked + R"( }
+            ]
+        })";
+
+        CHECK_FALSE(parse_beat_map(json, map, errors));
+        REQUIRE_FALSE(errors.empty());
+        CHECK(errors[0].message.find("Missing required shape") != std::string::npos);
+    }
+}
+
+TEST_CASE("parse: lane_block does not require shape", "[parse][shape][issue224]") {
+    BeatMap map;
+    std::vector<BeatMapError> errors;
+    std::string json = R"({
+        "song_id": "lane_block_test",
+        "bpm": 120,
+        "offset": 0.0,
+        "lead_beats": 4,
+        "duration_sec": 60.0,
+        "beats": [
+            { "beat": 2, "kind": "lane_block", "blocked": [1] }
+        ]
+    })";
+
+    CHECK(parse_beat_map(json, map, errors));
+    REQUIRE(map.beats.size() == 1);
+    CHECK(map.beats[0].kind == ObstacleKind::LaneBlock);
+}
+
 TEST_CASE("parse: same beat_index entries are ordered by resolved time_sec", "[parse][beat_times][ordering]") {
     BeatMap map;
     std::vector<BeatMapError> errors;


### PR DESCRIPTION
## Summary
- reject shape_gate, combo_gate, and split_path entries that omit required shape during beatmap parsing
- reuse the shape-bearing-kind check in validation
- add regression coverage for issue #224 and update valid-kind parser fixtures

Fixes #224

## Verification
- VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./build.sh
- ./build/shapeshifter_tests "[issue224],[parse][kind]"
- ./build/shapeshifter_tests