### PR TITLE
Make runtime resource contexts RAII-owned

### DIFF
--- a/app/audio/audio_types.h
+++ b/app/audio/audio_types.h
@@ -29,4 +29,13 @@ struct SFXBank {
     Sound sounds[SFX_COUNT]       = {};
     bool  sound_loaded[SFX_COUNT] = {};
     bool  loaded                  = false;
+
+    SFXBank() = default;
+    SFXBank(const SFXBank&) = delete;
+    SFXBank& operator=(const SFXBank&) = delete;
+    SFXBank(SFXBank&& other) noexcept;
+    SFXBank& operator=(SFXBank&& other) noexcept;
+    ~SFXBank();
+
+    void release();
 };

--- a/app/audio/music_context.h
+++ b/app/audio/music_context.h
@@ -10,4 +10,55 @@ struct MusicContext {
     bool  started = false; // PlayMusicStream has been called
     bool  paused  = false; // PauseMusicStream called; consumed by one-shot resume
     float volume  = 0.8f;  // master volume [0.0, 1.0]
+
+    MusicContext() = default;
+    MusicContext(const MusicContext&) = delete;
+    MusicContext& operator=(const MusicContext&) = delete;
+    MusicContext(MusicContext&& other) noexcept;
+    MusicContext& operator=(MusicContext&& other) noexcept;
+    ~MusicContext();
+
+    void release();
 };
+
+inline void MusicContext::release() {
+    if (loaded && IsMusicValid(stream)) {
+        StopMusicStream(stream);
+        UnloadMusicStream(stream);
+    }
+    stream = {};
+    loaded = false;
+    started = false;
+    paused = false;
+}
+
+inline MusicContext::~MusicContext() { release(); }
+
+inline MusicContext::MusicContext(MusicContext&& other) noexcept
+    : stream{other.stream},
+      loaded{other.loaded},
+      started{other.started},
+      paused{other.paused},
+      volume{other.volume}
+{
+    other.stream = {};
+    other.loaded = false;
+    other.started = false;
+    other.paused = false;
+}
+
+inline MusicContext& MusicContext::operator=(MusicContext&& other) noexcept {
+    if (this != &other) {
+        release();
+        stream = other.stream;
+        loaded = other.loaded;
+        started = other.started;
+        paused = other.paused;
+        volume = other.volume;
+        other.stream = {};
+        other.loaded = false;
+        other.started = false;
+        other.paused = false;
+    }
+    return *this;
+}

--- a/app/audio/sfx_bank.cpp
+++ b/app/audio/sfx_bank.cpp
@@ -133,11 +133,45 @@ void sfx_bank_unload(entt::registry& reg) {
     auto* bank = reg.ctx().find<SFXBank>();
     if (!bank) return;
 
+    bank->release();
+}
+
+void SFXBank::release() {
     for (int idx = 0; idx < SFX_COUNT; ++idx) {
-        if (bank->sound_loaded[idx] && IsSoundValid(bank->sounds[idx])) {
-            UnloadSound(bank->sounds[idx]);
-            bank->sound_loaded[idx] = false;
+        if (sound_loaded[idx] && IsSoundValid(sounds[idx])) {
+            UnloadSound(sounds[idx]);
         }
+        sounds[idx] = {};
+        sound_loaded[idx] = false;
     }
-    bank->loaded = false;
+    loaded = false;
+}
+
+SFXBank::~SFXBank() { release(); }
+
+SFXBank::SFXBank(SFXBank&& other) noexcept
+    : loaded{other.loaded}
+{
+    for (int idx = 0; idx < SFX_COUNT; ++idx) {
+        sounds[idx] = other.sounds[idx];
+        sound_loaded[idx] = other.sound_loaded[idx];
+        other.sounds[idx] = {};
+        other.sound_loaded[idx] = false;
+    }
+    other.loaded = false;
+}
+
+SFXBank& SFXBank::operator=(SFXBank&& other) noexcept {
+    if (this != &other) {
+        release();
+        for (int idx = 0; idx < SFX_COUNT; ++idx) {
+            sounds[idx] = other.sounds[idx];
+            sound_loaded[idx] = other.sound_loaded[idx];
+            other.sounds[idx] = {};
+            other.sound_loaded[idx] = false;
+        }
+        loaded = other.loaded;
+        other.loaded = false;
+    }
+    return *this;
 }

--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -99,13 +99,7 @@ bool load_default_text_fonts(TextContext& ctx) {
 }
 
 void unload_text_fonts(TextContext& ctx) {
-    if (ctx.font_large.baseSize > 0)  UnloadFont(ctx.font_large);
-    if (ctx.font_medium.baseSize > 0) UnloadFont(ctx.font_medium);
-    if (ctx.font_small.baseSize > 0)  UnloadFont(ctx.font_small);
-    ctx.font_large = {};
-    ctx.font_medium = {};
-    ctx.font_small = {};
-    ctx.loaded = false;
+    ctx.release();
 }
 
 void log_persistence_result(const char* operation, const persistence::Result& result) {
@@ -360,10 +354,8 @@ void game_loop_shutdown(entt::registry& reg) {
     }
     {
         auto* music = reg.ctx().find<MusicContext>();
-        if (music && music->loaded) {
-            StopMusicStream(music->stream);
-            UnloadMusicStream(music->stream);
-            music->loaded = false;
+        if (music) {
+            music->release();
         }
     }
     camera::shutdown(reg);

--- a/app/rendering/text_resources.h
+++ b/app/rendering/text_resources.h
@@ -9,4 +9,58 @@ struct TextContext {
     Font font_medium{};
     Font font_large{};
     bool loaded = false;
+
+    TextContext() = default;
+    TextContext(const TextContext&) = delete;
+    TextContext& operator=(const TextContext&) = delete;
+    TextContext(TextContext&& other) noexcept;
+    TextContext& operator=(TextContext&& other) noexcept;
+    ~TextContext();
+
+    void release();
 };
+
+inline void TextContext::release() {
+    if (IsFontValid(font_large)) {
+        UnloadFont(font_large);
+    }
+    if (IsFontValid(font_medium)) {
+        UnloadFont(font_medium);
+    }
+    if (IsFontValid(font_small)) {
+        UnloadFont(font_small);
+    }
+    font_large = {};
+    font_medium = {};
+    font_small = {};
+    loaded = false;
+}
+
+inline TextContext::~TextContext() { release(); }
+
+inline TextContext::TextContext(TextContext&& other) noexcept
+    : font_small{other.font_small},
+      font_medium{other.font_medium},
+      font_large{other.font_large},
+      loaded{other.loaded}
+{
+    other.font_small = {};
+    other.font_medium = {};
+    other.font_large = {};
+    other.loaded = false;
+}
+
+inline TextContext& TextContext::operator=(TextContext&& other) noexcept {
+    if (this != &other) {
+        release();
+        font_small = other.font_small;
+        font_medium = other.font_medium;
+        font_large = other.font_large;
+        loaded = other.loaded;
+        other.font_small = {};
+        other.font_medium = {};
+        other.font_large = {};
+        other.loaded = false;
+    }
+    return *this;
+}

--- a/app/session/play_session.cpp
+++ b/app/session/play_session.cpp
@@ -108,11 +108,8 @@ void setup_play_session(entt::registry& reg) {
 
     // Load music (only if MusicContext exists — not in test mode)
     auto* music = reg.ctx().find<MusicContext>();
-    if (music && music->loaded) {
-        StopMusicStream(music->stream);
-        UnloadMusicStream(music->stream);
-        music->loaded = false;
-        music->started = false;
+    if (music) {
+        music->release();
     }
     if (music && !beatmap.song_path.empty()) {
         std::string exe_audio = std::string(GetApplicationDirectory()) + beatmap.song_path;

--- a/app/util/session_logger.cpp
+++ b/app/util/session_logger.cpp
@@ -9,6 +9,7 @@
 #include <cstdarg>
 #include <cmath>
 #include <string_view>
+#include <utility>
 
 #include <magic_enum/magic_enum.hpp>
 #include <raylib.h>
@@ -25,8 +26,45 @@ std::string_view session_log_enum_name_or_unknown(E value) {
 
 // ── Core log function ────────────────────────────────────────
 
+SessionLog::SessionLog(SessionLog&& other) noexcept
+    : file{other.file},
+      frame{other.frame},
+      buffer{std::move(other.buffer)},
+      last_logged_beat{other.last_logged_beat}
+{
+    other.file = nullptr;
+    if (buffer.capacity() < kMaxLogBufferBytes) {
+        buffer.reserve(kMaxLogBufferBytes);
+    }
+}
+
+SessionLog& SessionLog::operator=(SessionLog&& other) noexcept {
+    if (this != &other) {
+        release();
+        file = other.file;
+        frame = other.frame;
+        buffer = std::move(other.buffer);
+        last_logged_beat = other.last_logged_beat;
+        other.file = nullptr;
+        if (buffer.capacity() < kMaxLogBufferBytes) {
+            buffer.reserve(kMaxLogBufferBytes);
+        }
+    }
+    return *this;
+}
+
+SessionLog::~SessionLog() { release(); }
+
+void SessionLog::release() {
+    session_log_flush(*this);
+    if (file) {
+        std::fclose(file);
+        file = nullptr;
+    }
+}
+
 void session_log_open(SessionLog& log, const char* path) {
-    if (log.file) std::fclose(log.file);
+    log.release();
     log.file = std::fopen(path, "w");
     if (log.file) {
         std::fprintf(log.file, "══════ Test Session started runtime=%.3fs ══════\n\n", GetTime());
@@ -36,11 +74,7 @@ void session_log_open(SessionLog& log, const char* path) {
 }
 
 void session_log_close(SessionLog& log) {
-    session_log_flush(log);  // flush any remaining buffered lines
-    if (log.file) {
-        std::fclose(log.file);
-        log.file = nullptr;
-    }
+    log.release();
 }
 
 void session_log_write(SessionLog& log, float song_time,

--- a/app/util/session_logger.h
+++ b/app/util/session_logger.h
@@ -17,6 +17,13 @@ struct SessionLog {
     int         last_logged_beat = -1;  // beat_log_system tracks last emitted beat
 
     SessionLog() { buffer.reserve(kMaxLogBufferBytes); }
+    SessionLog(const SessionLog&) = delete;
+    SessionLog& operator=(const SessionLog&) = delete;
+    SessionLog(SessionLog&& other) noexcept;
+    SessionLog& operator=(SessionLog&& other) noexcept;
+    ~SessionLog();
+
+    void release();
 };
 
 // ── Free functions ───────────────────────────────────────────

--- a/tests/test_gpu_resource_lifecycle.cpp
+++ b/tests/test_gpu_resource_lifecycle.cpp
@@ -10,10 +10,16 @@
 // game_loop_init -> game_loop_shutdown integration run.
 
 #include <catch2/catch_test_macros.hpp>
+#include <cstdio>
+#include <entt/entt.hpp>
 #include <type_traits>
 
+#include "audio/audio_types.h"
+#include "audio/music_context.h"
 #include "rendering/camera_resources.h"
 #include "entities/camera_entity.h"  // GameCamera, UICamera
+#include "rendering/text_resources.h"
+#include "util/session_logger.h"
 
 // ── ShapeMeshes type traits ──────────────────────────────────────────────────
 
@@ -44,6 +50,60 @@ static_assert(std::is_move_constructible_v<RenderTargets>,
 
 static_assert(std::is_move_assignable_v<RenderTargets>,
     "RenderTargets must be move-assignable.");
+
+// ── Runtime context type traits ───────────────────────────────────────────────
+
+static_assert(!std::is_copy_constructible_v<TextContext>,
+    "TextContext must not be copy-constructible: copying Font handles would "
+    "cause double-unload on destruction.");
+
+static_assert(!std::is_copy_assignable_v<TextContext>,
+    "TextContext must not be copy-assignable.");
+
+static_assert(std::is_move_constructible_v<TextContext>,
+    "TextContext must be move-constructible for registry ctx emplace.");
+
+static_assert(std::is_move_assignable_v<TextContext>,
+    "TextContext must be move-assignable.");
+
+static_assert(!std::is_copy_constructible_v<SFXBank>,
+    "SFXBank must not be copy-constructible: copying Sound handles would "
+    "cause double-unload on destruction.");
+
+static_assert(!std::is_copy_assignable_v<SFXBank>,
+    "SFXBank must not be copy-assignable.");
+
+static_assert(std::is_move_constructible_v<SFXBank>,
+    "SFXBank must be move-constructible for registry ctx emplace.");
+
+static_assert(std::is_move_assignable_v<SFXBank>,
+    "SFXBank must be move-assignable.");
+
+static_assert(!std::is_copy_constructible_v<MusicContext>,
+    "MusicContext must not be copy-constructible: copying Music handles would "
+    "cause double-unload on destruction.");
+
+static_assert(!std::is_copy_assignable_v<MusicContext>,
+    "MusicContext must not be copy-assignable.");
+
+static_assert(std::is_move_constructible_v<MusicContext>,
+    "MusicContext must be move-constructible for registry ctx emplace.");
+
+static_assert(std::is_move_assignable_v<MusicContext>,
+    "MusicContext must be move-assignable.");
+
+static_assert(!std::is_copy_constructible_v<SessionLog>,
+    "SessionLog must not be copy-constructible: copying FILE* would "
+    "cause double-close on destruction.");
+
+static_assert(!std::is_copy_assignable_v<SessionLog>,
+    "SessionLog must not be copy-assignable.");
+
+static_assert(std::is_move_constructible_v<SessionLog>,
+    "SessionLog must be move-constructible for registry ctx emplace.");
+
+static_assert(std::is_move_assignable_v<SessionLog>,
+    "SessionLog must be move-assignable.");
 
 // ── Default state: owned = false, so destructor is a no-op ──────────────────
 
@@ -91,4 +151,70 @@ TEST_CASE("RenderTargets: release is idempotent when not owned", "[gpu_resource_
     rt.release();
     rt.release();
     SUCCEED("double release on unowned RenderTargets does not crash");
+}
+
+TEST_CASE("runtime contexts: registry erase releases default resources safely",
+          "[resource_lifecycle][issue648]") {
+    entt::registry reg;
+
+    reg.ctx().emplace<TextContext>();
+    reg.ctx().emplace<SFXBank>();
+    reg.ctx().emplace<MusicContext>();
+    reg.ctx().emplace<SessionLog>();
+
+    reg.ctx().erase<TextContext>();
+    reg.ctx().erase<SFXBank>();
+    reg.ctx().erase<MusicContext>();
+    reg.ctx().erase<SessionLog>();
+
+    SUCCEED("default runtime contexts are RAII-safe under registry erase");
+}
+
+TEST_CASE("runtime contexts: explicit release is idempotent without live handles",
+          "[resource_lifecycle][issue648]") {
+    TextContext text;
+    SFXBank sfx;
+    MusicContext music;
+    SessionLog log;
+
+    text.loaded = true;
+    sfx.loaded = true;
+    music.loaded = true;
+    music.started = true;
+    music.paused = true;
+
+    text.release();
+    text.release();
+    sfx.release();
+    sfx.release();
+    music.release();
+    music.release();
+    log.release();
+    log.release();
+
+    CHECK_FALSE(text.loaded);
+    CHECK_FALSE(sfx.loaded);
+    CHECK_FALSE(music.loaded);
+    CHECK_FALSE(music.started);
+    CHECK_FALSE(music.paused);
+    CHECK(log.file == nullptr);
+}
+
+TEST_CASE("SessionLog: move transfers file ownership",
+          "[resource_lifecycle][session_log][issue648]") {
+    SessionLog first;
+#ifdef _WIN32
+    first.file = std::fopen("NUL", "w");
+#else
+    first.file = std::fopen("/dev/null", "w");
+#endif
+    REQUIRE(first.file != nullptr);
+    first.buffer.append("pending\n");
+
+    SessionLog second{std::move(first)};
+
+    CHECK(first.file == nullptr);
+    CHECK(second.file != nullptr);
+    second.release();
+    CHECK(second.file == nullptr);
 }


### PR DESCRIPTION
## Summary
- Make TextContext, SFXBank, MusicContext, and SessionLog move-only owners with idempotent release/close paths
- Route existing deterministic shutdown through release() so registry teardown is safe against leaks and double release
- Add lifecycle/type-trait regression coverage for issue #648

Fixes #648

## Verification
- VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./build.sh
- ./build/shapeshifter_tests "[resource_lifecycle][issue648]"
- ./build/shapeshifter_tests