### PR TITLE
Fix rejected music stream cleanup

### DIFF
--- a/app/audio/music_context.h
+++ b/app/audio/music_context.h
@@ -11,3 +11,18 @@ struct MusicContext {
     bool  paused  = false; // PauseMusicStream called; consumed by one-shot resume
     float volume  = 0.8f;  // master volume [0.0, 1.0]
 };
+
+inline bool music_stream_is_valid(Music stream) {
+    return IsMusicValid(stream);
+}
+
+inline bool music_stream_may_own_resources(const Music& stream) {
+    return stream.ctxData != nullptr || stream.stream.buffer != nullptr;
+}
+
+inline void unload_music_stream_resources(Music& stream) {
+    if (music_stream_may_own_resources(stream)) {
+        UnloadMusicStream(stream);
+    }
+    stream = Music{};
+}

--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -362,8 +362,10 @@ void game_loop_shutdown(entt::registry& reg) {
         auto* music = reg.ctx().find<MusicContext>();
         if (music && music->loaded) {
             StopMusicStream(music->stream);
-            UnloadMusicStream(music->stream);
+            unload_music_stream_resources(music->stream);
             music->loaded = false;
+            music->started = false;
+            music->paused = false;
         }
     }
     camera::shutdown(reg);

--- a/app/session/play_session.cpp
+++ b/app/session/play_session.cpp
@@ -110,9 +110,10 @@ void setup_play_session(entt::registry& reg) {
     auto* music = reg.ctx().find<MusicContext>();
     if (music && music->loaded) {
         StopMusicStream(music->stream);
-        UnloadMusicStream(music->stream);
+        unload_music_stream_resources(music->stream);
         music->loaded = false;
         music->started = false;
+        music->paused = false;
     }
     if (music && !beatmap.song_path.empty()) {
         std::string exe_audio = std::string(GetApplicationDirectory()) + beatmap.song_path;
@@ -120,14 +121,16 @@ void setup_play_session(entt::registry& reg) {
         for (const char* path : audio_paths) {
             Music stream = LoadMusicStream(path);
             stream.looping = false;
-            if (stream.frameCount > 0) {
+            if (music_stream_is_valid(stream)) {
                 music->stream  = stream;
                 music->loaded  = true;
                 music->started = false;
+                music->paused = false;
                 SetMusicVolume(music->stream, music->volume);
                 TraceLog(LOG_INFO, "Loaded music: %s", path);
                 break;
             }
+            unload_music_stream_resources(stream);
         }
     }
 

--- a/tests/test_song_playback_system.cpp
+++ b/tests/test_song_playback_system.cpp
@@ -3,6 +3,23 @@
 #include "test_helpers.h"
 #include "audio/music_context.h"
 
+TEST_CASE("music stream helpers validate and identify unloadable rejected handles",
+          "[song_playback][music][issue651]") {
+    Music empty{};
+    CHECK_FALSE(music_stream_is_valid(empty));
+    CHECK_FALSE(music_stream_may_own_resources(empty));
+
+    Music partial_context{};
+    partial_context.ctxData = reinterpret_cast<void*>(0x1);
+    CHECK_FALSE(music_stream_is_valid(partial_context));
+    CHECK(music_stream_may_own_resources(partial_context));
+
+    Music partial_buffer{};
+    partial_buffer.stream.buffer = reinterpret_cast<rAudioBuffer*>(0x1);
+    CHECK_FALSE(music_stream_is_valid(partial_buffer));
+    CHECK(music_stream_may_own_resources(partial_buffer));
+}
+
 // ── song_playback_system: time advancement ───────────────────
 
 TEST_CASE("song_playback: song_time advances by dt", "[song_playback]") {


### PR DESCRIPTION
## Summary
- use raylib `IsMusicValid` before accepting loaded music streams
- unload rejected stream handles before trying fallback audio paths
- reset MusicContext playback flags when unloading an active stream

Closes #651

## Verification
- `VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./build.sh`
- `./build/shapeshifter_tests "[song_playback][music][issue651]"`
- `./build/shapeshifter_tests`