### PR TITLE
Validate all authored beat indices

### DIFF
--- a/tools/test_validate_beatmap_offset.py
+++ b/tools/test_validate_beatmap_offset.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -39,6 +40,45 @@ class TestValidateBeatmapOffset(unittest.TestCase):
             with _WorkingDirectory(Path(__file__).resolve().parent):
                 rc = offset_validator.main([])
         self.assertEqual(rc, 0)
+
+    def test_rejects_non_anchor_beat_index_outside_analysis_range(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            beatmap_path = tmp_path / "fixture_beatmap.json"
+            analysis_path = tmp_path / "fixture_analysis.json"
+            beatmap_path.write_text(
+                """{
+                    "bpm": 120.0,
+                    "offset": 0.0,
+                    "difficulties": {
+                        "easy": {
+                            "beats": [
+                                {"beat": 2},
+                                {"beat": 4},
+                                {"beat": 100}
+                            ]
+                        }
+                    }
+                }"""
+            )
+            analysis_path.write_text(
+                """{
+                    "beats": [
+                        0.0, 0.5, 1.0, 1.5, 2.0,
+                        2.5, 3.0, 3.5, 4.0, 4.5
+                    ]
+                }"""
+            )
+
+            errors = offset_validator.validate_beatmap_pair(
+                beatmap_path,
+                analysis_path,
+                offset_validator.TOLERANCE_MS_DEFAULT,
+            )
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("authored beat index out of range", errors[0])
+        self.assertIn("100", errors[0])
 
 
 if __name__ == "__main__":

--- a/tools/validate_beatmap_offset.py
+++ b/tools/validate_beatmap_offset.py
@@ -62,14 +62,22 @@ def validate_beatmap_pair(beatmap_path: Path, analysis_path: Path,
         errors.append(f"{beatmap_path.name}: no authored beats in any difficulty")
         return errors
 
-    anchor_idx = min(all_authored)
-    if anchor_idx >= len(beats):
+    invalid_indices = sorted({
+        beat_index
+        for beat_index in all_authored
+        if beat_index < 0 or beat_index >= len(beats)
+    })
+    if invalid_indices:
+        sample = ", ".join(str(beat_index) for beat_index in invalid_indices[:10])
+        if len(invalid_indices) > 10:
+            sample += ", ..."
         errors.append(
-            f"{beatmap_path.name}: anchor_idx={anchor_idx} out of range "
-            f"(beats has {len(beats)} entries)"
+            f"{beatmap_path.name}: authored beat index out of range "
+            f"(valid range: 0..{len(beats) - 1}; invalid: {sample})"
         )
         return errors
 
+    anchor_idx = min(all_authored)
     anchor_time = beats[anchor_idx]
     expected_offset = anchor_time - anchor_idx * beat_period
     delta_ms = abs(offset - expected_offset) * 1000.0


### PR DESCRIPTION
## Summary
- validate every authored beat index against the paired analysis beat array before anchor offset checks
- report out-of-range authored beat indices with the valid analysis range
- add regression coverage for a non-anchor beat index that exceeds analysis length

Fixes #815

## Verification
- python3 tools/test_validate_beatmap_offset.py
- python3 tools/validate_beatmap_offset.py
- cmake -B build -S . -Wno-dev && cmake --build build && ./build/shapeshifter_tests
- ctest --test-dir build --output-on-failure -R "^(python_tool_tests|validate_offset_semantics)$"