### PR TITLE
Content: gate shipped shape-change spacing

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -96,7 +96,7 @@ jobs:
           mkdir -p build/ci
           ctest --test-dir build -N \
             | sed -nE 's/^ *Test *#[0-9]+: (.*)$/\1/p' \
-            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
+            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
             | sort -u > build/ci/ctest-nonbench-catch.txt
           ./build/shapeshifter_tests --list-tests "~[bench]" --verbosity quiet \
             | sort -u > build/ci/catch-nonbench.txt
@@ -104,7 +104,7 @@ jobs:
           ./build/shapeshifter_tests "~[bench]"
           xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24" \
             ctest --test-dir build --output-on-failure -R "^startup_shutdown_smoke$"
-          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
+          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
 
       - name: Upload artifact
         if: success()

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -98,14 +98,14 @@ jobs:
           mkdir -p build/ci
           ctest --test-dir build -N \
             | sed -nE 's/^ *Test *#[0-9]+: (.*)$/\1/p' \
-            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
+            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
             | sort -u > build/ci/ctest-nonbench-catch.txt
           ./build/shapeshifter_tests --list-tests "~[bench]" --verbosity quiet \
             | sort -u > build/ci/catch-nonbench.txt
           diff -u build/ci/ctest-nonbench-catch.txt build/ci/catch-nonbench.txt
           ./build/shapeshifter_tests "~[bench]"
           ctest --test-dir build --output-on-failure -R "^startup_shutdown_smoke$"
-          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
+          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
 
       - name: Upload artifact
         if: success()

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -91,7 +91,7 @@ jobs:
           mkdir -p build/ci
           ctest --test-dir build -N \
             | sed -nE 's/^ *Test *#[0-9]+: (.*)$/\1/p' \
-            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
+            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
             | tr -d '\r' \
             | sort -u > build/ci/ctest-nonbench-catch.txt
           ./build/shapeshifter_tests.exe --list-tests "~[bench]" --verbosity quiet \
@@ -100,7 +100,7 @@ jobs:
           diff -u build/ci/ctest-nonbench-catch.txt build/ci/catch-nonbench.txt
           ./build/shapeshifter_tests.exe "~[bench]"
           ctest --test-dir build --output-on-failure -R "^startup_shutdown_smoke$"
-          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
+          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
         shell: bash
 
       - name: Upload artifact

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -615,6 +615,11 @@ if(NOT EMSCRIPTEN AND NOT SHAPESHIFTER_IOS)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/validate_no_simultaneous_shape_gates.py
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     )
+    add_test(
+        NAME check_shape_change_gap
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/check_shape_change_gap.py
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    )
     find_program(NODE_EXECUTABLE node)
     if(NODE_EXECUTABLE)
         file(GLOB _beatmap_editor_node_test_files CONFIGURE_DEPENDS

--- a/content/beatmaps/1_stomper_beatmap.json
+++ b/content/beatmaps/1_stomper_beatmap.json
@@ -1023,7 +1023,7 @@
         },
         {
           "beat": 307,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -1176,7 +1176,7 @@
         },
         {
           "beat": 462,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -1346,7 +1346,7 @@
         },
         {
           "beat": 480,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "circle",
           "onset_class": "harmonic",
@@ -1576,7 +1576,7 @@
         },
         {
           "beat": 14,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -1792,7 +1792,7 @@
         },
         {
           "beat": 142,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -2260,7 +2260,7 @@
         },
         {
           "beat": 384,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -2603,7 +2603,7 @@
         },
         {
           "beat": 14,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -2960,7 +2960,7 @@
         },
         {
           "beat": 144,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "circle",
           "onset_class": "harmonic",
@@ -2994,7 +2994,7 @@
         },
         {
           "beat": 177,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -3572,7 +3572,7 @@
         },
         {
           "beat": 386,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "circle",
           "onset_class": "harmonic",
@@ -3878,7 +3878,7 @@
         },
         {
           "beat": 474,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",

--- a/content/beatmaps/2_drama_beatmap.json
+++ b/content/beatmaps/2_drama_beatmap.json
@@ -695,7 +695,7 @@
         },
         {
           "beat": 60,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -1171,7 +1171,7 @@
         },
         {
           "beat": 274,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -1528,7 +1528,7 @@
         },
         {
           "beat": 341,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -1681,7 +1681,7 @@
         },
         {
           "beat": 396,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -2197,7 +2197,7 @@
         },
         {
           "beat": 7,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -2359,7 +2359,7 @@
         },
         {
           "beat": 55,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -2863,7 +2863,7 @@
         },
         {
           "beat": 215,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "circle",
           "onset_class": "harmonic",
@@ -3295,7 +3295,7 @@
         },
         {
           "beat": 333,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -3475,7 +3475,7 @@
         },
         {
           "beat": 393,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "circle",
           "onset_class": "harmonic",
@@ -3964,7 +3964,7 @@
         },
         {
           "beat": 7,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -4032,7 +4032,7 @@
         },
         {
           "beat": 11,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -5443,7 +5443,7 @@
         },
         {
           "beat": 318,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -5511,7 +5511,7 @@
         },
         {
           "beat": 325,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -5630,7 +5630,7 @@
         },
         {
           "beat": 332,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -5970,7 +5970,7 @@
         },
         {
           "beat": 397,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -6225,7 +6225,7 @@
         },
         {
           "beat": 418,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -6378,7 +6378,7 @@
         },
         {
           "beat": 442,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -6480,7 +6480,7 @@
         },
         {
           "beat": 452,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "circle",
           "onset_class": "harmonic",
@@ -6565,7 +6565,7 @@
         },
         {
           "beat": 464,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",

--- a/content/beatmaps/3_mental_corruption_beatmap.json
+++ b/content/beatmaps/3_mental_corruption_beatmap.json
@@ -1053,7 +1053,7 @@
         },
         {
           "beat": 194,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -1138,7 +1138,7 @@
         },
         {
           "beat": 199,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -1801,7 +1801,7 @@
         },
         {
           "beat": 385,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -1954,7 +1954,7 @@
         },
         {
           "beat": 400,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -2039,7 +2039,7 @@
         },
         {
           "beat": 415,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -2614,7 +2614,7 @@
         },
         {
           "beat": 56,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -2938,7 +2938,7 @@
         },
         {
           "beat": 142,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -3514,7 +3514,7 @@
         },
         {
           "beat": 304,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -3891,7 +3891,7 @@
         },
         {
           "beat": 413,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -4215,7 +4215,7 @@
         },
         {
           "beat": 504,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",
@@ -4251,7 +4251,7 @@
         },
         {
           "beat": 508,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "circle",
           "onset_class": "harmonic",
@@ -4359,7 +4359,7 @@
         },
         {
           "beat": 527,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -5662,7 +5662,7 @@
         },
         {
           "beat": 304,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 1,
           "shape": "square",
           "onset_class": "full-spectrum",


### PR DESCRIPTION
## Summary
- converts too-close different-shape playable gates in shipped beatmaps to onset markers, preserving onset metadata without spawning unfair shape changes
- registers tools/check_shape_change_gap.py as the check_shape_change_gap CTest gate
- keeps Loop 2 strict content gates passing after the content adjustment

Closes #723

## Verification
- python3 tools/check_shape_change_gap.py
- python3 tools/validate_loop2_content_gates.py --strict
- cmake -B build -S . -Wno-dev -DCMAKE_PREFIX_PATH=/Users/yashasgujjar/dev/bullethell/build/vcpkg_installed/arm64-osx && cmake --build build && ./build/shapeshifter_tests
- ctest --test-dir build --output-on-failure