### PR TITLE
Update squad promote checkout action

### DIFF
--- a/.github/workflows/squad-promote.yml
+++ b/.github/workflows/squad-promote.yml
@@ -18,7 +18,7 @@ jobs:
     name: Promote dev → preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
     needs: dev-to-preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- update both squad-promote.yml checkout steps from actions/checkout@v4 to @v6
- removes the remaining Node 16 checkout runtime usage in the promote workflow

Fixes #197.

## Verification
- `! grep -n 'actions/checkout@v4' .github/workflows/squad-promote.yml`\n- `grep -n 'actions/checkout@v6' .github/workflows/squad-promote.yml`