### PR TITLE
Fix stale shape press timing reset

### DIFF
--- a/app/systems/shape_window_system.cpp
+++ b/app/systems/shape_window_system.cpp
@@ -66,6 +66,7 @@ void shape_window_system(entt::registry& reg, float /*dt*/) {
                     swindow.target_shape = Shape::Hexagon;
                     swindow.phase = WindowPhase::Idle;
                     swindow.window_timer = 0.0f;
+                    swindow.press_time = -1.0f;
                     swindow.window_scale = 1.0f;
                     swindow.graded = false;
                     apply_shape_color(reg, entity, Shape::Hexagon);

--- a/tests/test_shape_window_extended.cpp
+++ b/tests/test_shape_window_extended.cpp
@@ -78,6 +78,7 @@ TEST_CASE("shape_window: MorphOut returns to Idle with Hexagon", "[shape_window]
     ps.previous = Shape::Circle;
     sw.phase = WindowPhase::MorphOut;
     sw.window_start = song.song_time;
+    sw.press_time = song.song_time - 0.25f;
     ps.morph_t = 0.0f;
 
     // Advance past morph_duration
@@ -88,6 +89,7 @@ TEST_CASE("shape_window: MorphOut returns to Idle with Hexagon", "[shape_window]
     CHECK(ps.current == Shape::Hexagon);
     CHECK(ps.previous == Shape::Hexagon);
     CHECK(sw.target_shape == Shape::Hexagon);
+    CHECK(sw.press_time == -1.0f);
     CHECK(sw.window_scale == 1.0f);
     CHECK_FALSE(sw.graded);
 }


### PR DESCRIPTION
## Summary\n- reset ShapeWindow::press_time when MorphOut returns the player to Idle\n- extend the shape-window lifecycle regression to assert stale press time is cleared\n\n## Verification\n- cmake -B build -S . -Wno-dev && cmake --build build && ./build/shapeshifter_tests\n\nCloses #798