### PR TITLE
Remove shape window duration dead branch

### DIFF
--- a/app/systems/shape_window_system.cpp
+++ b/app/systems/shape_window_system.cpp
@@ -44,9 +44,7 @@ void shape_window_system(entt::registry& reg, float /*dt*/) {
             case WindowPhase::Active: {
                 float active_elapsed = song->song_time - swindow.window_start;
                 swindow.window_timer = active_elapsed;
-                float effective_duration = (swindow.window_scale > 1.0f)
-                    ? song->window_duration * swindow.window_scale
-                    : song->window_duration;
+                float effective_duration = song->window_duration;
                 if (active_elapsed >= effective_duration) {
                     swindow.phase = WindowPhase::MorphOut;
                     swindow.window_start = swindow.window_start + effective_duration;

--- a/tests/test_shape_window_extended.cpp
+++ b/tests/test_shape_window_extended.cpp
@@ -108,7 +108,7 @@ TEST_CASE("shape_window: Idle phase does nothing", "[shape_window][rhythm]") {
     CHECK(ps.current == original_shape);
 }
 
-TEST_CASE("shape_window: window_scale > 1 extends Active duration", "[shape_window][rhythm]") {
+TEST_CASE("shape_window: Active duration is driven by song window duration", "[shape_window][rhythm]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& ps = reg.get<PlayerShape>(player);
@@ -118,16 +118,11 @@ TEST_CASE("shape_window: window_scale > 1 extends Active duration", "[shape_wind
     ps.current = Shape::Circle;
     sw.phase = WindowPhase::Active;
     sw.window_start = song.song_time;
-    sw.window_scale = 1.50f;  // hypothetical extended scale (system-level test)
+    sw.window_scale = 1.50f;
 
-    // Advance by normal window_duration — should still be Active
+    // window_scale is recorded for grading state; collision_system applies
+    // valid shortening by shifting window_start, not by extending duration here.
     song.song_time += song.window_duration + 0.01f;
-    shape_window_system(reg, 0.016f);
-
-    CHECK(sw.phase == WindowPhase::Active);
-
-    // Now advance past the extended duration
-    song.song_time += song.window_duration * 0.6f;
     shape_window_system(reg, 0.016f);
 
     CHECK(sw.phase == WindowPhase::MorphOut);


### PR DESCRIPTION
Closes #742\n\n## Summary\n- Simplify shape_window_system Active duration to use song.window_duration directly.\n- Update shape-window coverage to assert window_scale does not extend Active duration; valid shortening remains handled through collision_system window_start adjustment.\n\n## Verification\n- Reproduced unreachable window_scale > 1.0f branch in app/systems/shape_window_system.cpp.\n- cmake -B build -S . -Wno-dev -DCMAKE_TOOLCHAIN_FILE=/Users/yashasgujjar/vcpkg/scripts/buildsystems/vcpkg.cmake\n- cmake --build build\n- ./build/shapeshifter_tests