### PR TITLE
Fix beatmap scalar field validation

### DIFF
--- a/app/util/beat_map_loader.cpp
+++ b/app/util/beat_map_loader.cpp
@@ -3,6 +3,7 @@
 #include <nlohmann/json.hpp>
 #include <cmath>
 #include <algorithm>
+#include <limits>
 #include <optional>
 #include <utility>
 #include <raylib.h>
@@ -96,7 +97,23 @@ bool read_optional_int(const json& object,
         push_type_error(errors, beat_index, field, "an integer", value);
         return false;
     }
-    out = value.get<int>();
+    if (value.is_number_unsigned()) {
+        const auto raw = value.get<std::uint64_t>();
+        if (raw > static_cast<std::uint64_t>(std::numeric_limits<int>::max())) {
+            errors.push_back({beat_index, std::string("'") + field + "' must fit in a 32-bit integer"});
+            return false;
+        }
+        out = static_cast<int>(raw);
+        return true;
+    }
+
+    const auto raw = value.get<std::int64_t>();
+    if (raw < static_cast<std::int64_t>(std::numeric_limits<int>::min()) ||
+        raw > static_cast<std::int64_t>(std::numeric_limits<int>::max())) {
+        errors.push_back({beat_index, std::string("'") + field + "' must fit in a 32-bit integer"});
+        return false;
+    }
+    out = static_cast<int>(raw);
     return true;
 }
 } // namespace
@@ -314,6 +331,12 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
             parse_ok = false;
             continue;
         }
+        if (b.contains("lane") && (lane_value < 0 || lane_value > 2)) {
+            errors.push_back({entry.beat_index,
+                "'lane' must be in range [0, 2] at beat " + std::to_string(entry.beat_index)});
+            parse_ok = false;
+            continue;
+        }
         entry.lane = static_cast<int8_t>(lane_value);
 
         const float grid_time = out.offset + entry.beat_index * (60.0f / out.bpm);
@@ -324,10 +347,13 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
             beat_time = out.beat_times[static_cast<size_t>(entry.beat_index)];
         }
 
-        const bool has_time_sec = b.contains("time_sec") &&
-                                  (b["time_sec"].is_number_float() || b["time_sec"].is_number_integer());
+        const bool has_time_sec = b.contains("time_sec");
         entry.has_time_sec = has_time_sec;
-        entry.time_sec = has_time_sec ? b["time_sec"].get<float>() : beat_time;
+        entry.time_sec = beat_time;
+        if (has_time_sec && !read_optional_float(b, "time_sec", entry.time_sec, errors, entry.beat_index)) {
+            parse_ok = false;
+            continue;
+        }
 
         std::string timing_source;
         if (!read_optional_string(b, "timing_source", timing_source, errors, entry.beat_index)) {

--- a/tests/test_beat_map_validation.cpp
+++ b/tests/test_beat_map_validation.cpp
@@ -732,6 +732,26 @@ TEST_CASE("parse: beat without time_sec falls back to beat_times", "[parse][beat
     CHECK_THAT(map.beats[0].time_sec, Catch::Matchers::WithinAbs(1.4f, 0.001f));
 }
 
+TEST_CASE("parse: non-numeric time_sec fails", "[parse][beat_times][time_sec]") {
+    BeatMap map;
+    std::vector<BeatMapError> errors;
+    std::string json = R"({
+        "song_id": "timing_test",
+        "bpm": 120,
+        "offset": 0.0,
+        "lead_beats": 4,
+        "duration_sec": 60.0,
+        "beat_times": [0.1, 0.7, 1.4],
+        "beats": [
+            { "beat": 2, "time_sec": "1.4", "kind": "shape_gate", "shape": "circle", "lane": 1 }
+        ]
+    })";
+
+    CHECK_FALSE(parse_beat_map(json, map, errors));
+    REQUIRE_FALSE(errors.empty());
+    CHECK(errors[0].message.find("'time_sec'") != std::string::npos);
+}
+
 TEST_CASE("parse: shape-bearing obstacles require explicit shape", "[parse][shape][issue224]") {
     const char* shape_bearing_kinds[] = {"shape_gate", "combo_gate", "split_path"};
 
@@ -837,6 +857,29 @@ TEST_CASE("parse: invalid blocked lane index fails", "[parse][blocked_mask]") {
     CHECK_FALSE(parse_beat_map(json, map, errors));
     REQUIRE_FALSE(errors.empty());
     CHECK(errors[0].message.find("range [0, 2]") != std::string::npos);
+}
+
+TEST_CASE("parse: invalid scalar lane values fail before narrowing", "[parse][lane]") {
+    const char* invalid_lanes[] = {"-1", "3", "257", "2147483648"};
+
+    for (const char* lane : invalid_lanes) {
+        BeatMap map;
+        std::vector<BeatMapError> errors;
+        const std::string json = std::string(R"({
+            "song_id": "lane_test",
+            "bpm": 120,
+            "offset": 0.0,
+            "lead_beats": 4,
+            "duration_sec": 60.0,
+            "beats": [
+                { "beat": 2, "kind": "shape_gate", "shape": "circle", "lane": )") + lane + R"( }
+            ]
+        })";
+
+        CHECK_FALSE(parse_beat_map(json, map, errors));
+        REQUIRE_FALSE(errors.empty());
+        CHECK(errors[0].message.find("'lane'") != std::string::npos);
+    }
 }
 
 TEST_CASE("validate: authored time_sec beyond duration fails", "[validate][beat_times][time_sec]") {


### PR DESCRIPTION
Closes #736

## Summary
- reject integer beatmap fields that do not fit in int before conversion
- validate scalar lane values before narrowing to int8_t
- require time_sec to be numeric whenever present
- add regression coverage for invalid lane and time_sec inputs

## Verification
- VCPKG_ROOT="$HOME/vcpkg" ./build.sh && ./build/shapeshifter_tests