### PR TITLE
Fix architecture system numbering

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -591,20 +591,20 @@ the same frame (unidirectional data flow).
  │
  │  ┌─ PHASE 5: CLEANUP & FX ──────────────────────────────┐
  │  │                                                        │
- │  │ 12. particle_system       Tick ParticleData.remaining. │
+ │  │ 13. particle_system       Tick ParticleData.remaining. │
  │  │                           Destroy expired particles.   │
  │  │                           Apply gravity to survivors.  │
  │  │                                                        │
- │  │ 13. obstacle_despawn_     Destroy obstacles past the   │
+ │  │ 14. obstacle_despawn_     Destroy obstacles past the   │
  │  │     system                camera Z / DESTROY_Y limit.  │
  │  │                                                        │
- │  │ 14. popup_display_system  Tick ScorePopup.remaining.   │
+ │  │ 15. popup_display_system  Tick ScorePopup.remaining.   │
  │  │                           Fade and destroy popups.     │
  │  └────────────────────────────────────────────────────────┘
  │
  │  ┌─ PHASE 6: RENDER (always runs) ──────────────────────┐
  │  │                                                        │
- │  │ 15. render systems        BeginDrawing/ClearBackground.│
+ │  │ 16. render systems        BeginDrawing/ClearBackground.│
  │  │                           Draw background.             │
  │  │                           Draw obstacles (Layer::Game).│
  │  │                           Draw player (Layer::Game).   │


### PR DESCRIPTION
Closes #740\n\n## Summary\n- Renumber the architecture fixed-tick pipeline after scoring so the diagram is sequential.\n- Update the following render phase number to avoid introducing a new duplicate.\n\n## Verification\n- Reproduced duplicate numbering in design-docs/architecture.md.\n- cmake -B build -S . -Wno-dev -DCMAKE_TOOLCHAIN_FILE=/Users/yashasgujjar/vcpkg/scripts/buildsystems/vcpkg.cmake\n- cmake --build build\n- ./build/shapeshifter_tests