### PR TITLE
docs: clarify migration documentation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 A rhythm game where obstacles ARE the beats. Match shapes and dodge lane blocks in time with the music — the closer to the beat, the higher your score.
 
 Built with **C++20** and **EnTT** using Data-Oriented Design.
-Current architecture direction is direct **SDL2/SDL_mixer/SDL_ttf + glm**
+Current architecture direction is direct **raylib/raygui + glm**
 at runtime boundaries, without wrapper abstraction layers.
 
 **[Play in browser](https://yashasg.github.io/friendly-parakeet/)** (WebAssembly)
@@ -78,6 +78,9 @@ See `ios/README.md` for blocker checklist and full command modes.
 ## Architecture
 
 **Data-Oriented Design** with EnTT ECS — components are plain structs, systems are free functions.
+
+Migration-related docs are indexed in [`docs/ongoing_migration.md`](docs/ongoing_migration.md);
+it identifies historical migration plans and the current authoritative runtime direction.
 
 ### System Pipeline (per frame)
 
@@ -166,8 +169,8 @@ The level designer uses song structure (intro/verse/chorus/bridge) to control de
 
 | Library | Version | Purpose |
 |---------|---------|---------|
-| SDL2 / SDL_mixer / SDL_ttf | planned migration target | Runtime input, rendering, text, audio |
-| glm | planned migration target | Math data and transforms |
+| raylib / raygui | vcpkg | Runtime input, rendering, text, audio, immediate-mode UI |
+| glm | vcpkg | Math data and transforms |
 | [EnTT](https://github.com/skypjack/entt) | 3.16.0 | Entity Component System |
 | [nlohmann-json](https://github.com/nlohmann/json) | 3.12+ | Beatmap JSON parsing |
 | [Catch2](https://github.com/catchorg/Catch2) | 3.13+ | Testing framework |

--- a/docs/ongoing_migration.md
+++ b/docs/ongoing_migration.md
@@ -1,16 +1,21 @@
-# Ongoing Migration Status
+# Migration Documentation Status
 
-This file tracks the active dependency-boundary direction.
+This file is the authoritative index for migration-related documentation.
 
-## Decision
+## Current architecture direction
 
-1. Runtime/platform calls should use direct **SDL2 / SDL_mixer / SDL_ttf** and **glm**.
+1. Runtime/platform calls use direct **raylib / raygui** and **glm**.
 2. ECS components and gameplay systems remain plain data + free functions.
 3. No compatibility wrapper layer should be introduced.
 
+## Historical migration docs
+
+- `docs/raylib-migration.md` is historical. The migration to raylib/raygui is complete; keep it only as context for why wrapper layers were rejected.
+- `docs/sokol-migration.md` is historical. It describes an abandoned SDL2 to Sokol plan and is not implementation guidance.
+
 ## Repository implications
 
-- Previous raylib migration docs are historical only.
+- New runtime work should extend the existing raylib/raygui path unless a new architecture decision supersedes this file.
 - Runtime-only systems must stay separated from the headless ECS API surface.
 - Backend handle types must not leak into common ECS component headers.
 

--- a/docs/raylib-migration.md
+++ b/docs/raylib-migration.md
@@ -1,12 +1,12 @@
-# Historical Note: superseded migration plan
+# Historical Note: completed raylib migration
 
 This document is retained only as historical context.
 
 ## Current architecture direction (authoritative)
 
-- Use direct **SDL2 / SDL_mixer / SDL_ttf** and **glm** APIs at runtime boundaries.
+- Use direct **raylib / raygui** and **glm** APIs at runtime boundaries.
 - Keep ECS data backend-neutral: components stay plain data with no rendering/audio backend handles.
 - Do **not** introduce wrapper abstraction layers (`Renderer`, `AudioEngine`, `InputHandler`, `core_types`, `runtime_compat`, etc.).
 
-The old SDL2→raylib plan in this file is no longer the active direction.
-When migration work is planned, use this decision as the source of truth.
+The old SDL2 to raylib migration is complete; do not use this file as an active task list.
+For current status, use `docs/ongoing_migration.md` as the source of truth.

--- a/docs/sokol-migration.md
+++ b/docs/sokol-migration.md
@@ -1,4 +1,9 @@
-# SDL2 → Sokol Migration Plan
+# Historical Note: abandoned SDL2 to Sokol migration plan
+
+This document is retained only as historical context. It is not an active
+implementation plan. The current runtime direction is direct **raylib / raygui**
+and **glm**, with no wrapper abstraction layer; see `docs/ongoing_migration.md`
+for the authoritative migration-document status.
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- mark migration docs status as authoritative in docs/ongoing_migration.md
- mark completed/abandoned migration plans as historical
- link the authoritative migration-doc index from README and update runtime dependency wording

Fixes #81

## Validation
- cmake -B build -S . -Wno-dev
- cmake --build build
- ./build/shapeshifter_tests