### PR TITLE
Fix MorphOut rhythm shape gate matches

### DIFF
--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -22,18 +22,21 @@ Rectangle centered_hitbox_rect(float x) {
 
 bool player_matches_required_shape(const PlayerShape& p_shape,
                                     const ShapeWindow& p_window,
-                                    Shape required) {
-    if (p_shape.current == required && p_shape.current != Shape::Hexagon) {
+                                    Shape required,
+                                    bool rhythm_mode) {
+    if (required == Shape::Hexagon) {
+        return false;
+    }
+
+    if (rhythm_mode && p_window.phase != WindowPhase::Active) {
+        return false;
+    }
+
+    if (p_shape.current == required) {
         return true;
     }
-    // Press-time judgment: during an active/morphing window, the selected target
-    // shape should satisfy shape-gates even before visual morph completion.
-    if (p_window.phase != WindowPhase::Idle &&
-        p_window.target_shape == required &&
-        p_window.target_shape != Shape::Hexagon) {
-        return true;
-    }
-    return false;
+
+    return p_window.phase != WindowPhase::Idle && p_window.target_shape == required;
 }
 
 }  // namespace
@@ -47,6 +50,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
         player_view.get<WorldTransform, PlayerShape, ShapeWindow, Lane, VerticalState>(player_entity);
 
     auto& song = reg.ctx().get<SongState>();
+    const bool rhythm_mode = song.playing;
 
     // Frame-constant precomputes — both values are invariant across all obstacle
     // loops since player transform and vertical state don't change mid-frame.
@@ -125,7 +129,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
                     resolve(e, wt.position.y, false);
                     continue;
                 }
-                bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape);
+                bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
                 bool cleared = shape_match;
                 if (cleared) grade_shape_timing(e, info.arrival_time);
                 resolve(e, wt.position.y, cleared);
@@ -139,7 +143,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
                     resolve(e, wt.position.y, false);
                     continue;
                 }
-                bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape);
+                bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
                 resolve(e, wt.position.y, shape_match);
             }
         }
@@ -154,7 +158,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
                     resolve(e, wt.position.y, false);
                     continue;
                 }
-                bool shape_ok = player_matches_required_shape(p_shape, p_window, req.shape);
+                bool shape_ok = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
                 bool cleared = shape_ok;
                 if (cleared) grade_shape_timing(e, info.arrival_time);
                 resolve(e, wt.position.y, cleared);
@@ -168,7 +172,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
                     resolve(e, wt.position.y, false);
                     continue;
                 }
-                bool shape_ok = player_matches_required_shape(p_shape, p_window, req.shape);
+                bool shape_ok = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
                 resolve(e, wt.position.y, shape_ok);
             }
         }
@@ -183,7 +187,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
                     resolve(e, wt.position.y, false);
                     continue;
                 }
-                bool shape_ok = player_matches_required_shape(p_shape, p_window, req.shape);
+                bool shape_ok = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
                 bool cleared = shape_ok;
                 if (cleared) grade_shape_timing(e, info.arrival_time);
                 resolve(e, wt.position.y, cleared);
@@ -197,7 +201,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
                     resolve(e, wt.position.y, false);
                     continue;
                 }
-                bool shape_ok = player_matches_required_shape(p_shape, p_window, req.shape);
+                bool shape_ok = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
                 resolve(e, wt.position.y, shape_ok);
             }
         }
@@ -212,7 +216,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
                     resolve(e, wt.position.y, false);
                     continue;
                 }
-                bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape);
+                bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
                 resolve(e, wt.position.y, shape_match);
             }
         }
@@ -227,7 +231,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
                     resolve(e, wt.position.y, false);
                     continue;
                 }
-                bool shape_ok = player_matches_required_shape(p_shape, p_window, req.shape);
+                bool shape_ok = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
                 resolve(e, wt.position.y, shape_ok);
             }
         }
@@ -242,7 +246,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
                     resolve(e, wt.position.y, false);
                     continue;
                 }
-                bool shape_ok = player_matches_required_shape(p_shape, p_window, req.shape);
+                bool shape_ok = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
                 resolve(e, wt.position.y, shape_ok);
             }
         }

--- a/tests/test_collision_extended.cpp
+++ b/tests/test_collision_extended.cpp
@@ -138,6 +138,53 @@ TEST_CASE("collision: rhythm mode assigns Bad for far-off hit", "[collision][rhy
     CHECK(reg.get<TimingGrade>(obs).tier == TimingTier::Bad);
 }
 
+TEST_CASE("collision: rhythm shape gate only matches during Active window",
+          "[collision][rhythm][issue765]") {
+    auto active_reg = make_rhythm_registry();
+    auto active_player = make_rhythm_player(active_reg);
+    auto& active_shape = active_reg.get<PlayerShape>(active_player);
+    auto& active_window = active_reg.get<ShapeWindow>(active_player);
+    auto& active_song = active_reg.ctx().get<SongState>();
+
+    active_song.song_time = 5.0f;
+    active_shape.current = Shape::Circle;
+    active_window.target_shape = Shape::Circle;
+    active_window.phase = WindowPhase::Active;
+    active_window.press_time = active_song.song_time;
+
+    auto active_obs = make_shape_gate(active_reg, Shape::Circle, constants::PLAYER_Y);
+    active_reg.emplace<BeatInfo>(active_obs, 0, active_song.song_time,
+                                 active_song.song_time - active_song.lead_time);
+
+    collision_system(active_reg, 0.016f);
+
+    CHECK(active_reg.all_of<ScoredTag>(active_obs));
+    CHECK_FALSE(active_reg.all_of<MissTag>(active_obs));
+    CHECK(active_reg.all_of<TimingGrade>(active_obs));
+
+    auto morphout_reg = make_rhythm_registry();
+    auto morphout_player = make_rhythm_player(morphout_reg);
+    auto& morphout_shape = morphout_reg.get<PlayerShape>(morphout_player);
+    auto& morphout_window = morphout_reg.get<ShapeWindow>(morphout_player);
+    auto& morphout_song = morphout_reg.ctx().get<SongState>();
+
+    morphout_song.song_time = 5.0f;
+    morphout_shape.current = Shape::Circle;
+    morphout_window.target_shape = Shape::Circle;
+    morphout_window.phase = WindowPhase::MorphOut;
+    morphout_window.press_time = morphout_song.song_time - morphout_song.window_duration;
+
+    auto morphout_obs = make_shape_gate(morphout_reg, Shape::Circle, constants::PLAYER_Y);
+    morphout_reg.emplace<BeatInfo>(morphout_obs, 0, morphout_song.song_time,
+                                   morphout_song.song_time - morphout_song.lead_time);
+
+    collision_system(morphout_reg, 0.016f);
+
+    CHECK(morphout_reg.all_of<ScoredTag>(morphout_obs));
+    CHECK(morphout_reg.all_of<MissTag>(morphout_obs));
+    CHECK_FALSE(morphout_reg.all_of<TimingGrade>(morphout_obs));
+}
+
 TEST_CASE("collision: rhythm miss increments miss_count in SongResults", "[collision][rhythm]") {
     auto reg = make_rhythm_registry();
     make_rhythm_player(reg);


### PR DESCRIPTION
## Summary
- Require rhythm-mode shape gates to match only during the Active shape window.
- Preserve non-rhythm shape matching behavior.
- Add regression coverage for Active vs MorphOut behavior.

Fixes #765

## Verification
- cmake -B build -S . -Wno-dev
- cmake --build build
- ./build/shapeshifter_tests