### PR TITLE
Remove obsolete Burnout feedback paths

### DIFF
--- a/app/audio/audio_types.h
+++ b/app/audio/audio_types.h
@@ -9,16 +9,13 @@ enum class SFX : uint8_t {
     Crash,
     UITap,
     ChainBonus,
-    ZoneRisky,
-    ZoneDanger,
-    ZoneDead,
     ScorePopup,
     GameStart,
 };
 
 // Compile-time guard: SFX values must be contiguous and zero-based so that
 // static arrays indexed by static_cast<int>(sfx) are always in-bounds.
-static_assert(magic_enum::enum_count<SFX>() == 9,
+static_assert(magic_enum::enum_count<SFX>() == 6,
               "SFX enum changed — update sfx_bank.cpp SFX_SPECS and this guard");
 static_assert(static_cast<int>(SFX::ShapeShift) == 0,
               "SFX enum must be zero-based for array indexing");

--- a/app/audio/sfx_bank.cpp
+++ b/app/audio/sfx_bank.cpp
@@ -36,9 +36,6 @@ constexpr std::array<SfxSpec, SFX_COUNT> SFX_SPECS{{
     {180.0f, 0.220f, 0.45f, ProceduralWave::Noise, 3u},      // Crash
     {880.0f, 0.050f, 0.25f, ProceduralWave::Sine, 4u},       // UITap
     {784.0f, 0.120f, 0.35f, ProceduralWave::Sine, 5u},       // ChainBonus
-    {440.0f, 0.100f, 0.30f, ProceduralWave::Sine, 6u},       // ZoneRisky
-    {330.0f, 0.140f, 0.35f, ProceduralWave::Square, 7u},     // ZoneDanger
-    {220.0f, 0.180f, 0.40f, ProceduralWave::DownSweep, 8u},  // ZoneDead
     {988.0f, 0.060f, 0.25f, ProceduralWave::Sine, 9u},       // ScorePopup
     {587.0f, 0.180f, 0.35f, ProceduralWave::Sine, 10u},      // GameStart
 }};

--- a/app/components/haptics.h
+++ b/app/components/haptics.h
@@ -5,19 +5,10 @@
 // Haptic feedback events — sourced from design-docs/game-flow.md Appendix B.
 // All haptics are opt-out (enabled by default).
 // Players with haptics OFF receive 0 ms vibration (no fallback) per spec.
-//
-// Burnout zone → multiplier mapping (see constants.h):
-//   Risky  = 1.5×  →  Burnout1_5x
-//   Danger = 3.0×  →  Burnout3_0x
-//   Dead   = 5.0×  →  Burnout5_0x
 enum class HapticEvent : uint8_t {
     ShapeShift  = 0,  // Light tap       — player changes shape
     LaneSwitch,       // Ultra-light tap — player changes lane
     JumpLand,         // Light tap       — player lands from a jump (not takeoff)
-    Burnout1_5x,      // Light tap       — entering Risky zone  (1.5× multiplier)
-    Burnout3_0x,      // Medium tap      — entering Danger zone (3.0× multiplier)
-    Burnout5_0x,      // Triple-pulse Heavy — entering Dead zone (5.0× multiplier)
-    NearMiss,         // Heavy pulse     — scored in Dead zone (survived danger)
     DeathCrash,       // Double-pulse Heavy — player death
     NewHighScore,     // Triple-tap Medium  — new personal high score achieved
     RetryTap,         // Crisp tap       — end-screen Restart pressed

--- a/app/components/player.h
+++ b/app/components/player.h
@@ -20,7 +20,7 @@ struct PlayerShape {
 };
 
 // Rhythm-mode shape window timing — read by shape_window_system,
-// collision_system, player_action_system.
+// collision_system, and player input handlers.
 struct ShapeWindow {
     Shape       target_shape  = Shape::Circle;
     WindowPhase phase         = WindowPhase::Idle;

--- a/app/platform/haptics_backend.cpp
+++ b/app/platform/haptics_backend.cpp
@@ -49,16 +49,10 @@ TriggerPattern pattern_for_event(HapticEvent event) noexcept {
             return {ImpactStyle::Light, 1};
         case HapticEvent::ShapeShift:
         case HapticEvent::JumpLand:
-        case HapticEvent::Burnout1_5x:
         case HapticEvent::RetryTap:
             return {ImpactStyle::Light, 1};
-        case HapticEvent::Burnout3_0x:
         case HapticEvent::NewHighScore:
             return {ImpactStyle::Medium, 1};
-        case HapticEvent::NearMiss:
-            return {ImpactStyle::Heavy, 1};
-        case HapticEvent::Burnout5_0x:
-            return {ImpactStyle::Heavy, 3};
         case HapticEvent::DeathCrash:
             return {ImpactStyle::Heavy, 2};
         default:

--- a/app/platform/ios/haptics_ios_bridge_ios.mm
+++ b/app/platform/ios/haptics_ios_bridge_ios.mm
@@ -24,16 +24,10 @@ IOSPattern ios_pattern_for_event(HapticEvent event) {
         case HapticEvent::UIButtonTap:
         case HapticEvent::ShapeShift:
         case HapticEvent::JumpLand:
-        case HapticEvent::Burnout1_5x:
         case HapticEvent::RetryTap:
             return {UIImpactFeedbackStyleLight, 1};
-        case HapticEvent::Burnout3_0x:
         case HapticEvent::NewHighScore:
             return {UIImpactFeedbackStyleMedium, 1};
-        case HapticEvent::NearMiss:
-            return {UIImpactFeedbackStyleHeavy, 1};
-        case HapticEvent::Burnout5_0x:
-            return {UIImpactFeedbackStyleHeavy, 3};
         case HapticEvent::DeathCrash:
             return {UIImpactFeedbackStyleHeavy, 2};
         default:

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -437,9 +437,6 @@ enum class SFX : uint8_t {
     Crash,
     UITap,
     ChainBonus,
-    ZoneRisky,
-    ZoneDanger,
-    ZoneDead,
     ScorePopup,
     GameStart,
 };

--- a/design-docs/beatmap-integration.md
+++ b/design-docs/beatmap-integration.md
@@ -213,7 +213,7 @@ creates the standard runtime obstacle archetypes via `spawn_rhythm_obstacle()`.
   │  game_state_system       (phase transitions)                    │
   │  ✅ song_playback_system (advances SongState.song_time)         │
   │  ✅ beat_scheduler_system (SongState + BeatMap → spawn entities)│
-  │  player_action_system    (GestureResult → PlayerShape, Lane)    │
+  │  player_input handlers   (ButtonPressEvent/GoEvent → Player)    │
   │  shape_window_system     (timing window morphing)               │
   │  player_movement_system  (animate Position from Lane/VState)    │
   │  difficulty_system       (elapsed → speed/spawn ramp)           │

--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -161,7 +161,8 @@ constexpr int32_t CHAIN_MULT_BONUS_STEPS_CAP = 20; // caps at 2.0x from chain 21
   ┌──────────────────────────────────────────────────────────────┐
   │  PER-ENTITY COMPONENTS                                       │
   ├──────────────────────────────────────────────────────────────┤
-  │  PlayerShape       24B ← current shape + window state       │
+  │  PlayerShape       8B  ← current/previous shape + morph     │
+  │  ShapeWindow      24B  ← rhythm window timing state         │
   │  Position           8B ← world position                     │
   │  Velocity           8B ← dx, dy                             │
   │  ObstacleTag        0B ← marker                             │
@@ -215,14 +216,20 @@ struct SongState {
 enum class WindowPhase { Idle, MorphIn, Active, MorphOut };
 
 struct PlayerShape {
-    Shape        current       = Shape::Hexagon;
-    Shape        target        = Shape::Hexagon;
-    float        morph_t       = 0.0f;     // [0,1] visual interpolation
-    WindowPhase  phase         = WindowPhase::Idle;
-    float        phase_timer   = 0.0f;     // seconds in current phase
-    float        peak_time     = 0.0f;     // absolute song_time of window peak
-    float        window_scale  = 1.0f;     // shortening factor from early hit
-    bool         graded        = false;    // window already graded this cycle
+    Shape current  = Shape::Circle;  // player_entity initializes this to Hexagon
+    Shape previous = Shape::Circle;
+    float morph_t  = 1.0f;           // [0,1] visual interpolation
+};
+
+struct ShapeWindow {
+    Shape       target_shape = Shape::Circle; // player_entity initializes this to Hexagon
+    WindowPhase phase        = WindowPhase::Idle;
+    bool        graded       = false;         // window already graded this cycle
+    float       window_timer = 0.0f;          // seconds in current phase/window
+    float       window_start = 0.0f;          // absolute song_time of window start
+    float       press_time   = -1.0f;         // absolute song_time of input
+    float       peak_time    = 0.0f;          // absolute song_time of window peak
+    float       window_scale = 1.0f;          // shortening factor from early hit
 };
 ```
 
@@ -281,10 +288,10 @@ struct SongResults {
   │   → spawns obstacle entities when song_time >= beat_time   │
   │   → advances next_spawn_idx                                │
   │                                                            │
-  │ player_action_system                           [MOD]       │
-  │   → handles ShapeChangeEvent                               │
-  │   → transitions PlayerShape into MorphIn phase             │
-  │   → resets graded + window_scale on new window start       │
+  │ player_input_system handlers                  [MOD]       │
+  │   → handle ButtonPressEvent shape input                    │
+  │   → transition ShapeWindow into MorphIn phase              │
+  │   → reset graded + window_scale on new window start        │
   │                                                            │
   │ shape_window_system                           ★ NEW        │
   │   → advances WindowPhase state machine                     │
@@ -574,7 +581,7 @@ The default (OK) timing = the full active window. Better timing shrinks the rema
   Effect: a PERFECT press returns the player to Hexagon
   faster, ready for the next obstacle sooner.
 
-  The `graded` flag on PlayerShape prevents a second obstacle
+  The `graded` flag on ShapeWindow prevents a second obstacle
   in the same window from re-applying the scale factor.
 ```
 
@@ -620,8 +627,8 @@ if (!song) return;  // no rhythm context — skip
 
 ```
   Player taps the same shape button while already in that window:
-    → player_action_system sees target == current → no-op
-    → window is not restarted or extended
+    → player_input_handle_press sees target == current
+    → active window timing is refreshed for the repeated same-shape press
 ```
 
 ## Different-shape interrupt
@@ -678,8 +685,8 @@ if (!song) return;  // no rhythm context — skip
 ## Phase 3 — Shape window (DONE)
 ```
   • shape_window_system: Idle→MorphIn→Active→MorphOut→Idle
-  • player_action_system: triggers window, resets graded/window_scale
-  • PlayerShape: added window_scale + graded fields
+  • player_input_system handlers: trigger window, reset graded/window_scale
+  • ShapeWindow: owns window_scale + graded fields
   • collision_system: window scaling on GOOD/PERFECT
 ```
 

--- a/design-docs/tester-personas-tech-spec.md
+++ b/design-docs/tester-personas-tech-spec.md
@@ -77,10 +77,10 @@
   └──────────────────────────────────────────────────────────┘
                          │
                          ▼ consumed by
-                 gesture_system (existing)
+                 semantic input event queue
                          │
                          ▼
-                 player_action_system (existing)
+                 player_input handlers (existing)
 ```
 
 
@@ -101,11 +101,9 @@ test_player_system(reg, raw_dt);    // Phase 0.5: ★ NEW — injects AI input
 
 // ── INSIDE fixed timestep loop ──────────────────────
 while (accumulator >= FIXED_DT) {
-    gesture_system(reg, FIXED_DT);       // reads InputState → GestureResult
-    game_state_system(reg, FIXED_DT);
+    game_state_system(reg, FIXED_DT);    // drains semantic input events
     song_playback_system(reg, FIXED_DT);
     beat_scheduler_system(reg, FIXED_DT);
-    player_action_system(reg, FIXED_DT);
     shape_window_system(reg, FIXED_DT);
     player_movement_system(reg, FIXED_DT);
     difficulty_system(reg, FIXED_DT);
@@ -125,12 +123,12 @@ while (accumulator >= FIXED_DT) {
 ## System Dependency Chain
 
 ```
-  input_system ──▶ test_player_system ──▶ gesture_system ──▶ player_action_system
+  input_system ──▶ test_player_system ──▶ game_state_system ──▶ player_input handlers
        │                │                      │
     clears           writes                 reads
     key_* flags      key_* flags           key_* flags
-                                            writes GestureResult /
-                                            ShapeButtonEvent
+                                            drains ButtonPressEvent /
+                                            GoEvent
 
   scroll_system ──▶ ring_zone_log_system ──▶ collision_system ──▶ scoring_system
        │                │                         │                  │
@@ -347,9 +345,9 @@ multiple iterations of gesture_system within one frame. Verified safe:
 
 ```
   Iteration 1: gesture_system reads key_1 → sets ShapeButtonEvent
-               player_action_system reads ShapeButtonEvent → MorphIn
+               player_input_handle_press reads ButtonPressEvent → MorphIn
   Iteration 2: gesture_system reads key_1 again → sets ShapeButtonEvent
-               player_action_system checks phase → now MorphIn, not Idle
+               player_input_handle_press checks phase → now MorphIn, not Idle
                → Idle branch fails → no-op ✓ (idempotent)
 ```
 
@@ -680,7 +678,7 @@ Linear iteration over contiguous storage — hardware prefetcher friendly.
   ├─────┼────────────────────────────────────────────────────────┤
   │ 🟢6 │  Key flags persist across multiple fixed-step          │
   │     │  iterations within one frame. Verified idempotent:     │
-  │     │  gesture_system re-fires but player_action_system      │
+  │     │  input event dispatch re-fires but player input        │
   │     │  phase check prevents double-processing.               │
   ├─────┼────────────────────────────────────────────────────────┤
   │ 🟢7 │  std::mt19937 is 2.5KB — large but acceptable for a   │

--- a/tests/test_haptics_backend.cpp
+++ b/tests/test_haptics_backend.cpp
@@ -9,10 +9,6 @@ TEST_CASE("haptics backend maps burst patterns for heavy events", "[haptic]") {
     const auto death = platform::haptics::pattern_for_event(HapticEvent::DeathCrash);
     CHECK(death.style == platform::haptics::ImpactStyle::Heavy);
     CHECK(death.pulse_count == 2);
-
-    const auto burnout = platform::haptics::pattern_for_event(HapticEvent::Burnout5_0x);
-    CHECK(burnout.style == platform::haptics::ImpactStyle::Heavy);
-    CHECK(burnout.pulse_count == 3);
 }
 
 TEST_CASE("haptics backend maps light and medium events deterministically", "[haptic]") {


### PR DESCRIPTION
## Summary
- Removes obsolete Burnout haptic events and zone SFX definitions now that the Burnout mechanic is retired.
- Updates haptic tests and iOS/backend haptic mappings to cover only active events.
- Syncs rhythm docs with the current PlayerShape/ShapeWindow split and player input handlers.

## Root cause
Burnout was removed from the design, but some feedback enums, generated SFX specs, haptic mappings, and docs still described the old Burnout zone model and the pre-dispatch player_action_system naming.

## Verification
- cmake -B build -S . -Wno-dev
- cmake --build build
- ./build/shapeshifter_tests

Closes #800
Closes #801