### PR TITLE
Fix same-shape rhythm spam and refresh docs/tests

### DIFF
--- a/app/systems/player_input_system.cpp
+++ b/app/systems/player_input_system.cpp
@@ -91,13 +91,6 @@ void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt)
                 begin_shape_window(pshape, swindow);
             } else if (phase == WindowPhase::Active && pressed_shape != pshape.current) {
                 begin_shape_window(pshape, swindow);
-            } else if (phase == WindowPhase::Active && pressed_shape == pshape.current) {
-                swindow.window_timer = 0.0f;
-                swindow.window_start = song->song_time;
-                swindow.press_time = song->song_time;
-                swindow.peak_time = song->song_time + song->half_window;
-                swindow.window_scale = 1.0f;
-                swindow.graded = false;
             } else if (phase == WindowPhase::MorphOut) {
                 begin_shape_window(pshape, swindow);
             }

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -199,12 +199,14 @@ enum class ObstacleKind : uint8_t {
     LaneBlock,   // legacy value kept for backward compat
     ComboGate,   // shape + lane
     SplitPath,   // shape + specific lane
+    OnsetMarker, // virtual beat marker; scheduler does not spawn an obstacle
 };
 
 struct Obstacle {
-    ObstacleKind kind       = ObstacleKind::ShapeGate;
     int16_t      base_points = 200;   // PTS_SHAPE_GATE etc.
 };
+// Runtime kind is derived from optional components (RequiredShape,
+// BlockedLanes, RequiredLane) via obstacle_kind_from_components().
 // Existential tag: presence means the obstacle has been cleared and awaits scoring.
 struct ScoredTag {};
 ```
@@ -261,9 +263,11 @@ struct ScoreState {
 
 /// Score popup entity component. 8 bytes.
 struct ScorePopup {
-    int32_t  value       = 0;    // points to display
-    uint8_t  tier        = 0;    // 0=normal, 1=nice, 2=great, 3=clutch, 4=insane, 5=legendary
-    uint8_t  timing_tier = 255;  // TimingTier value, 255 = no timing
+    int32_t    value           = 0;              // points to display
+    bool       has_timing_tier = false;          // false when no TimingGrade was present
+    TimingTier timing_tier     = TimingTier::Ok; // valid only when has_timing_tier is true
+    float      remaining       = 0.0f;           // seconds left to display
+    float      max_time        = 0.0f;           // initial lifetime for fade/scale
 };
 ```
 
@@ -1539,10 +1543,9 @@ entt::entity spawn_shape_gate(entt::registry& reg, Shape required,
                                int8_t lane, float scroll_speed) {
     auto e = reg.create();
     reg.emplace<ObstacleTag>(e);
-    reg.emplace<Position>(e, constants::LANE_X[lane], constants::SPAWN_Y);
-    reg.emplace<Velocity>(e, 0.0f, scroll_speed);
-    reg.emplace<Obstacle>(e, ObstacleKind::ShapeGate,
-                          static_cast<int16_t>(constants::PTS_SHAPE_GATE));
+    reg.emplace<WorldTransform>(e, WorldTransform{{constants::LANE_X[lane], constants::SPAWN_Y}});
+    reg.emplace<MotionVelocity>(e, MotionVelocity{{0.0f, scroll_speed}});
+    reg.emplace<Obstacle>(e, int16_t{constants::PTS_SHAPE_GATE});
     reg.emplace<RequiredShape>(e, required);
     reg.emplace<Color>(e, shape_color(required));
     reg.emplace<DrawSize>(e, static_cast<float>(constants::SCREEN_W), 80.0f);

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -291,6 +291,46 @@ TEST_CASE("game_state: game_over main_menu button triggers title", "[gamestate]"
     CHECK(gs.next_phase == GamePhase::Title);
 }
 
+TEST_CASE("game_state: game_over level_select button triggers level_select", "[gamestate]") {
+    auto reg = make_registry();
+    auto& gs = reg.ctx().get<GameState>();
+    gs.phase = GamePhase::GameOver;
+    gs.phase_timer = 0.5f;
+    gs.end_choice = EndScreenChoice::LevelSelect;
+
+    game_state_system(reg, 0.016f);
+
+    CHECK(gs.transition_pending);
+    CHECK(gs.next_phase == GamePhase::LevelSelect);
+    CHECK(gs.end_choice == EndScreenChoice::None);
+}
+
+TEST_CASE("game_state: game_over ignores choice at readiness boundary", "[gamestate]") {
+    auto reg = make_registry();
+    auto& gs = reg.ctx().get<GameState>();
+    gs.phase = GamePhase::GameOver;
+    gs.phase_timer = 0.4f;
+    gs.end_choice = EndScreenChoice::Restart;
+
+    game_state_system(reg, 0.0f);
+
+    CHECK_FALSE(gs.transition_pending);
+    CHECK(gs.end_choice == EndScreenChoice::Restart);
+}
+
+TEST_CASE("game_state: game_over ignores missing end choice", "[gamestate]") {
+    auto reg = make_registry();
+    auto& gs = reg.ctx().get<GameState>();
+    gs.phase = GamePhase::GameOver;
+    gs.phase_timer = 0.5f;
+    gs.end_choice = EndScreenChoice::None;
+
+    game_state_system(reg, 0.016f);
+
+    CHECK_FALSE(gs.transition_pending);
+    CHECK(gs.end_choice == EndScreenChoice::None);
+}
+
 TEST_CASE("game_state: game_over restart enters fresh play session on next tick", "[gamestate][play_session]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();

--- a/tests/test_player_action_rhythm.cpp
+++ b/tests/test_player_action_rhythm.cpp
@@ -52,7 +52,7 @@ TEST_CASE("player_action: rhythm mode calculates peak_time correctly", "[player_
     CHECK_THAT(sw.peak_time, Catch::Matchers::WithinAbs(expected_peak, 0.001f));
 }
 
-TEST_CASE("player_action: rhythm mode ignores same shape during Active (spam protection)", "[player_rhythm]") {
+TEST_CASE("player_action: rhythm mode treats same shape during Active as no-op", "[player_rhythm]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& ps = reg.get<PlayerShape>(player);
@@ -60,16 +60,27 @@ TEST_CASE("player_action: rhythm mode ignores same shape during Active (spam pro
     sw.phase = WindowPhase::Active;
     ps.current = Shape::Square;
     sw.window_timer = 0.1f;
+    sw.window_start = 1.0f;
+    sw.press_time = 1.0f;
+    sw.peak_time = 1.15f;
+    sw.graded = true;
+
+    const float initial_window_start = sw.window_start;
+    const float initial_window_timer = sw.window_timer;
+    const float initial_press_time = sw.press_time;
+    const float initial_peak_time = sw.peak_time;
 
     auto btn = make_shape_button(reg, Shape::Square);
     press_button(reg, btn);
 
     run_semantic_input_tick(reg, 0.016f);
 
-    // Same shape re-press: window timer resets for next obstacle
     CHECK(sw.phase == WindowPhase::Active);
-    CHECK(sw.window_timer == 0.0f);
-    CHECK_FALSE(sw.graded);
+    CHECK(sw.window_start == initial_window_start);
+    CHECK(sw.window_timer == initial_window_timer);
+    CHECK(sw.press_time == initial_press_time);
+    CHECK(sw.peak_time == initial_peak_time);
+    CHECK(sw.graded);
 }
 
 TEST_CASE("player_action: rhythm mode interrupts Active with different shape", "[player_rhythm]") {

--- a/tests/test_player_input_rhythm_extended.cpp
+++ b/tests/test_player_input_rhythm_extended.cpp
@@ -44,7 +44,7 @@ TEST_CASE("player_input_rhythm: different shape in Active restarts window", "[pl
     CHECK(sw.target_shape == Shape::Square);
 }
 
-TEST_CASE("player_input_rhythm: same shape in Active re-extends window", "[player][rhythm]") {
+TEST_CASE("player_input_rhythm: same shape in Active is no-op", "[player][rhythm]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& ps = reg.get<PlayerShape>(player);
@@ -54,18 +54,27 @@ TEST_CASE("player_input_rhythm: same shape in Active re-extends window", "[playe
     ps.current = Shape::Circle;
     sw.phase = WindowPhase::Active;
     sw.window_start = song.song_time - 0.5f;
+    sw.window_timer = 0.5f;
+    sw.press_time = song.song_time - 0.5f;
+    sw.peak_time = song.song_time - 0.25f;
     sw.graded = true;  // was previously graded
+
+    const float initial_window_start = sw.window_start;
+    const float initial_window_timer = sw.window_timer;
+    const float initial_press_time = sw.press_time;
+    const float initial_peak_time = sw.peak_time;
 
     auto btn = make_shape_button(reg, Shape::Circle);
     press_button(reg, btn);
 
     run_semantic_input_tick(reg);
 
-    // Should remain Active and reset timing
     CHECK(sw.phase == WindowPhase::Active);
-    CHECK(sw.window_timer == 0.0f);
-    CHECK(sw.window_start == song.song_time);
-    CHECK_FALSE(sw.graded);
+    CHECK(sw.window_start == initial_window_start);
+    CHECK(sw.window_timer == initial_window_timer);
+    CHECK(sw.press_time == initial_press_time);
+    CHECK(sw.peak_time == initial_peak_time);
+    CHECK(sw.graded);
 }
 
 TEST_CASE("player_input_rhythm: shape change pushes ShapeShift SFX", "[player][rhythm]") {


### PR DESCRIPTION
## Summary
- Fixes #803 by making same-shape presses during an Active rhythm window a no-op, matching rhythm-spec same-shape spam behavior.
- Fixes #804 by refreshing architecture snippets for ObstacleKind, Obstacle, ScorePopup, and obstacle spawn components.
- Fixes #805 by adding GameOver LevelSelect and readiness guard coverage.

## Verification
- cmake -B build -S . -Wno-dev
- cmake --build build
- ./build/shapeshifter_tests