### PR TITLE
Resolve validation constants relative to app directory

### DIFF
--- a/app/util/beat_map_loader.cpp
+++ b/app/util/beat_map_loader.cpp
@@ -9,6 +9,18 @@
 using json = nlohmann::json;
 namespace {
 constexpr uint8_t kLaneBitsMask = 0x07;
+constexpr const char* kValidationConstantsPath = "content/constants.json";
+
+std::string constants_path_for_app_dir(const std::string& app_dir) {
+    if (app_dir.empty()) {
+        return kValidationConstantsPath;
+    }
+    const char last = app_dir.back();
+    if (last == '/' || last == '\\') {
+        return app_dir + kValidationConstantsPath;
+    }
+    return app_dir + "/" + kValidationConstantsPath;
+}
 
 bool has_only_lane_bits(const uint8_t mask) {
     return (mask & static_cast<uint8_t>(~kLaneBitsMask)) == 0;
@@ -63,10 +75,19 @@ static bool try_load_constants_from(const std::string& path, ValidationConstants
 
 ValidationConstants load_validation_constants(const std::string& app_dir) {
     ValidationConstants vc;
-    if (!app_dir.empty() && try_load_constants_from(app_dir + "content/constants.json", vc)) {
+    const std::string exe_relative_path =
+        constants_path_for_app_dir(app_dir.empty() ? std::string(GetApplicationDirectory()) : app_dir);
+    if (try_load_constants_from(exe_relative_path, vc)) {
         return vc;
     }
-    try_load_constants_from("content/constants.json", vc);
+    if (exe_relative_path != kValidationConstantsPath &&
+        try_load_constants_from(kValidationConstantsPath, vc)) {
+        return vc;
+    }
+    TraceLog(LOG_WARNING,
+             "Validation constants not found; using compiled defaults (tried '%s'%s)",
+             exe_relative_path.c_str(),
+             exe_relative_path == kValidationConstantsPath ? "" : " and 'content/constants.json'");
     return vc;
 }
 

--- a/app/util/beat_map_loader.h
+++ b/app/util/beat_map_loader.h
@@ -23,9 +23,9 @@ struct ValidationConstants {
 };
 
 // Load validation constants from content/constants.json.
-// If app_dir is non-empty, tries app_dir + "content/constants.json" first,
+// Tries the app-directory path first (explicit app_dir or GetApplicationDirectory()),
 // then falls back to the CWD-relative "content/constants.json".
-// Returns compiled-in defaults silently if neither file is found or parseable.
+// Returns compiled-in defaults and logs a warning if neither file is found or parseable.
 ValidationConstants load_validation_constants(const std::string& app_dir = "");
 
 // Load a beat map from a JSON file. Returns true on success.
@@ -43,9 +43,7 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
 bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors,
                        const ValidationConstants& vc);
 
-// Validate a loaded beat map, loading constants from CWD-relative path.
-// Prefer the three-argument overload when the application directory is available
-// (e.g. pass GetApplicationDirectory() to load_validation_constants first).
+// Validate a loaded beat map, loading constants from app-directory/CWD paths.
 bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors);
 
 // Initialize SongState from a loaded BeatMap.

--- a/tests/test_beat_map_validation.cpp
+++ b/tests/test_beat_map_validation.cpp
@@ -1,5 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <filesystem>
+#include <fstream>
 #include <limits>
 #include "test_helpers.h"
 #include "util/beat_map_loader.h"
@@ -498,8 +500,7 @@ TEST_CASE("song_state_compute_derived: scroll_speed calculation", "[rhythm_helpe
 
 // ── load_validation_constants: path resolution ───────────────
 
-TEST_CASE("load_validation_constants: missing file returns compiled-in defaults", "[validate][constants]") {
-    // No constants.json exists at CWD or an empty app_dir path; defaults must be returned.
+TEST_CASE("load_validation_constants: default paths load shipped defaults", "[validate][constants]") {
     ValidationConstants vc = load_validation_constants("");
     CHECK(vc.bpm_min == 60.0f);
     CHECK(vc.bpm_max == 300.0f);
@@ -510,10 +511,31 @@ TEST_CASE("load_validation_constants: missing file returns compiled-in defaults"
     CHECK(vc.min_shape_change_gap == 3);
 }
 
-TEST_CASE("load_validation_constants: bad app_dir falls back to CWD path silently", "[validate][constants]") {
+TEST_CASE("load_validation_constants: explicit app_dir takes precedence over CWD fallback", "[validate][constants]") {
+    const std::filesystem::path root = "test_validation_constants_app_dir";
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root / "content");
+    {
+        std::ofstream out(root / "content" / "constants.json");
+        REQUIRE(out.good());
+        out << R"({"validation":{"bpm_min":72,"bpm_max":240,"offset_max":2.5,"min_shape_change_gap":4}})";
+    }
+
+    ValidationConstants vc = load_validation_constants(root.string());
+    CHECK(vc.bpm_min == 72.0f);
+    CHECK(vc.bpm_max == 240.0f);
+    CHECK(vc.offset_min == -0.1f);
+    CHECK(vc.offset_max == 2.5f);
+    CHECK(vc.lead_beats_min == 2);
+    CHECK(vc.lead_beats_max == 8);
+    CHECK(vc.min_shape_change_gap == 4);
+
+    std::filesystem::remove_all(root);
+}
+
+TEST_CASE("load_validation_constants: bad app_dir falls back to CWD path", "[validate][constants]") {
     // A nonsense app_dir that doesn't contain a constants.json; must not throw or crash.
     ValidationConstants vc = load_validation_constants("/nonexistent_dir_xyz/");
-    // Defaults must still be intact.
     CHECK(vc.bpm_min == 60.0f);
     CHECK(vc.bpm_max == 300.0f);
 }


### PR DESCRIPTION
## Summary
- Try the application-directory constants path before the CWD fallback in `load_validation_constants()`
- Log a warning when validation constants cannot be loaded and compiled defaults are used
- Add path precedence coverage for explicit app directories

Fixes #235

## Verification
- `VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./build.sh`
- `./build/shapeshifter_tests`