### PR TITLE
Guard level-select semantic indices

### DIFF
--- a/app/content/level_content_config.h
+++ b/app/content/level_content_config.h
@@ -9,10 +9,28 @@ namespace content_config {
 
 inline constexpr int LEVEL_COUNT = 3;
 inline constexpr int DIFFICULTY_COUNT = 3;
+inline constexpr int DEFAULT_LEVEL_INDEX = 0;
+inline constexpr int DEFAULT_DIFFICULTY_INDEX = 1;
 
 extern const LevelInfo LEVELS[LEVEL_COUNT];
 extern const char* const LEVEL_KEYS[LEVEL_COUNT];
 extern const char* const DIFFICULTY_NAMES[DIFFICULTY_COUNT];
 extern const char* const DIFFICULTY_KEYS[DIFFICULTY_COUNT];
+
+[[nodiscard]] constexpr bool is_valid_level_index(int index) noexcept {
+    return index >= 0 && index < LEVEL_COUNT;
+}
+
+[[nodiscard]] constexpr bool is_valid_difficulty_index(int index) noexcept {
+    return index >= 0 && index < DIFFICULTY_COUNT;
+}
+
+[[nodiscard]] constexpr int level_index_or_default(int index) noexcept {
+    return is_valid_level_index(index) ? index : DEFAULT_LEVEL_INDEX;
+}
+
+[[nodiscard]] constexpr int difficulty_index_or_default(int index) noexcept {
+    return is_valid_difficulty_index(index) ? index : DEFAULT_DIFFICULTY_INDEX;
+}
 
 }  // namespace content_config

--- a/app/session/play_session.cpp
+++ b/app/session/play_session.cpp
@@ -97,6 +97,8 @@ void setup_play_session(entt::registry& reg) {
     auto& lss = reg.ctx().get<LevelSelectState>();
     auto& beatmap = reg.ctx().get<BeatMap>();
     beatmap = BeatMap{};
+    lss.selected_level = content_config::level_index_or_default(lss.selected_level);
+    lss.selected_difficulty = content_config::difficulty_index_or_default(lss.selected_difficulty);
     const char* beatmap_path = content_config::LEVELS[lss.selected_level].beatmap_path;
     const char* difficulty_key = content_config::DIFFICULTY_KEYS[lss.selected_difficulty];
 

--- a/app/ui/level_select_controller.cpp
+++ b/app/ui/level_select_controller.cpp
@@ -32,10 +32,14 @@ void level_select_handle_press(entt::registry& reg, const ButtonPressEvent& evt)
             lss.confirmed = true;
             break;
         case MenuActionKind::SelectLevel:
-            lss.selected_level = evt.menu_index;
+            if (content_config::is_valid_level_index(evt.menu_index)) {
+                lss.selected_level = evt.menu_index;
+            }
             break;
         case MenuActionKind::SelectDiff:
-            lss.selected_difficulty = evt.menu_index;
+            if (content_config::is_valid_difficulty_index(evt.menu_index)) {
+                lss.selected_difficulty = evt.menu_index;
+            }
             break;
         default: break;
     }

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -42,6 +42,21 @@ TEST_CASE("High score integration: setup_play_session loads selected song diffic
     CHECK_FALSE(reg.view<UICamera>().empty());
 }
 
+TEST_CASE("Play session: invalid level-select indices fall back before content lookup",
+          "[play_session][issue738]") {
+    auto reg = make_registry();
+    auto& lss = reg.ctx().get<LevelSelectState>();
+    lss.selected_level = 99;
+    lss.selected_difficulty = 99;
+
+    setup_play_session(reg);
+
+    CHECK(lss.selected_level == content_config::DEFAULT_LEVEL_INDEX);
+    CHECK(lss.selected_difficulty == content_config::DEFAULT_DIFFICULTY_INDEX);
+    CHECK(reg.ctx().get<HighScoreState>().current_key_hash
+        == high_score::make_key_hash("1_stomper", "medium"));
+}
+
 TEST_CASE("Play session: SongResults total_notes matches every shipped song difficulty",
           "[play_session][song_results][issue-114]") {
     for (int level = 0; level < content_config::LEVEL_COUNT; ++level) {

--- a/tests/test_level_select_controller.cpp
+++ b/tests/test_level_select_controller.cpp
@@ -34,6 +34,28 @@ TEST_CASE("level_select_controller: select level press updates state", "[level_s
     CHECK(lss.selected_level == 2);
 }
 
+TEST_CASE("level_select_controller: invalid semantic indices do not update selection",
+          "[level_select][ui][issue738]") {
+    auto reg = make_registry();
+    auto& gs = reg.ctx().get<GameState>();
+    gs.phase = GamePhase::LevelSelect;
+    gs.phase_timer = 0.2f;
+
+    auto& lss = reg.ctx().get<LevelSelectState>();
+    lss.selected_level = 1;
+    lss.selected_difficulty = 2;
+
+    level_select_handle_press(reg, ButtonPressEvent{
+        ButtonPressKind::Menu, Shape::Circle, MenuActionKind::SelectLevel, 255
+    });
+    level_select_handle_press(reg, ButtonPressEvent{
+        ButtonPressKind::Menu, Shape::Circle, MenuActionKind::SelectDiff, 255
+    });
+
+    CHECK(lss.selected_level == 1);
+    CHECK(lss.selected_difficulty == 2);
+}
+
 TEST_CASE("level_select_controller: ignores menu presses during entry delay", "[level_select][ui]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();


### PR DESCRIPTION
## Summary
- Add shared level/difficulty index validation in content_config.
- Ignore malformed level-select semantic events instead of storing out-of-range indices.
- Sanitize LevelSelectState before play-session content/high-score lookups so fixed arrays are indexed safely.

## Root cause
Level-select semantic menu events copied menu_index directly into LevelSelectState, and setup_play_session later trusted those state values when indexing fixed content arrays. A malformed or stale event could therefore persist an invalid index until session setup.

## Verification
- VCPKG_ROOT=/Users/yashasgujjar/vcpkg cmake -B build -S . -Wno-dev && cmake --build build && ./build/shapeshifter_tests

Closes #738