### PR TITLE
Register disabled service worker Node test fallback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -636,8 +636,14 @@ if(NOT EMSCRIPTEN AND NOT SHAPESHIFTER_IOS)
             NAME beatmap_editor_node_tests
             COMMAND ${CMAKE_COMMAND} -E echo "SKIPPED: beatmap_editor_node_tests (node executable not found)"
         )
+        add_test(
+            NAME service_worker_cache_policy_node_tests
+            COMMAND ${CMAKE_COMMAND} -E echo "SKIPPED: service_worker_cache_policy_node_tests (node executable not found)"
+        )
         set_tests_properties(beatmap_editor_node_tests PROPERTIES DISABLED TRUE)
+        set_tests_properties(service_worker_cache_policy_node_tests PROPERTIES DISABLED TRUE)
         message(STATUS "beatmap_editor_node_tests disabled: node executable not found")
+        message(STATUS "service_worker_cache_policy_node_tests disabled: node executable not found")
     endif()
 else()
     # Run the Emscripten Catch2 binary under Node. NODERAWFS lets tests read


### PR DESCRIPTION
Fixes #720.\n\n## Summary\n- Registers `service_worker_cache_policy_node_tests` as a disabled CTest entry when Node.js is unavailable\n- Keeps the existing Node-present test behavior unchanged\n- Adds a clear configure status message for the disabled fallback\n\n## Verification\n- `cmake -B build -S . -Wno-dev -DCMAKE_TOOLCHAIN_FILE=/Users/yashasgujjar/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=arm64-osx`\n- `cmake --build build`\n- `./build/shapeshifter_tests`\n- `cmake -B build-no-node -S . -Wno-dev -DCMAKE_TOOLCHAIN_FILE=/Users/yashasgujjar/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=arm64-osx -DNODE_EXECUTABLE=NODE_EXECUTABLE-NOTFOUND`\n- `ctest --test-dir build-no-node -N | grep -E 'beatmap_editor_node_tests|service_worker_cache_policy_node_tests'`