### PR TITLE
docs: clarify Hexagon rest-state role

### DIFF
--- a/content/ui/screens/gameplay.rgl
+++ b/content/ui/screens/gameplay.rgl
@@ -8,6 +8,7 @@
 # approach_ring data is OUT OF SCOPE per user directive and should not be
 # carried forward. Energy bar placement is data-driven. DummyRec controls
 # serve as layout slots for custom-rendered elements.
+# Hexagon is the automatic rest silhouette only; do not add a Hexagon button.
 #
 # Ref. window:    r <x> <y> <width> <height>
 # Anchor info:    a <id> <name> <posx> <posy> <enabled>

--- a/design-docs/game.md
+++ b/design-docs/game.md
@@ -22,7 +22,7 @@ Rhythm runner where the player shifts between 3 geometric shapes to pass through
 
 ---
 
-## Player Shapes (3 active + Hexagon default)
+## Player Shapes (3 playable + Hexagon rest)
 
 | Shape    | Symbol | Passes Through       |
 |----------|--------|----------------------|
@@ -31,7 +31,7 @@ Rhythm runner where the player shifts between 3 geometric shapes to pass through
 | Triangle | ▲      | Triangle holes/gates |
 | Hexagon  | ⬡      | None (default/rest)  |
 
-The player is always one of these shapes. Hexagon is the default resting shape — the player returns to it between obstacles. Hexagon does not pass through any gates; any gate arriving while in Hexagon = MISS. Tap a shape button to switch instantly.
+The player is always one of these shapes, but only Circle, Square, and Triangle are playable inputs. Hexagon is the automatic rest/default state between shape windows: the player returns to it after MorphOut and cannot choose it from the HUD or keyboard. Hexagon does not pass through any gates; any gate arriving while in Hexagon = MISS. Tap a playable shape button to switch instantly.
 
 ---
 
@@ -52,7 +52,7 @@ The screen is divided into two zones:
   - `[ ■ ]` Square
   - `[ ▲ ]` Triangle
 
-  The currently active shape button is highlighted/glowing. Tapping a button immediately shifts the player to that shape.
+  The currently active playable shape button is highlighted/glowing. There is no Hexagon button: Hexagon is a visible rest silhouette only, restored automatically by the shape-window system.
 
 - **Keyboard fallback** mirrors lane layout for shipped beatmaps: `Z`/`1` selects the left-lane shape, `X`/`2` selects center, and `C`/`3` selects right.
 
@@ -206,7 +206,9 @@ Difficulty is selected per song (easy / medium / hard) and is expressed primaril
   at y=1120). Currently selected button is highlighted, and each is
   wrapped by a **proximity ring** that shrinks toward the button as
   the matching obstacle approaches, providing the live timing cue
-  (see `rhythm-spec.md` §6 / `rhythm-design.md` §4).
+  (see `rhythm-spec.md` §6 / `rhythm-design.md` §4). The HUD must
+  not expose a fourth Hexagon control; rest-state feedback comes from
+  the player silhouette returning to Hexagon after MorphOut.
 
 > Any future redesign that wants to relocate the energy bar to the
 > top of the HUD must land as an explicit change to

--- a/design-docs/rhythm-design.md
+++ b/design-docs/rhythm-design.md
@@ -388,6 +388,14 @@ The player can hear the beat coming. The timing is legible. What the player cann
   ╚═════════════════════════════════════════════════════════════╝
 ```
 
+## Decision
+
+Hexagon remains in the game as an automatic rest state, not a fourth playable
+shape. Players perform notes with Circle, Square, or Triangle; the shape-window
+system restores Hexagon after MorphOut so the player is visually "released"
+between notes. The UI therefore exposes exactly three shape inputs and no
+Hexagon button/key.
+
 ## Hexagon Design Principles
 
 ```
@@ -400,6 +408,11 @@ The player can hear the beat coming. The timing is legible. What the player cann
 
   3.  No scoring  — Hexagon state contributes nothing to score.
       Every moment as Hexagon is an opportunity to be ready.
+
+  4.  Content must respect release  — authored shape changes must
+      leave enough beat spacing for MorphOut/rest readability.
+      If a sequence makes auto-return feel like a surprise penalty,
+      adjust the beatmap spacing rather than adding a Hexagon input.
 ```
 
 ---

--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -578,6 +578,12 @@ The default (OK) timing = the full active window. Better timing shrinks the rema
   in the same window from re-applying the scale factor.
 ```
 
+Auto-return to Hexagon is intentional and should not be balanced as a
+punishment. It is the release/readiness beat between playable notes; authored
+shape changes must preserve enough spacing for the return to read clearly. If a
+chart makes the auto-return feel punitive, fix the chart spacing or timing
+window before adding any player-facing Hexagon input.
+
 ## `shape_window_system` guard condition
 
 ```cpp


### PR DESCRIPTION
## Summary
- decide Hexagon remains an automatic rest/default state, not a fourth playable shape
- document that gameplay UI exposes only Circle, Square, and Triangle inputs
- add authoring guidance that punitive-feeling auto-return should be fixed through chart spacing/timing, not a Hexagon input

## Root cause
Hexagon was referenced as default/rest in some places, but the GDD and HUD guidance did not explicitly say whether it is playable, why no Hexagon control exists, or how to handle auto-return if it feels punitive.

## Verification
- git diff --check
- VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./build.sh
- ./build/shapeshifter_tests

Fixes #79