### PR TITLE
Guard beat scheduler lane lookup

### DIFF
--- a/app/systems/beat_scheduler_system.cpp
+++ b/app/systems/beat_scheduler_system.cpp
@@ -71,7 +71,12 @@ void beat_scheduler_system(entt::registry& reg, float /*dt*/) {
         // use entry.lane directly; bar/gate types default to center lane.
         float x_pos = constants::LANE_X[1];
         if (entry.kind == ObstacleKind::ShapeGate) {
-            x_pos = constants::LANE_X[static_cast<int>(entry.lane)];
+            const int lane = static_cast<int>(entry.lane);
+            if (lane >= 0 && lane < constants::LANE_COUNT) {
+                x_pos = constants::LANE_X[lane];
+            } else {
+                TraceLog(LOG_WARNING, "Invalid ShapeGate lane %d; defaulting to center lane", lane);
+            }
         } else if (entry.kind == ObstacleKind::LaneBlock) {
             int display_lane = 1;
             for (int l = 0; l < 3; ++l) {

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -89,6 +89,25 @@ TEST_CASE("beat_scheduler: spawns ShapeGate when time passes spawn_time", "[beat
     }
 }
 
+TEST_CASE("beat_scheduler: defaults invalid ShapeGate lane to center lane", "[beat_scheduler]") {
+    auto reg = make_rhythm_registry();
+    auto& song = reg.ctx().get<SongState>();
+    auto& map = reg.ctx().get<BeatMap>();
+
+    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 9, 0});
+    song.song_time = 0.0f;
+    song.next_spawn_idx = 0;
+
+    beat_scheduler_system(reg, 0.016f);
+
+    auto view = reg.view<ObstacleTag, WorldTransform>();
+    REQUIRE(view.size_hint() == 1);
+    for (auto [e, wt] : view.each()) {
+        (void)e;
+        CHECK_THAT(wt.position.x, Catch::Matchers::WithinAbs(constants::LANE_X[1], 0.01f));
+    }
+}
+
 TEST_CASE("beat_scheduler: does not spawn before spawn_time", "[beat_scheduler]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();


### PR DESCRIPTION
## Summary
- Guard `ShapeGate` lane lookups before indexing `constants::LANE_X`.
- Keep invalid runtime lane data safe by logging a warning and defaulting to the center lane.
- Add a beat scheduler regression test for invalid lane context data.

## Verification
- `cmake -B build -S . -Wno-dev -DCMAKE_TOOLCHAIN_FILE=/Users/yashasgujjar/vcpkg/scripts/buildsystems/vcpkg.cmake && cmake --build build && ./build/shapeshifter_tests && ./build/shapeshifter_tests "[beat_scheduler]"`

Closes #741
