### PR TITLE
Update shipped beatmap counts in docs

### DIFF
--- a/design-docs/feature-specs.md
+++ b/design-docs/feature-specs.md
@@ -468,7 +468,7 @@ void scoring_system(entt::registry& reg, float dt);
 >   Progression" and `rhythm-spec.md` for the authoritative model.
 > - **Combo / Split-Path generation at brackets 4+.** No shipped beatmap
 >   emits `combo_gate` or `split_path`; `level_designer.py` produces
->   100% `shape_gate` content across all 9 shipped beatmaps. The
+>   100% `shape_gate` content across all 3 shipped beatmaps / 9 difficulty arrays. The
 >   "combo every 3 obstacles at bracket 4" rule no longer applies.
 > - **Burnout detection-range shrink.** The burnout mechanic itself was
 >   removed (#239 — see SPEC 2 banner above). `BASE_RANGE / (1 +

--- a/design-docs/game.md
+++ b/design-docs/game.md
@@ -66,8 +66,9 @@ The screen is divided into two zones:
 
 3 lanes: left, center, right. Player starts in center.
 
-> ⚠️ **Current shipped behavior — see issue #441.** Across all 9 shipped
-> beatmap arrays (**1046 obstacles total** as of Round 6 audit; see
+> ⚠️ **Current shipped behavior — see issue #441.** Across all 3 shipped
+> beatmaps / 9 difficulty arrays (**924 obstacles total** as of the current
+> content audit; see
 > the per-difficulty table in `rhythm-design.md` §8), shape and lane
 > are fused 1:1 by
 > `tools/level_designer.py:ONSET_CLASS_TO_OBSTACLE` — every triangle is
@@ -164,7 +165,7 @@ Difficulty is selected per song (easy / medium / hard) and is expressed primaril
 
 † Timing windows are not difficulty-scaled today: every difficulty uses the same BPM-derived hit window defined in `rhythm-spec.md` (`audio_offset` + BPM-derived window). The "Timing Window" column is preserved for forward compatibility if per-difficulty scaling is reintroduced.
 
-‡ As shipped today (see #420, #446), all 9 beatmaps in `content/beatmaps/` are 100% `shape_gate`. Difficulty between Easy / Medium / Hard is expressed only through **obstacle density**, **shape-gate kind/lane distribution**, and **onset selection** — not through additional obstacle kinds. The earlier `lane_push` pacing-insert plan (decisions.md "#135 — Difficulty Ramp", `LANEPUSH_RAMP`) and the older "+ Low/high bars, combos, split paths" cell for Hard were aspirational; no `lane_push` / `low_bar` / `high_bar` / `combo_gate` / `split_path` content is currently produced by `level_designer.py`, and `LanePush` is queued for removal/rework (#328). Those obstacle kinds remain in the catalog as future design space; if/when a committed plan to reintroduce them lands, this table will be revised.
+‡ As shipped today (see #420, #446), all 3 beatmaps / 9 difficulty arrays in `content/beatmaps/` are 100% `shape_gate`. Difficulty between Easy / Medium / Hard is expressed only through **obstacle density**, **shape-gate kind/lane distribution**, and **onset selection** — not through additional obstacle kinds. The earlier `lane_push` pacing-insert plan (decisions.md "#135 — Difficulty Ramp", `LANEPUSH_RAMP`) and the older "+ Low/high bars, combos, split paths" cell for Hard were aspirational; no `lane_push` / `low_bar` / `high_bar` / `combo_gate` / `split_path` content is currently produced by `level_designer.py`, and `LanePush` is queued for removal/rework (#328). Those obstacle kinds remain in the catalog as future design space; if/when a committed plan to reintroduce them lands, this table will be revised.
 
 ### Player Emotion Arc
 - **Early song** → "I'm finding the rhythm" (entrainment)

--- a/design-docs/rhythm-design.md
+++ b/design-docs/rhythm-design.md
@@ -505,8 +505,8 @@ them ends the run on their own — only `energy <= 0.0f` does.
 
 > ⚠️ **Shipped scope — only `shape_gate` ships today (issues #420, #446,
 > #328, #479).** Mirroring the caveat in `game.md` "Difficulty
-> Progression": across all 9 shipped beatmap arrays in
-> `content/beatmaps/` (**898 obstacles total** as of Round 10 audit;
+> Progression": across all 3 shipped beatmaps / 9 difficulty arrays in
+> `content/beatmaps/` (**924 obstacles total** as of the current content audit;
 > see per-difficulty table in §8 "Difficulty Progression" below),
 > `tools/level_designer.py` emits 100% `shape_gate`. The `lane_push`, `low_bar`, and `high_bar` names
 > described below are **not currently produced** by the generator and
@@ -599,14 +599,15 @@ them ends the run on their own — only `energy <= 0.0f` does.
            archival/future-only and are not authoring guidance.
 ```
 
-### Shipped per-difficulty obstacle counts (Round 10 audit)
+### Shipped per-difficulty obstacle counts (current content audit)
 
 | Song                  | easy | medium | hard |
 |-----------------------|-----:|-------:|-----:|
-| 1_stomper             |   60 |     61 |   97 |
-| 2_drama               |   96 |     97 |  132 |
-| 3_mental_corruption   |  110 |    111 |  134 |
-| **Total (all 9 arrays)** |      |        | **898** |
+| 1_stomper             |   56 |     57 |   93 |
+| 2_drama               |   96 |     97 |  169 |
+| 3_mental_corruption   |  110 |    112 |  134 |
+| **Total (3 beatmaps / 9 arrays)** | **262** | **266** | **396** |
+| **Grand total**       |      |        | **924** |
 
 Even Hard never approaches "every beat" — `1_stomper` Hard averages
 roughly one obstacle every ~2.5 musical beats. Treat these counts as


### PR DESCRIPTION
## Summary
- Update stale shipped beatmap references from ambiguous "9 shipped beatmaps" to 3 shipped beatmaps / 9 difficulty arrays.
- Refresh the documented shipped obstacle totals to the verified 924 total.
- Update the per-song, per-difficulty count table from current `content/beatmaps/*_beatmap.json` data.

Fixes #715

## Verification
- Recounted `content/beatmaps/*_beatmap.json` with `jq`: easy 262, medium 266, hard 396, total 924.
- `git diff --check`
