### PR TITLE
Run test-player coverage on WASM

### DIFF
--- a/tests/test_test_player_system.cpp
+++ b/tests/test_test_player_system.cpp
@@ -3,8 +3,6 @@
 #include "components/test_player.h"
 #include "util/session_logger.h"
 
-#ifdef PLATFORM_DESKTOP
-
 static entt::registry make_test_player_registry(TestPlayerSkill skill = TestPlayerSkill::Pro) {
     entt::registry reg = make_rhythm_registry();
     auto& tp = reg.ctx().emplace<TestPlayerState>();
@@ -250,5 +248,3 @@ TEST_CASE("test_player: shape gate then lane block requiring opposite direction"
     tick_systems(reg, 800);
     CHECK(survived(reg));
 }
-
-#endif


### PR DESCRIPTION
## Summary
- Removes the `PLATFORM_DESKTOP` wrapper around `tests/test_test_player_system.cpp` so these pure ECS tests are compiled for `PLATFORM_WEB`/Emscripten too.
- Keeps the native behavior unchanged while preventing silent test-count drift in WASM CI.

Fixes #218

## Verification
- `VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./build.sh`
- `./build/shapeshifter_tests "[test_player]"`
- `./build/shapeshifter_tests`