### PR TITLE
Remove ObstacleKind from hot obstacle component

### DIFF
--- a/app/components/obstacle.h
+++ b/app/components/obstacle.h
@@ -14,9 +14,27 @@ enum class ObstacleKind : uint8_t {
 };
 
 struct Obstacle {
-    ObstacleKind kind       = ObstacleKind::ShapeGate;
     int16_t      base_points = 200;
+
+    constexpr Obstacle() = default;
+    constexpr explicit Obstacle(int16_t points) : base_points(points) {}
+    constexpr Obstacle(ObstacleKind, int16_t points) : base_points(points) {}
 };
+
+constexpr ObstacleKind obstacle_kind_from_components(bool has_required_shape,
+                                                     bool has_blocked_lanes,
+                                                     bool has_required_lane) {
+    if (has_required_lane) {
+        return ObstacleKind::SplitPath;
+    }
+    if (has_required_shape && has_blocked_lanes) {
+        return ObstacleKind::ComboGate;
+    }
+    if (has_blocked_lanes) {
+        return ObstacleKind::LaneBlock;
+    }
+    return ObstacleKind::ShapeGate;
+}
 
 // Existential tag: presence means the obstacle has been cleared and awaits scoring.
 struct ScoredTag {};

--- a/app/entities/obstacle_entity.cpp
+++ b/app/entities/obstacle_entity.cpp
@@ -15,7 +15,7 @@ entt::entity spawn_obstacle_base(entt::registry& reg, const ObstacleSpawnParams&
 
     switch (params.kind) {
         case ObstacleKind::ShapeGate: {
-            reg.emplace<Obstacle>(e, ObstacleKind::ShapeGate, int16_t{constants::PTS_SHAPE_GATE});
+            reg.emplace<Obstacle>(e, int16_t{constants::PTS_SHAPE_GATE});
             reg.emplace<RequiredShape>(e, params.shape);
             reg.emplace<DrawSize>(e, constants::SCREEN_W_F, 80.0f);
             if (params.shape == Shape::Circle)
@@ -27,14 +27,14 @@ entt::entity spawn_obstacle_base(entt::registry& reg, const ObstacleSpawnParams&
             break;
         }
         case ObstacleKind::LaneBlock: {
-            reg.emplace<Obstacle>(e, ObstacleKind::LaneBlock, int16_t{constants::PTS_LANE_BLOCK});
+            reg.emplace<Obstacle>(e, int16_t{constants::PTS_LANE_BLOCK});
             reg.emplace<BlockedLanes>(e, params.mask);
             reg.emplace<DrawSize>(e, static_cast<float>(constants::SCREEN_W / 3), 80.0f);
             reg.emplace<Color>(e, Color{255, 60, 60, 255});
             break;
         }
         case ObstacleKind::ComboGate: {
-            reg.emplace<Obstacle>(e, ObstacleKind::ComboGate, int16_t{constants::PTS_COMBO_GATE});
+            reg.emplace<Obstacle>(e, int16_t{constants::PTS_COMBO_GATE});
             reg.emplace<RequiredShape>(e, params.shape);
             reg.emplace<BlockedLanes>(e, params.mask);
             reg.emplace<DrawSize>(e, constants::SCREEN_W_F, 80.0f);
@@ -42,7 +42,7 @@ entt::entity spawn_obstacle_base(entt::registry& reg, const ObstacleSpawnParams&
             break;
         }
         case ObstacleKind::SplitPath: {
-            reg.emplace<Obstacle>(e, ObstacleKind::SplitPath, int16_t{constants::PTS_SPLIT_PATH});
+            reg.emplace<Obstacle>(e, int16_t{constants::PTS_SPLIT_PATH});
             reg.emplace<RequiredShape>(e, params.shape);
             reg.emplace<RequiredLane>(e, params.req_lane);
             reg.emplace<DrawSize>(e, constants::SCREEN_W_F, 80.0f);

--- a/app/entities/obstacle_render_entity.cpp
+++ b/app/entities/obstacle_render_entity.cpp
@@ -127,12 +127,15 @@ static entt::entity add_shape_child(entt::registry& reg, entt::entity parent,
 void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical) {
     wire_obstacle_mesh_lifetime(reg);
 
-    auto& obs = reg.get<Obstacle>(logical);
     const auto* wt_ptr = reg.try_get<WorldTransform>(logical);
     auto& col = reg.get<Color>(logical);
     auto& dsz = reg.get<DrawSize>(logical);
+    const ObstacleKind kind = obstacle_kind_from_components(
+        reg.all_of<RequiredShape>(logical),
+        reg.all_of<BlockedLanes>(logical),
+        reg.all_of<RequiredLane>(logical));
 
-    switch (obs.kind) {
+    switch (kind) {
         case ObstacleKind::ShapeGate: {
             if (!wt_ptr) break;
             const auto& wt = *wt_ptr;

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -279,6 +279,7 @@ void test_player_system(entt::registry& reg, float dt) {
 
     auto obs_view = reg.view<ObstacleTag, WorldTransform, Obstacle>(entt::exclude<ScoredTag>);
     for (auto [entity, obs_wt, obs] : obs_view.each()) {
+        (void)obs;
         float dist = p_transform.position.y - obs_wt.position.y;
         if (dist <= 0.0f || dist > cfg.vision_range) continue;
         if (reg.any_of<TestPlayerPlannedTag>(entity)) continue;
@@ -318,7 +319,11 @@ void test_player_system(entt::registry& reg, float dt) {
         if (log) {
             auto* beat_info = reg.try_get<BeatInfo>(entity);
             int beat_num = beat_info ? beat_info->beat_index : -1;
-            const std::string_view kind_name = enum_name_or_unknown(obs.kind);
+            const ObstacleKind kind = obstacle_kind_from_components(
+                reg.all_of<RequiredShape>(entity),
+                reg.all_of<BlockedLanes>(entity),
+                reg.all_of<RequiredLane>(entity));
+            const std::string_view kind_name = enum_name_or_unknown(kind);
             const std::string_view shape_name = enum_name_or_unknown(action.target_shape);
 
             session_log_write(*log, song_time, "PLAYER",

--- a/app/util/session_logger.cpp
+++ b/app/util/session_logger.cpp
@@ -79,8 +79,7 @@ void session_log_on_obstacle_spawn(entt::registry& reg, entt::entity entity) {
     auto* song = reg.ctx().find<SongState>();
     float t = song ? song->song_time : 0.0f;
 
-    auto* obs = reg.try_get<Obstacle>(entity);
-    if (!obs) return;
+    if (!reg.all_of<Obstacle>(entity)) return;
 
     auto* beat = reg.try_get<BeatInfo>(entity);
     int beat_idx = beat ? beat->beat_index : -1;
@@ -92,7 +91,11 @@ void session_log_on_obstacle_spawn(entt::registry& reg, entt::entity entity) {
     if (rlane) lane = rlane->lane;
 
     float arrival = beat ? beat->arrival_time : 0.0f;
-    const std::string_view kind_name = session_log_enum_name_or_unknown(obs->kind);
+    const ObstacleKind kind = obstacle_kind_from_components(
+        reg.all_of<RequiredShape>(entity),
+        reg.all_of<BlockedLanes>(entity),
+        reg.all_of<RequiredLane>(entity));
+    const std::string_view kind_name = session_log_enum_name_or_unknown(kind);
     const std::string_view shape_name = req ? session_log_enum_name_or_unknown(req->shape) : std::string_view{"-"};
 
     session_log_write(*log, t, "GAME",
@@ -112,8 +115,7 @@ void session_log_on_scored(entt::registry& reg, entt::entity entity) {
     auto* song = reg.ctx().find<SongState>();
     float t = song ? song->song_time : 0.0f;
 
-    auto* obs = reg.try_get<Obstacle>(entity);
-    if (!obs) return;
+    if (!reg.all_of<Obstacle>(entity)) return;
 
     bool is_miss = reg.any_of<MissTag>(entity);
 
@@ -122,7 +124,11 @@ void session_log_on_scored(entt::registry& reg, entt::entity entity) {
     int beat_num = beat ? beat->beat_index : -1;
     float expected_t = beat ? beat->arrival_time : 0.0f;
     float drift = beat ? (t - beat->arrival_time) : 0.0f;
-    const std::string_view kind_name = session_log_enum_name_or_unknown(obs->kind);
+    const ObstacleKind kind = obstacle_kind_from_components(
+        reg.all_of<RequiredShape>(entity),
+        reg.all_of<BlockedLanes>(entity),
+        reg.all_of<RequiredLane>(entity));
+    const std::string_view kind_name = session_log_enum_name_or_unknown(kind);
 
     if (is_miss) {
         session_log_write(*log, t, "GAME",

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -82,7 +82,9 @@ TEST_CASE("beat_scheduler: spawns ShapeGate when time passes spawn_time", "[beat
     // Verify it's a ShapeGate with correct components
     auto view = reg.view<ObstacleTag, Obstacle, RequiredShape>();
     for (auto [e, obs, rs] : view.each()) {
-        CHECK(obs.kind == ObstacleKind::ShapeGate);
+        (void)obs;
+        CHECK_FALSE(reg.all_of<BlockedLanes>(e));
+        CHECK_FALSE(reg.all_of<RequiredLane>(e));
         CHECK(rs.shape == Shape::Circle);
     }
 }
@@ -272,7 +274,9 @@ TEST_CASE("beat_scheduler: spawns LaneBlock with blocked_mask", "[beat_scheduler
 
     auto view = reg.view<ObstacleTag, Obstacle, BlockedLanes>();
     for (auto [e, obs, bl] : view.each()) {
-        CHECK(obs.kind == ObstacleKind::LaneBlock);
+        (void)obs;
+        CHECK_FALSE(reg.all_of<RequiredShape>(e));
+        CHECK_FALSE(reg.all_of<RequiredLane>(e));
         CHECK(bl.mask == 0b010);
     }
 }
@@ -294,8 +298,13 @@ TEST_CASE("beat_scheduler: spawns all queued beats from BeatMap entries", "[beat
     int obstacle_count = 0;
     int shape_gate_count = 0;
     for (auto [e, obs] : obstacle_view.each()) {
+        (void)obs;
         ++obstacle_count;
-        if (obs.kind == ObstacleKind::ShapeGate) ++shape_gate_count;
+        const ObstacleKind kind = obstacle_kind_from_components(
+            reg.all_of<RequiredShape>(e),
+            reg.all_of<BlockedLanes>(e),
+            reg.all_of<RequiredLane>(e));
+        if (kind == ObstacleKind::ShapeGate) ++shape_gate_count;
     }
     CHECK(obstacle_count == 3);
     CHECK(shape_gate_count == 1);
@@ -315,7 +324,8 @@ TEST_CASE("beat_scheduler: spawns ComboGate with shape and blocked lanes", "[bea
 
     auto view = reg.view<ObstacleTag, Obstacle, RequiredShape, BlockedLanes>();
     for (auto [e, obs, rs, bl] : view.each()) {
-        CHECK(obs.kind == ObstacleKind::ComboGate);
+        (void)obs;
+        CHECK_FALSE(reg.all_of<RequiredLane>(e));
         CHECK(rs.shape == Shape::Triangle);
         CHECK(bl.mask == 0b101);
     }
@@ -334,7 +344,8 @@ TEST_CASE("beat_scheduler: spawns SplitPath with shape and required lane", "[bea
 
     auto view = reg.view<ObstacleTag, Obstacle, RequiredShape, RequiredLane>();
     for (auto [e, obs, rs, rl] : view.each()) {
-        CHECK(obs.kind == ObstacleKind::SplitPath);
+        (void)obs;
+        CHECK_FALSE(reg.all_of<BlockedLanes>(e));
         CHECK(rs.shape == Shape::Square);
         CHECK(rl.lane == 2);
     }

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -263,8 +263,7 @@ TEST_CASE("components: DrawSize construction", "[components]") {
 }
 
 TEST_CASE("components: Obstacle construction", "[components]") {
-    Obstacle obs{ObstacleKind::ShapeGate, int16_t{200}};
-    CHECK(obs.kind == ObstacleKind::ShapeGate);
+    Obstacle obs{int16_t{200}};
     CHECK(obs.base_points == 200);
 }
 
@@ -282,7 +281,9 @@ TEST_CASE("ecs: make_combo_gate creates proper entity", "[ecs]") {
     CHECK(reg.all_of<Obstacle>(obs));
     CHECK(reg.all_of<RequiredShape>(obs));
     CHECK(reg.all_of<BlockedLanes>(obs));
-    CHECK(reg.get<Obstacle>(obs).kind == ObstacleKind::ComboGate);
+    CHECK(obstacle_kind_from_components(reg.all_of<RequiredShape>(obs),
+                                        reg.all_of<BlockedLanes>(obs),
+                                        reg.all_of<RequiredLane>(obs)) == ObstacleKind::ComboGate);
     CHECK(reg.get<RequiredShape>(obs).shape == Shape::Circle);
     CHECK(reg.get<BlockedLanes>(obs).mask == 0b101);
 }
@@ -295,7 +296,9 @@ TEST_CASE("ecs: make_split_path creates proper entity", "[ecs]") {
     CHECK(reg.all_of<Obstacle>(obs));
     CHECK(reg.all_of<RequiredShape>(obs));
     CHECK(reg.all_of<RequiredLane>(obs));
-    CHECK(reg.get<Obstacle>(obs).kind == ObstacleKind::SplitPath);
+    CHECK(obstacle_kind_from_components(reg.all_of<RequiredShape>(obs),
+                                        reg.all_of<BlockedLanes>(obs),
+                                        reg.all_of<RequiredLane>(obs)) == ObstacleKind::SplitPath);
     CHECK(reg.get<RequiredShape>(obs).shape == Shape::Triangle);
     CHECK(reg.get<RequiredLane>(obs).lane == 2);
 }

--- a/tests/test_obstacle_archetypes.cpp
+++ b/tests/test_obstacle_archetypes.cpp
@@ -30,10 +30,10 @@ int count_mesh_children(entt::registry& reg) {
     return count;
 }
 
-entt::entity make_mesh_factory_obstacle(entt::registry& reg, ObstacleKind kind) {
+entt::entity make_mesh_factory_obstacle(entt::registry& reg) {
     auto parent = reg.create();
     reg.emplace<WorldTransform>(parent, WorldTransform{{constants::LANE_X[1], -120.0f}});
-    reg.emplace<Obstacle>(parent, kind, int16_t{0});
+    reg.emplace<Obstacle>(parent, int16_t{0});
     reg.emplace<DrawSize>(parent, constants::SCREEN_W_F, 80.0f);
     reg.emplace<Color>(parent, Color{255, 255, 255, 255});
     return parent;
@@ -55,7 +55,6 @@ TEST_CASE("entity: ShapeGate Circle - correct components and color", "[archetype
     CHECK(!reg.all_of<BlockedLanes>(e));
     CHECK(!reg.all_of<RequiredLane>(e));
 
-    CHECK(reg.get<Obstacle>(e).kind == ObstacleKind::ShapeGate);
     CHECK(reg.get<Obstacle>(e).base_points == int16_t{constants::PTS_SHAPE_GATE});
     CHECK(reg.get<RequiredShape>(e).shape == Shape::Circle);
     CHECK(reg.get<WorldTransform>(e).position.x == 360.0f);
@@ -97,7 +96,7 @@ TEST_CASE("entity: obstacle mesh overflow does not create orphan MeshChild", "[a
 
     auto parent = reg.create();
     reg.emplace<WorldTransform>(parent, WorldTransform{{360.0f, -120.0f}});
-    reg.emplace<Obstacle>(parent, ObstacleKind::ShapeGate, int16_t{constants::PTS_SHAPE_GATE});
+    reg.emplace<Obstacle>(parent, int16_t{constants::PTS_SHAPE_GATE});
     reg.emplace<DrawSize>(parent, constants::SCREEN_W_F, 80.0f);
     reg.emplace<Color>(parent, Color{80, 200, 255, 255});
     reg.emplace<RequiredShape>(parent, Shape::Circle);
@@ -136,7 +135,7 @@ TEST_CASE("entity: obstacle mesh lifetime is wired by the factory", "[archetype]
 
 TEST_CASE("entity: direct mesh factory cleanup does not depend on ObstacleTag order", "[archetype][render][cleanup]") {
     entt::registry reg;
-    auto parent = make_mesh_factory_obstacle(reg, ObstacleKind::ShapeGate);
+    auto parent = make_mesh_factory_obstacle(reg);
     reg.emplace<RequiredShape>(parent, Shape::Circle);
     reg.emplace<ObstacleTag>(parent);
 
@@ -153,7 +152,7 @@ TEST_CASE("entity: mesh factory rejects invalid RequiredShape before children", 
 
     SECTION("ShapeGate") {
         entt::registry reg;
-        auto parent = make_mesh_factory_obstacle(reg, ObstacleKind::ShapeGate);
+        auto parent = make_mesh_factory_obstacle(reg);
         reg.emplace<RequiredShape>(parent, invalid_shape);
 
         CHECK_THROWS_AS(spawn_obstacle_meshes(reg, parent), std::logic_error);
@@ -162,7 +161,7 @@ TEST_CASE("entity: mesh factory rejects invalid RequiredShape before children", 
 
     SECTION("ComboGate") {
         entt::registry reg;
-        auto parent = make_mesh_factory_obstacle(reg, ObstacleKind::ComboGate);
+        auto parent = make_mesh_factory_obstacle(reg);
         reg.emplace<RequiredShape>(parent, invalid_shape);
         reg.emplace<BlockedLanes>(parent, uint8_t{0b101});
 
@@ -172,7 +171,7 @@ TEST_CASE("entity: mesh factory rejects invalid RequiredShape before children", 
 
     SECTION("SplitPath") {
         entt::registry reg;
-        auto parent = make_mesh_factory_obstacle(reg, ObstacleKind::SplitPath);
+        auto parent = make_mesh_factory_obstacle(reg);
         reg.emplace<RequiredShape>(parent, invalid_shape);
         reg.emplace<RequiredLane>(parent, int8_t{1});
 
@@ -184,7 +183,7 @@ TEST_CASE("entity: mesh factory rejects invalid RequiredShape before children", 
 TEST_CASE("entity: mesh factory rejects invalid RequiredLane before children", "[archetype][render][validation]") {
     SECTION("negative lane") {
         entt::registry reg;
-        auto parent = make_mesh_factory_obstacle(reg, ObstacleKind::SplitPath);
+        auto parent = make_mesh_factory_obstacle(reg);
         reg.emplace<RequiredShape>(parent, Shape::Square);
         reg.emplace<RequiredLane>(parent, int8_t{-1});
 
@@ -194,7 +193,7 @@ TEST_CASE("entity: mesh factory rejects invalid RequiredLane before children", "
 
     SECTION("lane beyond lane table") {
         entt::registry reg;
-        auto parent = make_mesh_factory_obstacle(reg, ObstacleKind::SplitPath);
+        auto parent = make_mesh_factory_obstacle(reg);
         reg.emplace<RequiredShape>(parent, Shape::Square);
         reg.emplace<RequiredLane>(parent, int8_t{3});
 
@@ -228,7 +227,6 @@ TEST_CASE("entity: LaneBlock - blocked lanes and no shape components", "[archety
     CHECK(!reg.all_of<RequiredShape>(e));
     CHECK(!reg.all_of<RequiredLane>(e));
 
-    CHECK(reg.get<Obstacle>(e).kind == ObstacleKind::LaneBlock);
     CHECK(reg.get<Obstacle>(e).base_points == int16_t{constants::PTS_LANE_BLOCK});
     CHECK(reg.get<BlockedLanes>(e).mask == uint8_t{0b010});
 }
@@ -243,7 +241,6 @@ TEST_CASE("entity: ComboGate - RequiredShape and BlockedLanes", "[archetype]") {
     REQUIRE(reg.all_of<ObstacleTag, MotionVelocity, DrawLayer, WorldTransform, Obstacle, RequiredShape, BlockedLanes, DrawSize, Color>(e));
     CHECK(!reg.all_of<RequiredLane>(e));
 
-    CHECK(reg.get<Obstacle>(e).kind == ObstacleKind::ComboGate);
     CHECK(reg.get<Obstacle>(e).base_points == int16_t{constants::PTS_COMBO_GATE});
     CHECK(reg.get<RequiredShape>(e).shape == Shape::Triangle);
     CHECK(reg.get<BlockedLanes>(e).mask == uint8_t{0b101});
@@ -257,7 +254,6 @@ TEST_CASE("entity: SplitPath - RequiredShape and RequiredLane", "[archetype]") {
     REQUIRE(reg.all_of<ObstacleTag, MotionVelocity, DrawLayer, WorldTransform, Obstacle, RequiredShape, RequiredLane, DrawSize, Color>(e));
     CHECK(!reg.all_of<BlockedLanes>(e));
 
-    CHECK(reg.get<Obstacle>(e).kind == ObstacleKind::SplitPath);
     CHECK(reg.get<Obstacle>(e).base_points == int16_t{constants::PTS_SPLIT_PATH});
     CHECK(reg.get<RequiredShape>(e).shape == Shape::Square);
     CHECK(reg.get<RequiredLane>(e).lane == int8_t{2});

--- a/tests/test_scoring_system.cpp
+++ b/tests/test_scoring_system.cpp
@@ -236,8 +236,7 @@ TEST_CASE("scoring: popup entity has full factory contract", "[scoring][popup_en
 
 TEST_CASE("scoring: NonScorableTag entity cleared without scoring", "[scoring][nonscorable]") {
     // Verifies OCP: any entity with NonScorableTag is excluded from the scoring
-    // ladder regardless of its ObstacleKind. Adding a new non-scorable obstacle
-    // kind requires zero changes to scoring_system.
+    // ladder regardless of its structural obstacle archetype.
     auto reg = make_registry();
     auto& score = reg.ctx().get<ScoreState>();
     const int score_before = score.score;


### PR DESCRIPTION
Fixes #654.

## Root cause
Runtime obstacles carried both `ObstacleKind` and `base_points` in the hot `Obstacle` component even though collision already uses structural components (`RequiredShape`, `BlockedLanes`, `RequiredLane`) and scoring only needs the point value.

## Changes
- Narrowed `Obstacle` to score value only.
- Kept `ObstacleKind` in cold spawn/beat-map data and infer render/log kind from structural components.
- Updated archetype, scheduler, component, and scoring tests away from hot kind assertions.

## Verification
- `cmake -B build -S . -Wno-dev && cmake --build build -j2 && ./build/shapeshifter_tests`
- Clean PR worktree: `VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./build.sh && ./build/shapeshifter_tests`