### PR TITLE
Fix energy depletion GameOver timing

### DIFF
--- a/app/components/song_state.h
+++ b/app/components/song_state.h
@@ -29,8 +29,8 @@ struct SongState {
     float  song_time     = 0.0f;   // mutated every frame by song_playback_system
     int    current_beat  = -1;     // mutated every frame by song_playback_system
     bool   playing       = false;  // set true by setup_play_session; cleared by
-                                   //   song_playback_system (end-of-song) or energy_system (death)
-    bool   finished      = false;  // set true by song_playback_system or energy_system
+                                   //   song_playback_system or terminal GameOver entry
+    bool   finished      = false;  // set true by song_playback_system or terminal GameOver entry
     bool   restart_music = false;  // set true by setup_play_session; consumed/cleared
                                    //   on the next tick by song_playback_system
 

--- a/app/systems/energy_system.cpp
+++ b/app/systems/energy_system.cpp
@@ -5,10 +5,27 @@
 #include "../constants.h"
 #include <raymath.h>
 
+namespace {
+
+void request_energy_depleted_game_over(entt::registry& reg) {
+    auto& gs = reg.ctx().get<GameState>();
+    if (gs.transition_pending) return;
+
+    auto* gos = reg.ctx().find<GameOverState>();
+    if (gos) {
+        gos->cause = DeathCause::EnergyDepleted;
+    }
+    gs.transition_pending = true;
+    gs.next_phase = GamePhase::GameOver;
+}
+
+}  // namespace
+
 void energy_system(entt::registry& reg, float dt) {
     if (reg.ctx().get<GameState>().phase != GamePhase::Playing) return;
     auto* energy = reg.ctx().find<EnergyState>();
     if (!energy) return;
+    auto* song = reg.ctx().find<SongState>();
 
     auto apply_clamped_delta = [&](float delta) {
         energy->energy = Clamp(energy->energy + delta, 0.0f, constants::ENERGY_MAX);
@@ -26,6 +43,10 @@ void energy_system(entt::registry& reg, float dt) {
             }
         }
         pending.events.clear();
+    }
+
+    if (song && song->playing && energy->energy <= 0.0f) {
+        request_energy_depleted_game_over(reg);
     }
 
     // Smooth display toward actual energy

--- a/tests/test_death_model_unified.cpp
+++ b/tests/test_death_model_unified.cpp
@@ -29,7 +29,7 @@ TEST_CASE("death_model: one miss drains energy without immediate GameOver", "[de
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
 }
 
-TEST_CASE("death_model: GameOver is deferred to energy depletion", "[death_model]") {
+TEST_CASE("death_model: GameOver is requested when energy depletes", "[death_model]") {
     auto reg = make_rhythm_registry();
     make_player(reg);
 
@@ -60,9 +60,9 @@ TEST_CASE("death_model: GameOver is deferred to energy depletion", "[death_model
     energy_system(reg, 0.016f);
 
     CHECK(energy.energy == 0.0f);
-    CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
+    CHECK(reg.ctx().get<GameState>().transition_pending);
+    CHECK(reg.ctx().get<GameState>().next_phase == GamePhase::GameOver);
 
-    game_state_system(reg, 0.016f);
     game_state_system(reg, 0.016f);
 
     const auto& state = reg.ctx().get<GameState>();
@@ -140,7 +140,7 @@ TEST_CASE("death_model: close miss drains energy instead of instant GameOver", "
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
 }
 
-TEST_CASE("death_model: collision clamps depleted energy before GameOver transition", "[death_model]") {
+TEST_CASE("death_model: collision clamps depleted energy and requests GameOver", "[death_model]") {
     auto reg = make_rhythm_registry();
     make_player(reg);
 
@@ -153,13 +153,14 @@ TEST_CASE("death_model: collision clamps depleted energy before GameOver transit
     energy_system(reg, 0.016f);
 
     CHECK(energy.energy == 0.0f);
-    CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
+    CHECK(reg.ctx().get<GameState>().transition_pending);
+    CHECK(reg.ctx().get<GameState>().next_phase == GamePhase::GameOver);
 
     game_state_system(reg, 0.016f);
-    CHECK(reg.ctx().get<GameState>().transition_pending);
+    CHECK(reg.ctx().get<GameState>().phase == GamePhase::GameOver);
 }
 
-TEST_CASE("death_model: scroll-past miss drains energy without directly requesting GameOver", "[death_model]") {
+TEST_CASE("death_model: scroll-past miss drains energy and requests GameOver", "[death_model]") {
     auto reg = make_rhythm_registry();
 
     auto& energy = reg.ctx().get<EnergyState>();
@@ -184,10 +185,11 @@ TEST_CASE("death_model: scroll-past miss drains energy without directly requesti
 
     CHECK(energy.energy == 0.0f);
     CHECK(reg.ctx().get<SongResults>().miss_count == 1);
-    CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
+    CHECK(reg.ctx().get<GameState>().transition_pending);
+    CHECK(reg.ctx().get<GameState>().next_phase == GamePhase::GameOver);
 
     game_state_system(reg, 0.016f);
-    CHECK(reg.ctx().get<GameState>().transition_pending);
+    CHECK(reg.ctx().get<GameState>().phase == GamePhase::GameOver);
 }
 
 // Regression: a scroll-past miss that depletes energy to 0 triggers GameOver
@@ -208,10 +210,11 @@ TEST_CASE("death_model: scroll-past fatal miss triggers GameOver same frame", "[
     energy_system(reg, 0.016f);
 
     CHECK(energy.energy == 0.0f);
-    CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
+    CHECK(reg.ctx().get<GameState>().transition_pending);
+    CHECK(reg.ctx().get<GameState>().next_phase == GamePhase::GameOver);
 
     game_state_system(reg, 0.016f);
-    CHECK(reg.ctx().get<GameState>().transition_pending);
+    CHECK(reg.ctx().get<GameState>().phase == GamePhase::GameOver);
 }
 
 // Regression: a scroll-past miss must not double-drain (energy delta = exactly

--- a/tests/test_phase_runner.cpp
+++ b/tests/test_phase_runner.cpp
@@ -107,3 +107,46 @@ TEST_CASE("tick_fixed_systems: popup_feedback and energy run in score-feedback c
     // Pending events must be cleared.
     CHECK(pending.events.empty());
 }
+
+TEST_CASE("tick_fixed_systems: energy depletion requests GameOver before next Playing pass",
+          "[phase_guard][energy][regression][issue781]") {
+    auto reg = make_rhythm_registry();
+    auto& gs = reg.ctx().get<GameState>();
+    auto& energy = reg.ctx().get<EnergyState>();
+    auto& pending = reg.ctx().get<PendingEnergyEffects>();
+    auto& results = reg.ctx().get<SongResults>();
+
+    energy.energy = constants::ENERGY_DRAIN_MISS;
+    pending.events.push_back({-constants::ENERGY_DRAIN_MISS, true});
+
+    tick_fixed_systems(reg, 0.016f);
+
+    REQUIRE(energy.energy == 0.0f);
+    REQUIRE(gs.transition_pending);
+    REQUIRE(gs.next_phase == GamePhase::GameOver);
+    CHECK(reg.ctx().get<GameOverState>().cause == DeathCause::EnergyDepleted);
+    CHECK(pending.events.empty());
+
+    auto late_miss = reg.create();
+    reg.emplace<ObstacleTag>(late_miss);
+    reg.emplace<ScoredTag>(late_miss);
+    reg.emplace<MissTag>(late_miss);
+    reg.emplace<Obstacle>(late_miss, ObstacleKind::ShapeGate, int16_t{constants::PTS_SHAPE_GATE});
+
+    tick_fixed_systems(reg, 0.016f);
+
+    CHECK(gs.phase == GamePhase::GameOver);
+    CHECK(results.miss_count == 0);
+
+    const auto sfx = drain_sfx_events(reg);
+    CHECK(sfx.count == 1);
+    CHECK(sfx.buf[0] == SFX::Crash);
+
+    const auto haptics = drain_haptic_events(reg);
+    REQUIRE(haptics.count >= 1);
+    CHECK(haptics.buf[0] == HapticEvent::DeathCrash);
+
+    tick_fixed_systems(reg, 0.016f);
+    CHECK(drain_sfx_events(reg).count == 0);
+    CHECK(drain_haptic_events(reg).count == 0);
+}


### PR DESCRIPTION
## Summary
- request a deferred GameOver transition immediately after queued energy effects clamp energy to zero
- preserve terminal entry ownership in game_state_system while preventing the next fixed tick from running Playing-only systems
- update death-model expectations and add a full fixed-tick regression for #781

## Root cause
`game_state_system` checked depleted energy before `energy_system` applied the current tick queued drain. A fatal miss could leave the game in `Playing` until a later tick, allowing Playing-only systems to run again before terminal entry.

## Verification
- `cmake -B build -S . -Wno-dev && cmake --build build && ./build/shapeshifter_tests`

Fixes #781