### PR TITLE
fix: calibrate floor beat visuals

### DIFF
--- a/app/rendering/camera_resources.h
+++ b/app/rendering/camera_resources.h
@@ -2,6 +2,9 @@
 
 #include <raylib.h>
 #include <cstdint>
+#include <algorithm>
+
+#include "../constants.h"
 
 // Per-frame render parameters computed from SongState beat pulse.
 struct FloorParams {
@@ -10,6 +13,29 @@ struct FloorParams {
     float   thick = 0.0f;
     uint8_t alpha = 0;
 };
+
+namespace floor_visuals {
+
+inline float calibrated_beat_time(float beat_time, float audio_offset_sec) {
+    return beat_time + audio_offset_sec;
+}
+
+inline float beat_line_z(float song_time, float beat_time, float scroll_speed,
+                         float audio_offset_sec) {
+    return constants::PLAYER_Y
+        + (song_time - calibrated_beat_time(beat_time, audio_offset_sec)) * scroll_speed;
+}
+
+inline float pulse_for_beat(float song_time, float beat_time, float audio_offset_sec) {
+    const float time_since_beat =
+        song_time - calibrated_beat_time(beat_time, audio_offset_sec);
+    const float pulse_t =
+        std::clamp(time_since_beat / constants::FLOOR_PULSE_DECAY, 0.0f, 1.0f);
+    const float ease = 1.0f - (1.0f - pulse_t) * (1.0f - pulse_t);
+    return 1.0f - ease;
+}
+
+} // namespace floor_visuals
 
 // Render targets for world (3D) and UI (2D) layers.
 // RAII owner: destructor calls UnloadRenderTexture only when owned == true,

--- a/app/systems/camera_system.cpp
+++ b/app/systems/camera_system.cpp
@@ -11,6 +11,7 @@
 #include "../components/song_state.h"
 #include "../components/system_scratch.h"
 #include "../constants.h"
+#include "../entities/settings.h"
 #include "../platform_display.h"
 #include <glm/mat4x4.hpp>
 #include <raylib.h>
@@ -321,6 +322,8 @@ void game_camera_system(entt::registry& reg, float /*dt*/) {
         auto& fp = reg.ctx().get<FloorParams>();
         auto* song = reg.ctx().find<SongState>();
         auto* map = find_beat_map(reg);
+        const auto* settings = find_settings_state(reg);
+        const float audio_offset_sec = settings ? settings::audio_offset_seconds(*settings) : 0.0f;
         float pulse = 0.0f;
         if (song && song->playing && song->beat_period > 0.0f && song->current_beat >= 0) {
             float beat_time = song->offset + static_cast<float>(song->current_beat) * song->beat_period;
@@ -328,10 +331,7 @@ void game_camera_system(entt::registry& reg, float /*dt*/) {
             if (map && beat_index < map->beat_times.size()) {
                 beat_time = map->beat_times[beat_index];
             }
-            float time_since_beat = song->song_time - beat_time;
-            float pulse_t = Clamp(time_since_beat / constants::FLOOR_PULSE_DECAY, 0.0f, 1.0f);
-            float ease = 1.0f - (1.0f - pulse_t) * (1.0f - pulse_t);
-            pulse = 1.0f - ease;
+            pulse = floor_visuals::pulse_for_beat(song->song_time, beat_time, audio_offset_sec);
         }
         float alpha_f = Lerp(constants::FLOOR_ALPHA_REST, constants::FLOOR_ALPHA_PEAK, pulse);
         float scale = Lerp(constants::FLOOR_SCALE_REST, constants::FLOOR_SCALE_PEAK, pulse);

--- a/app/systems/floor_render_system.cpp
+++ b/app/systems/floor_render_system.cpp
@@ -3,6 +3,7 @@
 #include "../entities/beat_map.h"
 #include "../components/song_state.h"
 #include "../constants.h"
+#include "../entities/settings.h"
 #include "../rendering/camera_resources.h"
 
 #include <raylib.h>
@@ -128,7 +129,7 @@ void draw_floor_rings(const FloorParams& fp) {
     rlEnd();
 }
 
-void draw_floor_beat_lines(const SongState* song, const BeatMap* map) {
+void draw_floor_beat_lines(const SongState* song, const BeatMap* map, float audio_offset_sec) {
     if (!song || !song->playing || song->scroll_speed <= 0.0f) {
         return;
     }
@@ -144,7 +145,8 @@ void draw_floor_beat_lines(const SongState* song, const BeatMap* map) {
         + (constants::PLAYER_Y - z_min) / song->scroll_speed;
 
     const auto draw_line_at_time = [&](float beat_time) {
-        const float z = constants::PLAYER_Y + (song->song_time - beat_time) * song->scroll_speed;
+        const float z = floor_visuals::beat_line_z(
+            song->song_time, beat_time, song->scroll_speed, audio_offset_sec);
         if (z < z_min || z > z_max) {
             return;
         }
@@ -160,13 +162,13 @@ void draw_floor_beat_lines(const SongState* song, const BeatMap* map) {
 
     if (map && !map->beat_times.empty()) {
         const auto& beats = map->beat_times;
-        auto it = std::lower_bound(beats.begin(), beats.end(), visible_time_min);
-        for (; it != beats.end() && *it <= visible_time_max; ++it) {
+        auto it = std::lower_bound(beats.begin(), beats.end(), visible_time_min - audio_offset_sec);
+        for (; it != beats.end() && *it <= visible_time_max - audio_offset_sec; ++it) {
             draw_line_at_time(*it);
         }
     } else if (song->beat_period > 0.0f) {
         int beat_index = static_cast<int>(
-            std::ceil((visible_time_min - song->offset) / song->beat_period));
+            std::ceil((visible_time_min - audio_offset_sec - song->offset) / song->beat_period));
         if (beat_index < 0) {
             beat_index = 0;
         }
@@ -186,8 +188,10 @@ void floor_render_system(const entt::registry& reg) {
     const auto& floor_params = reg.ctx().get<FloorParams>();
     const auto* song = reg.ctx().find<SongState>();
     const auto* map = find_beat_map(reg);
+    const auto* settings = find_settings_state(reg);
+    const float audio_offset_sec = settings ? settings::audio_offset_seconds(*settings) : 0.0f;
 
     draw_floor_lines(floor_params);
-    draw_floor_beat_lines(song, map);
+    draw_floor_beat_lines(song, map, audio_offset_sec);
     draw_floor_rings(floor_params);
 }

--- a/tests/test_audio_offset_calibration.cpp
+++ b/tests/test_audio_offset_calibration.cpp
@@ -9,7 +9,10 @@
 #include "test_helpers.h"
 #include "entities/beat_map.h"
 #include "components/rhythm.h"
+#include "components/shape_mesh.h"
+#include "rendering/camera_resources.h"
 #include "systems/all_systems.h"
+#include "systems/runtime_systems.h"
 #include "util/rhythm_math.h"
 #include "entities/settings.h"
 
@@ -322,4 +325,56 @@ TEST_CASE("score and energy semantics stay aligned under signed audio offsets",
     CHECK(advanced.perfect_count == baseline.perfect_count);
     CHECK(delayed.miss_count == baseline.miss_count);
     CHECK(advanced.miss_count == baseline.miss_count);
+}
+
+TEST_CASE("floor beat visuals use calibrated beat timing",
+          "[floor_visuals][audio_offset][issue810]") {
+    constexpr float song_time = 1.25f;
+    constexpr float beat_time = 1.00f;
+    constexpr float scroll_speed = 100.0f;
+
+    const float baseline_z =
+        floor_visuals::beat_line_z(song_time, beat_time, scroll_speed, 0.0f);
+    const float delayed_z =
+        floor_visuals::beat_line_z(song_time, beat_time, scroll_speed, +0.25f);
+    const float advanced_z =
+        floor_visuals::beat_line_z(song_time, beat_time, scroll_speed, -0.25f);
+
+    CHECK_THAT(delayed_z - baseline_z, Catch::Matchers::WithinAbs(-25.0f, 1e-4f));
+    CHECK_THAT(advanced_z - baseline_z, Catch::Matchers::WithinAbs(+25.0f, 1e-4f));
+
+    CHECK_THAT(floor_visuals::pulse_for_beat(song_time, beat_time, +0.25f),
+               Catch::Matchers::WithinAbs(1.0f, 1e-6f));
+    CHECK(floor_visuals::pulse_for_beat(song_time, beat_time, 0.0f)
+          < floor_visuals::pulse_for_beat(song_time, beat_time, +0.25f));
+    CHECK_THAT(floor_visuals::calibrated_beat_time(beat_time, -0.25f),
+               Catch::Matchers::WithinAbs(0.75f, 1e-6f));
+}
+
+TEST_CASE("game camera floor pulse honors audio_offset_ms",
+          "[camera3d][floor_visuals][audio_offset][issue810]") {
+    auto reg = make_rhythm_registry();
+    reg.ctx().emplace<FloorParams>();
+    reg.ctx().emplace<ShapeMeshConfig>();
+
+    auto& settings = settings_state(reg);
+    settings.audio_offset_ms = +250;
+
+    auto& song = reg.ctx().get<SongState>();
+    song.song_time = 1.25f;
+    song.current_beat = 0;
+    song.playing = true;
+
+    auto& map = beat_map(reg);
+    map.beat_times = {1.0f};
+
+    game_camera_system(reg, 0.0f);
+    const auto delayed_alpha = reg.ctx().get<FloorParams>().alpha;
+
+    settings.audio_offset_ms = 0;
+    game_camera_system(reg, 0.0f);
+    const auto baseline_alpha = reg.ctx().get<FloorParams>().alpha;
+
+    CHECK(delayed_alpha > baseline_alpha);
+    CHECK(delayed_alpha == static_cast<uint8_t>(constants::FLOOR_ALPHA_PEAK));
 }


### PR DESCRIPTION
## Summary
- apply SettingsState::audio_offset_ms to floor beat-line positions
- apply the same calibrated beat time to floor pulse alpha/scale
- add regression coverage for positive and negative visual timing offsets

Root cause: gameplay scheduling and song beat advancement used the calibrated beat time, but floor beat visuals continued rendering and pulsing against raw beat timestamps.

Fixes #810

## Verification
- cmake -B build -S . -Wno-dev && cmake --build build && ./build/shapeshifter_tests