### PR TITLE
Fix shape lane mapping

### DIFF
--- a/app/input/keyboard_shape_mapping.h
+++ b/app/input/keyboard_shape_mapping.h
@@ -11,9 +11,9 @@ enum class KeyboardShapeSlot : uint8_t {
 
 inline constexpr Shape shape_for_keyboard_slot(KeyboardShapeSlot slot) noexcept {
     switch (slot) {
-        case KeyboardShapeSlot::Left:   return Shape::Triangle;
+        case KeyboardShapeSlot::Left:   return Shape::Circle;
         case KeyboardShapeSlot::Center: return Shape::Square;
-        case KeyboardShapeSlot::Right:  return Shape::Circle;
+        case KeyboardShapeSlot::Right:  return Shape::Triangle;
     }
     return Shape::Square;
 }

--- a/app/util/shape_lane_mapping.h
+++ b/app/util/shape_lane_mapping.h
@@ -4,13 +4,13 @@
 
 #include <cstdint>
 
-// Canonical shape→lane pairing authored by shipped beatmaps.
+// Canonical shape→lane pairing authored by shipped beatmaps and HUD buttons.
 // Keep runtime input auto-targeting aligned with this helper.
 inline constexpr int8_t lane_for_shape(Shape shape) noexcept {
     switch (shape) {
-        case Shape::Triangle: return 0;
+        case Shape::Circle:   return 0;
         case Shape::Square:   return 1;
-        case Shape::Circle:   return 2;
+        case Shape::Triangle: return 2;
         case Shape::Hexagon:  return -1;
     }
     return -1;

--- a/content/beatmaps/1_stomper_beatmap.json
+++ b/content/beatmaps/1_stomper_beatmap.json
@@ -616,7 +616,7 @@
         {
           "beat": 80,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 3,
@@ -701,7 +701,7 @@
         {
           "beat": 112,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 5,
@@ -752,7 +752,7 @@
         {
           "beat": 129,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 5,
@@ -769,7 +769,7 @@
         {
           "beat": 142,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 5,
@@ -803,7 +803,7 @@
         {
           "beat": 208,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 8,
@@ -820,7 +820,7 @@
         {
           "beat": 225,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 9,
@@ -854,7 +854,7 @@
         {
           "beat": 276,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -871,7 +871,7 @@
         {
           "beat": 282,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -905,7 +905,7 @@
         {
           "beat": 285,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -939,7 +939,7 @@
         {
           "beat": 301,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -956,7 +956,7 @@
         {
           "beat": 302,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -990,7 +990,7 @@
         {
           "beat": 305,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -1007,7 +1007,7 @@
         {
           "beat": 306,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -1024,7 +1024,7 @@
         {
           "beat": 307,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -1041,7 +1041,7 @@
         {
           "beat": 310,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -1058,7 +1058,7 @@
         {
           "beat": 312,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -1126,7 +1126,7 @@
         {
           "beat": 384,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -1160,7 +1160,7 @@
         {
           "beat": 461,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -1194,7 +1194,7 @@
         {
           "beat": 463,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -1279,7 +1279,7 @@
         {
           "beat": 475,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -1330,7 +1330,7 @@
         {
           "beat": 479,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -1347,7 +1347,7 @@
         {
           "beat": 480,
           "kind": "onset_marker",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -1364,7 +1364,7 @@
         {
           "beat": 482,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -1381,7 +1381,7 @@
         {
           "beat": 483,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -1466,7 +1466,7 @@
         {
           "beat": 514,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 15,
@@ -1483,7 +1483,7 @@
         {
           "beat": 515,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -1577,7 +1577,7 @@
         {
           "beat": 14,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -1595,7 +1595,7 @@
         {
           "beat": 46,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 2,
@@ -1613,7 +1613,7 @@
         {
           "beat": 47,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 2,
@@ -1631,7 +1631,7 @@
         {
           "beat": 48,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 2,
@@ -1649,7 +1649,7 @@
         {
           "beat": 79,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 3,
@@ -1667,7 +1667,7 @@
         {
           "beat": 80,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 3,
@@ -1757,7 +1757,7 @@
         {
           "beat": 112,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 5,
@@ -1775,7 +1775,7 @@
         {
           "beat": 128,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 5,
@@ -1793,7 +1793,7 @@
         {
           "beat": 142,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 5,
@@ -1811,7 +1811,7 @@
         {
           "beat": 144,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 6,
@@ -1919,7 +1919,7 @@
         {
           "beat": 207,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 8,
@@ -1937,7 +1937,7 @@
         {
           "beat": 208,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 8,
@@ -1955,7 +1955,7 @@
         {
           "beat": 209,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 8,
@@ -1973,7 +1973,7 @@
         {
           "beat": 225,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 9,
@@ -2063,7 +2063,7 @@
         {
           "beat": 274,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -2081,7 +2081,7 @@
         {
           "beat": 276,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -2099,7 +2099,7 @@
         {
           "beat": 282,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -2117,7 +2117,7 @@
         {
           "beat": 285,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -2135,7 +2135,7 @@
         {
           "beat": 290,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -2171,7 +2171,7 @@
         {
           "beat": 312,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -2189,7 +2189,7 @@
         {
           "beat": 313,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -2261,7 +2261,7 @@
         {
           "beat": 384,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -2279,7 +2279,7 @@
         {
           "beat": 386,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 12,
@@ -2387,7 +2387,7 @@
         {
           "beat": 456,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -2405,7 +2405,7 @@
         {
           "beat": 457,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -2423,7 +2423,7 @@
         {
           "beat": 458,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -2441,7 +2441,7 @@
         {
           "beat": 462,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -2459,7 +2459,7 @@
         {
           "beat": 466,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -2495,7 +2495,7 @@
         {
           "beat": 482,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -2513,7 +2513,7 @@
         {
           "beat": 514,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 15,
@@ -2604,7 +2604,7 @@
         {
           "beat": 14,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -2638,7 +2638,7 @@
         {
           "beat": 46,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 2,
@@ -2655,7 +2655,7 @@
         {
           "beat": 47,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 2,
@@ -2672,7 +2672,7 @@
         {
           "beat": 48,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 2,
@@ -2706,7 +2706,7 @@
         {
           "beat": 79,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 3,
@@ -2723,7 +2723,7 @@
         {
           "beat": 80,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 3,
@@ -2740,7 +2740,7 @@
         {
           "beat": 81,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -2774,7 +2774,7 @@
         {
           "beat": 96,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 4,
@@ -2791,7 +2791,7 @@
         {
           "beat": 97,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 4,
@@ -2876,7 +2876,7 @@
         {
           "beat": 112,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 5,
@@ -2927,7 +2927,7 @@
         {
           "beat": 129,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 5,
@@ -2944,7 +2944,7 @@
         {
           "beat": 142,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 5,
@@ -2961,7 +2961,7 @@
         {
           "beat": 144,
           "kind": "onset_marker",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 6,
@@ -2978,7 +2978,7 @@
         {
           "beat": 176,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 7,
@@ -3080,7 +3080,7 @@
         {
           "beat": 207,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 8,
@@ -3097,7 +3097,7 @@
         {
           "beat": 208,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 8,
@@ -3114,7 +3114,7 @@
         {
           "beat": 209,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 8,
@@ -3131,7 +3131,7 @@
         {
           "beat": 225,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 9,
@@ -3233,7 +3233,7 @@
         {
           "beat": 272,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -3250,7 +3250,7 @@
         {
           "beat": 274,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -3284,7 +3284,7 @@
         {
           "beat": 276,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -3301,7 +3301,7 @@
         {
           "beat": 281,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -3318,7 +3318,7 @@
         {
           "beat": 282,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -3352,7 +3352,7 @@
         {
           "beat": 285,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -3386,7 +3386,7 @@
         {
           "beat": 301,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -3403,7 +3403,7 @@
         {
           "beat": 306,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -3437,7 +3437,7 @@
         {
           "beat": 308,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -3454,7 +3454,7 @@
         {
           "beat": 312,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -3471,7 +3471,7 @@
         {
           "beat": 313,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -3556,7 +3556,7 @@
         {
           "beat": 384,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -3573,7 +3573,7 @@
         {
           "beat": 386,
           "kind": "onset_marker",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 12,
@@ -3624,7 +3624,7 @@
         {
           "beat": 418,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 13,
@@ -3743,7 +3743,7 @@
         {
           "beat": 459,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -3777,7 +3777,7 @@
         {
           "beat": 462,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -3811,7 +3811,7 @@
         {
           "beat": 465,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -3845,7 +3845,7 @@
         {
           "beat": 469,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -3879,7 +3879,7 @@
         {
           "beat": 474,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -3913,7 +3913,7 @@
         {
           "beat": 476,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -3947,7 +3947,7 @@
         {
           "beat": 482,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -3964,7 +3964,7 @@
         {
           "beat": 483,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -4083,7 +4083,7 @@
         {
           "beat": 514,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 15,
@@ -4100,7 +4100,7 @@
         {
           "beat": 515,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,

--- a/content/beatmaps/2_drama_beatmap.json
+++ b/content/beatmaps/2_drama_beatmap.json
@@ -543,7 +543,7 @@
         {
           "beat": 9,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -560,7 +560,7 @@
         {
           "beat": 10,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -577,7 +577,7 @@
         {
           "beat": 12,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -594,7 +594,7 @@
         {
           "beat": 14,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -611,7 +611,7 @@
         {
           "beat": 53,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 2,
@@ -628,7 +628,7 @@
         {
           "beat": 56,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 2,
@@ -645,7 +645,7 @@
         {
           "beat": 57,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 2,
@@ -679,7 +679,7 @@
         {
           "beat": 59,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 2,
@@ -713,7 +713,7 @@
         {
           "beat": 61,
           "kind": "onset_marker",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 2,
@@ -730,7 +730,7 @@
         {
           "beat": 62,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 2,
@@ -747,7 +747,7 @@
         {
           "beat": 70,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 2,
@@ -764,7 +764,7 @@
         {
           "beat": 73,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 2,
@@ -798,7 +798,7 @@
         {
           "beat": 75,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -815,7 +815,7 @@
         {
           "beat": 79,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -832,7 +832,7 @@
         {
           "beat": 81,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -849,7 +849,7 @@
         {
           "beat": 82,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -934,7 +934,7 @@
         {
           "beat": 110,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 4,
@@ -951,7 +951,7 @@
         {
           "beat": 122,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 4,
@@ -968,7 +968,7 @@
         {
           "beat": 133,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 4,
@@ -985,7 +985,7 @@
         {
           "beat": 171,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 5,
@@ -1002,7 +1002,7 @@
         {
           "beat": 177,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 5,
@@ -1019,7 +1019,7 @@
         {
           "beat": 183,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -1036,7 +1036,7 @@
         {
           "beat": 186,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -1053,7 +1053,7 @@
         {
           "beat": 189,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -1087,7 +1087,7 @@
         {
           "beat": 266,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -1104,7 +1104,7 @@
         {
           "beat": 269,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -1121,7 +1121,7 @@
         {
           "beat": 270,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -1138,7 +1138,7 @@
         {
           "beat": 272,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -1189,7 +1189,7 @@
         {
           "beat": 275,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 8,
@@ -1206,7 +1206,7 @@
         {
           "beat": 276,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 9,
@@ -1223,7 +1223,7 @@
         {
           "beat": 279,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 9,
@@ -1240,7 +1240,7 @@
         {
           "beat": 281,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 9,
@@ -1325,7 +1325,7 @@
         {
           "beat": 314,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -1342,7 +1342,7 @@
         {
           "beat": 318,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -1359,7 +1359,7 @@
         {
           "beat": 325,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -1376,7 +1376,7 @@
         {
           "beat": 326,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -1410,7 +1410,7 @@
         {
           "beat": 329,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -1444,7 +1444,7 @@
         {
           "beat": 331,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -1461,7 +1461,7 @@
         {
           "beat": 332,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -1495,7 +1495,7 @@
         {
           "beat": 337,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -1512,7 +1512,7 @@
         {
           "beat": 339,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -1546,7 +1546,7 @@
         {
           "beat": 342,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -1563,7 +1563,7 @@
         {
           "beat": 345,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -1614,7 +1614,7 @@
         {
           "beat": 392,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -1648,7 +1648,7 @@
         {
           "beat": 394,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -1665,7 +1665,7 @@
         {
           "beat": 395,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -1699,7 +1699,7 @@
         {
           "beat": 397,
           "kind": "onset_marker",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -1716,7 +1716,7 @@
         {
           "beat": 398,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -1733,7 +1733,7 @@
         {
           "beat": 406,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -1767,7 +1767,7 @@
         {
           "beat": 409,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -1801,7 +1801,7 @@
         {
           "beat": 412,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -1818,7 +1818,7 @@
         {
           "beat": 415,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -1835,7 +1835,7 @@
         {
           "beat": 417,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -1852,7 +1852,7 @@
         {
           "beat": 418,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -1937,7 +1937,7 @@
         {
           "beat": 442,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -1971,7 +1971,7 @@
         {
           "beat": 450,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -1988,7 +1988,7 @@
         {
           "beat": 455,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -2005,7 +2005,7 @@
         {
           "beat": 458,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -2022,7 +2022,7 @@
         {
           "beat": 465,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -2039,7 +2039,7 @@
         {
           "beat": 470,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -2056,7 +2056,7 @@
         {
           "beat": 471,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -2073,7 +2073,7 @@
         {
           "beat": 473,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -2158,7 +2158,7 @@
         {
           "beat": 507,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 19,
@@ -2180,7 +2180,7 @@
         {
           "beat": 6,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -2216,7 +2216,7 @@
         {
           "beat": 8,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -2234,7 +2234,7 @@
         {
           "beat": 9,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -2324,7 +2324,7 @@
         {
           "beat": 52,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 2,
@@ -2342,7 +2342,7 @@
         {
           "beat": 53,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 2,
@@ -2414,7 +2414,7 @@
         {
           "beat": 75,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -2432,7 +2432,7 @@
         {
           "beat": 76,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -2468,7 +2468,7 @@
         {
           "beat": 81,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -2558,7 +2558,7 @@
         {
           "beat": 110,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 4,
@@ -2594,7 +2594,7 @@
         {
           "beat": 122,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 4,
@@ -2630,7 +2630,7 @@
         {
           "beat": 133,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 4,
@@ -2666,7 +2666,7 @@
         {
           "beat": 165,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 5,
@@ -2684,7 +2684,7 @@
         {
           "beat": 166,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 5,
@@ -2738,7 +2738,7 @@
         {
           "beat": 180,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -2756,7 +2756,7 @@
         {
           "beat": 183,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -2774,7 +2774,7 @@
         {
           "beat": 185,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -2792,7 +2792,7 @@
         {
           "beat": 186,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -2864,7 +2864,7 @@
         {
           "beat": 215,
           "kind": "onset_marker",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 6,
@@ -2954,7 +2954,7 @@
         {
           "beat": 266,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -2972,7 +2972,7 @@
         {
           "beat": 267,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -2990,7 +2990,7 @@
         {
           "beat": 269,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -3008,7 +3008,7 @@
         {
           "beat": 270,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -3026,7 +3026,7 @@
         {
           "beat": 276,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 9,
@@ -3044,7 +3044,7 @@
         {
           "beat": 279,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 9,
@@ -3062,7 +3062,7 @@
         {
           "beat": 281,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 9,
@@ -3080,7 +3080,7 @@
         {
           "beat": 282,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 9,
@@ -3170,7 +3170,7 @@
         {
           "beat": 314,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -3188,7 +3188,7 @@
         {
           "beat": 315,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -3206,7 +3206,7 @@
         {
           "beat": 317,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -3224,7 +3224,7 @@
         {
           "beat": 318,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -3296,7 +3296,7 @@
         {
           "beat": 333,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -3314,7 +3314,7 @@
         {
           "beat": 336,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -3332,7 +3332,7 @@
         {
           "beat": 337,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -3350,7 +3350,7 @@
         {
           "beat": 339,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -3440,7 +3440,7 @@
         {
           "beat": 388,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -3476,7 +3476,7 @@
         {
           "beat": 393,
           "kind": "onset_marker",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -3530,7 +3530,7 @@
         {
           "beat": 412,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -3548,7 +3548,7 @@
         {
           "beat": 414,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -3584,7 +3584,7 @@
         {
           "beat": 416,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -3674,7 +3674,7 @@
         {
           "beat": 441,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -3692,7 +3692,7 @@
         {
           "beat": 442,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -3728,7 +3728,7 @@
         {
           "beat": 447,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -3746,7 +3746,7 @@
         {
           "beat": 450,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -3764,7 +3764,7 @@
         {
           "beat": 465,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -3782,7 +3782,7 @@
         {
           "beat": 467,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -3800,7 +3800,7 @@
         {
           "beat": 468,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -3818,7 +3818,7 @@
         {
           "beat": 470,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -3890,7 +3890,7 @@
         {
           "beat": 507,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 19,
@@ -3908,7 +3908,7 @@
         {
           "beat": 515,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 19,
@@ -3931,7 +3931,7 @@
         {
           "beat": 5,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -3948,7 +3948,7 @@
         {
           "beat": 6,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -3982,7 +3982,7 @@
         {
           "beat": 8,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -4016,7 +4016,7 @@
         {
           "beat": 10,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -4033,7 +4033,7 @@
         {
           "beat": 11,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -4050,7 +4050,7 @@
         {
           "beat": 12,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -4169,7 +4169,7 @@
         {
           "beat": 53,
           "kind": "onset_marker",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 2,
@@ -4203,7 +4203,7 @@
         {
           "beat": 55,
           "kind": "onset_marker",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 2,
@@ -4237,7 +4237,7 @@
         {
           "beat": 57,
           "kind": "onset_marker",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 2,
@@ -4254,7 +4254,7 @@
         {
           "beat": 58,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 2,
@@ -4271,7 +4271,7 @@
         {
           "beat": 59,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 2,
@@ -4288,7 +4288,7 @@
         {
           "beat": 60,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 2,
@@ -4339,7 +4339,7 @@
         {
           "beat": 64,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 2,
@@ -4356,7 +4356,7 @@
         {
           "beat": 70,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 2,
@@ -4373,7 +4373,7 @@
         {
           "beat": 71,
           "kind": "onset_marker",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 2,
@@ -4407,7 +4407,7 @@
         {
           "beat": 73,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 2,
@@ -4441,7 +4441,7 @@
         {
           "beat": 76,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -4475,7 +4475,7 @@
         {
           "beat": 78,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -4509,7 +4509,7 @@
         {
           "beat": 81,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -4543,7 +4543,7 @@
         {
           "beat": 83,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -4645,7 +4645,7 @@
         {
           "beat": 110,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 4,
@@ -4662,7 +4662,7 @@
         {
           "beat": 122,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 4,
@@ -4679,7 +4679,7 @@
         {
           "beat": 133,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 4,
@@ -4696,7 +4696,7 @@
         {
           "beat": 160,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 5,
@@ -4713,7 +4713,7 @@
         {
           "beat": 165,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 5,
@@ -4730,7 +4730,7 @@
         {
           "beat": 166,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 5,
@@ -4747,7 +4747,7 @@
         {
           "beat": 167,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 5,
@@ -4781,7 +4781,7 @@
         {
           "beat": 169,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 5,
@@ -4798,7 +4798,7 @@
         {
           "beat": 170,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 5,
@@ -4815,7 +4815,7 @@
         {
           "beat": 171,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 5,
@@ -4849,7 +4849,7 @@
         {
           "beat": 180,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -4866,7 +4866,7 @@
         {
           "beat": 181,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -4883,7 +4883,7 @@
         {
           "beat": 183,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -4900,7 +4900,7 @@
         {
           "beat": 185,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -4917,7 +4917,7 @@
         {
           "beat": 186,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -4951,7 +4951,7 @@
         {
           "beat": 188,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -4968,7 +4968,7 @@
         {
           "beat": 215,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -5087,7 +5087,7 @@
         {
           "beat": 268,
           "kind": "onset_marker",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -5104,7 +5104,7 @@
         {
           "beat": 269,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 8,
@@ -5121,7 +5121,7 @@
         {
           "beat": 270,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -5155,7 +5155,7 @@
         {
           "beat": 272,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 8,
@@ -5172,7 +5172,7 @@
         {
           "beat": 274,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -5206,7 +5206,7 @@
         {
           "beat": 276,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 8,
@@ -5240,7 +5240,7 @@
         {
           "beat": 278,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 8,
@@ -5274,7 +5274,7 @@
         {
           "beat": 280,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 8,
@@ -5376,7 +5376,7 @@
         {
           "beat": 314,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -5410,7 +5410,7 @@
         {
           "beat": 316,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -5427,7 +5427,7 @@
         {
           "beat": 317,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -5461,7 +5461,7 @@
         {
           "beat": 319,
           "kind": "onset_marker",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -5478,7 +5478,7 @@
         {
           "beat": 320,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -5512,7 +5512,7 @@
         {
           "beat": 325,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -5563,7 +5563,7 @@
         {
           "beat": 328,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -5614,7 +5614,7 @@
         {
           "beat": 331,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -5631,7 +5631,7 @@
         {
           "beat": 332,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -5648,7 +5648,7 @@
         {
           "beat": 333,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 11,
@@ -5682,7 +5682,7 @@
         {
           "beat": 335,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -5699,7 +5699,7 @@
         {
           "beat": 339,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -5733,7 +5733,7 @@
         {
           "beat": 341,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -5852,7 +5852,7 @@
         {
           "beat": 389,
           "kind": "onset_marker",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -5869,7 +5869,7 @@
         {
           "beat": 390,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -5886,7 +5886,7 @@
         {
           "beat": 392,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -5903,7 +5903,7 @@
         {
           "beat": 393,
           "kind": "onset_marker",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -5937,7 +5937,7 @@
         {
           "beat": 395,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -5988,7 +5988,7 @@
         {
           "beat": 398,
           "kind": "onset_marker",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -6022,7 +6022,7 @@
         {
           "beat": 400,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -6056,7 +6056,7 @@
         {
           "beat": 406,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -6090,7 +6090,7 @@
         {
           "beat": 409,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -6124,7 +6124,7 @@
         {
           "beat": 411,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 14,
@@ -6158,7 +6158,7 @@
         {
           "beat": 413,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -6175,7 +6175,7 @@
         {
           "beat": 415,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -6209,7 +6209,7 @@
         {
           "beat": 417,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -6243,7 +6243,7 @@
         {
           "beat": 419,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -6260,7 +6260,7 @@
         {
           "beat": 420,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -6362,7 +6362,7 @@
         {
           "beat": 441,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -6379,7 +6379,7 @@
         {
           "beat": 442,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 17,
@@ -6396,7 +6396,7 @@
         {
           "beat": 443,
           "kind": "onset_marker",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -6430,7 +6430,7 @@
         {
           "beat": 447,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -6464,7 +6464,7 @@
         {
           "beat": 451,
           "kind": "onset_marker",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -6481,7 +6481,7 @@
         {
           "beat": 452,
           "kind": "onset_marker",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -6515,7 +6515,7 @@
         {
           "beat": 456,
           "kind": "onset_marker",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -6566,7 +6566,7 @@
         {
           "beat": 464,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -6583,7 +6583,7 @@
         {
           "beat": 465,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -6600,7 +6600,7 @@
         {
           "beat": 467,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -6617,7 +6617,7 @@
         {
           "beat": 468,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -6634,7 +6634,7 @@
         {
           "beat": 470,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -6668,7 +6668,7 @@
         {
           "beat": 492,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -6702,7 +6702,7 @@
         {
           "beat": 497,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 19,
@@ -6736,7 +6736,7 @@
         {
           "beat": 500,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 19,
@@ -6770,7 +6770,7 @@
         {
           "beat": 507,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 19,
@@ -6787,7 +6787,7 @@
         {
           "beat": 515,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 19,

--- a/content/beatmaps/3_mental_corruption_beatmap.json
+++ b/content/beatmaps/3_mental_corruption_beatmap.json
@@ -578,7 +578,7 @@
         {
           "beat": 10,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -612,7 +612,7 @@
         {
           "beat": 80,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 2,
@@ -629,7 +629,7 @@
         {
           "beat": 85,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 2,
@@ -646,7 +646,7 @@
         {
           "beat": 86,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 2,
@@ -663,7 +663,7 @@
         {
           "beat": 96,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -680,7 +680,7 @@
         {
           "beat": 98,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -697,7 +697,7 @@
         {
           "beat": 102,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -714,7 +714,7 @@
         {
           "beat": 106,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -799,7 +799,7 @@
         {
           "beat": 134,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 5,
@@ -816,7 +816,7 @@
         {
           "beat": 135,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 5,
@@ -833,7 +833,7 @@
         {
           "beat": 140,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 5,
@@ -850,7 +850,7 @@
         {
           "beat": 142,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 5,
@@ -867,7 +867,7 @@
         {
           "beat": 143,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 5,
@@ -901,7 +901,7 @@
         {
           "beat": 153,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -918,7 +918,7 @@
         {
           "beat": 157,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -935,7 +935,7 @@
         {
           "beat": 158,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -952,7 +952,7 @@
         {
           "beat": 162,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -1020,7 +1020,7 @@
         {
           "beat": 190,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -1037,7 +1037,7 @@
         {
           "beat": 192,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -1054,7 +1054,7 @@
         {
           "beat": 194,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 8,
@@ -1071,7 +1071,7 @@
         {
           "beat": 195,
           "kind": "onset_marker",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -1105,7 +1105,7 @@
         {
           "beat": 197,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -1122,7 +1122,7 @@
         {
           "beat": 198,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 8,
@@ -1156,7 +1156,7 @@
         {
           "beat": 201,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 8,
@@ -1173,7 +1173,7 @@
         {
           "beat": 203,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 8,
@@ -1207,7 +1207,7 @@
         {
           "beat": 209,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 9,
@@ -1224,7 +1224,7 @@
         {
           "beat": 211,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 9,
@@ -1258,7 +1258,7 @@
         {
           "beat": 213,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 9,
@@ -1275,7 +1275,7 @@
         {
           "beat": 215,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 9,
@@ -1360,7 +1360,7 @@
         {
           "beat": 247,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -1377,7 +1377,7 @@
         {
           "beat": 254,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -1394,7 +1394,7 @@
         {
           "beat": 255,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -1411,7 +1411,7 @@
         {
           "beat": 258,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -1428,7 +1428,7 @@
         {
           "beat": 261,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -1445,7 +1445,7 @@
         {
           "beat": 262,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -1530,7 +1530,7 @@
         {
           "beat": 322,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -1547,7 +1547,7 @@
         {
           "beat": 323,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -1564,7 +1564,7 @@
         {
           "beat": 327,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -1581,7 +1581,7 @@
         {
           "beat": 331,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -1598,7 +1598,7 @@
         {
           "beat": 342,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -1615,7 +1615,7 @@
         {
           "beat": 345,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -1632,7 +1632,7 @@
         {
           "beat": 346,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -1649,7 +1649,7 @@
         {
           "beat": 349,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -1734,7 +1734,7 @@
         {
           "beat": 377,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -1751,7 +1751,7 @@
         {
           "beat": 379,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -1768,7 +1768,7 @@
         {
           "beat": 381,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -1785,7 +1785,7 @@
         {
           "beat": 383,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -1802,7 +1802,7 @@
         {
           "beat": 385,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 17,
@@ -1836,7 +1836,7 @@
         {
           "beat": 388,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 17,
@@ -1853,7 +1853,7 @@
         {
           "beat": 390,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 17,
@@ -1887,7 +1887,7 @@
         {
           "beat": 392,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 17,
@@ -1904,7 +1904,7 @@
         {
           "beat": 394,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 17,
@@ -1921,7 +1921,7 @@
         {
           "beat": 396,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 17,
@@ -1938,7 +1938,7 @@
         {
           "beat": 398,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 17,
@@ -1972,7 +1972,7 @@
         {
           "beat": 401,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 17,
@@ -1989,7 +1989,7 @@
         {
           "beat": 409,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -2023,7 +2023,7 @@
         {
           "beat": 414,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -2040,7 +2040,7 @@
         {
           "beat": 415,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -2057,7 +2057,7 @@
         {
           "beat": 417,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -2091,7 +2091,7 @@
         {
           "beat": 473,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 21,
@@ -2108,7 +2108,7 @@
         {
           "beat": 475,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 21,
@@ -2125,7 +2125,7 @@
         {
           "beat": 478,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 21,
@@ -2210,7 +2210,7 @@
         {
           "beat": 504,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 23,
@@ -2227,7 +2227,7 @@
         {
           "beat": 505,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 23,
@@ -2261,7 +2261,7 @@
         {
           "beat": 507,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 23,
@@ -2278,7 +2278,7 @@
         {
           "beat": 508,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 23,
@@ -2295,7 +2295,7 @@
         {
           "beat": 510,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 23,
@@ -2312,7 +2312,7 @@
         {
           "beat": 515,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 23,
@@ -2329,7 +2329,7 @@
         {
           "beat": 518,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 23,
@@ -2346,7 +2346,7 @@
         {
           "beat": 519,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 23,
@@ -2380,7 +2380,7 @@
         {
           "beat": 527,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 24,
@@ -2397,7 +2397,7 @@
         {
           "beat": 529,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 24,
@@ -2414,7 +2414,7 @@
         {
           "beat": 531,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 24,
@@ -2431,7 +2431,7 @@
         {
           "beat": 534,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 24,
@@ -2453,7 +2453,7 @@
         {
           "beat": 7,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -2489,7 +2489,7 @@
         {
           "beat": 9,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -2597,7 +2597,7 @@
         {
           "beat": 55,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 1,
@@ -2669,7 +2669,7 @@
         {
           "beat": 78,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 2,
@@ -2705,7 +2705,7 @@
         {
           "beat": 80,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 2,
@@ -2723,7 +2723,7 @@
         {
           "beat": 85,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 2,
@@ -2741,7 +2741,7 @@
         {
           "beat": 95,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -2759,7 +2759,7 @@
         {
           "beat": 96,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -2795,7 +2795,7 @@
         {
           "beat": 99,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -2885,7 +2885,7 @@
         {
           "beat": 134,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 5,
@@ -2903,7 +2903,7 @@
         {
           "beat": 135,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 5,
@@ -2921,7 +2921,7 @@
         {
           "beat": 141,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 5,
@@ -2957,7 +2957,7 @@
         {
           "beat": 152,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -2975,7 +2975,7 @@
         {
           "beat": 153,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -2993,7 +2993,7 @@
         {
           "beat": 155,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -3011,7 +3011,7 @@
         {
           "beat": 157,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -3101,7 +3101,7 @@
         {
           "beat": 193,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -3119,7 +3119,7 @@
         {
           "beat": 194,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -3155,7 +3155,7 @@
         {
           "beat": 196,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -3209,7 +3209,7 @@
         {
           "beat": 211,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 9,
@@ -3245,7 +3245,7 @@
         {
           "beat": 214,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 9,
@@ -3263,7 +3263,7 @@
         {
           "beat": 215,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 9,
@@ -3353,7 +3353,7 @@
         {
           "beat": 247,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -3371,7 +3371,7 @@
         {
           "beat": 254,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -3389,7 +3389,7 @@
         {
           "beat": 261,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -3407,7 +3407,7 @@
         {
           "beat": 262,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -3425,7 +3425,7 @@
         {
           "beat": 263,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -3443,7 +3443,7 @@
         {
           "beat": 265,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -3479,7 +3479,7 @@
         {
           "beat": 302,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 13,
@@ -3568,7 +3568,7 @@
         {
           "beat": 339,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -3586,7 +3586,7 @@
         {
           "beat": 341,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -3604,7 +3604,7 @@
         {
           "beat": 342,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -3622,7 +3622,7 @@
         {
           "beat": 343,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -3712,7 +3712,7 @@
         {
           "beat": 377,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -3730,7 +3730,7 @@
         {
           "beat": 378,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -3766,7 +3766,7 @@
         {
           "beat": 382,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -3856,7 +3856,7 @@
         {
           "beat": 409,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -3874,7 +3874,7 @@
         {
           "beat": 412,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -3910,7 +3910,7 @@
         {
           "beat": 414,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -3928,7 +3928,7 @@
         {
           "beat": 415,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -4018,7 +4018,7 @@
         {
           "beat": 464,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 20,
@@ -4036,7 +4036,7 @@
         {
           "beat": 466,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 20,
@@ -4054,7 +4054,7 @@
         {
           "beat": 471,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 21,
@@ -4072,7 +4072,7 @@
         {
           "beat": 473,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 21,
@@ -4090,7 +4090,7 @@
         {
           "beat": 475,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 21,
@@ -4108,7 +4108,7 @@
         {
           "beat": 478,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 21,
@@ -4198,7 +4198,7 @@
         {
           "beat": 502,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 23,
@@ -4252,7 +4252,7 @@
         {
           "beat": 508,
           "kind": "onset_marker",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 23,
@@ -4360,7 +4360,7 @@
         {
           "beat": 527,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 24,
@@ -4378,7 +4378,7 @@
         {
           "beat": 530,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 24,
@@ -4396,7 +4396,7 @@
         {
           "beat": 531,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 24,
@@ -4414,7 +4414,7 @@
         {
           "beat": 537,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 24,
@@ -4432,7 +4432,7 @@
         {
           "beat": 538,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 24,
@@ -4450,7 +4450,7 @@
         {
           "beat": 543,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 24,
@@ -4473,7 +4473,7 @@
         {
           "beat": 5,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -4490,7 +4490,7 @@
         {
           "beat": 6,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -4507,7 +4507,7 @@
         {
           "beat": 7,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -4524,7 +4524,7 @@
         {
           "beat": 9,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -4541,7 +4541,7 @@
         {
           "beat": 10,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 0,
@@ -4643,7 +4643,7 @@
         {
           "beat": 55,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 1,
@@ -4660,7 +4660,7 @@
         {
           "beat": 78,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 2,
@@ -4677,7 +4677,7 @@
         {
           "beat": 79,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 2,
@@ -4694,7 +4694,7 @@
         {
           "beat": 80,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 2,
@@ -4711,7 +4711,7 @@
         {
           "beat": 81,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 2,
@@ -4728,7 +4728,7 @@
         {
           "beat": 82,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 2,
@@ -4745,7 +4745,7 @@
         {
           "beat": 95,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -4762,7 +4762,7 @@
         {
           "beat": 96,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -4779,7 +4779,7 @@
         {
           "beat": 97,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -4796,7 +4796,7 @@
         {
           "beat": 98,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -4813,7 +4813,7 @@
         {
           "beat": 99,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 3,
@@ -4915,7 +4915,7 @@
         {
           "beat": 134,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 5,
@@ -4932,7 +4932,7 @@
         {
           "beat": 135,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 5,
@@ -4949,7 +4949,7 @@
         {
           "beat": 136,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 5,
@@ -4966,7 +4966,7 @@
         {
           "beat": 137,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 5,
@@ -4983,7 +4983,7 @@
         {
           "beat": 139,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 5,
@@ -5000,7 +5000,7 @@
         {
           "beat": 152,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -5017,7 +5017,7 @@
         {
           "beat": 153,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -5034,7 +5034,7 @@
         {
           "beat": 154,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -5051,7 +5051,7 @@
         {
           "beat": 155,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -5068,7 +5068,7 @@
         {
           "beat": 157,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 6,
@@ -5170,7 +5170,7 @@
         {
           "beat": 190,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -5187,7 +5187,7 @@
         {
           "beat": 192,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -5204,7 +5204,7 @@
         {
           "beat": 193,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -5221,7 +5221,7 @@
         {
           "beat": 194,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -5238,7 +5238,7 @@
         {
           "beat": 195,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 8,
@@ -5255,7 +5255,7 @@
         {
           "beat": 210,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 9,
@@ -5272,7 +5272,7 @@
         {
           "beat": 211,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 9,
@@ -5289,7 +5289,7 @@
         {
           "beat": 212,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 9,
@@ -5306,7 +5306,7 @@
         {
           "beat": 213,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 9,
@@ -5323,7 +5323,7 @@
         {
           "beat": 214,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 9,
@@ -5425,7 +5425,7 @@
         {
           "beat": 246,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -5442,7 +5442,7 @@
         {
           "beat": 247,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -5459,7 +5459,7 @@
         {
           "beat": 248,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -5476,7 +5476,7 @@
         {
           "beat": 253,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -5493,7 +5493,7 @@
         {
           "beat": 254,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -5510,7 +5510,7 @@
         {
           "beat": 255,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 11,
@@ -5527,7 +5527,7 @@
         {
           "beat": 259,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -5544,7 +5544,7 @@
         {
           "beat": 261,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -5561,7 +5561,7 @@
         {
           "beat": 262,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -5578,7 +5578,7 @@
         {
           "beat": 263,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -5595,7 +5595,7 @@
         {
           "beat": 265,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 12,
@@ -5629,7 +5629,7 @@
         {
           "beat": 302,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 13,
@@ -5714,7 +5714,7 @@
         {
           "beat": 322,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -5731,7 +5731,7 @@
         {
           "beat": 323,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -5748,7 +5748,7 @@
         {
           "beat": 324,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -5765,7 +5765,7 @@
         {
           "beat": 327,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -5782,7 +5782,7 @@
         {
           "beat": 328,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -5799,7 +5799,7 @@
         {
           "beat": 329,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 14,
@@ -5816,7 +5816,7 @@
         {
           "beat": 339,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -5833,7 +5833,7 @@
         {
           "beat": 340,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -5850,7 +5850,7 @@
         {
           "beat": 341,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -5867,7 +5867,7 @@
         {
           "beat": 342,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -5884,7 +5884,7 @@
         {
           "beat": 343,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 15,
@@ -5986,7 +5986,7 @@
         {
           "beat": 377,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -6003,7 +6003,7 @@
         {
           "beat": 378,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -6020,7 +6020,7 @@
         {
           "beat": 379,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -6037,7 +6037,7 @@
         {
           "beat": 380,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -6054,7 +6054,7 @@
         {
           "beat": 381,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 17,
@@ -6071,7 +6071,7 @@
         {
           "beat": 409,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -6088,7 +6088,7 @@
         {
           "beat": 410,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -6105,7 +6105,7 @@
         {
           "beat": 412,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -6122,7 +6122,7 @@
         {
           "beat": 413,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -6139,7 +6139,7 @@
         {
           "beat": 414,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 18,
@@ -6241,7 +6241,7 @@
         {
           "beat": 453,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 20,
@@ -6258,7 +6258,7 @@
         {
           "beat": 455,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 20,
@@ -6275,7 +6275,7 @@
         {
           "beat": 462,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 20,
@@ -6292,7 +6292,7 @@
         {
           "beat": 463,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 20,
@@ -6309,7 +6309,7 @@
         {
           "beat": 464,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 20,
@@ -6326,7 +6326,7 @@
         {
           "beat": 465,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 20,
@@ -6343,7 +6343,7 @@
         {
           "beat": 471,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 21,
@@ -6360,7 +6360,7 @@
         {
           "beat": 472,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 21,
@@ -6377,7 +6377,7 @@
         {
           "beat": 473,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 21,
@@ -6394,7 +6394,7 @@
         {
           "beat": 474,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 21,
@@ -6411,7 +6411,7 @@
         {
           "beat": 475,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 21,
@@ -6513,7 +6513,7 @@
         {
           "beat": 502,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 23,
@@ -6530,7 +6530,7 @@
         {
           "beat": 504,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 23,
@@ -6547,7 +6547,7 @@
         {
           "beat": 505,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 23,
@@ -6564,7 +6564,7 @@
         {
           "beat": 506,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 23,
@@ -6581,7 +6581,7 @@
         {
           "beat": 507,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 23,
@@ -6598,7 +6598,7 @@
         {
           "beat": 527,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 24,
@@ -6615,7 +6615,7 @@
         {
           "beat": 528,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 24,
@@ -6632,7 +6632,7 @@
         {
           "beat": 530,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 24,
@@ -6649,7 +6649,7 @@
         {
           "beat": 531,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 24,
@@ -6666,7 +6666,7 @@
         {
           "beat": 532,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 24,
@@ -6683,7 +6683,7 @@
         {
           "beat": 537,
           "kind": "shape_gate",
-          "lane": 2,
+          "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",
           "segment_idx": 24,
@@ -6700,7 +6700,7 @@
         {
           "beat": 538,
           "kind": "onset_marker",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 24,
@@ -6717,7 +6717,7 @@
         {
           "beat": 543,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 24,
@@ -6734,7 +6734,7 @@
         {
           "beat": 545,
           "kind": "shape_gate",
-          "lane": 0,
+          "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
           "segment_idx": 24,

--- a/design-docs/game.md
+++ b/design-docs/game.md
@@ -71,8 +71,8 @@ The screen is divided into two zones:
 > content audit; see
 > the per-difficulty table in `rhythm-design.md` §8), shape and lane
 > are fused 1:1 by
-> `tools/level_designer.py:ONSET_CLASS_TO_OBSTACLE` — every triangle is
-> on lane 0, every square on lane 1, every circle on lane 2. As a
+> `tools/level_designer.py:ONSET_CLASS_TO_OBSTACLE` — every circle is
+> on lane 0, every square on lane 1, every triangle on lane 2. As a
 > result, **strafing input is currently redundant**: choosing the
 > correct shape implies the correct lane, and a player who never strafes
 > still passes 100% of shape gates. The Controls section above and the

--- a/design-docs/rhythm-design.md
+++ b/design-docs/rhythm-design.md
@@ -132,9 +132,9 @@ The shape and lane of every obstacle come directly from which broad layer fired 
 
 ```
   ┌────────────────────────────────────────────────────────────────┐
-  │  Percussive onset at beat 4?    → Triangle gate, lane 0 (LEFT) │
+  │  Percussive onset at beat 4?    → Triangle gate, lane 2 (RIGHT)│
   │  Full-spectrum onset at beat 6? → Square gate,   lane 1 (CTR)  │
-  │  Harmonic onset at beat 7?      → Circle gate,   lane 2 (RIGHT)│
+  │  Harmonic onset at beat 7?      → Circle gate,   lane 0 (LEFT) │
   │  Multiple layers at beat 8?     → Separate candidates by layer │
   │                                                                │
   │  (Instrument names like "kick / snare / hi-hat" are not part   │
@@ -738,9 +738,9 @@ For shipped per-difficulty obstacle counts, see the table in
 
   Onset        Moment of sudden energy increase detected by librosa
                on one of the broad layers (percussive / harmonic /
-               full-spectrum). Percussive → triangle / lane 0.
+               full-spectrum). Percussive → triangle / lane 2.
                Full-spectrum → square / lane 1.
-               Harmonic → circle / lane 2.
+               Harmonic → circle / lane 0.
 
   Layer        One of three broad librosa layer classes used for
                classification: percussive, harmonic, full-spectrum.

--- a/design-docs/rhythm-design.md
+++ b/design-docs/rhythm-design.md
@@ -112,7 +112,7 @@
   │          │                │                    │                │
   │          ▼                ▼                    ▼                │
   │       TRIANGLE          SQUARE              CIRCLE              │
-  │       LANE 0            LANE 1              LANE 2              │
+  │       LANE 2            LANE 1              LANE 0              │
   │                                                                 │
   │   Each onset = one obstacle spawn candidate.                    │
   │   Snap to beat grid (within 80ms). That's your note.            │

--- a/tests/test_input_pipeline_behavior.cpp
+++ b/tests/test_input_pipeline_behavior.cpp
@@ -156,7 +156,7 @@ TEST_CASE("pipeline: semantic shape press remaps lane target to shape lane",
         {ButtonPressKind::Shape, Shape::Circle, MenuActionKind::Confirm, 0});
     run_pipeline(reg);
 
-    CHECK(lane.target == 2);
+    CHECK(lane.target == 0);
 }
 
 TEST_CASE("pipeline: desktop keyboard slot mapping keeps Z left and C right lanes",
@@ -264,7 +264,7 @@ TEST_CASE("pipeline: mixed swipe and tap both take effect within a single pipeli
 
     run_pipeline(reg);
 
-    CHECK(lane.target     == 0);                  // shape auto-target wins
+    CHECK(lane.target     == 2);                  // shape auto-target wins
     CHECK(sw.phase        == WindowPhase::Active); // tap processed
     CHECK(sw.target_shape == Shape::Triangle);
 }

--- a/tests/test_player_input_rhythm_extended.cpp
+++ b/tests/test_player_input_rhythm_extended.cpp
@@ -92,7 +92,7 @@ TEST_CASE("player_input_rhythm: shape press auto-target follows shipped mapping"
     press_button(reg, btn);
     run_semantic_input_tick(reg);
 
-    CHECK(lane.target == 0);
+    CHECK(lane.target == 2);
 }
 
 TEST_CASE("player_input_rhythm: shape press does not set stale target when already in shipped lane",
@@ -100,7 +100,7 @@ TEST_CASE("player_input_rhythm: shape press does not set stale target when alrea
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& lane = reg.get<Lane>(player);
-    lane.current = 2;
+    lane.current = 0;
     lane.target = -1;
 
     auto btn = make_shape_button(reg, Shape::Circle);
@@ -194,23 +194,23 @@ TEST_CASE("player_input: non-rhythm shape press updates Color", "[player]") {
 }
 
 
-TEST_CASE("player_input_rhythm: circle press in lane 2 does not force mismatch before collision",
+TEST_CASE("player_input_rhythm: circle press in lane 0 does not force mismatch before collision",
           "[player][rhythm][issue531]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& lane = reg.get<Lane>(player);
     auto& transform = reg.get<WorldTransform>(player);
 
-    lane.current = 2;
+    lane.current = 0;
     lane.target = -1;
     lane.lerp_t = 1.0f;
-    transform.position.x = constants::LANE_X[2];
+    transform.position.x = constants::LANE_X[0];
 
     auto& ps = reg.get<PlayerShape>(player);
     ps.current = Shape::Hexagon;
 
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
-    reg.get<WorldTransform>(obs).position.x = constants::LANE_X[2];
+    reg.get<WorldTransform>(obs).position.x = constants::LANE_X[0];
 
     auto btn = make_shape_button(reg, Shape::Circle);
     press_button(reg, btn);

--- a/tests/test_shipped_beatmap_medium_balance.cpp
+++ b/tests/test_shipped_beatmap_medium_balance.cpp
@@ -31,9 +31,9 @@ static std::vector<std::string> find_shipped_beatmaps() {
 
 static int expected_lane_for_shape(Shape shape) {
     switch (shape) {
-        case Shape::Triangle: return 0;
+        case Shape::Circle: return 0;
         case Shape::Square: return 1;
-        case Shape::Circle: return 2;
+        case Shape::Triangle: return 2;
         case Shape::Hexagon: return -1;
     }
     return -1;

--- a/tests/test_shipped_beatmap_onset_metadata.cpp
+++ b/tests/test_shipped_beatmap_onset_metadata.cpp
@@ -139,13 +139,13 @@ TEST_CASE("shipped beatmaps: onset metadata invariants", "[shipped_beatmaps][iss
                 int expected_lane = -1;
                 std::string expected_shape;
                 if (source_class == "percussive") {
-                    expected_lane = 0;
+                    expected_lane = 2;
                     expected_shape = "triangle";
                 } else if (source_class == "full-spectrum") {
                     expected_lane = 1;
                     expected_shape = "square";
                 } else if (source_class == "harmonic") {
-                    expected_lane = 2;
+                    expected_lane = 0;
                     expected_shape = "circle";
                 }
 

--- a/tools/level_designer.py
+++ b/tools/level_designer.py
@@ -45,8 +45,8 @@ from collections import Counter, defaultdict
 # CONSTANTS
 # ═══════════════════════════════════════════════════════════════
 
-SHAPE_TO_LANE = {"triangle": 0, "square": 1, "circle": 2}
-LANE_TO_SHAPE = {0: "triangle", 1: "square", 2: "circle"}
+SHAPE_TO_LANE = {"circle": 0, "square": 1, "triangle": 2}
+LANE_TO_SHAPE = {0: "circle", 1: "square", 2: "triangle"}
 ALL_SHAPES = ["circle", "square", "triangle"]
 SUBDIVISION_FRACTIONS = [
     (0.0, "downbeat"),
@@ -62,8 +62,8 @@ SUBDIVISION_TO_LANE = {
     "offgrid": 1,   # fallback
 }
 ONSET_CLASS_TO_OBSTACLE = {
-    "percussive": {"lane": 0, "shape": "triangle"},
-    "harmonic": {"lane": 2, "shape": "circle"},
+    "percussive": {"lane": 2, "shape": "triangle"},
+    "harmonic": {"lane": 0, "shape": "circle"},
     "full-spectrum": {"lane": 1, "shape": "square"},
 }
 SHAPE_TO_ONSET_CLASS = {
@@ -210,9 +210,9 @@ MAX_SAME_LANE_RUN = {"easy": 4, "medium": 5, "hard": 6}
 SUBDIVISION_SNAP_TOLERANCE_SEC = 0.060
 DENSE_CLUSTER_SOFT_CAP = {"medium": 6, "hard": 10}
 MEDIUM_SHAPE_TARGETS = {
-    0: (25, 45),  # Triangle / lane 0
+    0: (10, 20),  # Circle / lane 0
     1: (45, 60),  # Square / lane 1
-    2: (10, 20),  # Circle / lane 2
+    2: (25, 45),  # Triangle / lane 2
 }
 HARD_TRIANGLE_FLOOR_PCT = 25
 HARD_CIRCLE_CEIL_PCT = 40
@@ -1586,7 +1586,7 @@ def _choose_segment_focus(class_stats, prev_focuses):
     }
 
     # Issue #420 — force rotation across all available broad onset
-    # layers so harmonic (lane 2 / circle) and other underrepresented
+    # layers so harmonic (lane 0 / circle) and other underrepresented
     # layers actually get picked when they have non-empty events in a
     # segment.  Forbid up to ``SEGMENT_FOCUS_ANTI_REPEAT_MAX`` of the
     # most recently used classes from the eligible pool whenever doing
@@ -2729,7 +2729,7 @@ def design_level_segment_focus(analysis, difficulty, cleanup_enabled=False):
     compatibility but its value is always ignored — passing True has no effect.
 
     Motif n-gram detection is NOT used for obstacle selection here.
-    Class mapping: percussive→lane 0+triangle, harmonic→lane 2+circle,
+    Class mapping: percussive→lane 2+triangle, harmonic→lane 0+circle,
                    full-spectrum→lane 1+square.
     Difficulty controls how many onset events per segment are included.
     """

--- a/tools/rhythm_pipeline.py
+++ b/tools/rhythm_pipeline.py
@@ -63,8 +63,8 @@ ONSET_PASSES = [
 # used for lane/shape assignment.  These classes must NOT be merged across
 # each other even when their timestamps are very close (< 50 ms).
 #
-#   percussive    — bass / broadband / high-mid → lane 0, triangle
-#   harmonic      — low-mid                     → lane 2, circle
+#   percussive    — bass / broadband / high-mid → lane 2, triangle
+#   harmonic      — low-mid                     → lane 0, circle
 #   full-spectrum — spectral flux (catch-all)   → lane 1, square
 #
 # Legacy aliases (kick / snare / hihat / melody / flux) are kept ONLY so

--- a/tools/test_level_designer_onset_spike.py
+++ b/tools/test_level_designer_onset_spike.py
@@ -107,7 +107,7 @@ class TestExperimentalOnsetTiming(unittest.TestCase):
         self.assertEqual(obs["source_onset_class"], "percussive")
         self.assertEqual(obs["onset_class"], "percussive")
         self.assertEqual(obs["shape"], "triangle")
-        self.assertEqual(obs["lane"], 0)
+        self.assertEqual(obs["lane"], 2)
 
     def test_defaults_use_onset_timing(self):
         beatmap = ld.build_beatmap(_analysis_fixture(), ["easy"], cleanup_enabled=True)
@@ -220,10 +220,10 @@ class TestExperimentalOnsetTiming(unittest.TestCase):
         for obs in mapped:
             onset_class = obs.get("onset_class")
             if onset_class == "percussive":
-                self.assertEqual(obs["lane"], 0)
+                self.assertEqual(obs["lane"], 2)
                 self.assertEqual(obs["shape"], "triangle")
             elif onset_class == "harmonic":
-                self.assertEqual(obs["lane"], 2)
+                self.assertEqual(obs["lane"], 0)
                 self.assertEqual(obs["shape"], "circle")
             elif onset_class == "full-spectrum":
                 self.assertEqual(obs["lane"], 1)

--- a/tools/test_validate_loop2_content_gates.py
+++ b/tools/test_validate_loop2_content_gates.py
@@ -310,11 +310,11 @@ class TestShippedBeatmapInvariants(unittest.TestCase):
             f"(+200ms slack) (#418/#506/#527/#528)"
         )
 
-    def test_circle_and_lane2_share_nontrivial_at_medium(self):
+    def test_circle_and_lane0_share_nontrivial_at_medium(self):
         """#420 — every shipped beatmap×medium must include a
-        non-trivial share of ``shape == "circle"`` AND ``lane == 2`` so the
-        third broad onset layer (harmonic) and the third lane are reachable
-        design space rather than dead UI.  Floor: 10% per cohort. Hard
+        non-trivial share of ``shape == "circle"`` AND ``lane == 0`` so the
+        harmonic layer and the left shape lane are reachable design space
+        rather than dead UI.  Floor: 10% per cohort. Hard
         onset-only charts may be governed by source-layer distribution instead
         of post-hoc shape remapping.
         """
@@ -331,16 +331,16 @@ class TestShippedBeatmapInvariants(unittest.TestCase):
                 if not beats:
                     continue
                 circle_share = sum(1 for b in beats if b.get("shape") == "circle") / len(beats)
-                lane2_share = sum(1 for b in beats if b.get("lane") == 2) / len(beats)
+                lane0_share = sum(1 for b in beats if b.get("lane") == 0) / len(beats)
                 self.assertGreaterEqual(
                     circle_share, floor,
                     f"{path.name} [{difficulty}]: circle share "
                     f"{circle_share:.1%} below 10% floor (#420)"
                 )
                 self.assertGreaterEqual(
-                    lane2_share, floor,
-                    f"{path.name} [{difficulty}]: lane-2 share "
-                    f"{lane2_share:.1%} below 10% floor (#420)"
+                    lane0_share, floor,
+                    f"{path.name} [{difficulty}]: lane-0 share "
+                    f"{lane0_share:.1%} below 10% floor (#420)"
                 )
 
 

--- a/tools/test_validate_loop2_content_gates.py
+++ b/tools/test_validate_loop2_content_gates.py
@@ -69,9 +69,9 @@ class TestLoop2MetricCalculations(unittest.TestCase):
 
     def test_split_path_counts_as_supported_shape_obstacle(self):
         beats = [
-            {"beat": 0, "kind": "split_path", "shape": "triangle", "lane": 0},
+            {"beat": 0, "kind": "split_path", "shape": "triangle", "lane": 2},
             {"beat": 4, "kind": "shape_gate", "shape": "square", "lane": 1},
-            {"beat": 8, "kind": "split_path", "shape": "circle", "lane": 2},
+            {"beat": 8, "kind": "split_path", "shape": "circle", "lane": 0},
         ]
         metrics = gates.calculate_content_metrics(beats, expected_count=3)
 
@@ -82,9 +82,9 @@ class TestLoop2MetricCalculations(unittest.TestCase):
 
     def test_onset_marker_is_supported_but_not_counted_as_shape_obstacle(self):
         beats = [
-            {"beat": 0, "kind": "shape_gate", "shape": "triangle", "lane": 0},
+            {"beat": 0, "kind": "shape_gate", "shape": "triangle", "lane": 2},
             {"beat": 1, "kind": "onset_marker", "shape": "square", "lane": 1},
-            {"beat": 4, "kind": "shape_gate", "shape": "circle", "lane": 2},
+            {"beat": 4, "kind": "shape_gate", "shape": "circle", "lane": 0},
         ]
         metrics = gates.calculate_content_metrics(beats, expected_count=3)
 

--- a/tools/test_validate_medium_balance.py
+++ b/tools/test_validate_medium_balance.py
@@ -30,21 +30,21 @@ class TestValidateMediumBalance(unittest.TestCase):
 
     def test_validate_beatmap_passes_within_target_ranges(self):
         beats = (
-            [{"kind": "shape_gate", "shape": "circle", "lane": 2} for _ in range(3)]
+            [{"kind": "shape_gate", "shape": "circle", "lane": 0} for _ in range(3)]
             + [{"kind": "shape_gate", "shape": "square", "lane": 1} for _ in range(10)]
-            + [{"kind": "shape_gate", "shape": "triangle", "lane": 0} for _ in range(7)]
+            + [{"kind": "shape_gate", "shape": "triangle", "lane": 2} for _ in range(7)]
         )
         path = self._write_beatmap("fixture_pass_beatmap.json", beats)
         issues = medium_balance.validate_beatmap(path)
         self.assertEqual(issues, [])
 
     def test_validate_beatmap_flags_shape_and_lane_distribution(self):
-        beats = [{"kind": "shape_gate", "shape": "circle", "lane": 2} for _ in range(10)]
+        beats = [{"kind": "shape_gate", "shape": "circle", "lane": 0} for _ in range(10)]
         path = self._write_beatmap("fixture_fail_beatmap.json", beats)
         issues = medium_balance.validate_beatmap(path)
         self.assertGreaterEqual(len(issues), 4)
         self.assertTrue(any("circle" in issue for issue in issues))
-        self.assertTrue(any("lane 2" in issue for issue in issues))
+        self.assertTrue(any("lane 0" in issue for issue in issues))
 
 
 if __name__ == "__main__":

--- a/tools/validate_loop2_content_gates.py
+++ b/tools/validate_loop2_content_gates.py
@@ -36,9 +36,9 @@ SHAPE_OBSTACLE_KINDS = {"shape_gate", "split_path"}
 SUPPORTED_NON_BLOCKING_KINDS = {"onset_marker"}
 # Issue #420 — broad-layer/lane reachability floor at medium/hard.
 # Each shipped beatmap×difficulty must include at least this share of
-# circle (lane-2 / harmonic-mapped) obstacles so the third shape and the
-# right strafe stay reachable design space.
-CIRCLE_LANE2_SHARE_FLOOR = {"medium": 0.10, "hard": 0.10}
+# circle (lane-0 / harmonic-mapped) obstacles so the left shape lane stays
+# reachable design space.
+CIRCLE_LANE0_SHARE_FLOOR = {"medium": 0.10, "hard": 0.10}
 
 
 def _ordered_valid_beats(beats: list[dict]) -> list[dict]:
@@ -213,6 +213,7 @@ def calculate_content_metrics(
         "shape_clusters_over_warn": 0,
         "triangle_share": (shape_counts.get("triangle", 0) / total_shape_gates) if total_shape_gates else 0.0,
         "circle_share": (shape_counts.get("circle", 0) / total_shape_gates) if total_shape_gates else 0.0,
+        "lane0_share": (lane_counts.get(0, 0) / total_shape_gates) if total_shape_gates else 0.0,
         "lane2_share": (lane_counts.get(2, 0) / total_shape_gates) if total_shape_gates else 0.0,
         "min_ioi_ms": min_ioi_ms,
         "ioi_index_error": ioi_index_error,
@@ -288,19 +289,19 @@ def evaluate_content_gates(metrics: dict[str, float | int | bool | None], diffic
         if float(metrics["circle_share"]) > 0.40:
             findings.append(f"hard circle share {float(metrics['circle_share']):.1%} above ceiling 40%")
 
-    # Issue #420 — circle/lane-2 reachability floors at medium/hard.
-    share_floor = CIRCLE_LANE2_SHARE_FLOOR.get(difficulty)
+    # Issue #420 — circle/lane-0 reachability floors at medium/hard.
+    share_floor = CIRCLE_LANE0_SHARE_FLOOR.get(difficulty)
     if share_floor is not None and not onset_timed:
         circle_share = metrics.get("circle_share")
-        lane2_share = metrics.get("lane2_share")
+        lane0_share = metrics.get("lane0_share")
         if circle_share is not None and float(circle_share) < share_floor:
             findings.append(
                 f"circle share {float(circle_share):.1%} below floor "
                 f"{share_floor:.0%} (issue #420)"
             )
-        if lane2_share is not None and float(lane2_share) < share_floor:
+        if lane0_share is not None and float(lane0_share) < share_floor:
             findings.append(
-                f"lane-2 share {float(lane2_share):.1%} below floor "
+                f"lane-0 share {float(lane0_share):.1%} below floor "
                 f"{share_floor:.0%} (issue #420)"
             )
 

--- a/tools/validate_medium_balance.py
+++ b/tools/validate_medium_balance.py
@@ -22,9 +22,9 @@ TARGET_RANGES = {
 }
 
 LANE_NAMES = {
-    0: "triangle",
+    0: "circle",
     1: "square",
-    2: "circle",
+    2: "triangle",
 }
 
 


### PR DESCRIPTION
## Summary
- align Z/X/C shortcuts and runtime shape auto-targeting with HUD lane order: circle left, square center, triangle right
- update shipped beatmap lane metadata plus authoring/validation tools to use circle=0, square=1, triangle=2
- refresh docs and tests for the canonical mapping

Fixes #726

## Verification
- cmake -B build -S . -Wno-dev -DCMAKE_PREFIX_PATH=/Users/yashasgujjar/dev/bullethell/build/vcpkg_installed/arm64-osx
- cmake --build build
- ./build/shapeshifter_tests
- ctest --test-dir build --output-on-failure
- python3 tools/validate_medium_balance.py
- python3 tools/validate_loop2_content_gates.py --strict
- python3 tools/check_shape_change_gap.py