### PR TITLE
Fix rhythm input MorphIn transition

### DIFF
--- a/app/systems/player_input_system.cpp
+++ b/app/systems/player_input_system.cpp
@@ -56,22 +56,18 @@ void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt)
     auto pressed_shape = evt.shape;
     auto shape_lane = lane_for_shape(pressed_shape);
 
-    auto begin_shape_window = [&](entt::entity entity, PlayerShape& ps, ShapeWindow& sw) {
+    auto begin_shape_window = [&](PlayerShape& ps, ShapeWindow& sw) {
         Shape previous_shape = ps.current;
         sw.target_shape = pressed_shape;
         ps.previous = previous_shape;
-        ps.current = pressed_shape;  // Instant swap: no MorphIn delay
-        sw.phase = WindowPhase::Active;
+        sw.phase = WindowPhase::MorphIn;
         sw.window_timer = 0.0f;
         sw.window_start = song->song_time;
         sw.press_time = song->song_time;
         sw.peak_time = song->song_time + song->half_window;
-        ps.morph_t = 1.0f;
+        ps.morph_t = 0.0f;
         sw.window_scale = 1.0f;
         sw.graded = false;
-        auto si = static_cast<int>(pressed_shape);
-        auto& sc = constants::SHAPE_COLORS[si];
-        reg.replace<Color>(entity, sc);
         if (auto* disp = reg.ctx().find<entt::dispatcher>()) {
             disp->enqueue<PlaySfxEvent>({SFX::ShapeShift});
         }
@@ -92,9 +88,9 @@ void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt)
         if (rhythm_mode) {
             auto phase = swindow.phase;
             if (phase == WindowPhase::Idle) {
-                begin_shape_window(entity, pshape, swindow);
+                begin_shape_window(pshape, swindow);
             } else if (phase == WindowPhase::Active && pressed_shape != pshape.current) {
-                begin_shape_window(entity, pshape, swindow);
+                begin_shape_window(pshape, swindow);
             } else if (phase == WindowPhase::Active && pressed_shape == pshape.current) {
                 swindow.window_timer = 0.0f;
                 swindow.window_start = song->song_time;
@@ -103,7 +99,7 @@ void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt)
                 swindow.window_scale = 1.0f;
                 swindow.graded = false;
             } else if (phase == WindowPhase::MorphOut) {
-                begin_shape_window(entity, pshape, swindow);
+                begin_shape_window(pshape, swindow);
             }
         } else {
             if (pressed_shape != pshape.current) {

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -174,7 +174,7 @@ TEST_CASE("ecs: make_registry dispatcher is wired — ButtonPressEvent listeners
     disp.update<ButtonPressEvent>();
 
     // If dispatcher listeners were NOT wired, sw.phase would stay Idle.
-    CHECK(sw.phase        == WindowPhase::Active);  // listener wired: handle_press fired
+    CHECK(sw.phase        == WindowPhase::MorphIn);  // listener wired: handle_press fired
     CHECK(sw.target_shape == Shape::Triangle);
 }
 
@@ -205,7 +205,7 @@ TEST_CASE("ecs: wire_input_dispatcher is idempotent", "[ecs][dispatcher]") {
     press_button(reg, btn);
     reg.ctx().get<entt::dispatcher>().update<ButtonPressEvent>();
 
-    CHECK(reg.get<ShapeWindow>(player).phase == WindowPhase::Active);
+    CHECK(reg.get<ShapeWindow>(player).phase == WindowPhase::MorphIn);
     CHECK(drain_sfx_events(reg).count == 1);
 }
 
@@ -388,7 +388,7 @@ TEST_CASE("ecs: dispatcher rewire-after-unwire does not duplicate semantic deliv
     press_button(reg, button);
     reg.ctx().get<entt::dispatcher>().update<ButtonPressEvent>();
 
-    CHECK(sw.phase == WindowPhase::Active);
+    CHECK(sw.phase == WindowPhase::MorphIn);
     CHECK(sw.target_shape == Shape::Square);
     CHECK(drain_sfx_events(reg).count == 1);
 }
@@ -409,7 +409,7 @@ TEST_CASE("ecs: repeated unwire_input_dispatcher is idempotent before rewire",
     press_button(reg, button);
     reg.ctx().get<entt::dispatcher>().update<ButtonPressEvent>();
 
-    CHECK(sw.phase == WindowPhase::Active);
+    CHECK(sw.phase == WindowPhase::MorphIn);
     CHECK(sw.target_shape == Shape::Triangle);
     CHECK(drain_sfx_events(reg).count == 1);
 }

--- a/tests/test_input_pipeline_behavior.cpp
+++ b/tests/test_input_pipeline_behavior.cpp
@@ -141,7 +141,7 @@ TEST_CASE("pipeline: semantic shape press triggers shape change in same pipeline
         {ButtonPressKind::Shape, Shape::Square, MenuActionKind::Confirm, 0});
     run_pipeline(reg);
 
-    CHECK(sw.phase        == WindowPhase::Active);
+    CHECK(sw.phase        == WindowPhase::MorphIn);
     CHECK(sw.target_shape == Shape::Square);
 }
 
@@ -179,7 +179,7 @@ TEST_CASE("pipeline: gameplay HUD raygui shape press triggers player shape input
                                       false);
     run_pipeline(reg);
 
-    CHECK(sw.phase == WindowPhase::Active);
+    CHECK(sw.phase == WindowPhase::MorphIn);
     CHECK(sw.target_shape == Shape::Square);
 }
 
@@ -265,7 +265,7 @@ TEST_CASE("pipeline: mixed swipe and tap both take effect within a single pipeli
     run_pipeline(reg);
 
     CHECK(lane.target     == 2);                  // shape auto-target wins
-    CHECK(sw.phase        == WindowPhase::Active); // tap processed
+    CHECK(sw.phase        == WindowPhase::MorphIn); // tap processed
     CHECK(sw.target_shape == Shape::Triangle);
 }
 
@@ -329,11 +329,11 @@ TEST_CASE("pipeline: tap consumed after first sub-tick — second sub-tick does 
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 5.0f;
 
-    // Sub-tick 1: tap opens Active.
+    // Sub-tick 1: tap opens MorphIn.
     reg.ctx().get<entt::dispatcher>().enqueue<ButtonPressEvent>(
         {ButtonPressKind::Shape, Shape::Circle, MenuActionKind::Confirm, 0});
     run_pipeline(reg);
-    CHECK(sw.phase        == WindowPhase::Active);
+    CHECK(sw.phase        == WindowPhase::MorphIn);
     float start1 = sw.window_start;
 
     // Advance song time so a replayed window would produce a different window_start.

--- a/tests/test_player_action_rhythm.cpp
+++ b/tests/test_player_action_rhythm.cpp
@@ -4,7 +4,7 @@
 
 // ── semantic input pipeline: rhythm mode ───────────────────────────────
 
-TEST_CASE("player_action: rhythm mode starts window on button press from Idle", "[player_rhythm]") {
+TEST_CASE("player_action: rhythm mode starts MorphIn on button press from Idle", "[player_rhythm]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& ps = reg.get<PlayerShape>(player);
@@ -12,18 +12,25 @@ TEST_CASE("player_action: rhythm mode starts window on button press from Idle", 
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 5.0f;
 
-    auto btn = make_shape_button(reg, Shape::Circle);
+    auto btn = make_shape_button(reg, Shape::Triangle);
     press_button(reg, btn);
 
     run_semantic_input_tick(reg, 0.016f);
 
-    CHECK(sw.target_shape == Shape::Circle);
-    CHECK(sw.phase == WindowPhase::Active);
+    CHECK(sw.target_shape == Shape::Triangle);
+    CHECK(sw.phase == WindowPhase::MorphIn);
     CHECK(sw.window_timer == 0.0f);
-    CHECK(ps.morph_t == 1.0f);
+    CHECK(ps.current == Shape::Hexagon);
+    CHECK(ps.morph_t == 0.0f);
     CHECK(sw.window_start == 5.0f);
     CHECK(sw.graded == false);
     CHECK(sw.window_scale == 1.0f);
+
+    song.song_time += song.morph_duration + 0.01f;
+    shape_window_system(reg, song.morph_duration + 0.01f);
+    CHECK(sw.phase == WindowPhase::Active);
+    CHECK(ps.current == Shape::Triangle);
+    CHECK(ps.morph_t == 1.0f);
 
     // SFX should be pushed
     CHECK(drain_sfx_events(reg).count > 0);
@@ -82,9 +89,9 @@ TEST_CASE("player_action: rhythm mode interrupts Active with different shape", "
     run_semantic_input_tick(reg, 0.016f);
 
     CHECK(sw.target_shape == Shape::Triangle);
-    CHECK(sw.phase == WindowPhase::Active);
+    CHECK(sw.phase == WindowPhase::MorphIn);
     CHECK(sw.window_timer == 0.0f);
-    CHECK(ps.morph_t == 1.0f);
+    CHECK(ps.morph_t == 0.0f);
     CHECK(sw.window_start == 8.0f);
     CHECK(sw.graded == false);
 }
@@ -137,11 +144,11 @@ TEST_CASE("player_action: rhythm mode ACCEPTS button press during MorphOut (#209
 
     run_semantic_input_tick(reg, 0.016f);
 
-    // MorphOut interrupted: new Active window started for Triangle
+    // MorphOut interrupted: new MorphIn window started for Triangle
     CHECK(sw.target_shape == Shape::Triangle);
-    CHECK(sw.phase == WindowPhase::Active);
+    CHECK(sw.phase == WindowPhase::MorphIn);
     CHECK(sw.window_timer == 0.0f);
-    CHECK(ps.morph_t == 1.0f);
+    CHECK(ps.morph_t == 0.0f);
     CHECK(sw.window_start == 15.0f);
     CHECK(sw.graded == false);
     CHECK(drain_sfx_events(reg).count > 0);
@@ -238,9 +245,9 @@ TEST_CASE("player_input: ButtonPressEvents consumed after first tick (#213)", "[
     auto btn = make_shape_button(reg, Shape::Circle);
     press_button(reg, btn);
 
-    // First tick: starts an Active window, consumes the event.
+    // First tick: starts a MorphIn window, consumes the event.
     run_semantic_input_tick(reg, 1.0f / 60.0f);
-    CHECK(sw.phase == WindowPhase::Active);
+    CHECK(sw.phase == WindowPhase::MorphIn);
 
     // Record state after first tick.
     float start_after_tick1 = sw.window_start;

--- a/tests/test_player_input_rhythm_extended.cpp
+++ b/tests/test_player_input_rhythm_extended.cpp
@@ -4,7 +4,7 @@
 
 // ── semantic input pipeline: rhythm mode window management ───────
 
-TEST_CASE("player_input_rhythm: shape press in Idle begins Active window", "[player][rhythm]") {
+TEST_CASE("player_input_rhythm: shape press in Idle begins MorphIn window", "[player][rhythm]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& sw = reg.get<ShapeWindow>(player);
@@ -17,7 +17,7 @@ TEST_CASE("player_input_rhythm: shape press in Idle begins Active window", "[pla
 
     run_semantic_input_tick(reg);
 
-    CHECK(sw.phase == WindowPhase::Active);
+    CHECK(sw.phase == WindowPhase::MorphIn);
     CHECK(sw.target_shape == Shape::Circle);
     CHECK(sw.window_start == song.song_time);
 }
@@ -39,8 +39,8 @@ TEST_CASE("player_input_rhythm: different shape in Active restarts window", "[pl
 
     run_semantic_input_tick(reg);
 
-    // Should restart as Active for Square
-    CHECK(sw.phase == WindowPhase::Active);
+    // Should restart as MorphIn for Square.
+    CHECK(sw.phase == WindowPhase::MorphIn);
     CHECK(sw.target_shape == Shape::Square);
 }
 
@@ -215,6 +215,9 @@ TEST_CASE("player_input_rhythm: circle press in lane 0 does not force mismatch b
     auto btn = make_shape_button(reg, Shape::Circle);
     press_button(reg, btn);
     reg.ctx().get<entt::dispatcher>().update<ButtonPressEvent>();
+    auto& song = reg.ctx().get<SongState>();
+    song.song_time += song.morph_duration + 0.01f;
+    shape_window_system(reg, song.morph_duration + 0.01f);
     player_movement_system(reg, 0.016f);
     collision_system(reg, 0.016f);
 

--- a/tests/test_rhythm_system.cpp
+++ b/tests/test_rhythm_system.cpp
@@ -407,14 +407,14 @@ TEST_CASE("shape_window: full lifecycle", "[rhythm][window]") {
 
 // Player Action System (Rhythm Mode)
 
-TEST_CASE("player_action: button press starts window in rhythm mode", "[rhythm][action]") {
+TEST_CASE("player_action: button press starts MorphIn window in rhythm mode", "[rhythm][action]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto btn = make_shape_button(reg, Shape::Triangle);
     press_button(reg, btn);
     run_semantic_input_tick(reg, 0.016f);
     auto& sw = reg.get<ShapeWindow>(player);
-    CHECK(sw.phase == WindowPhase::Active);
+    CHECK(sw.phase == WindowPhase::MorphIn);
     CHECK(sw.target_shape == Shape::Triangle);
 }
 
@@ -453,7 +453,7 @@ TEST_CASE("player_action: different shape mid-window restarts", "[rhythm][action
     auto btn = make_shape_button(reg, Shape::Circle);
     press_button(reg, btn);
     run_semantic_input_tick(reg, 0.016f);
-    CHECK(sw.phase == WindowPhase::Active);
+    CHECK(sw.phase == WindowPhase::MorphIn);
     CHECK(sw.target_shape == Shape::Circle);
 }
 


### PR DESCRIPTION
## Summary
- Route rhythm shape presses through WindowPhase::MorphIn instead of jumping directly to Active.
- Leave shape/color activation owned by shape_window_system when MorphIn completes.
- Update input pipeline and dispatcher tests to assert MorphIn starts, including coverage that MorphIn advances to Active.

Fixes #783.

## Verification
- cmake -B build -S . -Wno-dev
- cmake --build build
- ./build/shapeshifter_tests