### PR TITLE
Fix fixed-step passive scoring

### DIFF
--- a/app/components/scoring.h
+++ b/app/components/scoring.h
@@ -11,7 +11,8 @@ struct ScoreState {
     int32_t high_score        = 0;
     int32_t chain_count       = 0;
     float   chain_timer       = 0.0f;
-    float   distance_traveled = 0.0f;
+    float   distance_traveled       = 0.0f;
+    float   passive_score_remainder = 0.0f;
 };
 
 struct TerminalResultState {

--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -55,7 +55,11 @@ void scoring_system(entt::registry& reg, float dt) {
     const bool allow_passive_score = (song == nullptr) || !song->finished;
     if (allow_passive_score) {
         score.distance_traveled += scroll_speed * dt;
-        score.score += static_cast<int>(dt * constants::PTS_PER_SECOND);
+        const float passive_score = score.passive_score_remainder +
+            dt * static_cast<float>(constants::PTS_PER_SECOND);
+        const int whole_points = static_cast<int>(std::floor(passive_score));
+        score.score += whole_points;
+        score.passive_score_remainder = passive_score - static_cast<float>(whole_points);
     }
 
     // Track rest duration for diagnostics/feedback, but only misses break chain.

--- a/tests/test_scoring_system.cpp
+++ b/tests/test_scoring_system.cpp
@@ -58,6 +58,20 @@ TEST_CASE("scoring: distance bonus accumulates", "[scoring]") {
     CHECK(score.distance_traveled > 0.0f);
 }
 
+TEST_CASE("scoring: distance bonus accumulates across fixed ticks", "[scoring][issue764]") {
+    auto reg = make_registry();
+
+    constexpr float fixed_dt = 1.0f / 60.0f;
+    for (int tick = 0; tick < 60; ++tick) {
+        scoring_system(reg, fixed_dt);
+    }
+
+    auto& score = reg.ctx().get<ScoreState>();
+    CHECK(score.score == constants::PTS_PER_SECOND);
+    CHECK(score.passive_score_remainder >= 0.0f);
+    CHECK(score.passive_score_remainder < 1.0f);
+}
+
 TEST_CASE("scoring: scored obstacle awards points", "[scoring]") {
     auto reg = make_registry();
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);


### PR DESCRIPTION
## Summary

- Carry fractional passive-score accrual between scoring ticks so the 10 points/sec distance bonus works at the normal fixed-step cadence.
- Add a regression test covering 60 fixed ticks awarding the expected passive score.

## Verification

- `cmake -B build -S . -Wno-dev && cmake --build build && ./build/shapeshifter_tests`

Fixes #764