### PR TITLE
Clarify migration documentation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@
 
 A rhythm game where obstacles ARE the beats. Match shapes and dodge lane blocks in time with the music — the closer to the beat, the higher your score.
 
-Built with **C++20** and **EnTT** using Data-Oriented Design.
-Current architecture direction is direct **SDL2/SDL_mixer/SDL_ttf + glm**
-at runtime boundaries, without wrapper abstraction layers.
+Built with **C++20**, **raylib/raygui**, **EnTT**, and **glm** using
+Data-Oriented Design. The current runtime uses raylib directly for windowing,
+input, rendering, and audio at the platform boundary; older backend migration
+plans are historical only.
 
 **[Play in browser](https://yashasg.github.io/friendly-parakeet/)** (WebAssembly)
 
@@ -171,6 +172,14 @@ The level designer uses song structure (intro/verse/chorus/bridge) to control de
 | [EnTT](https://github.com/skypjack/entt) | 3.16.0 | Entity Component System |
 | [nlohmann-json](https://github.com/nlohmann/json) | 3.12+ | Beatmap JSON parsing |
 | [Catch2](https://github.com/catchorg/Catch2) | 3.13+ | Testing framework |
+
+## Documentation Status
+
+- `design-docs/` contains the authoritative gameplay and ECS architecture docs.
+- `docs/ongoing_migration.md` records the current dependency-boundary status:
+  there is no active backend migration; raylib/raygui is the shipped runtime.
+- `docs/raylib-migration.md` and `docs/sokol-migration.md` are retained as
+  historical migration notes and should not be used as implementation plans.
 
 ## CI/CD
 

--- a/docs/ongoing_migration.md
+++ b/docs/ongoing_migration.md
@@ -1,17 +1,22 @@
-# Ongoing Migration Status
+# Runtime Dependency Status
 
-This file tracks the active dependency-boundary direction.
+This file tracks the active dependency-boundary direction and supersedes older
+backend migration notes.
 
 ## Decision
 
-1. Runtime/platform calls should use direct **SDL2 / SDL_mixer / SDL_ttf** and **glm**.
-2. ECS components and gameplay systems remain plain data + free functions.
-3. No compatibility wrapper layer should be introduced.
+1. The shipped runtime uses direct **raylib/raygui** APIs for windowing, input,
+   rendering, UI, and audio.
+2. **glm** is the math type dependency for transforms and geometry data.
+3. ECS components and gameplay systems remain plain data + free functions.
+4. No compatibility wrapper layer should be introduced.
 
 ## Repository implications
 
-- Previous raylib migration docs are historical only.
+- There is no active SDL, Sokol, or backend-wrapper migration plan.
+- `docs/raylib-migration.md` and `docs/sokol-migration.md` are historical only.
 - Runtime-only systems must stay separated from the headless ECS API surface.
-- Backend handle types must not leak into common ECS component headers.
+- Backend handles should stay at runtime/render/audio boundaries unless a
+  component is intentionally runtime-facing.
 
 If any code or docs conflict with this decision, treat this file as authoritative.

--- a/docs/raylib-migration.md
+++ b/docs/raylib-migration.md
@@ -1,12 +1,18 @@
-# Historical Note: superseded migration plan
+# Historical Note: completed/superseded migration plan
 
 This document is retained only as historical context.
 
 ## Current architecture direction (authoritative)
 
-- Use direct **SDL2 / SDL_mixer / SDL_ttf** and **glm** APIs at runtime boundaries.
-- Keep ECS data backend-neutral: components stay plain data with no rendering/audio backend handles.
-- Do **not** introduce wrapper abstraction layers (`Renderer`, `AudioEngine`, `InputHandler`, `core_types`, `runtime_compat`, etc.).
+- The shipped runtime uses direct **raylib/raygui** APIs at windowing, input,
+  rendering, UI, and audio boundaries.
+- **glm** is used for math data and transforms.
+- ECS gameplay code remains data-oriented: components are plain data and
+  systems are free functions.
+- Do **not** introduce wrapper abstraction layers (`Renderer`, `AudioEngine`,
+  `InputHandler`, `core_types`, `runtime_compat`, etc.).
 
-The old SDL2→raylib plan in this file is no longer the active direction.
-When migration work is planned, use this decision as the source of truth.
+The old SDL2 -> raylib plan in this file is no longer an active migration plan;
+the repository has already moved to raylib/raygui. For current dependency
+status, use `docs/ongoing_migration.md` and the build files as the source of
+truth.

--- a/docs/sokol-migration.md
+++ b/docs/sokol-migration.md
@@ -1,5 +1,10 @@
 # SDL2 → Sokol Migration Plan
 
+> **Historical only.** This plan is not active. The shipped runtime currently
+> uses direct raylib/raygui APIs with glm, and `docs/ongoing_migration.md`
+> records the authoritative dependency-boundary status. Do not use this file as
+> implementation guidance unless a new issue explicitly reactivates Sokol work.
+
 ## Overview
 
 Migrate the rendering, windowing, input, timing, and audio platform layer from


### PR DESCRIPTION
## Summary
- Update README to name the current raylib/raygui + EnTT + glm stack.
- Mark raylib and Sokol migration docs as historical.
- Make docs/ongoing_migration.md the authoritative runtime dependency status page.

## Root cause
README and migration notes still described older SDL/Sokol migration directions even though CMake and app code use raylib/raygui directly.

## Verification
- Audited CMake/vcpkg dependencies and app includes for the current runtime stack.
- Ran `git diff --check` for the documentation patch.

Fixes #81