### PR TITLE
Fix ShapeGate hexagon color and README drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ See `ios/README.md` for blocker checklist and full command modes.
 | Shape: Triangle | 3 / C | Tap right button |
 | Move left | A / ← | Swipe left |
 | Move right | D / → | Swipe right |
+| Jump | W / ↑ | Swipe up |
+| Slide | S / ↓ | Swipe down |
 
 ## Architecture
 
@@ -126,7 +128,7 @@ app/
     player.h              #   PlayerShape, ShapeWindow, Lane
     rhythm.h              #   TimingGrade, BeatInfo, WindowPhase
     beat_map.h            #   BeatEntry, BeatMap (loaded data)
-    song_state.h          #   SongState, HPState, SongResults
+    song_state.h          #   SongState, EnergyState, SongResults
   systems/                # system functions
     all_systems.h         #   declarations + pipeline order
     play_session.cpp      #   entity setup on game start

--- a/app/entities/obstacle_entity.cpp
+++ b/app/entities/obstacle_entity.cpp
@@ -18,12 +18,8 @@ entt::entity spawn_obstacle_base(entt::registry& reg, const ObstacleSpawnParams&
             reg.emplace<Obstacle>(e, int16_t{constants::PTS_SHAPE_GATE});
             reg.emplace<RequiredShape>(e, params.shape);
             reg.emplace<DrawSize>(e, constants::SCREEN_W_F, 80.0f);
-            if (params.shape == Shape::Circle)
-                reg.emplace<Color>(e, Color{80, 200, 255, 255});
-            else if (params.shape == Shape::Square)
-                reg.emplace<Color>(e, Color{255, 100, 100, 255});
-            else
-                reg.emplace<Color>(e, Color{100, 255, 100, 255});
+            const auto shape_index = static_cast<int>(params.shape);
+            reg.emplace<Color>(e, constants::SHAPE_COLORS[shape_index]);
             break;
         }
         case ObstacleKind::LaneBlock: {

--- a/docs/audio-pipeline-spec.md
+++ b/docs/audio-pipeline-spec.md
@@ -1,6 +1,12 @@
 
 # SHAPESHIFTER: Audio & Content Data Pipeline — Implementation Specification
 
+> Historical implementation plan. The current runtime uses `EnergyState`,
+> dispatcher-based `PlaySfxEvent` / `PlayHapticEvent` audio routing, and CMake
+> content copy rules; use `README.md`, `design-docs/beatmap-integration.md`,
+> and the code under `app/audio/` and `app/systems/` as the authoritative
+> implementation reference.
+
 ## Data Flow Diagram
 
 ```

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -488,6 +488,25 @@ TEST_CASE("beat_scheduler: ShapeGate Triangle has green color", "[beat_scheduler
     }
 }
 
+TEST_CASE("beat_scheduler: ShapeGate Hexagon has hexagon color", "[beat_scheduler]") {
+    auto reg = make_rhythm_registry();
+    auto& song = reg.ctx().get<SongState>();
+    auto& map = beat_map(reg);
+
+    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Hexagon, 1, 0});
+    song.song_time = 10.0f;
+    song.next_spawn_idx = 0;
+
+    beat_scheduler_system(reg, 0.016f);
+
+    auto view = reg.view<ObstacleTag, Color>();
+    for (auto [e, dc] : view.each()) {
+        CHECK(dc.r == 80);
+        CHECK(dc.g == 180);
+        CHECK(dc.b == 255);
+    }
+}
+
 TEST_CASE("beat_scheduler: clamped late-spawn stores adjusted spawn_time in BeatInfo", "[beat_scheduler]") {
     // When song_time overshoots spawn_time by so much that start_y would exceed
     // max_start_y (PLAYER_Y), the position is clamped.


### PR DESCRIPTION
## Summary\n- Fixes #761 by deriving ShapeGate colors from constants::SHAPE_COLORS for every Shape value\n- Adds Hexagon ShapeGate color regression coverage\n- Fixes #762 by documenting jump/slide controls and EnergyState in README\n- Marks the legacy audio pipeline implementation spec as historical so HPState/AudioQueue snippets are not treated as current guidance\n\n## Verification\n- cmake -B build -S . -Wno-dev -DCMAKE_TOOLCHAIN_FILE=/Users/yashasgujjar/vcpkg/scripts/buildsystems/vcpkg.cmake\n- cmake --build build\n- ./build/shapeshifter_tests