### PR TITLE
Fix editor onset imports and checkout action

### DIFF
--- a/.github/workflows/squad-promote.yml
+++ b/.github/workflows/squad-promote.yml
@@ -18,7 +18,7 @@ jobs:
     name: Promote dev → preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
     needs: dev-to-preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/tools/beatmap-editor/js/constants.js
+++ b/tools/beatmap-editor/js/constants.js
@@ -10,6 +10,7 @@ export let SHAPES = ["circle", "square", "triangle"];
 export let LANES = [0, 1, 2];
 export let KINDS_WITH_SHAPE = ["shape_gate", "combo_gate", "split_path"];
 export const DIFFICULTY_KEYS = Object.freeze(["easy", "medium", "hard"]);
+export const RHYTHM_LAYER_KEYS = Object.freeze(["percussive", "harmonic", "full-spectrum"]);
 export let VALIDATION = {
     BPM_MIN: 60,
     BPM_MAX: 300,

--- a/tools/beatmap-editor/js/io.js
+++ b/tools/beatmap-editor/js/io.js
@@ -1,7 +1,7 @@
 // io.js — Beatmap file I/O and validation (pure functions, no DOM except downloadFile)
 
 import {
-    SHAPES, LANES, KINDS_WITH_SHAPE, DIFFICULTY_KEYS, VALIDATION,
+    SHAPES, LANES, KINDS_WITH_SHAPE, DIFFICULTY_KEYS, RHYTHM_LAYER_KEYS, VALIDATION,
 } from './constants.js';
 
 const LOADER_KINDS = Object.freeze([
@@ -9,6 +9,14 @@ const LOADER_KINDS = Object.freeze([
     'combo_gate',
     'split_path',
 ]);
+
+const LEGACY_ONSET_LAYER_MAP = Object.freeze({
+    kick: 'percussive',
+    snare: 'percussive',
+    hihat: 'percussive',
+    melody: 'harmonic',
+    flux: 'full-spectrum',
+});
 
 function isPlainObject(value) {
     return value !== null && typeof value === 'object' && !Array.isArray(value);
@@ -28,6 +36,39 @@ function isAllowedShape(shape) {
 
 function isAllowedDifficultyKey(key) {
     return DIFFICULTY_KEYS.includes(key);
+}
+
+function normalizeOnsetLayers(onsets) {
+    const warnings = [];
+    const normalized = {};
+    if (!isPlainObject(onsets)) {
+        return { onsets: normalized, warnings };
+    }
+
+    for (const [sourceKey, value] of Object.entries(onsets)) {
+        const layerKey = RHYTHM_LAYER_KEYS.includes(sourceKey)
+            ? sourceKey
+            : LEGACY_ONSET_LAYER_MAP[sourceKey];
+        if (!layerKey) {
+            warnings.push(`Dropped unsupported onset layer '${sourceKey}'`);
+            continue;
+        }
+        if (!isPlainObject(value)) {
+            warnings.push(`Dropped onset layer '${sourceKey}' because it must be an object`);
+            continue;
+        }
+
+        const timestamps = Array.isArray(value.timestamps) ? value.timestamps : [];
+        const target = normalized[layerKey] ?? { timestamps: [] };
+        target.timestamps.push(...timestamps);
+        normalized[layerKey] = target;
+
+        if (layerKey !== sourceKey) {
+            warnings.push(`Mapped legacy onset layer '${sourceKey}' to '${layerKey}'`);
+        }
+    }
+
+    return { onsets: normalized, warnings };
 }
 
 /**
@@ -393,6 +434,8 @@ export function importAnalysis(jsonString) {
         return null;
     }
 
+    const normalizedOnsets = normalizeOnsetLayers(j.onsets);
+
     return {
         title: j.title ?? '',
         source: j.source ?? '',
@@ -400,9 +443,10 @@ export function importAnalysis(jsonString) {
         duration: j.duration ?? 0,
         beats: Array.isArray(j.beats) ? j.beats : [],
         structure: Array.isArray(j.structure) ? j.structure : [],
-        onsets: (j.onsets && typeof j.onsets === 'object' && !Array.isArray(j.onsets)) ? j.onsets : {},
+        onsets: normalizedOnsets.onsets,
         events: Array.isArray(j.events) ? j.events : [],
         quietRegions: Array.isArray(j.quiet_regions) ? j.quiet_regions : [],
+        warnings: normalizedOnsets.warnings,
     };
 }
 

--- a/tools/beatmap-editor/js/panels.js
+++ b/tools/beatmap-editor/js/panels.js
@@ -272,6 +272,7 @@ async function loadBundledLevel(level, { recordUndo }) {
                 const analysisResponse = await fetch(getContentUrl(level.analysisPath));
                 if (analysisResponse.ok) {
                     state.analysisData = importAnalysis(await analysisResponse.text());
+                    showAnalysisWarnings(state.analysisData);
                 }
             } catch (analysisError) {
                 console.warn('Failed to auto-load bundled analysis:', analysisError);
@@ -548,6 +549,7 @@ async function handleImportAnalysis() {
         if (result) {
             state.analysisData = result;
             emit('analysis-loaded');
+            showAnalysisWarnings(result);
         }
     } catch (e) {
         console.error('Failed to import analysis:', e);
@@ -600,6 +602,17 @@ function showValidationErrors(errors) {
     }
 
     els.validationPanel.classList.toggle('has-errors', errors.length > 0);
+}
+
+function showAnalysisWarnings(analysisData) {
+    const warnings = Array.isArray(analysisData?.warnings) ? analysisData.warnings : [];
+    if (warnings.length === 0) return;
+
+    showValidationErrors(warnings.map((message) => ({
+        message,
+        severity: 'warning',
+        beatIndex: -1,
+    })));
 }
 
 // ── Drag and Drop ───────────────────────────────────

--- a/tools/beatmap-editor/js/timeline.js
+++ b/tools/beatmap-editor/js/timeline.js
@@ -9,6 +9,7 @@ import {
     WAVEFORM_HEIGHT,
     TIMELINE_PADDING_LEFT,
     LANE_LABELS,
+    RHYTHM_LAYER_KEYS,
 } from './constants.js';
 
 let canvas = null;
@@ -157,7 +158,7 @@ export function render(state, waveformData, validationErrors) {
         renderWaveform(ctx, state, waveformData, w);
     }
 
-    // 4b. Analysis onset rows (kick/snare/hihat/etc)
+    // 4b. Analysis onset rows
     renderOnsetTracks(ctx, state, w, h);
 
     // 5. Beat grid lines
@@ -226,8 +227,9 @@ function getOnsetRows(analysisData) {
     const onsetMap = analysisData?.onsets;
     if (!onsetMap || typeof onsetMap !== 'object') return [];
 
-    // Preserve source order from analysis JSON; do not impose class ordering here.
-    return Object.entries(onsetMap)
+    return RHYTHM_LAYER_KEYS
+        .filter((name) => Object.prototype.hasOwnProperty.call(onsetMap, name))
+        .map((name) => [name, onsetMap[name]])
         .filter(([, value]) => value && typeof value === 'object')
         .map(([name, value]) => ({
         name,

--- a/tools/beatmap-editor/test/io-hardening.test.js
+++ b/tools/beatmap-editor/test/io-hardening.test.js
@@ -264,18 +264,42 @@ test('timeline render positions separate same-time lane stacks', () => {
   assert.equal(entryRenderX(beats, 1, state), entryToX(beats[1], state) + 5);
 });
 
-test('analysis import preserves onset object keys in source order', () => {
+test('analysis import normalizes public and legacy onset layers', () => {
   const analysis = importAnalysis(JSON.stringify({
     title: 'Demo',
     onsets: {
-      clap: { timestamps: [0.5] },
+      percussive: { timestamps: [0.25] },
       kick: { timestamps: [1.0] },
       snare: { timestamps: [1.5] },
+      hihat: { timestamps: [2.0] },
+      melody: { timestamps: [2.5] },
+      flux: { timestamps: [3.0] },
     },
   }));
 
   assert.ok(analysis);
-  assert.deepEqual(Object.keys(analysis.onsets), ['clap', 'kick', 'snare']);
+  assert.deepEqual(Object.keys(analysis.onsets), ['percussive', 'harmonic', 'full-spectrum']);
+  assert.deepEqual(analysis.onsets.percussive.timestamps, [0.25, 1.0, 1.5, 2.0]);
+  assert.deepEqual(analysis.onsets.harmonic.timestamps, [2.5]);
+  assert.deepEqual(analysis.onsets['full-spectrum'].timestamps, [3.0]);
+  assert.match(analysis.warnings.join('\n'), /Mapped legacy onset layer 'kick'/);
+});
+
+test('analysis import drops unsupported onset layers with warnings', () => {
+  const analysis = importAnalysis(JSON.stringify({
+    title: 'Demo',
+    onsets: {
+      clap: { timestamps: [0.5] },
+      unknown: { timestamps: [1.0] },
+      harmonic: { timestamps: [1.5] },
+    },
+  }));
+
+  assert.ok(analysis);
+  assert.deepEqual(Object.keys(analysis.onsets), ['harmonic']);
+  assert.deepEqual(analysis.onsets.harmonic.timestamps, [1.5]);
+  assert.match(analysis.warnings.join('\n'), /Dropped unsupported onset layer 'clap'/);
+  assert.match(analysis.warnings.join('\n'), /Dropped unsupported onset layer 'unknown'/);
 });
 
 test('malformed JSON import is rejected with parse error', () => {


### PR DESCRIPTION
## Summary
- Update `squad-promote.yml` to `actions/checkout@v6` in both jobs.
- Normalize beatmap editor analysis imports to the public rhythm layers: `percussive`, `harmonic`, and `full-spectrum`.
- Map legacy `kick`/`snare`/`hihat` to `percussive`, `melody` to `harmonic`, `flux` to `full-spectrum`, and drop unsupported onset keys with visible validation warnings.
- Restrict timeline onset rows to public rhythm layers and cover legacy/unknown onset keys in tests.

## Root cause
- `squad-promote.yml` lagged behind the rest of the workflows on `actions/checkout@v4`, which emits deprecated Node runtime warnings.
- `importAnalysis` accepted `j.onsets` verbatim and the timeline rendered arbitrary onset keys, exposing raw/unknown detection labels in the editor.

## Verification
- `cd tools/beatmap-editor && npm test`
- `VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./build.sh && ./build/shapeshifter_tests`

Fixes #197
Fixes #644