### PR TITLE
Ensure test-player regressions run on WASM

### DIFF
--- a/.github/workflows/ci-wasm.yml
+++ b/.github/workflows/ci-wasm.yml
@@ -95,6 +95,12 @@ jobs:
         run: |
           node --version
           cd build-web
+          node ./shapeshifter_tests.js --list-tests "~[bench]" --verbosity quiet \
+            | sort -u > wasm-catch-tests.txt
+          echo "WASM Catch2 non-benchmark test count: $(wc -l < wasm-catch-tests.txt | tr -d ' ')"
+          grep -Fx "test_player: clears shape gate in same lane" wasm-catch-tests.txt
+          grep -Fx "session_logger: non-fatal MissTag logs result MISS (#111)" wasm-catch-tests.txt
+          grep -Fx "session_logger: fatal MissTag logs result MISS (#111)" wasm-catch-tests.txt
           ctest --verbose --output-on-failure
 
       - name: Setup Chrome

--- a/tests/test_test_player_system.cpp
+++ b/tests/test_test_player_system.cpp
@@ -3,7 +3,8 @@
 #include "components/test_player.h"
 #include "util/session_logger.h"
 
-#ifdef PLATFORM_DESKTOP
+#include <cstdio>
+#include <string>
 
 static entt::registry make_test_player_registry(TestPlayerSkill skill = TestPlayerSkill::Pro) {
     entt::registry reg = make_rhythm_registry();
@@ -54,6 +55,25 @@ static void tick_systems(entt::registry& reg, int frames, float dt = 1.0f / 60.0
 static bool survived(entt::registry& reg) {
     auto& gs = reg.ctx().get<GameState>();
     return gs.phase == GamePhase::Playing && !gs.transition_pending;
+}
+
+static entt::entity make_loggable_obstacle(entt::registry& reg) {
+    auto obs = reg.create();
+    reg.emplace<ObstacleTag>(obs);
+    reg.emplace<Obstacle>(obs, ObstacleKind::ShapeGate, int16_t{constants::PTS_SHAPE_GATE});
+    reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
+    reg.emplace<BeatInfo>(obs, 7, 2.0f, 0.0f);
+    return obs;
+}
+
+static std::string read_session_log(SessionLog& log) {
+    session_log_flush(log);
+    std::fflush(log.file);
+    std::fseek(log.file, 0, SEEK_SET);
+
+    char buffer[1024] = {};
+    const std::size_t bytes_read = std::fread(buffer, 1, sizeof(buffer) - 1, log.file);
+    return std::string(buffer, bytes_read);
 }
 
 // ── CORE: shape gate in same lane ────────────────────────────
@@ -251,4 +271,36 @@ TEST_CASE("test_player: shape gate then lane block requiring opposite direction"
     CHECK(survived(reg));
 }
 
-#endif
+TEST_CASE("session_logger: non-fatal MissTag logs result MISS (#111)",
+          "[session_logger][issue-111]") {
+    auto reg = make_rhythm_registry();
+    auto& log = reg.ctx().emplace<SessionLog>();
+    log.file = std::tmpfile();
+    REQUIRE(log.file != nullptr);
+
+    auto obs = make_loggable_obstacle(reg);
+    reg.emplace<MissTag>(obs);
+    session_log_on_scored(reg, obs);
+
+    const std::string contents = read_session_log(log);
+    CHECK(contents.find("result=MISS") != std::string::npos);
+    CHECK(contents.find("result=CLEAR") == std::string::npos);
+}
+
+TEST_CASE("session_logger: fatal MissTag logs result MISS (#111)",
+          "[session_logger][issue-111]") {
+    auto reg = make_rhythm_registry();
+    reg.ctx().get<GameState>().transition_pending = true;
+    reg.ctx().get<GameState>().next_phase = GamePhase::GameOver;
+    auto& log = reg.ctx().emplace<SessionLog>();
+    log.file = std::tmpfile();
+    REQUIRE(log.file != nullptr);
+
+    auto obs = make_loggable_obstacle(reg);
+    reg.emplace<MissTag>(obs);
+    session_log_on_scored(reg, obs);
+
+    const std::string contents = read_session_log(log);
+    CHECK(contents.find("result=MISS") != std::string::npos);
+    CHECK(contents.find("result=CLEAR") == std::string::npos);
+}


### PR DESCRIPTION
## Summary
- Fixes #218 by removing the file-level PLATFORM_DESKTOP guard from pure ECS test-player coverage so it is compiled for PLATFORM_WEB too.
- Adds explicit [session_logger][issue-111] non-fatal and fatal MissTag regression tests that assert session logs emit result=MISS, not result=CLEAR.
- Updates WASM CI to list Catch2 tests, print the non-benchmark test count, and fail if the formerly skipped test names are absent before running CTest.

## Verification
- `cmake -B build -S . -Wno-dev && cmake --build build && ./build/shapeshifter_tests "[test_player],[session_logger][issue-111]"`
- `./build/shapeshifter_tests`

Root cause: `tests/test_test_player_system.cpp` was entirely wrapped in `#ifdef PLATFORM_DESKTOP`, while Emscripten builds define `PLATFORM_WEB PLATFORM_HAS_KEYBOARD`, so Catch2 never registered those tests in the WASM test binary.

Fixes #218