### PR TITLE
Clarify first-collision floor coverage

### DIFF
--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -98,16 +98,15 @@ obstacle later (e.g. easy's 6.8 s drama opener). They exist to prevent a
 readability cliff at song start where the obstacle has spawned before the
 player's first reaction window opens (issue #175).
 
-**Authoring rule:** If a generated beatmap violates the floor, the level
-designer must postpone `first.beat` to the smallest beat index whose
-`offset + beat * 60/bpm` clears the floor, preserving the rhythm grid for all
-subsequent obstacles. If postponement would collide with the next authored
-obstacle (overlap or sub-`min_gap` distance), drop the offending leading
-obstacle instead and re-evaluate.
+**Authoring rule:** The active onset-motif path enforces the floor before
+obstacle materialization by dropping snapped onset candidates whose audio time
+falls inside the per-difficulty floor. Legacy cleanup-enabled generation still
+uses `enforce_first_collision_floor` to postpone or drop an already-authored
+leading obstacle while preserving the rhythm grid for subsequent obstacles.
 
-`tools/level_designer.py` enforces this rule in `enforce_first_collision_floor`,
-and `tests/test_shipped_beatmap_first_collision.cpp` is the shipped-content
-regression gate.
+`tests/test_shipped_beatmap_first_collision.cpp` is not a shipped-content floor
+gate for the onset-motif path. It is a structural integrity guard that ensures
+each shipped difficulty has authored beats and a non-negative first beat index.
 
 ---
 ---

--- a/tests/test_shipped_beatmap_first_collision.cpp
+++ b/tests/test_shipped_beatmap_first_collision.cpp
@@ -1,9 +1,10 @@
 // Regression coverage for first authored obstacle integrity.
 //
-// The approved onset-motif spike path disables first-collision floor
-// post-processing. This guard now checks structural integrity only:
-// each shipped difficulty must contain at least one authored beat and the
-// first authored beat index must be non-negative.
+// The approved onset-motif spike path enforces first-collision timing before
+// obstacle materialization rather than through shipped-content post-processing.
+// This guard checks structural integrity only: each shipped difficulty must
+// contain at least one authored beat and the first authored beat index must be
+// non-negative.
 //
 // CWD when run via CTest is the build/ directory which has a mirrored
 // content/beatmaps/ copy via CMake POST_BUILD commands.


### PR DESCRIPTION
## Summary\n- Clarifies that the active onset-motif path enforces first-collision timing before obstacle materialization.\n- Updates the shipped-content test comment to match its current structural-integrity scope.\n- Resolves #730.\n\n## Verification\n- cmake -B build -S . -Wno-dev -DCMAKE_TOOLCHAIN_FILE=/Users/yashasgujjar/vcpkg/scripts/buildsystems/vcpkg.cmake\n- cmake --build build\n- ./build/shapeshifter_tests