### PR TITLE
Fix terminal state and beatmap parser regressions

### DIFF
--- a/app/entities/beat_map.cpp
+++ b/app/entities/beat_map.cpp
@@ -45,6 +45,11 @@ bool kind_requires_shape(const ObstacleKind kind) {
            kind == ObstacleKind::SplitPath;
 }
 
+bool kind_requires_lane(const ObstacleKind kind) {
+    return kind == ObstacleKind::ShapeGate ||
+           kind == ObstacleKind::SplitPath;
+}
+
 std::string type_error_message(const char* field, const char* expected, const json& value) {
     return std::string("'") + field + "' must be " + expected + " (got " + value.type_name() + ")";
 }
@@ -364,6 +369,11 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
         }
 
         BeatEntry entry;
+        if (!b.contains("beat")) {
+            errors.push_back({-1, "Missing required beat for obstacle entry"});
+            parse_ok = false;
+            continue;
+        }
         if (!read_optional_int(b, "beat", entry.beat_index, errors, -1)) {
             parse_ok = false;
             continue;
@@ -407,6 +417,13 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
 
         int lane_value = entry.lane;
         if (!read_optional_int(b, "lane", lane_value, errors, entry.beat_index)) {
+            parse_ok = false;
+            continue;
+        }
+        if (!b.contains("lane") && kind_requires_lane(entry.kind)) {
+            errors.push_back({entry.beat_index,
+                "Missing required lane for obstacle kind '" + kind_str + "' at beat "
+                    + std::to_string(entry.beat_index)});
             parse_ok = false;
             continue;
         }

--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -148,7 +148,7 @@ void game_state_system(entt::registry& reg, float dt) {
     if (gs.phase == GamePhase::Playing) {
         auto* energy = reg.ctx().find<EnergyState>();
         auto* song = reg.ctx().find<SongState>();
-        if (energy && song && song->playing && energy->energy <= 0.0f) {
+        if (energy && energy->energy <= 0.0f) {
             auto* gos = reg.ctx().find<GameOverState>();
             if (gos) {
                 gos->cause = DeathCause::EnergyDepleted;

--- a/app/systems/player_movement_system.cpp
+++ b/app/systems/player_movement_system.cpp
@@ -26,6 +26,7 @@ void player_movement_system(entt::registry& reg, float dt) {
         if (lane.target == lane.current) {
             lane.target = -1;
             lane.lerp_t = 1.0f;
+            transform.position.x = constants::LANE_X[lane.current];
         }
         if (lane.target >= 0 && lane.target != lane.current) {
             lane.lerp_t += dt * constants::LANE_SWITCH_SPEED;

--- a/tests/test_beat_map_parser_unknown_fields.cpp
+++ b/tests/test_beat_map_parser_unknown_fields.cpp
@@ -224,6 +224,57 @@ TEST_CASE("parse: wrong lane type reports BeatMapError instead of throwing", "[p
     CHECK(errors[0].message.find("integer") != std::string::npos);
 }
 
+TEST_CASE("parse: missing beat is rejected", "[parse][beat][required][issue757]") {
+    BeatMap map;
+    std::vector<BeatMapError> errors;
+    std::string json = R"({
+        "bpm": 120, "offset": 0.0, "lead_beats": 4, "duration_sec": 60.0,
+        "beats": [
+            { "kind": "shape_gate", "shape": "circle", "lane": 1 }
+        ]
+    })";
+
+    CHECK_FALSE(parse_beat_map(json, map, errors));
+    REQUIRE_FALSE(errors.empty());
+    CHECK(errors[0].beat_index == -1);
+    CHECK(errors[0].message.find("beat") != std::string::npos);
+    CHECK(map.beats.empty());
+}
+
+TEST_CASE("parse: missing shape gate lane is rejected", "[parse][lane][required][issue757]") {
+    BeatMap map;
+    std::vector<BeatMapError> errors;
+    std::string json = R"({
+        "bpm": 120, "offset": 0.0, "lead_beats": 4, "duration_sec": 60.0,
+        "beats": [
+            { "beat": 4, "kind": "shape_gate", "shape": "circle" }
+        ]
+    })";
+
+    CHECK_FALSE(parse_beat_map(json, map, errors));
+    REQUIRE_FALSE(errors.empty());
+    CHECK(errors[0].beat_index == 4);
+    CHECK(errors[0].message.find("lane") != std::string::npos);
+    CHECK(map.beats.empty());
+}
+
+TEST_CASE("parse: missing split path lane is rejected", "[parse][lane][required][issue757]") {
+    BeatMap map;
+    std::vector<BeatMapError> errors;
+    std::string json = R"({
+        "bpm": 120, "offset": 0.0, "lead_beats": 4, "duration_sec": 60.0,
+        "beats": [
+            { "beat": 8, "kind": "split_path", "shape": "triangle" }
+        ]
+    })";
+
+    CHECK_FALSE(parse_beat_map(json, map, errors));
+    REQUIRE_FALSE(errors.empty());
+    CHECK(errors[0].beat_index == 8);
+    CHECK(errors[0].message.find("lane") != std::string::npos);
+    CHECK(map.beats.empty());
+}
+
 TEST_CASE("parse: wrong metadata types report BeatMapError instead of throwing", "[parse][metadata][types][regression]") {
     BeatMap map;
     std::vector<BeatMapError> errors;

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -19,6 +19,25 @@ TEST_CASE("game_state: song complete when song finished and no obstacles", "[gam
     CHECK(gs.next_phase == GamePhase::SongComplete);
 }
 
+TEST_CASE("game_state: energy depletion beats song complete after playback finishes",
+          "[gamestate][issue755]") {
+    auto reg = make_rhythm_registry();
+    auto& gs = reg.ctx().get<GameState>();
+    gs.phase = GamePhase::Playing;
+    auto& song = reg.ctx().get<SongState>();
+    song.finished = true;
+    song.playing = false;
+    reg.ctx().get<EnergyState>().energy = 0.0f;
+    auto& game_over = reg.ctx().get<GameOverState>();
+    game_over.cause = DeathCause::None;
+
+    game_state_system(reg, 0.016f);
+
+    CHECK(gs.transition_pending);
+    CHECK(gs.next_phase == GamePhase::GameOver);
+    CHECK(game_over.cause == DeathCause::EnergyDepleted);
+}
+
 TEST_CASE("game_state: song complete waits for obstacles to clear", "[gamestate]") {
     auto reg = make_rhythm_registry();
     auto& gs = reg.ctx().get<GameState>();

--- a/tests/test_player_systems.cpp
+++ b/tests/test_player_systems.cpp
@@ -179,14 +179,17 @@ TEST_CASE("player_movement: clears stale lane target when target equals current"
     auto reg = make_registry();
     auto p = make_player(reg);
     auto& lane = reg.get<Lane>(p);
+    auto& transform = reg.get<WorldTransform>(p);
     lane.current = 1;
     lane.target = 1;
     lane.lerp_t = 0.0f;
+    transform.position.x = (constants::LANE_X[1] + constants::LANE_X[2]) * 0.5f;
 
     player_movement_system(reg, 0.016f);
 
     CHECK(lane.target == -1);
     CHECK(lane.lerp_t == 1.0f);
+    CHECK(transform.position.x == constants::LANE_X[1]);
 }
 
 TEST_CASE("player_movement: jump creates negative y_offset", "[player]") {


### PR DESCRIPTION
## Summary
- let energy depletion take precedence over song completion even after playback stops
- snap player x back to the current lane when cancelling an in-flight lane move
- reject beatmap entries missing required beat or lane fields

## Issues
Fixes #755
Fixes #756
Fixes #757

## Verification
- ./run.sh test