### PR TITLE
Fix session log frame advancement

### DIFF
--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -257,6 +257,9 @@ bool game_loop_init(entt::registry& reg,
 // One frame: input → fixed timestep → render → blit → audio.
 // Not in header — called by game_loop_run and platform_run_loop (Emscripten).
 void game_loop_frame(entt::registry& reg, float& accumulator) {
+    auto* session_log = reg.ctx().find<SessionLog>();
+    if (session_log) session_log_begin_frame(*session_log);
+
     float raw_dt = GetFrameTime();
     accumulator += raw_dt;
     if (accumulator > MAX_ACCUM) accumulator = MAX_ACCUM;
@@ -305,7 +308,6 @@ void game_loop_frame(entt::registry& reg, float& accumulator) {
     audio_system(reg);
     haptic_system(reg);
 
-    auto* session_log = reg.ctx().find<SessionLog>();
     if (session_log) session_log_flush(*session_log);
 }
 

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -196,8 +196,6 @@ void test_player_system(entt::registry& reg, float dt) {
     auto* song  = reg.ctx().find<SongState>();
     float song_time = song ? song->song_time : 0.0f;
 
-    if (log) log->frame = state->frame_count;
-
     // ── AUTO-START ───────────────────────────────────────────
     if (gs.phase == GamePhase::Title || gs.phase == GamePhase::GameOver ||
         gs.phase == GamePhase::SongComplete) {

--- a/app/util/session_logger.cpp
+++ b/app/util/session_logger.cpp
@@ -104,6 +104,10 @@ void session_log_flush(SessionLog& log) {
     log.buffer.clear();  // capacity preserved — no realloc next frame
 }
 
+void session_log_begin_frame(SessionLog& log) {
+    ++log.frame;
+}
+
 // ── EnTT signal: obstacle spawned ────────────────────────────
 
 void session_log_on_obstacle_spawn(entt::registry& reg, entt::entity entity) {

--- a/app/util/session_logger.h
+++ b/app/util/session_logger.h
@@ -39,6 +39,9 @@ void session_log_write(SessionLog& log, float song_time,
 // Flush buffered log lines to disk. Call once per frame, after all systems.
 void session_log_flush(SessionLog& log);
 
+// Advance the frame counter once from the central game-loop path.
+void session_log_begin_frame(SessionLog& log);
+
 // EnTT signal handlers — connect to registry during test_player setup.
 void session_log_on_obstacle_spawn(entt::registry& reg, entt::entity entity);
 void session_log_on_scored(entt::registry& reg, entt::entity entity);

--- a/tests/test_session_logger.cpp
+++ b/tests/test_session_logger.cpp
@@ -1,0 +1,15 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "util/session_logger.h"
+
+TEST_CASE("session log frame advances from central game-loop hook", "[session_logger][issue112]") {
+    SessionLog log{};
+
+    CHECK(log.frame == 0);
+
+    session_log_begin_frame(log);
+    CHECK(log.frame == 1);
+
+    session_log_begin_frame(log);
+    CHECK(log.frame == 2);
+}


### PR DESCRIPTION
Fixes #112.

## Summary
- advance SessionLog::frame once per game-loop frame before systems can write log entries
- stop the test-player system from owning the log frame counter
- add regression coverage for the central frame-advance hook

## Verification
- cmake -B build -S . -Wno-dev -DCMAKE_PREFIX_PATH=/Users/yashasgujjar/dev/bullethell/build/vcpkg_installed/arm64-osx
- cmake --build build
- ./build/shapeshifter_tests