### PR TITLE
Fix onset marker note totals and HUD docs

### DIFF
--- a/app/session/play_session.cpp
+++ b/app/session/play_session.cpp
@@ -35,6 +35,16 @@ bool is_runtime_allowed_validation_error(const BeatMapError& error) {
     return error.message == "Different-shape gates must be >= 3 beats apart";
 }
 
+int count_result_notes(const BeatMap& beatmap) {
+    int total = 0;
+    for (const BeatEntry& beat : beatmap.beats) {
+        if (beat.kind != ObstacleKind::OnsetMarker) {
+            ++total;
+        }
+    }
+    return total;
+}
+
 bool load_runtime_beat_map(const char* path,
                            BeatMap& out,
                            std::vector<BeatMapError>& errors,
@@ -194,7 +204,7 @@ void setup_play_session(entt::registry& reg) {
     assign_or_emplace_ctx(reg, EnergyState{});
     {
         SongResults results{};
-        results.total_notes = static_cast<int>(beatmap.beats.size());
+        results.total_notes = count_result_notes(beatmap);
         assign_or_emplace_ctx(reg, results);
     }
     assign_or_emplace_ctx(reg, GameOverState{});

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -47,10 +47,10 @@ Portrait mode. Logical resolution scales to device via raylib virtual resolution
     │          ● player           │
     │          y=920              │
     │─────────────────────────────│
-    │   energy bar     y~=1010    │
+    │   energy bar     y=790      │
     │─────────────────────────────│
     │  [ ● ]   [ ■ ]   [ ▲ ]     │
-    │          y=1180              │
+    │          y=1140             │
     │ (0,1280)          (720,1280)│
     └─────────────────────────────┘
 ```

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -20,6 +20,16 @@ void remove_path(const std::filesystem::path& path) {
     std::filesystem::remove_all(path, ec);
 }
 
+int count_result_notes(const BeatMap& beatmap) {
+    int total = 0;
+    for (const BeatEntry& beat : beatmap.beats) {
+        if (beat.kind != ObstacleKind::OnsetMarker) {
+            ++total;
+        }
+    }
+    return total;
+}
+
 }  // namespace
 
 TEST_CASE("High score integration: setup_play_session loads selected song difficulty score",
@@ -57,8 +67,9 @@ TEST_CASE("Play session: invalid level-select indices fall back before content l
         == high_score::make_key_hash("1_stomper", "medium"));
 }
 
-TEST_CASE("Play session: SongResults total_notes matches every shipped song difficulty",
-          "[play_session][song_results][issue-114]") {
+TEST_CASE("Play session: SongResults total_notes excludes onset marker metadata",
+          "[play_session][song_results][issue-773]") {
+    bool saw_onset_marker = false;
     for (int level = 0; level < content_config::LEVEL_COUNT; ++level) {
         for (int difficulty = 0; difficulty < content_config::DIFFICULTY_COUNT; ++difficulty) {
             auto reg = make_registry();
@@ -70,13 +81,15 @@ TEST_CASE("Play session: SongResults total_notes matches every shipped song diff
 
             const auto& beatmap = beat_map(reg);
             REQUIRE_FALSE(beatmap.beats.empty());
-            const int expected_total = static_cast<int>(beatmap.beats.size());
+            saw_onset_marker = saw_onset_marker || (count_result_notes(beatmap)
+                != static_cast<int>(beatmap.beats.size()));
 
             CAPTURE(content_config::LEVELS[level].title);
             CAPTURE(content_config::DIFFICULTY_KEYS[difficulty]);
-            CHECK(reg.ctx().get<SongResults>().total_notes == expected_total);
+            CHECK(reg.ctx().get<SongResults>().total_notes == count_result_notes(beatmap));
         }
     }
+    CHECK(saw_onset_marker);
 }
 
 TEST_CASE("High score integration: new song-complete high score persists",


### PR DESCRIPTION
## Summary

- Exclude onset marker metadata from `SongResults.total_notes`
- Update the shipped total-notes test to cover onset-marker beatmaps
- Correct stale HUD coordinates in the architecture diagram

## Root cause

`setup_play_session()` used `beatmap.beats.size()` for result totals, but onset markers are timing metadata skipped by the beat scheduler and never resolve into note results. The architecture diagram also still showed older HUD Y coordinates that no longer matched `content/ui/screens/gameplay.rgl`.

## Verification

- `cmake -B build -S . -Wno-dev`
- `cmake --build build`
- `./build/shapeshifter_tests`

Fixes #773
Fixes #774
