### PR TITLE
Cover Hexagon collision guards for combo and split paths

### DIFF
--- a/tests/test_collision_extended.cpp
+++ b/tests/test_collision_extended.cpp
@@ -200,6 +200,32 @@ TEST_CASE("collision: combo gate succeeds when both match", "[collision]") {
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
 }
 
+TEST_CASE("collision: Hexagon fails combo gate even when shape and lane match", "[collision][rhythm][issue219]") {
+    auto reg = make_rhythm_registry();
+    make_rhythm_player(reg);
+
+    auto obs = make_combo_gate(reg, Shape::Hexagon, 0b101, constants::PLAYER_Y);
+
+    collision_system(reg, 0.016f);
+
+    REQUIRE(reg.all_of<MissTag>(obs));
+    CHECK_FALSE(reg.all_of<TimingGrade>(obs));
+
+    scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
+
+    const auto& results = reg.ctx().get<SongResults>();
+    CHECK(results.miss_count == 1);
+    CHECK(results.perfect_count == 0);
+    CHECK(results.good_count == 0);
+    CHECK(results.ok_count == 0);
+    CHECK(results.bad_count == 0);
+
+    const auto& energy = reg.ctx().get<EnergyState>();
+    CHECK(energy.energy < 1.0f);
+    CHECK(energy.flash_timer > 0.0f);
+}
+
 // ── collision_system: split path ─────────────────────────────
 
 TEST_CASE("collision: split path succeeds with correct shape and lane", "[collision]") {
@@ -216,6 +242,32 @@ TEST_CASE("collision: split path succeeds with correct shape and lane", "[collis
     collision_system(reg, 0.016f);
 
     CHECK(reg.all_of<ScoredTag>(obs));
+}
+
+TEST_CASE("collision: Hexagon fails split path even when shape and lane match", "[collision][rhythm][issue219]") {
+    auto reg = make_rhythm_registry();
+    make_rhythm_player(reg);
+
+    auto obs = make_split_path(reg, Shape::Hexagon, 1, constants::PLAYER_Y);
+
+    collision_system(reg, 0.016f);
+
+    REQUIRE(reg.all_of<MissTag>(obs));
+    CHECK_FALSE(reg.all_of<TimingGrade>(obs));
+
+    scoring_system(reg, 0.016f);
+    energy_system(reg, 0.016f);
+
+    const auto& results = reg.ctx().get<SongResults>();
+    CHECK(results.miss_count == 1);
+    CHECK(results.perfect_count == 0);
+    CHECK(results.good_count == 0);
+    CHECK(results.ok_count == 0);
+    CHECK(results.bad_count == 0);
+
+    const auto& energy = reg.ctx().get<EnergyState>();
+    CHECK(energy.energy < 1.0f);
+    CHECK(energy.flash_timer > 0.0f);
 }
 
 // ── SRP observation: collision_system must NOT mutate SongResults ──────────


### PR DESCRIPTION
## Summary
- add issue #219 regression coverage for Hexagon failing ComboGate despite matching required shape and open lane
- add matching SplitPath coverage when Hexagon matches required shape and lane
- assert both paths route through miss/energy results instead of timing-hit counters

Fixes #219

## Verification
- `VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./build.sh`
- `./build/shapeshifter_tests "[issue219]"`
- `./build/shapeshifter_tests`