### PR TITLE
Fix docs drift for HUD and results screens

### DIFF
--- a/design-docs/game-flow.md
+++ b/design-docs/game-flow.md
@@ -354,7 +354,7 @@ Not shipped (intentionally absent from this wireframe):
   ╠═══════════════════════╬══════════════════╬═══════════════╣
   ║  Score bar            ║  x:0.05W y:0.02H ║  0.90W × 0.04H║
   ║  ├─ Score text        ║  left-aligned    ║  font: 0.03H  ║
-  ║  ├─ Pause icon (⏸)    ║  x:0.50W center  ║  0.04H × 0.04H║
+  ║  ├─ Pause button      ║  x:620 y:10      ║  80px × 50px  ║
   ║  └─ Best score text   ║  right-aligned   ║  font: 0.02H  ║
   ╠═══════════════════════╬══════════════════╬═══════════════╣
   ║  Speed bar            ║  x:0.05W y:0.06H ║  0.90W × 0.03H║
@@ -557,8 +557,9 @@ Not shipped (intentionally absent from this wireframe):
   ║     │  RESULTS                   │   ║
   ║     │  ─────────────────────     │   ║
   ║     │  Perfect      42           │   ║
-  ║     │  Great        18           │   ║
-  ║     │  Good          7           │   ║
+  ║     │  Good         18           │   ║
+  ║     │  Ok            7           │   ║
+  ║     │  Bad           1           │   ║
   ║     │  Miss          3           │   ║
   ║     └────────────────────────────┘   ║
   ║                                      ║

--- a/design-docs/game-flow.md
+++ b/design-docs/game-flow.md
@@ -354,7 +354,7 @@ Not shipped (intentionally absent from this wireframe):
   ╠═══════════════════════╬══════════════════╬═══════════════╣
   ║  Score bar            ║  x:0.05W y:0.02H ║  0.90W × 0.04H║
   ║  ├─ Score text        ║  left-aligned    ║  font: 0.03H  ║
-  ║  ├─ Pause button      ║  x:620 y:10      ║  80px × 50px  ║
+  ║  ├─ Pause button      ║  x:0.861W y:0.008H║ 0.111W × 0.039H║
   ║  └─ Best score text   ║  right-aligned   ║  font: 0.02H  ║
   ╠═══════════════════════╬══════════════════╬═══════════════╣
   ║  Speed bar            ║  x:0.05W y:0.06H ║  0.90W × 0.03H║

--- a/design-docs/game.md
+++ b/design-docs/game.md
@@ -205,8 +205,8 @@ Difficulty is selected per song (easy / medium / hard) and is expressed primaril
   the historical "no manual pause" complaint in #144 (now resolved
   by this button).
 - **Left edge — vertical Energy bar** (`EnergyBarLayout`, 14 px wide
-  × 180 px tall, anchored at x=16 with bottom y=965) with an **"ENERGY" text
-  label** (`EnergyLabel`) directly above it (x=10, y=745). The bar
+  × 180 px tall, anchored at x=16 with bottom y=965) with a controller-rendered
+  **"ENERGY" text label** directly above it (x=10, y=740). The bar
   drains on miss and recovers on hit. The label addresses the
   label-less-bar complaint in #171; both are shipped today.
 - **Bottom**: 3 shape buttons (`ShapeButtonCircle`,

--- a/design-docs/game.md
+++ b/design-docs/game.md
@@ -190,10 +190,11 @@ Difficulty is selected per song (easy / medium / hard) and is expressed primaril
 
 ## HUD Elements
 
-> **Source of truth for layout:** `content/ui/screens/gameplay.rgl`
-> (720×1280 portrait canvas). See also `design-docs/energy-bar.md`
-> for the energy-bar spec. If this list drifts from the `.rgl`, the
-> `.rgl` wins.
+> **Source of truth for static control layout:**
+> `content/ui/screens/gameplay.rgl` (720×1280 portrait canvas).
+> Dynamic energy-bar geometry is rendered from `EnergyBarLayout` in code;
+> see also `design-docs/energy-bar.md`. If this list drifts from those
+> implementation sources, the implementation wins.
 
 - **Top left**: Current score (`ScoreSlot`) and best score
   (`HighScoreSlot`), stacked vertically.
@@ -203,8 +204,8 @@ Difficulty is selected per song (easy / medium / hard) and is expressed primaril
   `game-flow.md` §1 "Master Screen Flow Map" / Pause Screen, and
   the historical "no manual pause" complaint in #144 (now resolved
   by this button).
-- **Left edge — vertical Energy bar** (`EnergyBarSlot`, ~30 px wide
-  × 200 px tall, anchored at x=10, y=790) with an **"ENERGY" text
+- **Left edge — vertical Energy bar** (`EnergyBarLayout`, 14 px wide
+  × 180 px tall, anchored at x=16 with bottom y=965) with an **"ENERGY" text
   label** (`EnergyLabel`) directly above it (x=10, y=745). The bar
   drains on miss and recovers on hit. The label addresses the
   label-less-bar complaint in #171; both are shipped today.


### PR DESCRIPTION
## Summary
- Closes #777 by documenting the shipped code-rendered energy bar geometry instead of implying the `.rgl` slot drives it.
- Closes #778 by updating the Song Complete mockup to the shipped Perfect/Good/Ok/Bad/Miss timing tiers.
- Closes #779 by aligning the gameplay pause button table with the shipped x=620, y=10, 80x50 px button.

## Root cause
- The docs mixed static rguilayout slots with controller-rendered dynamic HUD geometry.
- The Song Complete wireframe retained an old `Great` tier after runtime moved to the five-tier timing breakdown.
- The gameplay layout table still described the pause affordance as centered despite the shipped right-side button.

## Verification
- cmake -B build -S . -Wno-dev
- cmake --build build
- ./build/shapeshifter_tests