### PR TITLE
Exclude benchmarks from native CTest discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -569,6 +569,7 @@ if(NOT EMSCRIPTEN AND NOT SHAPESHIFTER_IOS)
     include(Catch)
     catch_discover_tests(
         shapeshifter_tests
+        TEST_SPEC "~[bench]"
         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     )
     add_test(


### PR DESCRIPTION
## Summary
- Add `TEST_SPEC "~[bench]"` to native Catch2 test discovery.
- Align native regular CTest behavior with the existing WASM runner filter.

## Root cause
Native `catch_discover_tests(shapeshifter_tests ...)` did not pass a Catch2 test spec, so benchmark-tagged cases were registered in the normal CTest suite even though WASM already excludes them.

## Verification
- `cmake -B build -S . -Wno-dev`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- `ctest --test-dir build -N | grep -i bench` returns no matches

Fixes #787