### PR TITLE
Validate beatmaps before runtime use

### DIFF
--- a/app/session/play_session.cpp
+++ b/app/session/play_session.cpp
@@ -30,6 +30,45 @@ void spawn_session_player(entt::registry& reg) {
     create_player_entity(reg);
 }
 
+bool is_runtime_allowed_validation_error(const BeatMapError& error) {
+    return error.message == "Different-shape gates must be >= 3 beats apart";
+}
+
+bool load_runtime_beat_map(const char* path,
+                           BeatMap& out,
+                           std::vector<BeatMapError>& errors,
+                           const std::string& difficulty_key) {
+    BeatMap candidate;
+    if (!load_beat_map(path, candidate, errors, difficulty_key)) {
+        return false;
+    }
+
+    std::vector<BeatMapError> validation_errors;
+    if (validate_beat_map(candidate, validation_errors)) {
+        out = std::move(candidate);
+        return true;
+    }
+
+    bool only_allowed_errors = !validation_errors.empty();
+    for (const BeatMapError& error : validation_errors) {
+        if (!is_runtime_allowed_validation_error(error)) {
+            only_allowed_errors = false;
+        }
+        errors.push_back(error);
+    }
+
+    if (!only_allowed_errors) {
+        return false;
+    }
+
+    for (const BeatMapError& error : validation_errors) {
+        TraceLog(LOG_WARNING, "Beatmap validation warning at beat %d: %s",
+                 error.beat_index, error.message.c_str());
+    }
+    out = std::move(candidate);
+    return true;
+}
+
 template <typename T>
 T& assign_or_emplace_ctx(entt::registry& reg, T value = T{}) {
     if (auto* existing = reg.ctx().find<T>()) {
@@ -52,7 +91,7 @@ void setup_play_session(entt::registry& reg) {
 
     // Load beatmap from level selection.
     // BeatMap is a context singleton (cold asset). It is reset here via move
-    // assignment and populated by load_beat_map(). It remains immutable for
+    // assignment and populated by the validated runtime loader. It remains immutable for
     // the duration of the play session. On song unload (next setup_play_session
     // call) the beat array is replaced in-place via another move assignment.
     auto& lss = reg.ctx().get<LevelSelectState>();
@@ -62,21 +101,27 @@ void setup_play_session(entt::registry& reg) {
     const char* difficulty_key = content_config::DIFFICULTY_KEYS[lss.selected_difficulty];
 
     std::vector<BeatMapError> load_errors;
+    std::vector<BeatMapError> reported_load_errors;
     std::string exe_path = std::string(GetApplicationDirectory()) + beatmap_path;
     const char* paths[] = { exe_path.c_str(), beatmap_path };
 
     bool loaded = false;
     for (const char* path : paths) {
         load_errors.clear();
-        if (load_beat_map(path, beatmap, load_errors, difficulty_key)) {
+        if (load_runtime_beat_map(path, beatmap, load_errors, difficulty_key)) {
             TraceLog(LOG_INFO, "Loaded beatmap: %s (%zu beats, difficulty=%s)",
                      path, beatmap.beats.size(), beatmap.difficulty.c_str());
             loaded = true;
             break;
         }
+        reported_load_errors.insert(reported_load_errors.end(), load_errors.begin(), load_errors.end());
     }
     if (!loaded) {
         TraceLog(LOG_WARNING, "Failed to load beatmap: %s", beatmap_path);
+        for (const BeatMapError& error : reported_load_errors) {
+            TraceLog(LOG_WARNING, "Beatmap load error at beat %d: %s",
+                     error.beat_index, error.message.c_str());
+        }
     }
     runtime_system_scratch_init(reg);
     runtime_system_scratch_reserve(reg, beatmap.beats.size());

--- a/app/util/beat_map_loader.cpp
+++ b/app/util/beat_map_loader.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <algorithm>
 #include <optional>
+#include <utility>
 #include <raylib.h>
 
 using json = nlohmann::json;
@@ -317,6 +318,20 @@ bool load_beat_map(const std::string& json_path, BeatMap& out,
     return parse_beat_map(content, out, errors, difficulty);
 }
 
+bool load_and_validate_beat_map(const std::string& json_path, BeatMap& out,
+                                std::vector<BeatMapError>& errors,
+                                const std::string& difficulty) {
+    BeatMap candidate;
+    if (!load_beat_map(json_path, candidate, errors, difficulty)) {
+        return false;
+    }
+    if (!validate_beat_map(candidate, errors)) {
+        return false;
+    }
+    out = std::move(candidate);
+    return true;
+}
+
 bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors) {
     return validate_beat_map(map, errors, load_validation_constants());
 }
@@ -396,7 +411,11 @@ bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors,
             has_prev_resolved_time_for_beat = true;
         }
 
-        // Rule 2: no beat index beyond song duration
+        // Rule 2: beat index must be within the playable song range
+        if (entry.beat_index < 0) {
+            errors.push_back({entry.beat_index, "Beat index must be non-negative"});
+            valid = false;
+        }
         if (entry.beat_index > max_beat) {
             errors.push_back({entry.beat_index, "Beat index exceeds song duration"});
             valid = false;

--- a/app/util/beat_map_loader.h
+++ b/app/util/beat_map_loader.h
@@ -33,6 +33,12 @@ bool load_beat_map(const std::string& json_path, BeatMap& out,
                    std::vector<BeatMapError>& errors,
                    const std::string& difficulty = "medium");
 
+// Load and validate a beat map from a JSON file. Returns true only when both
+// parsing and validation succeed.
+bool load_and_validate_beat_map(const std::string& json_path, BeatMap& out,
+                                std::vector<BeatMapError>& errors,
+                                const std::string& difficulty = "medium");
+
 // Parse a beat map from a JSON string. Returns true on success.
 //
 bool parse_beat_map(const std::string& json_str, BeatMap& out,

--- a/tests/test_beat_map_validation.cpp
+++ b/tests/test_beat_map_validation.cpp
@@ -7,6 +7,26 @@
 #include "util/beat_map_loader.h"
 #include "util/rhythm_math.h"
 
+namespace {
+
+struct TempBeatMapFile {
+    explicit TempBeatMapFile(const char* name, const std::string& json)
+        : path(std::filesystem::temp_directory_path() / name) {
+        std::filesystem::remove(path);
+        std::ofstream out(path);
+        REQUIRE(out.good());
+        out << json;
+    }
+
+    ~TempBeatMapFile() {
+        std::filesystem::remove(path);
+    }
+
+    std::filesystem::path path;
+};
+
+}  // namespace
+
 // ── validate_beat_map: BPM rules ─────────────────────────────
 
 TEST_CASE("validate: valid BPM passes", "[validate]") {
@@ -137,6 +157,20 @@ TEST_CASE("validate: lead_beats above 8 fails", "[validate]") {
 }
 
 // ── validate_beat_map: beat ordering ─────────────────────────
+
+TEST_CASE("validate: negative beat index fails", "[validate][issue132]") {
+    BeatMap map;
+    map.bpm = 120.0f;
+    map.offset = 0.0f;
+    map.lead_beats = 4;
+    map.duration = 60.0f;
+    map.beats.push_back({-1, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+
+    std::vector<BeatMapError> errors;
+    CHECK_FALSE(validate_beat_map(map, errors));
+    REQUIRE_FALSE(errors.empty());
+    CHECK(errors[0].message.find("non-negative") != std::string::npos);
+}
 
 TEST_CASE("validate: empty beats list fails", "[validate]") {
     BeatMap map;
@@ -537,6 +571,68 @@ TEST_CASE("load_validation_constants: bad app_dir falls back to CWD path", "[val
     ValidationConstants vc = load_validation_constants("/nonexistent_dir_xyz/");
     CHECK(vc.bpm_min == 60.0f);
     CHECK(vc.bpm_max == 300.0f);
+}
+
+TEST_CASE("load_and_validate_beat_map rejects invalid BPM at load time", "[load][validate][issue128]") {
+    TempBeatMapFile file("shapeshifter_invalid_bpm_beatmap.json", R"({
+        "song_id": "invalid_bpm",
+        "bpm": 30,
+        "offset": 0.0,
+        "lead_beats": 4,
+        "duration_sec": 60.0,
+        "beats": [
+            { "beat": 0, "kind": "shape_gate", "shape": "circle", "lane": 1 }
+        ]
+    })");
+
+    BeatMap map;
+    std::vector<BeatMapError> errors;
+    CHECK_FALSE(load_and_validate_beat_map(file.path.string(), map, errors));
+    REQUIRE_FALSE(errors.empty());
+    CHECK(errors[0].message.find("BPM") != std::string::npos);
+    CHECK(map.beats.empty());
+}
+
+TEST_CASE("load_and_validate_beat_map rejects negative beat_index at load time",
+          "[load][validate][issue128]") {
+    TempBeatMapFile file("shapeshifter_negative_beat_beatmap.json", R"({
+        "song_id": "negative_beat",
+        "bpm": 120,
+        "offset": 0.0,
+        "lead_beats": 4,
+        "duration_sec": 60.0,
+        "beats": [
+            { "beat": -1, "kind": "shape_gate", "shape": "circle", "lane": 1 }
+        ]
+    })");
+
+    BeatMap map;
+    std::vector<BeatMapError> errors;
+    CHECK_FALSE(load_and_validate_beat_map(file.path.string(), map, errors));
+    REQUIRE_FALSE(errors.empty());
+    CHECK(errors[0].message.find("Beat index") != std::string::npos);
+    CHECK(map.beats.empty());
+}
+
+TEST_CASE("load_and_validate_beat_map accepts valid beatmaps at load time",
+          "[load][validate][issue128]") {
+    TempBeatMapFile file("shapeshifter_valid_beatmap.json", R"({
+        "song_id": "valid_load",
+        "bpm": 120,
+        "offset": 0.0,
+        "lead_beats": 4,
+        "duration_sec": 60.0,
+        "beats": [
+            { "beat": 0, "kind": "shape_gate", "shape": "circle", "lane": 1 }
+        ]
+    })");
+
+    BeatMap map;
+    std::vector<BeatMapError> errors;
+    REQUIRE(load_and_validate_beat_map(file.path.string(), map, errors));
+    CHECK(errors.empty());
+    REQUIRE(map.beats.size() == 1);
+    CHECK(map.song_id == "valid_load");
 }
 
 TEST_CASE("validate_beat_map explicit constants: custom BPM range is respected", "[validate][constants]") {


### PR DESCRIPTION
## Summary
- add strict load_and_validate_beat_map() for parse + validation callers
- validate runtime beatmap loads before play-session setup, surfacing validation errors while allowing only the known shipped shape-gap warning tracked separately
- reject negative beat indices in validation and cover load-time/runtime validation paths

Closes #128
Closes #132

## Verification
- VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./build.sh
- ./build/shapeshifter_tests "[load],[validate]"
- ./build/shapeshifter_tests