### PR TITLE
Fix P2 squad regression guards

### DIFF
--- a/.github/workflows/ci-wasm.yml
+++ b/.github/workflows/ci-wasm.yml
@@ -101,6 +101,9 @@ jobs:
           grep -Fx "test_player: clears shape gate in same lane" wasm-catch-tests.txt
           grep -Fx "session_logger: non-fatal MissTag logs result MISS (#111)" wasm-catch-tests.txt
           grep -Fx "session_logger: fatal MissTag logs result MISS (#111)" wasm-catch-tests.txt
+          grep -Fx "difficulty ramp: shape-gate count increases with difficulty" wasm-catch-tests.txt
+          grep -Fx "shipped beatmaps: authored beats are strictly increasing" wasm-catch-tests.txt
+          grep -Fx "shipped beatmaps: subdivision labels include non-downbeat events" wasm-catch-tests.txt
           ctest --verbose --output-on-failure
 
       - name: Setup Chrome

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,6 +533,9 @@ target_link_libraries(shapeshifter_tests PRIVATE
     Catch2::Catch2WithMain
     shapeshifter_warnings
 )
+target_compile_definitions(shapeshifter_tests PRIVATE
+    SHAPESHIFTER_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
+)
 
 # Apply platform definitions to tests (same as shapeshifter_lib)
 if(SHAPESHIFTER_IOS)

--- a/design-docs/beatmap-editor.md
+++ b/design-docs/beatmap-editor.md
@@ -196,7 +196,7 @@ The editor enforces these in real-time with visual indicators:
 1. Beat indices monotonically increasing (auto-sorted)
 2. No beat index beyond song duration
 3. BPM in [60, 300]
-4. Offset in [0.0, 5.0]
+4. Offset in [-0.1, 5.0]
 5. Lead beats in [2, 8]
 6. At least 1 beat entry
 7. shape_gate / split_path lane must be 0–2
@@ -467,7 +467,7 @@ export function downloadFile(filename, content)        → void  // triggers bro
 //   1. Beat indices monotonically increasing
 //   2. No beat index beyond song duration
 //   3. BPM in [60, 300]
-//   4. Offset in [0.0, 5.0]
+//   4. Offset in [-0.1, 5.0]
 //   5. Lead beats in [2, 8]
 //   6. At least 1 beat entry
 //   7. shape_gate / split_path lane must be 0–2
@@ -479,10 +479,12 @@ export function downloadFile(filename, content)        → void  // triggers bro
 #### `constants.js` (Shared Constants)
 
 ```javascript
-// Active editor palette: only runtime-supported, authorable kinds.
+// Runtime-supported kinds imported/exported by the editor. Defaults mirror
+// content/constants.json and are refreshed by loadSharedConstants().
+export let OBSTACLE_KINDS = ["shape_gate", "combo_gate", "split_path", "onset_marker"];
+// Active editor palette: runtime-supported, authorable kinds only.
 export const EDITOR_OBSTACLE_KINDS = ["shape_gate", "split_path"];
-// Import validation accepts runtime-supported legacy/content kinds, but does not add them to the palette.
-export const IMPORTABLE_OBSTACLE_KINDS = ["shape_gate", "lane_block", "combo_gate", "split_path"];
+// onset_marker is import/export metadata for shipped beatmaps, not palette-authorable.
 // Archived/future catalog entries such as low_bar/high_bar are intentionally not constants here.
 export const SHAPES = ["circle", "square", "triangle"];
 export const LANES = [0, 1, 2];

--- a/tests/test_pr43_regression.cpp
+++ b/tests/test_pr43_regression.cpp
@@ -12,6 +12,7 @@
 #include "entities/obstacle_render_entity.h"
 #include "components/rendering.h"
 #include "constants.h"
+#include <filesystem>
 #include <fstream>
 #include <raylib.h>
 #include <sstream>
@@ -206,31 +207,25 @@ TEST_CASE("obstacle mesh lifetime: all children of destroyed parent removed",
 // legacy generic JSON render path in ui_render_system.cpp.
 // ═══════════════════════════════════════════════════════════════════════
 
+static std::filesystem::path ui_render_source_path() {
+    return std::filesystem::path{SHAPESHIFTER_SOURCE_DIR} / "app/systems/ui_render_system.cpp";
+}
+
 static std::string load_ui_render_source() {
-    const char* paths[] = {
-        "app/systems/ui_render_system.cpp",
-        "../app/systems/ui_render_system.cpp"
-    };
+    std::ifstream file(ui_render_source_path());
+    if (!file.is_open()) return {};
 
-    for (const char* path : paths) {
-        std::ifstream file(path);
-        if (!file.is_open()) continue;
-
-        std::ostringstream buffer;
-        buffer << file.rdbuf();
-        return buffer.str();
-    }
-
-    return {};
+    std::ostringstream buffer;
+    buffer << file.rdbuf();
+    return buffer.str();
 }
 
 
 TEST_CASE("ui_render_system: ECS is the only generic UI element render path",
           "[ui][render][issue259]") {
     const std::string source = load_ui_render_source();
-    if (source.empty()) {
-        SKIP("ui_render_system.cpp not accessible from test working directory");
-    }
+    INFO("Expected ui_render_system.cpp at " << ui_render_source_path().string());
+    REQUIRE_FALSE(source.empty());
 
     CHECK(source.find("render_elements(") == std::string::npos);
     CHECK(source.find("render_text(") == std::string::npos);


### PR DESCRIPTION
## Summary
- Closes #771 by adding WASM Catch2 presence checks for shipped beatmap difficulty-ramp, max-gap/order, and subdivision coverage regression tests.
- Closes #772 by resolving ui_render_system.cpp from the configured source root and failing the regression test when it cannot be read instead of skipping.
- Closes #770 by updating beatmap editor docs for offset [-0.1, 5.0] and the current OBSTACLE_KINDS / EDITOR_OBSTACLE_KINDS contract, including onset_marker import/export metadata.

## Root cause
- WASM CI only checked smoke/session tests, so shipped beatmap coverage could disappear unnoticed.
- The PR43 regression test depended on current working directory fallbacks and converted lookup failure into a skip.
- The editor design doc still described older validation ranges and a removed IMPORTABLE_OBSTACLE_KINDS split.

## Verification
- cmake -B build -S . -Wno-dev
- cmake --build build
- ./build/shapeshifter_tests
- Confirmed the three new WASM grep test names exist in the Catch2 test list.