### PR TITLE
Fix protected onset required gate conflicts

### DIFF
--- a/app/components/obstacle.h
+++ b/app/components/obstacle.h
@@ -11,6 +11,7 @@ enum class ObstacleKind : uint8_t {
     LaneBlock,
     ComboGate,
     SplitPath,
+    OnsetMarker,
 };
 
 struct Obstacle {

--- a/app/entities/obstacle_entity.cpp
+++ b/app/entities/obstacle_entity.cpp
@@ -49,6 +49,13 @@ entt::entity spawn_obstacle_base(entt::registry& reg, const ObstacleSpawnParams&
             reg.emplace<Color>(e, Color{255, 215, 0, 255});
             break;
         }
+        case ObstacleKind::OnsetMarker: {
+            reg.emplace<Obstacle>(e, int16_t{0});
+            reg.emplace<NonScorableTag>(e);
+            reg.emplace<DrawSize>(e, constants::SCREEN_W_F, 80.0f);
+            reg.emplace<Color>(e, Color{255, 255, 255, 80});
+            break;
+        }
     }
 
     return e;

--- a/app/systems/beat_scheduler_system.cpp
+++ b/app/systems/beat_scheduler_system.cpp
@@ -25,6 +25,10 @@ void beat_scheduler_system(entt::registry& reg, float /*dt*/) {
 
     while (song->next_spawn_idx < map->beats.size()) {
         const auto& entry = map->beats[song->next_spawn_idx];
+        if (entry.kind == ObstacleKind::OnsetMarker) {
+            song->next_spawn_idx++;
+            continue;
+        }
 
         float beat_time = song->offset + entry.beat_index * song->beat_period;
         if (!entry.has_time_sec &&

--- a/app/systems/miss_detection_system.cpp
+++ b/app/systems/miss_detection_system.cpp
@@ -8,7 +8,7 @@
 // Runs before scoring_system so that the MissTag is processed the same frame.
 // Energy drain and miss_count are handled exclusively by scoring_system's MissTag branch.
 void miss_detection_system(entt::registry& reg, float /*dt*/) {
-    auto view = reg.view<ObstacleTag, WorldTransform>(entt::exclude<ScoredTag>);
+    auto view = reg.view<ObstacleTag, WorldTransform>(entt::exclude<ScoredTag, NonScorableTag>);
     for (auto [entity, wt] : view.each()) {
         if (wt.position.y <= constants::DESTROY_Y) continue;
 

--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -78,7 +78,8 @@ void scoring_system(entt::registry& reg, float dt) {
         auto& miss_buf = scratch.miss_buf;
         miss_buf.clear();
 
-        auto miss_view_graded = reg.view<ObstacleTag, ScoredTag, MissTag, Obstacle, TimingGrade>();
+        auto miss_view_graded = reg.view<ObstacleTag, ScoredTag, MissTag, Obstacle, TimingGrade>(
+            entt::exclude<NonScorableTag>);
         for (auto e : miss_view_graded) {
             enqueue_energy_effect(reg, -constants::ENERGY_DRAIN_MISS, true);
             if (results) results->miss_count++;
@@ -91,7 +92,7 @@ void scoring_system(entt::registry& reg, float dt) {
         }
 
         auto miss_view_ungraded = reg.view<ObstacleTag, ScoredTag, MissTag, Obstacle>(
-            entt::exclude<TimingGrade>);
+            entt::exclude<TimingGrade, NonScorableTag>);
         for (auto e : miss_view_ungraded) {
             enqueue_energy_effect(reg, -constants::ENERGY_DRAIN_MISS, true);
             if (results) results->miss_count++;

--- a/app/util/beat_map_loader.cpp
+++ b/app/util/beat_map_loader.cpp
@@ -97,6 +97,7 @@ static std::optional<ObstacleKind> parse_kind(const std::string& s) {
     if (s == "lane_block")       return ObstacleKind::LaneBlock;
     if (s == "combo_gate")       return ObstacleKind::ComboGate;
     if (s == "split_path")       return ObstacleKind::SplitPath;
+    if (s == "onset_marker")     return ObstacleKind::OnsetMarker;
     return std::nullopt;
 }
 

--- a/content/beatmaps/1_stomper_beatmap.json
+++ b/content/beatmaps/1_stomper_beatmap.json
@@ -717,7 +717,7 @@
         },
         {
           "beat": 113,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -751,7 +751,7 @@
         },
         {
           "beat": 129,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -887,7 +887,7 @@
         },
         {
           "beat": 283,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -955,7 +955,7 @@
         },
         {
           "beat": 302,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -972,7 +972,7 @@
         },
         {
           "beat": 303,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -1006,7 +1006,7 @@
         },
         {
           "beat": 306,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -1193,7 +1193,7 @@
         },
         {
           "beat": 463,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -1278,7 +1278,7 @@
         },
         {
           "beat": 475,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -1329,7 +1329,7 @@
         },
         {
           "beat": 479,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -1380,7 +1380,7 @@
         },
         {
           "beat": 483,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -1397,7 +1397,7 @@
         },
         {
           "beat": 484,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -1482,7 +1482,7 @@
         },
         {
           "beat": 515,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -2152,7 +2152,7 @@
         },
         {
           "beat": 291,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -2739,7 +2739,7 @@
         },
         {
           "beat": 81,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -2756,7 +2756,7 @@
         },
         {
           "beat": 82,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -2790,7 +2790,7 @@
         },
         {
           "beat": 97,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -2807,7 +2807,7 @@
         },
         {
           "beat": 98,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -2892,7 +2892,7 @@
         },
         {
           "beat": 113,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -2926,7 +2926,7 @@
         },
         {
           "beat": 129,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -3266,7 +3266,7 @@
         },
         {
           "beat": 275,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -3334,7 +3334,7 @@
         },
         {
           "beat": 283,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -3419,7 +3419,7 @@
         },
         {
           "beat": 307,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -3589,7 +3589,7 @@
         },
         {
           "beat": 387,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -3640,7 +3640,7 @@
         },
         {
           "beat": 419,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -3742,7 +3742,7 @@
         },
         {
           "beat": 459,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -3776,7 +3776,7 @@
         },
         {
           "beat": 462,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -3810,7 +3810,7 @@
         },
         {
           "beat": 465,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -3844,7 +3844,7 @@
         },
         {
           "beat": 469,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -3912,7 +3912,7 @@
         },
         {
           "beat": 476,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -3963,7 +3963,7 @@
         },
         {
           "beat": 483,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -3980,7 +3980,7 @@
         },
         {
           "beat": 484,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -4099,7 +4099,7 @@
         },
         {
           "beat": 515,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",

--- a/content/beatmaps/2_drama_beatmap.json
+++ b/content/beatmaps/2_drama_beatmap.json
@@ -644,7 +644,7 @@
         },
         {
           "beat": 57,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -661,7 +661,7 @@
         },
         {
           "beat": 58,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -712,7 +712,7 @@
         },
         {
           "beat": 61,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "circle",
           "onset_class": "harmonic",
@@ -729,7 +729,7 @@
         },
         {
           "beat": 62,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -780,7 +780,7 @@
         },
         {
           "beat": 74,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -1154,7 +1154,7 @@
         },
         {
           "beat": 273,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -1188,7 +1188,7 @@
         },
         {
           "beat": 275,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -1375,7 +1375,7 @@
         },
         {
           "beat": 326,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -1392,7 +1392,7 @@
         },
         {
           "beat": 327,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -1426,7 +1426,7 @@
         },
         {
           "beat": 330,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -1443,7 +1443,7 @@
         },
         {
           "beat": 331,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -1477,7 +1477,7 @@
         },
         {
           "beat": 333,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -1630,7 +1630,7 @@
         },
         {
           "beat": 393,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -1698,7 +1698,7 @@
         },
         {
           "beat": 397,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "circle",
           "onset_class": "harmonic",
@@ -1715,7 +1715,7 @@
         },
         {
           "beat": 398,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -1749,7 +1749,7 @@
         },
         {
           "beat": 407,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -1783,7 +1783,7 @@
         },
         {
           "beat": 410,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -1953,7 +1953,7 @@
         },
         {
           "beat": 443,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -2215,7 +2215,7 @@
         },
         {
           "beat": 8,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -2449,7 +2449,7 @@
         },
         {
           "beat": 77,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -2575,7 +2575,7 @@
         },
         {
           "beat": 111,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -2611,7 +2611,7 @@
         },
         {
           "beat": 123,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -2701,7 +2701,7 @@
         },
         {
           "beat": 167,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -3565,7 +3565,7 @@
         },
         {
           "beat": 415,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -3709,7 +3709,7 @@
         },
         {
           "beat": 443,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -3981,7 +3981,7 @@
         },
         {
           "beat": 8,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -4015,7 +4015,7 @@
         },
         {
           "beat": 10,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -4168,7 +4168,7 @@
         },
         {
           "beat": 53,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "circle",
           "onset_class": "harmonic",
@@ -4202,7 +4202,7 @@
         },
         {
           "beat": 55,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "circle",
           "onset_class": "harmonic",
@@ -4236,7 +4236,7 @@
         },
         {
           "beat": 57,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "circle",
           "onset_class": "harmonic",
@@ -4253,7 +4253,7 @@
         },
         {
           "beat": 58,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -4287,7 +4287,7 @@
         },
         {
           "beat": 60,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -4304,7 +4304,7 @@
         },
         {
           "beat": 61,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -4338,7 +4338,7 @@
         },
         {
           "beat": 64,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -4372,7 +4372,7 @@
         },
         {
           "beat": 71,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "circle",
           "onset_class": "harmonic",
@@ -4389,7 +4389,7 @@
         },
         {
           "beat": 72,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -4423,7 +4423,7 @@
         },
         {
           "beat": 74,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -4457,7 +4457,7 @@
         },
         {
           "beat": 77,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -4491,7 +4491,7 @@
         },
         {
           "beat": 79,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -4525,7 +4525,7 @@
         },
         {
           "beat": 82,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -4746,7 +4746,7 @@
         },
         {
           "beat": 167,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -4763,7 +4763,7 @@
         },
         {
           "beat": 168,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -4933,7 +4933,7 @@
         },
         {
           "beat": 187,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -5086,7 +5086,7 @@
         },
         {
           "beat": 268,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "circle",
           "onset_class": "harmonic",
@@ -5103,7 +5103,7 @@
         },
         {
           "beat": 269,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -5137,7 +5137,7 @@
         },
         {
           "beat": 271,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -5154,7 +5154,7 @@
         },
         {
           "beat": 272,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -5188,7 +5188,7 @@
         },
         {
           "beat": 275,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -5205,7 +5205,7 @@
         },
         {
           "beat": 276,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -5239,7 +5239,7 @@
         },
         {
           "beat": 278,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -5273,7 +5273,7 @@
         },
         {
           "beat": 280,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -5392,7 +5392,7 @@
         },
         {
           "beat": 315,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -5409,7 +5409,7 @@
         },
         {
           "beat": 316,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -5460,7 +5460,7 @@
         },
         {
           "beat": 319,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "circle",
           "onset_class": "harmonic",
@@ -5528,7 +5528,7 @@
         },
         {
           "beat": 326,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -5562,7 +5562,7 @@
         },
         {
           "beat": 328,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -5613,7 +5613,7 @@
         },
         {
           "beat": 331,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -5664,7 +5664,7 @@
         },
         {
           "beat": 334,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -5715,7 +5715,7 @@
         },
         {
           "beat": 340,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -5851,7 +5851,7 @@
         },
         {
           "beat": 389,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "circle",
           "onset_class": "harmonic",
@@ -5868,7 +5868,7 @@
         },
         {
           "beat": 390,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -5902,7 +5902,7 @@
         },
         {
           "beat": 393,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "circle",
           "onset_class": "harmonic",
@@ -5919,7 +5919,7 @@
         },
         {
           "beat": 394,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -5953,7 +5953,7 @@
         },
         {
           "beat": 396,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -5987,7 +5987,7 @@
         },
         {
           "beat": 398,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "circle",
           "onset_class": "harmonic",
@@ -6021,7 +6021,7 @@
         },
         {
           "beat": 400,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -6072,7 +6072,7 @@
         },
         {
           "beat": 407,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -6106,7 +6106,7 @@
         },
         {
           "beat": 410,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -6140,7 +6140,7 @@
         },
         {
           "beat": 412,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -6191,7 +6191,7 @@
         },
         {
           "beat": 416,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -6242,7 +6242,7 @@
         },
         {
           "beat": 419,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -6395,7 +6395,7 @@
         },
         {
           "beat": 443,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "circle",
           "onset_class": "harmonic",
@@ -6412,7 +6412,7 @@
         },
         {
           "beat": 444,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -6463,7 +6463,7 @@
         },
         {
           "beat": 451,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "circle",
           "onset_class": "harmonic",
@@ -6514,7 +6514,7 @@
         },
         {
           "beat": 456,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "circle",
           "onset_class": "harmonic",
@@ -6667,7 +6667,7 @@
         },
         {
           "beat": 492,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -6701,7 +6701,7 @@
         },
         {
           "beat": 497,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -6735,7 +6735,7 @@
         },
         {
           "beat": 500,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",

--- a/content/beatmaps/3_mental_corruption_beatmap.json
+++ b/content/beatmaps/3_mental_corruption_beatmap.json
@@ -866,7 +866,7 @@
         },
         {
           "beat": 143,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -883,7 +883,7 @@
         },
         {
           "beat": 144,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -1070,7 +1070,7 @@
         },
         {
           "beat": 195,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "circle",
           "onset_class": "harmonic",
@@ -1087,7 +1087,7 @@
         },
         {
           "beat": 196,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -1121,7 +1121,7 @@
         },
         {
           "beat": 198,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -1189,7 +1189,7 @@
         },
         {
           "beat": 204,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -1240,7 +1240,7 @@
         },
         {
           "beat": 212,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -1818,7 +1818,7 @@
         },
         {
           "beat": 386,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -1869,7 +1869,7 @@
         },
         {
           "beat": 391,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -1971,7 +1971,7 @@
         },
         {
           "beat": 401,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -2022,7 +2022,7 @@
         },
         {
           "beat": 414,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -2226,7 +2226,7 @@
         },
         {
           "beat": 505,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -2243,7 +2243,7 @@
         },
         {
           "beat": 506,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -2362,7 +2362,7 @@
         },
         {
           "beat": 520,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -2470,7 +2470,7 @@
         },
         {
           "beat": 8,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -2506,7 +2506,7 @@
         },
         {
           "beat": 10,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -2686,7 +2686,7 @@
         },
         {
           "beat": 79,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -2776,7 +2776,7 @@
         },
         {
           "beat": 97,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -3136,7 +3136,7 @@
         },
         {
           "beat": 195,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -3226,7 +3226,7 @@
         },
         {
           "beat": 212,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -3496,7 +3496,7 @@
         },
         {
           "beat": 303,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -3747,7 +3747,7 @@
         },
         {
           "beat": 379,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -3909,7 +3909,7 @@
         },
         {
           "beat": 414,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -4431,7 +4431,7 @@
         },
         {
           "beat": 538,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -5645,7 +5645,7 @@
         },
         {
           "beat": 303,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -6699,7 +6699,7 @@
         },
         {
           "beat": 538,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",

--- a/tests/test_shipped_beatmap_difficulty_ramp.cpp
+++ b/tests/test_shipped_beatmap_difficulty_ramp.cpp
@@ -52,6 +52,10 @@ static bool is_removed_lane_kind(ObstacleKind k) {
     return k == ObstacleKind::LaneBlock;
 }
 
+static bool is_easy_allowed_kind(ObstacleKind k) {
+    return k == ObstacleKind::ShapeGate || k == ObstacleKind::OnsetMarker;
+}
+
 // ── Guard: content directory must be reachable ────────────────────────────
 
 TEST_CASE("difficulty ramp: content directory is reachable from test CWD",
@@ -60,12 +64,13 @@ TEST_CASE("difficulty ramp: content directory is reachable from test CWD",
     REQUIRE_FALSE(find_shipped_beatmaps().empty());
 }
 
-// ── Easy: shape_gate only ──────────────────────────────────────────────────
+// ── Easy: required shape gates plus non-blocking onset markers ──────────────
 //
-// Contract from #125: easy difficulty = shape_gate exclusively.
+// Contract from #125: easy difficulty = shape_gate required obstacles only.
+// Non-blocking onset_marker rows preserve public-layer onset metadata (#642).
 // This test is the regression guard Kujan required before merging #135.
 
-TEST_CASE("difficulty ramp: easy contains only shape_gate obstacles",
+TEST_CASE("difficulty ramp: easy contains only shape_gate obstacles or onset markers",
           "[difficulty_ramp][issue135][easy][shape_gate_only]") {
     const auto beatmaps = find_shipped_beatmaps();
     REQUIRE_FALSE(beatmaps.empty());
@@ -77,11 +82,12 @@ TEST_CASE("difficulty ramp: easy contains only shape_gate obstacles",
 
         for (const auto& beat : map.beats) {
             const auto k = beat.kind;
-            if (k != ObstacleKind::ShapeGate) {
+            if (!is_easy_allowed_kind(k)) {
                 FAIL_CHECK("easy shape_gate_only: " << path
-                           << " contains non-shape_gate obstacle kind="
+                           << " contains unsupported easy obstacle kind="
                            << static_cast<int>(k)
-                           << " (easy must be shape_gate-only per #125)");
+                           << " (easy required obstacles must be shape_gate-only per #125; "
+                              "onset_marker is non-blocking metadata per #642)");
             }
         }
     }

--- a/tests/test_shipped_beatmap_gap_one_readability.cpp
+++ b/tests/test_shipped_beatmap_gap_one_readability.cpp
@@ -1,8 +1,9 @@
 // Regression tests for GitHub issue #141 on the onset-motif spike path.
 //
 // The approved onset path disables legacy gap=1 readability enforcement.
-// We keep a lightweight guard: if consecutive beats are one beat apart,
-// obstacles must still be shape gates.
+// We keep a lightweight guard: if consecutive required obstacles are one beat
+// apart, they must still be shape gates. Non-blocking onset_marker rows preserve
+// protected public-layer metadata and are ignored by this required-action guard.
 
 #include <catch2/catch_test_macros.hpp>
 #include "components/beat_map.h"
@@ -49,12 +50,17 @@ TEST_CASE("gap=1 readability: adjacent authored beats remain shape gates",
             std::vector<BeatMapError> errors;
             if (!load_beat_map(path, map, errors, difficulty)) continue;
 
-            const auto& beats = map.beats;
-            if (beats.size() <= 1) continue;
+            std::vector<BeatEntry> required_beats;
+            for (const auto& beat : map.beats) {
+                if (beat.kind != ObstacleKind::OnsetMarker) {
+                    required_beats.push_back(beat);
+                }
+            }
+            if (required_beats.size() <= 1) continue;
 
-            for (size_t index = 1; index < beats.size(); ++index) {
-                const auto& left = beats[index - 1];
-                const auto& right = beats[index];
+            for (size_t index = 1; index < required_beats.size(); ++index) {
+                const auto& left = required_beats[index - 1];
+                const auto& right = required_beats[index];
                 const int gap = right.beat_index - left.beat_index;
 
                 if (gap != 1) continue;

--- a/tools/test_validate_loop2_content_gates.py
+++ b/tools/test_validate_loop2_content_gates.py
@@ -80,6 +80,19 @@ class TestLoop2MetricCalculations(unittest.TestCase):
         self.assertAlmostEqual(metrics["circle_share"], 1 / 3)
         self.assertAlmostEqual(metrics["lane2_share"], 1 / 3)
 
+    def test_onset_marker_is_supported_but_not_counted_as_shape_obstacle(self):
+        beats = [
+            {"beat": 0, "kind": "shape_gate", "shape": "triangle", "lane": 0},
+            {"beat": 1, "kind": "onset_marker", "shape": "square", "lane": 1},
+            {"beat": 4, "kind": "shape_gate", "shape": "circle", "lane": 2},
+        ]
+        metrics = gates.calculate_content_metrics(beats, expected_count=3)
+
+        self.assertTrue(metrics["all_shape_gate"])
+        self.assertAlmostEqual(metrics["triangle_share"], 1 / 2)
+        self.assertAlmostEqual(metrics["circle_share"], 1 / 2)
+        self.assertAlmostEqual(metrics["lane2_share"], 1 / 2)
+
 
 class TestLoop2GateEvaluation(unittest.TestCase):
     def test_evaluate_content_gates_flags_expected_issues(self):

--- a/tools/test_validate_no_simultaneous_shape_gates.py
+++ b/tools/test_validate_no_simultaneous_shape_gates.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Unit tests for validate_no_simultaneous_shape_gates.py (issue #528)."""
+"""Unit tests for validate_no_simultaneous_shape_gates.py (issue #642)."""
 
 from __future__ import annotations
 
@@ -16,6 +16,17 @@ def _gate(t, lane, shape):
     return {"kind": "shape_gate", "time_sec": t, "lane": lane, "shape": shape}
 
 
+def _marker(t, lane, shape, onset_class="percussive"):
+    return {
+        "kind": "onset_marker",
+        "time_sec": t,
+        "lane": lane,
+        "shape": shape,
+        "onset_class": onset_class,
+        "timing_source": "onset",
+    }
+
+
 class TestNoSimultaneousShapeGates(unittest.TestCase):
     def test_distinct_pair_within_morph_window_is_flagged(self):
         beats = [_gate(0.0, 0, "circle"), _gate(0.05, 1, "square")]
@@ -28,7 +39,7 @@ class TestNoSimultaneousShapeGates(unittest.TestCase):
         self.assertEqual(pairs, [])
 
     def test_pair_outside_morph_window_passes(self):
-        beats = [_gate(0.0, 0, "circle"), _gate(0.121, 1, "square")]
+        beats = [_gate(0.0, 0, "circle"), _gate(0.051, 1, "square")]
         pairs = v.find_simultaneous_shape_gate_pairs(beats)
         self.assertEqual(pairs, [])
 
@@ -41,6 +52,22 @@ class TestNoSimultaneousShapeGates(unittest.TestCase):
         pairs = v.find_simultaneous_shape_gate_pairs(beats)
         # (0,1), (0,2), (1,2)
         self.assertEqual(len(pairs), 3)
+
+    def test_protected_cross_layer_required_pair_is_flagged(self):
+        beats = [
+            {**_gate(1.0, 0, "triangle"), "onset_class": "percussive", "timing_source": "onset"},
+            {**_gate(1.0, 1, "square"), "onset_class": "full-spectrum", "timing_source": "onset"},
+        ]
+        groups = v.find_required_action_groups(beats)
+        self.assertEqual(len(groups), 1)
+
+    def test_onset_marker_preserves_sibling_without_required_action(self):
+        beats = [
+            {**_gate(1.0, 0, "triangle"), "onset_class": "percussive", "timing_source": "onset"},
+            _marker(1.0, 1, "square", "full-spectrum"),
+        ]
+        groups = v.find_required_action_groups(beats)
+        self.assertEqual(groups, [])
 
 
 if __name__ == "__main__":

--- a/tools/validate_difficulty_ramp.py
+++ b/tools/validate_difficulty_ramp.py
@@ -29,6 +29,7 @@ EASY_MAX_DOMINANT_SHAPE_PCT = 65   # no single shape > this % of all shape_gates
 EASY_MIN_DISTINCT_SHAPES    = 3    # all three shapes must appear at least once
 
 DEPRECATED_KINDS = {"lane_block"}
+EASY_ALLOWED_KINDS = {"shape_gate", "onset_marker"}
 
 # Issue #529 — strict per-song ramp invariants.
 # Counts must strictly increase from one tier to the next (no equality);
@@ -94,10 +95,15 @@ def median_ioi_sec(beats: list[dict]) -> float:
 def check_count_ramp(name: str, easy: list, medium: list, hard: list) -> list[str]:
     """Issue #529 — strict count ramp easy < medium < hard."""
     violations: list[str] = []
-    pairs = [("easy", easy, "medium", medium), ("medium", medium, "hard", hard)]
-    for lower_name, lower, upper_name, upper in pairs:
-        n_lo = len(lower)
-        n_hi = len(upper)
+    required_counts = {
+        "easy": sum(1 for b in easy if b.get("kind") == "shape_gate"),
+        "medium": sum(1 for b in medium if b.get("kind") == "shape_gate"),
+        "hard": sum(1 for b in hard if b.get("kind") == "shape_gate"),
+    }
+    pairs = [("easy", "medium"), ("medium", "hard")]
+    for lower_name, upper_name in pairs:
+        n_lo = required_counts[lower_name]
+        n_hi = required_counts[upper_name]
         if n_lo == 0 or n_hi == 0:
             continue
         if n_hi - n_lo < RAMP_MIN_COUNT_DELTA:
@@ -139,14 +145,14 @@ def check_median_ioi_ramp(name: str, easy: list, medium: list, hard: list) -> li
 
 
 def check_easy_shape_gate_only(name: str, beats: list) -> list[str]:
-    """Return violations if easy has any non-shape obstacle kind (#125 contract)."""
+    """Return violations if easy has unsupported required obstacle kinds."""
     violations = []
     for b in beats:
         kind = b.get("kind", "")
-        if kind != "shape_gate":
+        if kind not in EASY_ALLOWED_KINDS:
             violations.append(
                 f"{name} easy: forbidden obstacle '{kind}' found "
-                f"(easy must be shape_gate only per #125)"
+                f"(easy required obstacles must be shape_gate only per #125; onset_marker is non-blocking metadata per #642)"
             )
     return violations
 

--- a/tools/validate_loop2_content_gates.py
+++ b/tools/validate_loop2_content_gates.py
@@ -33,6 +33,7 @@ GAP_ONE_SHARE_CAP = {"medium": 0.20, "hard": 0.20}
 # the generator can satisfy them without inserting non-onset filler.
 MIN_IOI_MS = {"easy": 500.0, "medium": 350.0, "hard": 280.0}
 SHAPE_OBSTACLE_KINDS = {"shape_gate", "split_path"}
+SUPPORTED_NON_BLOCKING_KINDS = {"onset_marker"}
 # Issue #420 — broad-layer/lane reachability floor at medium/hard.
 # Each shipped beatmap×difficulty must include at least this share of
 # circle (lane-2 / harmonic-mapped) obstacles so the third shape and the
@@ -131,6 +132,7 @@ def calculate_content_metrics(
     raw_beat_rows = len(beats)
     ordered = _ordered_valid_beats(beats)
     shape_clusters = _shape_gate_clusters(ordered)
+    shape_obstacles = [beat for beat in ordered if beat.get("kind") in SHAPE_OBSTACLE_KINDS]
     cluster_sizes = [len(cluster) for cluster in shape_clusters]
     beat_indices = [beat["beat"] for beat in ordered]
     gaps = [beat_indices[i] - beat_indices[i - 1] for i in range(1, len(beat_indices))]
@@ -143,9 +145,9 @@ def calculate_content_metrics(
     )
     dominant_gap = gap_counts.most_common(1)[0][0] if gap_counts else None
 
-    shape_counts = Counter(beat.get("shape") for beat in ordered if beat.get("kind") in SHAPE_OBSTACLE_KINDS)
+    shape_counts = Counter(beat.get("shape") for beat in shape_obstacles)
     total_shape_gates = sum(shape_counts.values())
-    lane_counts = Counter(beat.get("lane") for beat in ordered if beat.get("kind") in SHAPE_OBSTACLE_KINDS)
+    lane_counts = Counter(beat.get("lane") for beat in shape_obstacles)
 
     onset_timed = _all_onset_timed(ordered)
 
@@ -195,13 +197,16 @@ def calculate_content_metrics(
         "strictly_increasing": all(
             beat_indices[i] > beat_indices[i - 1] for i in range(1, len(beat_indices))
         ),
-        "all_shape_gate": all(beat.get("kind") in SHAPE_OBSTACLE_KINDS for beat in ordered),
+        "all_shape_gate": all(
+            beat.get("kind") in SHAPE_OBSTACLE_KINDS | SUPPORTED_NON_BLOCKING_KINDS
+            for beat in ordered
+        ),
         "lane_range_ok": all(beat.get("lane") in (0, 1, 2) for beat in ordered),
         "dominant_gap": dominant_gap,
         "dominant_gap_share": dominant_gap_share,
         "gap_one_share": (gap_counts.get(1, 0) / len(gaps)) if gaps else 0.0,
         "gap_one_run": _longest_gap_one_run(gaps),
-        "longest_same_shape_run": _longest_same_shape_run(ordered) if ordered else 0,
+        "longest_same_shape_run": _longest_same_shape_run(shape_obstacles) if shape_obstacles else 0,
         "longest_same_shape_cluster_run": _longest_same_shape_cluster_run(shape_clusters) if shape_clusters else 0,
         "shape_cluster_count": len(shape_clusters),
         "max_shape_cluster_size": max(cluster_sizes) if cluster_sizes else 0,
@@ -232,7 +237,7 @@ def evaluate_content_gates(metrics: dict[str, float | int | bool | None], diffic
     if not bool(metrics["lane_range_ok"]):
         findings.append("lane outside {0,1,2}")
     if not bool(metrics["all_shape_gate"]):
-        findings.append("non-shape obstacle present")
+        findings.append("unsupported obstacle kind present")
 
     # Issue #443 — beat-ordinal gap monotony / gap=1 share / gap=1 run gates
     # were designed for beat-grid timing where `beat[i+1]-beat[i]` reflects

--- a/tools/validate_no_simultaneous_shape_gates.py
+++ b/tools/validate_no_simultaneous_shape_gates.py
@@ -1,20 +1,17 @@
 #!/usr/bin/env python3
-"""Validate that no unprotected ``shape_gate`` obstacles in the same difficulty
-are authored within ``MORPH_DURATION`` (120 ms) of each other unless they share
-``(lane, shape)`` (issue #528).
+"""Validate that no protected onset cluster contains conflicting required gates.
 
-Two ``shape_gate`` obstacles at near-zero ``Δt`` with different
-``(lane, shape)`` are physically unsatisfiable: the player can occupy only
-one lane and morphing between shapes takes 120 ms (see
-``design-docs/rhythm-spec.md`` ``MORPH_DURATION``).  Distinct broad-layer
-onsets within the protected 50 ms window are preserved as authored obstacles;
-outside that protected window, obstacles still need a hard playability minimum
-at the ``(lane, shape)`` level.
+Two required ``shape_gate`` obstacles inside the protected 50 ms public-layer
+window with different ``(lane, shape)`` are physically unsatisfiable: the
+player can occupy only one lane/shape at an instant. Distinct broad-layer
+onsets must remain in the beatmap, but only one row in a protected group may
+remain a required action; sibling public-layer rows should be non-blocking
+``onset_marker`` entries that preserve their onset metadata.
 
-The check is "selection-side de-conflict only" — no beat fallback, no
-synthetic filler.  Existing distinct cross-layer onsets that survive the
-collapse pass remain in the beatmap; only one obstacle is emitted per
-near-simultaneous distinct ``(lane, shape)`` pair.
+The check is "representation-side de-conflict only" — no beat fallback, no
+synthetic filler. Existing distinct cross-layer onsets remain in the beatmap;
+the validator only fails when more than one independent required action is
+authored in the same protected group.
 
 Exit codes:
   0 — all beatmaps pass
@@ -35,55 +32,57 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_DIR = REPO_ROOT / "content" / "beatmaps"
 
-# rhythm-spec.md MORPH_DURATION = 120 ms.  Pairs at exactly the same instant
-# are also caught (Δt = 0 ≤ 0.120).
-MORPH_DURATION_SEC = 0.120
 PROTECTED_CROSS_LAYER_SEC = 0.050
-PUBLIC_ONSET_CLASSES = {"percussive", "harmonic", "full-spectrum"}
+REQUIRED_ACTION_KINDS = {"shape_gate", "combo_gate", "split_path"}
 
 
-def is_protected_cross_layer_pair(a: dict, b: dict, dt: float) -> bool:
-    a_class = a.get("onset_class")
-    b_class = b.get("onset_class")
-    return (
-        isinstance(a_class, str)
-        and isinstance(b_class, str)
-        and a_class in PUBLIC_ONSET_CLASSES
-        and b_class in PUBLIC_ONSET_CLASSES
-        and a_class != b_class
-        and dt <= PROTECTED_CROSS_LAYER_SEC
-    )
+def required_action_key(beat: dict) -> tuple[object, object] | None:
+    kind = beat.get("kind", "shape_gate")
+    if kind not in REQUIRED_ACTION_KINDS:
+        return None
+    if kind == "combo_gate":
+        return (tuple(beat.get("blocked", ())), beat.get("shape"))
+    return (beat.get("lane"), beat.get("shape"))
 
 
-def find_simultaneous_shape_gate_pairs(
+def find_required_action_groups(
     beats: list[dict],
-    threshold_sec: float = MORPH_DURATION_SEC,
-) -> list[tuple[dict, dict, float]]:
-    """Return every ``(left, right, dt)`` pair of ``shape_gate`` obstacles
-    within ``threshold_sec`` whose ``(lane, shape)`` differ.
-    """
+    threshold_sec: float = PROTECTED_CROSS_LAYER_SEC,
+) -> list[list[dict]]:
+    """Return protected-time groups with conflicting required action keys."""
     rows = sorted(
         (b for b in beats
          if isinstance(b, dict)
-         and b.get("kind") == "shape_gate"
+         and required_action_key(b) is not None
          and isinstance(b.get("time_sec"), (int, float))
          and not isinstance(b.get("time_sec"), bool)),
         key=lambda b: float(b["time_sec"]),
     )
+    groups: list[list[dict]] = []
+    current: list[dict] = []
+    for row in rows:
+        if not current or float(row["time_sec"]) - float(current[-1]["time_sec"]) <= threshold_sec:
+            current.append(row)
+        else:
+            if len({required_action_key(item) for item in current}) > 1:
+                groups.append(current)
+            current = [row]
+    if len({required_action_key(item) for item in current}) > 1:
+        groups.append(current)
+    return groups
+
+
+def find_simultaneous_shape_gate_pairs(
+    beats: list[dict],
+    threshold_sec: float = PROTECTED_CROSS_LAYER_SEC,
+) -> list[tuple[dict, dict, float]]:
+    """Compatibility helper: expand conflicting protected groups into pairs."""
     pairs: list[tuple[dict, dict, float]] = []
-    n = len(rows)
-    for i in range(n):
-        a = rows[i]
-        a_t = float(a["time_sec"])
-        a_key = (a.get("lane"), a.get("shape"))
-        for j in range(i + 1, n):
-            b = rows[j]
-            b_t = float(b["time_sec"])
-            dt = b_t - a_t
-            if dt > threshold_sec:
-                break
-            if (b.get("lane"), b.get("shape")) != a_key and not is_protected_cross_layer_pair(a, b, dt):
-                pairs.append((a, b, dt))
+    for group in find_required_action_groups(beats, threshold_sec):
+        for i, a in enumerate(group):
+            for b in group[i + 1:]:
+                if required_action_key(a) != required_action_key(b):
+                    pairs.append((a, b, float(b["time_sec"]) - float(a["time_sec"])))
     return pairs
 
 
@@ -93,21 +92,26 @@ def validate_beatmap(path: Path) -> list[str]:
     findings: list[str] = []
     for difficulty, payload in beatmap.get("difficulties", {}).items():
         beats = payload.get("beats", []) or []
-        pairs = find_simultaneous_shape_gate_pairs(beats)
-        if not pairs:
+        groups = find_required_action_groups(beats)
+        if not groups:
             continue
         # Always show first 3 examples for actionable diagnostics.
-        sample = pairs[:3]
-        for a, b, dt in sample:
-            findings.append(
-                f"{name} [{difficulty}]: shape_gate pair Δt={dt*1000:.1f}ms "
-                f"(lane={a.get('lane')},shape={a.get('shape')}) vs "
-                f"(lane={b.get('lane')},shape={b.get('shape')}) at t≈{float(a['time_sec']):.3f}s (#528)"
+        sample = groups[:3]
+        for group in sample:
+            start = float(group[0]["time_sec"])
+            end = float(group[-1]["time_sec"])
+            keys = ", ".join(
+                f"(lane={beat.get('lane')},shape={beat.get('shape')},kind={beat.get('kind', 'shape_gate')},class={beat.get('onset_class')})"
+                for beat in group
             )
-        if len(pairs) > len(sample):
             findings.append(
-                f"{name} [{difficulty}]: total {len(pairs)} unplayable shape_gate "
-                f"pair(s) within {MORPH_DURATION_SEC*1000:.0f}ms (#528)"
+                f"{name} [{difficulty}]: protected group Δt={(end - start)*1000:.1f}ms "
+                f"has conflicting required actions at t≈{start:.3f}s: {keys} (#642)"
+            )
+        if len(groups) > len(sample):
+            findings.append(
+                f"{name} [{difficulty}]: total {len(groups)} protected group(s) "
+                f"with conflicting required actions within {PROTECTED_CROSS_LAYER_SEC*1000:.0f}ms (#642)"
             )
     return findings
 
@@ -127,12 +131,12 @@ def main(argv: list[str] | None = None) -> int:
         all_findings.extend(validate_beatmap(path))
 
     if all_findings:
-        print("SIMULTANEOUS SHAPE_GATE VIOLATIONS (#528):", file=sys.stderr)
+        print("PROTECTED REQUIRED-ACTION VIOLATIONS (#642):", file=sys.stderr)
         for finding in all_findings:
             print(f"  x {finding}", file=sys.stderr)
         return 1
 
-    print(f"OK: no near-simultaneous shape_gate pairs in {len(paths)} beatmap(s).")
+    print(f"OK: no protected required-action conflicts in {len(paths)} beatmap(s).")
     return 0
 
 


### PR DESCRIPTION
Closes #642.

## Root cause
Protected cross-layer public onsets inside the 50 ms preservation window were all still authored as required `shape_gate` actions. That preserved music metadata, but it could ask the player to satisfy multiple independent lane/shape requirements at the same collision instant.

## Changes
- Added `onset_marker` as a parsed non-blocking beatmap kind and skipped it in the rhythm scheduler.
- Converted 136 protected sibling gates across shipped beatmaps to `onset_marker`, preserving `time_sec`, `timing_source`, `onset_class`, `lane`, and `shape` metadata.
- Tightened `validate_no_simultaneous_shape_gates.py` to fail protected 50 ms groups with conflicting required actions instead of exempting cross-layer pairs.
- Updated content gates and C++ shipped-content guards to treat `onset_marker` as non-blocking metadata, not a required obstacle.

## Verification
- `python3 tools/validate_no_simultaneous_shape_gates.py`
- `python3 tools/validate_loop2_content_gates.py --strict`
- `python3 tools/validate_difficulty_ramp.py`
- `python3 tools/validate_gap_one_readability.py`
- `python3 -m unittest tools.test_validate_difficulty_ramp tools.test_validate_gap_one_readability tools.test_validate_no_simultaneous_shape_gates tools.test_validate_loop2_content_gates`
- `VCPKG_ROOT=/Users/yashasgujjar/vcpkg cmake -B build -S . -Wno-dev`
- `cmake --build build`
- `./build/shapeshifter_tests`