### PR TITLE
Fix zero-point scoring feedback

### DIFF
--- a/app/systems/popup_feedback_system.cpp
+++ b/app/systems/popup_feedback_system.cpp
@@ -17,7 +17,7 @@ void popup_feedback_system(entt::registry& reg, float /*dt*/) {
             ? std::make_optional(request.timing_tier)
             : std::nullopt;
         spawn_score_popup(reg, {request.x, request.y, request.points, timing_tier});
-        if (disp) disp->enqueue<PlaySfxEvent>({SFX::ScorePopup});
+        if (disp && request.points > 0) disp->enqueue<PlaySfxEvent>({SFX::ScorePopup});
     }
     queue.requests.clear();
 }

--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -164,15 +164,18 @@ void scoring_system(entt::registry& reg, float dt) {
                 std::floor(r.obs.base_points * timing_mult));
 
             // Chain bonus
-            score.chain_count++;
-            score.chain_timer = 0.0f;
-            if (score.chain_count >= 2 && score.chain_count <= 4) {
-                points += constants::CHAIN_BONUS[score.chain_count];
-            } else if (score.chain_count >= 5) {
-                points += constants::CHAIN_BONUS[4] + (score.chain_count - 4) * 100;
+            const bool contributes_to_chain = r.obs.base_points > 0;
+            if (contributes_to_chain) {
+                score.chain_count++;
+                score.chain_timer = 0.0f;
+                if (score.chain_count >= 2 && score.chain_count <= 4) {
+                    points += constants::CHAIN_BONUS[score.chain_count];
+                } else if (score.chain_count >= 5) {
+                    points += constants::CHAIN_BONUS[4] + (score.chain_count - 4) * 100;
+                }
             }
 
-            if (results && score.chain_count > results->max_chain) {
+            if (contributes_to_chain && results && score.chain_count > results->max_chain) {
                 results->max_chain = score.chain_count;
             }
 

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -603,10 +603,10 @@ the same frame (unidirectional data flow).
  │  │                           set transition → GAME_OVER.  │
  │  │                                                        │
  │  │ 11. scoring_system        Process scored obstacles.    │
- │  │                           Apply burnout multiplier.    │
- │  │                           Update chain. Spawn popup    │
- │  │                           entity. Add distance bonus.  │
- │  │                           Push SFX::BurnoutBank.       │
+ │  │                           Apply timing multiplier and  │
+ │  │                           chain bonus. Queue popup     │
+ │  │                           requests. Add distance bonus.│
+ │  │                           Positive popups emit SFX.    │
  │  └────────────────────────────────────────────────────────┘
  │
  │  ┌─ PHASE 5: CLEANUP & FX ──────────────────────────────┐
@@ -1131,14 +1131,13 @@ int main(int argc, char* argv[]) {
            │                ▼                                  │
            │     ┌───────────────────────────────────────────┐ │
            │     │ scoring_system:                            │ │
-           │     │   reads BurnoutState.zone at time of match│◀┘
-           │     │   multiplier = zone_to_mult(Danger) = 3.0 │
-           │     │   chain_bonus = chain_to_bonus(chain=3)   │
-           │     │              = +100                        │
-           │     │   total = 200 × 3.0 + 100 = 700           │
-           │     │   ScoreState.score += 700                  │
-           │     │   spawn ScorePopup(700, tier=3)            │
-           │     │   AudioQueue.push(BurnoutBank)             │
+           │     │   reads TimingGrade at time of match       │◀┘
+           │     │   timing_multiplier(Good) = 1.0            │
+           │     │   chain_bonus(chain=3) = +100              │
+           │     │   total = 200 × 1.0 + 100 = 300           │
+           │     │   ScoreState.score += 300                  │
+           │     │   queue ScorePopupRequest(300, Good)       │
+           │     │   popup_feedback emits ScorePopup SFX      │
            │     └───────────────────────────────────────────┘
            │
            ▼

--- a/tests/test_scoring_extended.cpp
+++ b/tests/test_scoring_extended.cpp
@@ -2,6 +2,30 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include "test_helpers.h"
 
+namespace {
+
+int score_shape_gate_with_tier(entt::registry& reg, TimingTier tier) {
+    auto& score = reg.ctx().get<ScoreState>();
+    const int before = score.score;
+    auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
+    reg.emplace<ScoredTag>(obs);
+    reg.emplace<TimingGrade>(obs, tier, 0.0f);
+
+    scoring_system(reg, 0.0f);
+    return score.score - before;
+}
+
+entt::entity make_zero_point_passive_obstacle(entt::registry& reg) {
+    auto obs = reg.create();
+    reg.emplace<ObstacleTag>(obs);
+    reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
+    reg.emplace<Obstacle>(obs, ObstacleKind::LaneBlock, int16_t{0});
+    reg.emplace<ScoredTag>(obs);
+    return obs;
+}
+
+}  // namespace
+
 // ── scoring_system: timing multiplier integration ────────────
 
 TEST_CASE("scoring: perfect timing multiplier gives 1.5x base", "[scoring][rhythm]") {
@@ -35,6 +59,28 @@ TEST_CASE("scoring: bad timing multiplier gives 0.25x base", "[scoring][rhythm]"
     CHECK(score.score < constants::PTS_SHAPE_GATE + 50);
 }
 
+TEST_CASE("scoring: timing multiplier applies end-to-end for good ok and bad", "[scoring][rhythm][issue221]") {
+    {
+        auto reg = make_registry();
+        CHECK(score_shape_gate_with_tier(reg, TimingTier::Good) == 200);
+    }
+    {
+        auto reg = make_registry();
+        CHECK(score_shape_gate_with_tier(reg, TimingTier::Ok) == 100);
+    }
+    {
+        auto reg = make_registry();
+        auto& energy = reg.ctx().get<EnergyState>();
+        energy.energy = 1.0f;
+
+        CHECK(score_shape_gate_with_tier(reg, TimingTier::Bad) == 50);
+        energy_system(reg, 0.0f);
+
+        CHECK_THAT(energy.energy,
+                   Catch::Matchers::WithinAbs(1.0f - constants::ENERGY_DRAIN_BAD, 0.0001f));
+    }
+}
+
 TEST_CASE("scoring: perfect timing and base points combine correctly", "[scoring][rhythm]") {
     auto reg = make_registry();
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
@@ -57,12 +103,41 @@ TEST_CASE("scoring: SongResults tracks max_chain", "[scoring]") {
         auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y + float(i));
         reg.emplace<ScoredTag>(obs);
         scoring_system(reg, 0.016f);
-    popup_feedback_system(reg, 0.016f);
-    energy_system(reg, 0.016f);
+        popup_feedback_system(reg, 0.016f);
+        energy_system(reg, 0.016f);
     }
 
     auto& results = reg.ctx().get<SongResults>();
     CHECK(results.max_chain == 4);
+}
+
+TEST_CASE("scoring: zero-point passive obstacles do not extend chain", "[scoring][issue225]") {
+    auto reg = make_registry();
+    auto& score = reg.ctx().get<ScoreState>();
+
+    CHECK(score_shape_gate_with_tier(reg, TimingTier::Good) == 200);
+    CHECK(score.chain_count == 1);
+
+    score.chain_timer = 1.0f;
+    for (int i = 0; i < 3; ++i) {
+        (void)make_zero_point_passive_obstacle(reg);
+        scoring_system(reg, 0.1f);
+    }
+
+    CHECK(score.chain_count == 1);
+    CHECK_THAT(score.chain_timer, Catch::Matchers::WithinAbs(1.3f, 0.0001f));
+    CHECK(score_shape_gate_with_tier(reg, TimingTier::Good) == 250);
+    CHECK(score.chain_count == 2);
+}
+
+TEST_CASE("scoring: zero-point score popups do not emit scoring sfx", "[scoring][issue215]") {
+    auto reg = make_registry();
+    (void)make_zero_point_passive_obstacle(reg);
+
+    scoring_system(reg, 0.0f);
+    popup_feedback_system(reg, 0.0f);
+
+    CHECK(drain_sfx_events(reg).count == 0);
 }
 
 TEST_CASE("scoring: TimingGrade removed from entity after scoring", "[scoring]") {


### PR DESCRIPTION
## Summary
- keep zero-point scored obstacles from advancing/resetting chains or max-chain stats
- suppress score-popup SFX when the popup awards 0 points
- add scoring_system integration coverage for Good, Ok, and Bad timing multipliers, including Bad energy drain
- refresh stale architecture scoring docs from burnout/BurnoutBank wording to current timing/popup flow

## Root cause
scoring_system treated every non-miss ScoredTag as chain-eligible regardless of awarded points, and popup_feedback_system emitted score SFX for every popup request regardless of point value. Timing multiplier integration coverage only checked Perfect end-to-end.

## Verification
- VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./build.sh
- ./build/shapeshifter_tests

Closes #221
Closes #215
Closes #225