### PR TITLE
Guard blocked lane index conversion

### DIFF
--- a/app/util/beat_map_loader.cpp
+++ b/app/util/beat_map_loader.cpp
@@ -86,13 +86,11 @@ bool read_optional_float(const json& object,
     return true;
 }
 
-bool read_optional_int(const json& object,
-                       const char* field,
-                       int& out,
-                       std::vector<BeatMapError>& errors,
-                       const int beat_index) {
-    if (!object.contains(field)) return true;
-    const auto& value = object[field];
+bool read_int_value(const json& value,
+                    const char* field,
+                    int& out,
+                    std::vector<BeatMapError>& errors,
+                    const int beat_index) {
     if (!value.is_number_integer() && !value.is_number_unsigned()) {
         push_type_error(errors, beat_index, field, "an integer", value);
         return false;
@@ -115,6 +113,15 @@ bool read_optional_int(const json& object,
     }
     out = static_cast<int>(raw);
     return true;
+}
+
+bool read_optional_int(const json& object,
+                       const char* field,
+                       int& out,
+                       std::vector<BeatMapError>& errors,
+                       const int beat_index) {
+    if (!object.contains(field)) return true;
+    return read_int_value(object[field], field, out, errors, beat_index);
 }
 
 std::optional<int> max_derived_beat_for_metadata(const float bpm, const float duration) {
@@ -400,15 +407,12 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
             entry.blocked_mask = 0;
             bool blocked_ok = true;
             for (const auto& lane_idx : b["blocked"]) {
-                if (!lane_idx.is_number_integer()) {
-                    errors.push_back({entry.beat_index,
-                        "'blocked' entries must be integer lane indices at beat "
-                        + std::to_string(entry.beat_index)});
+                int lane = 0;
+                if (!read_int_value(lane_idx, "blocked[]", lane, errors, entry.beat_index)) {
                     parse_ok = false;
                     blocked_ok = false;
                     break;
                 }
-                const int lane = lane_idx.get<int>();
                 if (lane < 0 || lane > 2) {
                     errors.push_back({entry.beat_index,
                         "'blocked' lane index must be in range [0, 2] at beat "

--- a/tests/test_beat_map_validation.cpp
+++ b/tests/test_beat_map_validation.cpp
@@ -859,6 +859,51 @@ TEST_CASE("parse: invalid blocked lane index fails", "[parse][blocked_mask]") {
     CHECK(errors[0].message.find("range [0, 2]") != std::string::npos);
 }
 
+TEST_CASE("parse: blocked lane index must fit before narrowing", "[parse][blocked_mask]") {
+    BeatMap map;
+    std::vector<BeatMapError> errors;
+    std::string json = R"({
+        "song_id": "timing_test",
+        "bpm": 120,
+        "offset": 0.0,
+        "lead_beats": 4,
+        "duration_sec": 60.0,
+        "beats": [
+            { "beat": 2, "kind": "combo_gate", "shape": "circle", "blocked": [4294967297] }
+        ]
+    })";
+
+    CHECK_FALSE(parse_beat_map(json, map, errors));
+    REQUIRE_FALSE(errors.empty());
+    CHECK(errors[0].message.find("blocked[]") != std::string::npos);
+    CHECK(errors[0].message.find("fit") != std::string::npos);
+}
+
+TEST_CASE("parse: valid blocked lane arrays remain accepted", "[parse][blocked_mask]") {
+    const char* blocked_arrays[] = {"[0]", "[1]", "[2]", "[0, 2]"};
+
+    for (const char* blocked : blocked_arrays) {
+        BeatMap map;
+        std::vector<BeatMapError> errors;
+        const std::string json = std::string(R"({
+            "song_id": "timing_test",
+            "bpm": 120,
+            "offset": 0.0,
+            "lead_beats": 4,
+            "duration_sec": 60.0,
+            "beats": [
+                { "beat": 2, "kind": "combo_gate", "shape": "circle", "blocked": )") + blocked + R"( }
+            ]
+        })";
+
+        INFO("blocked lanes: " << blocked);
+        CHECK(parse_beat_map(json, map, errors));
+        REQUIRE(map.beats.size() == 1);
+        CHECK(map.beats[0].blocked_mask != 0);
+        CHECK((map.beats[0].blocked_mask & static_cast<uint8_t>(~0x07U)) == 0);
+    }
+}
+
 TEST_CASE("parse: invalid scalar lane values fail before narrowing", "[parse][lane]") {
     const char* invalid_lanes[] = {"-1", "3", "257", "2147483648"};
 


### PR DESCRIPTION
## Summary
- Reuses the checked integer conversion path for `blocked[]` lane entries.
- Rejects oversized unsigned lane values before any `int` narrowing.
- Adds regression coverage for `blocked: [4294967297]` and valid blocked lane arrays.

Fixes #748

## Verification
- `cmake -B build -S . -Wno-dev -DCMAKE_TOOLCHAIN_FILE=/Users/yashasgujjar/vcpkg/scripts/buildsystems/vcpkg.cmake`
- `cmake --build build`
- `./build/shapeshifter_tests`