### PR TITLE
Normalize beatmap editor onset layers

### DIFF
--- a/tools/beatmap-editor/js/constants.js
+++ b/tools/beatmap-editor/js/constants.js
@@ -98,6 +98,27 @@ export const DEFAULT_LEVELS = Object.freeze([
     }),
 ]);
 
+export const PUBLIC_ONSET_LAYERS = Object.freeze(["percussive", "harmonic", "full-spectrum"]);
+
+export const LEGACY_ONSET_LAYER_ALIASES = Object.freeze({
+    percussive_bass: "percussive",
+    percussive_broadband: "percussive",
+    percussive_high_mid: "percussive",
+    harmonic_low_mid: "harmonic",
+    full_spectrum: "full-spectrum",
+    full_spectrum_flux: "full-spectrum",
+    kick: "percussive",
+    snare: "percussive",
+    hihat: "percussive",
+    melody: "harmonic",
+    flux: "full-spectrum",
+});
+
+export function normalizeOnsetLayerName(name) {
+    if (PUBLIC_ONSET_LAYERS.includes(name)) return name;
+    return LEGACY_ONSET_LAYER_ALIASES[name] || null;
+}
+
 // Obstacle kinds available in the editor UI (authoring surfaces only)
 export const EDITOR_OBSTACLE_KINDS = Object.freeze(["shape_gate", "split_path"]);
 

--- a/tools/beatmap-editor/js/io.js
+++ b/tools/beatmap-editor/js/io.js
@@ -2,6 +2,7 @@
 
 import {
     SHAPES, LANES, KINDS_WITH_SHAPE, DIFFICULTY_KEYS, VALIDATION,
+    normalizeOnsetLayerName, PUBLIC_ONSET_LAYERS,
 } from './constants.js';
 
 const LOADER_KINDS = Object.freeze([
@@ -380,6 +381,38 @@ function normalizeBlockedArray(blocked, path, errors) {
     return normalized;
 }
 
+function normalizeAnalysisOnsets(rawOnsets) {
+    const normalized = {};
+    const warnings = [];
+    if (!rawOnsets || typeof rawOnsets !== 'object' || Array.isArray(rawOnsets)) {
+        return { onsets: normalized, warnings };
+    }
+
+    for (const [rawName, value] of Object.entries(rawOnsets)) {
+        const publicName = normalizeOnsetLayerName(rawName);
+        if (!publicName) {
+            warnings.push(`Analysis onset layer '${rawName}' was dropped; supported layers are ${PUBLIC_ONSET_LAYERS.join(', ')}`);
+            continue;
+        }
+        if (!value || typeof value !== 'object') {
+            warnings.push(`Analysis onset layer '${rawName}' was dropped because it is not an object`);
+            continue;
+        }
+
+        const timestamps = Array.isArray(value.timestamps)
+            ? value.timestamps.filter(Number.isFinite)
+            : [];
+        if (!normalized[publicName]) normalized[publicName] = { timestamps: [] };
+        normalized[publicName].timestamps.push(...timestamps);
+
+        if (publicName !== rawName) {
+            warnings.push(`Analysis onset layer '${rawName}' was normalized to '${publicName}'`);
+        }
+    }
+
+    return { onsets: normalized, warnings };
+}
+
 /**
  * Parse an analysis JSON string and return a normalized object.
  * @param {string} jsonString
@@ -393,6 +426,8 @@ export function importAnalysis(jsonString) {
         return null;
     }
 
+    const { onsets, warnings } = normalizeAnalysisOnsets(j.onsets);
+
     return {
         title: j.title ?? '',
         source: j.source ?? '',
@@ -400,7 +435,8 @@ export function importAnalysis(jsonString) {
         duration: j.duration ?? 0,
         beats: Array.isArray(j.beats) ? j.beats : [],
         structure: Array.isArray(j.structure) ? j.structure : [],
-        onsets: (j.onsets && typeof j.onsets === 'object' && !Array.isArray(j.onsets)) ? j.onsets : {},
+        onsets,
+        warnings,
         events: Array.isArray(j.events) ? j.events : [],
         quietRegions: Array.isArray(j.quiet_regions) ? j.quiet_regions : [],
     };

--- a/tools/beatmap-editor/js/panels.js
+++ b/tools/beatmap-editor/js/panels.js
@@ -272,6 +272,7 @@ async function loadBundledLevel(level, { recordUndo }) {
                 const analysisResponse = await fetch(getContentUrl(level.analysisPath));
                 if (analysisResponse.ok) {
                     state.analysisData = importAnalysis(await analysisResponse.text());
+                    showAnalysisWarnings(state.analysisData);
                 }
             } catch (analysisError) {
                 console.warn('Failed to auto-load bundled analysis:', analysisError);
@@ -547,6 +548,7 @@ async function handleImportAnalysis() {
         const result = importAnalysis(text);
         if (result) {
             state.analysisData = result;
+            showAnalysisWarnings(result);
             emit('analysis-loaded');
         }
     } catch (e) {
@@ -600,6 +602,15 @@ function showValidationErrors(errors) {
     }
 
     els.validationPanel.classList.toggle('has-errors', errors.length > 0);
+}
+
+function showAnalysisWarnings(analysisData) {
+    if (!analysisData?.warnings?.length) return;
+    showValidationErrors(analysisData.warnings.map(message => ({
+        message,
+        severity: 'warning',
+        beatIndex: -1,
+    })));
 }
 
 // ── Drag and Drop ───────────────────────────────────

--- a/tools/beatmap-editor/js/timeline.js
+++ b/tools/beatmap-editor/js/timeline.js
@@ -9,6 +9,7 @@ import {
     WAVEFORM_HEIGHT,
     TIMELINE_PADDING_LEFT,
     LANE_LABELS,
+    normalizeOnsetLayerName,
 } from './constants.js';
 
 let canvas = null;
@@ -157,7 +158,7 @@ export function render(state, waveformData, validationErrors) {
         renderWaveform(ctx, state, waveformData, w);
     }
 
-    // 4b. Analysis onset rows (kick/snare/hihat/etc)
+    // 4b. Analysis onset rows (public rhythm layers)
     renderOnsetTracks(ctx, state, w, h);
 
     // 5. Beat grid lines
@@ -222,12 +223,14 @@ function renderAnalysisOverlay(ctx, state, w) {
     }
 }
 
-function getOnsetRows(analysisData) {
+export function getOnsetRows(analysisData) {
     const onsetMap = analysisData?.onsets;
     if (!onsetMap || typeof onsetMap !== 'object') return [];
 
-    // Preserve source order from analysis JSON; do not impose class ordering here.
+    // The import path normalizes analysis data; this guard prevents ad-hoc state
+    // from rendering raw detector names as editor-visible rhythm layers.
     return Object.entries(onsetMap)
+        .filter(([name]) => normalizeOnsetLayerName(name) === name)
         .filter(([, value]) => value && typeof value === 'object')
         .map(([name, value]) => ({
         name,

--- a/tools/beatmap-editor/test/io-hardening.test.js
+++ b/tools/beatmap-editor/test/io-hardening.test.js
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { importAnalysis, importBeatmap, exportBeatmap, validate } from '../js/io.js';
-import { entryRenderX, entryToX, timeToX } from '../js/timeline.js';
+import { entryRenderX, entryToX, getOnsetRows, timeToX } from '../js/timeline.js';
 import {
   DEFAULT_LEVELS,
   EDITOR_OBSTACLE_KINDS,
@@ -264,18 +264,43 @@ test('timeline render positions separate same-time lane stacks', () => {
   assert.equal(entryRenderX(beats, 1, state), entryToX(beats[1], state) + 5);
 });
 
-test('analysis import preserves onset object keys in source order', () => {
+test('analysis import normalizes onsets to public rhythm layers', () => {
   const analysis = importAnalysis(JSON.stringify({
     title: 'Demo',
     onsets: {
-      clap: { timestamps: [0.5] },
+      percussive: { timestamps: [0.25] },
       kick: { timestamps: [1.0] },
       snare: { timestamps: [1.5] },
+      hihat: { timestamps: [2.0] },
+      melody: { timestamps: [2.5] },
+      flux: { timestamps: [3.0] },
+      clap: { timestamps: [3.5] },
     },
   }));
 
   assert.ok(analysis);
-  assert.deepEqual(Object.keys(analysis.onsets), ['clap', 'kick', 'snare']);
+  assert.deepEqual(Object.keys(analysis.onsets), ['percussive', 'harmonic', 'full-spectrum']);
+  assert.deepEqual(analysis.onsets.percussive.timestamps, [0.25, 1.0, 1.5, 2.0]);
+  assert.deepEqual(analysis.onsets.harmonic.timestamps, [2.5]);
+  assert.deepEqual(analysis.onsets['full-spectrum'].timestamps, [3.0]);
+  assert.ok(analysis.warnings.some(w => w.includes("'kick'") && w.includes("'percussive'")));
+  assert.ok(analysis.warnings.some(w => w.includes("'melody'") && w.includes("'harmonic'")));
+  assert.ok(analysis.warnings.some(w => w.includes("'flux'") && w.includes("'full-spectrum'")));
+  assert.ok(analysis.warnings.some(w => w.includes("'clap'") && w.includes('dropped')));
+});
+
+test('timeline onset rows ignore raw or unknown detector keys', () => {
+  const rows = getOnsetRows({
+    onsets: {
+      percussive: { timestamps: [0.5] },
+      harmonic: { timestamps: [1.0] },
+      'full-spectrum': { timestamps: [1.5] },
+      kick: { timestamps: [2.0] },
+      unknown: { timestamps: [2.5] },
+    },
+  });
+
+  assert.deepEqual(rows.map(row => row.name), ['percussive', 'harmonic', 'full-spectrum']);
 });
 
 test('malformed JSON import is rejected with parse error', () => {


### PR DESCRIPTION
## Summary
- Closes #644
- normalize analysis import onsets to the public percussive/harmonic/full-spectrum layers
- map known legacy/raw detector keys to public layers and surface warnings for mapped or dropped keys
- guard timeline rendering so ad-hoc raw/unknown onset keys are not shown as rhythm rows

## Root cause
The editor imported `analysis.onsets` verbatim and the timeline rendered every key from that object, so raw detector names such as kick/snare/hihat/melody/flux or unknown keys became visible rhythm layers.

## Verification
- `cd tools/beatmap-editor && npm test -- --test-reporter=spec`
- `VCPKG_ROOT=/Users/yashasgujjar/vcpkg cmake -B build -S . -Wno-dev && cmake --build build && ./build/shapeshifter_tests`