### PR TITLE
Fix short cross-lane beatmap jumps

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -96,7 +96,7 @@ jobs:
           mkdir -p build/ci
           ctest --test-dir build -N \
             | sed -nE 's/^ *Test *#[0-9]+: (.*)$/\1/p' \
-            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
+            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|validate_required_cross_lane_jump_time|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
             | sort -u > build/ci/ctest-nonbench-catch.txt
           ./build/shapeshifter_tests --list-tests "~[bench]" --verbosity quiet \
             | sort -u > build/ci/catch-nonbench.txt
@@ -104,7 +104,7 @@ jobs:
           ./build/shapeshifter_tests "~[bench]"
           xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24" \
             ctest --test-dir build --output-on-failure -R "^startup_shutdown_smoke$"
-          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
+          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|validate_required_cross_lane_jump_time|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
 
       - name: Upload artifact
         if: success()

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -98,14 +98,14 @@ jobs:
           mkdir -p build/ci
           ctest --test-dir build -N \
             | sed -nE 's/^ *Test *#[0-9]+: (.*)$/\1/p' \
-            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
+            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|validate_required_cross_lane_jump_time|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
             | sort -u > build/ci/ctest-nonbench-catch.txt
           ./build/shapeshifter_tests --list-tests "~[bench]" --verbosity quiet \
             | sort -u > build/ci/catch-nonbench.txt
           diff -u build/ci/ctest-nonbench-catch.txt build/ci/catch-nonbench.txt
           ./build/shapeshifter_tests "~[bench]"
           ctest --test-dir build --output-on-failure -R "^startup_shutdown_smoke$"
-          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
+          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|validate_required_cross_lane_jump_time|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
 
       - name: Upload artifact
         if: success()

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -91,7 +91,7 @@ jobs:
           mkdir -p build/ci
           ctest --test-dir build -N \
             | sed -nE 's/^ *Test *#[0-9]+: (.*)$/\1/p' \
-            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
+            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|validate_required_cross_lane_jump_time|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
             | tr -d '\r' \
             | sort -u > build/ci/ctest-nonbench-catch.txt
           ./build/shapeshifter_tests.exe --list-tests "~[bench]" --verbosity quiet \
@@ -100,7 +100,7 @@ jobs:
           diff -u build/ci/ctest-nonbench-catch.txt build/ci/catch-nonbench.txt
           ./build/shapeshifter_tests.exe "~[bench]"
           ctest --test-dir build --output-on-failure -R "^startup_shutdown_smoke$"
-          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
+          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|validate_required_cross_lane_jump_time|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
         shell: bash
 
       - name: Upload artifact

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -620,6 +620,11 @@ if(NOT EMSCRIPTEN AND NOT SHAPESHIFTER_IOS)
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     )
     add_test(
+        NAME validate_required_cross_lane_jump_time
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/validate_required_cross_lane_jump_time.py
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    )
+    add_test(
         NAME check_shape_change_gap
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/check_shape_change_gap.py
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}

--- a/content/beatmaps/2_drama_beatmap.json
+++ b/content/beatmaps/2_drama_beatmap.json
@@ -1460,7 +1460,7 @@
         },
         {
           "beat": 332,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -5936,7 +5936,7 @@
         },
         {
           "beat": 395,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 0,
           "shape": "circle",
           "onset_class": "harmonic",

--- a/content/beatmaps/3_mental_corruption_beatmap.json
+++ b/content/beatmaps/3_mental_corruption_beatmap.json
@@ -1427,7 +1427,7 @@
         },
         {
           "beat": 261,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",

--- a/tools/test_validate_required_cross_lane_jump_time.py
+++ b/tools/test_validate_required_cross_lane_jump_time.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Unit tests for validate_required_cross_lane_jump_time.py (issue #819)."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import shutil
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import validate_required_cross_lane_jump_time as v  # noqa: E402
+
+
+def _gate(t, lane, shape):
+    return {"kind": "shape_gate", "time_sec": t, "lane": lane, "shape": shape}
+
+
+def _marker(t, lane, shape):
+    return {"kind": "onset_marker", "time_sec": t, "lane": lane, "shape": shape}
+
+
+class TestRequiredCrossLaneJumpTime(unittest.TestCase):
+    def setUp(self) -> None:
+        self.base = Path(__file__).resolve().parent / ".test_required_cross_lane_jump_time"
+        if self.base.exists():
+            shutil.rmtree(self.base)
+        self.base.mkdir(parents=True, exist_ok=True)
+        self.addCleanup(lambda: shutil.rmtree(self.base, ignore_errors=True))
+
+    def _write_beatmap(self, filename: str, beats: list[dict]) -> Path:
+        path = self.base / filename
+        path.write_text(json.dumps({"difficulties": {"easy": {"beats": beats}}}), encoding="utf-8")
+        return path
+
+    def test_short_zero_to_two_shape_change_is_flagged(self):
+        beats = [_gate(10.0, 0, "circle"), _gate(11.0, 2, "triangle")]
+        findings = v.find_short_cross_lane_shape_jumps(beats)
+        self.assertEqual(len(findings), 1)
+
+    def test_short_two_to_zero_shape_change_is_flagged(self):
+        beats = [_gate(10.0, 2, "triangle"), _gate(10.75, 0, "circle")]
+        findings = v.find_short_cross_lane_shape_jumps(beats)
+        self.assertEqual(len(findings), 1)
+
+    def test_non_blocking_marker_does_not_create_required_pair(self):
+        beats = [_gate(10.0, 0, "circle"), _marker(10.5, 2, "triangle"), _gate(11.5, 2, "triangle")]
+        findings = v.find_short_cross_lane_shape_jumps(beats)
+        self.assertEqual(findings, [])
+
+    def test_adjacent_same_shape_or_nearby_lane_passes(self):
+        self.assertEqual(v.find_short_cross_lane_shape_jumps([_gate(0.0, 0, "circle"), _gate(0.5, 2, "circle")]), [])
+        self.assertEqual(v.find_short_cross_lane_shape_jumps([_gate(0.0, 0, "circle"), _gate(0.5, 1, "square")]), [])
+
+    def test_pair_at_floor_passes(self):
+        beats = [_gate(10.0, 0, "circle"), _gate(11.2, 2, "triangle")]
+        findings = v.find_short_cross_lane_shape_jumps(beats)
+        self.assertEqual(findings, [])
+
+    def test_main_reports_violation(self):
+        path = self._write_beatmap("fixture_beatmap.json", [_gate(0.0, 0, "circle"), _gate(1.0, 2, "triangle")])
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            rc = v.main([str(path)])
+        self.assertEqual(rc, 1)
+        self.assertIn("REQUIRED CROSS-LANE JUMP VIOLATIONS", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/validate_required_cross_lane_jump_time.py
+++ b/tools/validate_required_cross_lane_jump_time.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Validate time-authored required gates for reachable 0<->2 lane jumps.
+
+Issue #819: a player cannot reliably clear adjacent required shape gates that
+also require a full left/right lane swap when they are authored too close
+together in real time. Non-blocking onset_marker rows preserve audio metadata
+and are ignored by this required-action check.
+
+Exit codes:
+  0 - all beatmaps pass
+  1 - one or more violations found
+
+Usage:
+    python3 tools/validate_required_cross_lane_jump_time.py
+    python3 tools/validate_required_cross_lane_jump_time.py content/beatmaps/2_drama_beatmap.json
+    python3 tools/validate_required_cross_lane_jump_time.py --min-sec 1.2
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_DIR = REPO_ROOT / "content" / "beatmaps"
+
+REQUIRED_KIND = "shape_gate"
+FULL_CROSS_LANE_JUMP = {0, 2}
+DEFAULT_MIN_CROSS_LANE_JUMP_SEC = 1.2
+
+
+def _numeric_time(row: dict) -> float | None:
+    value = row.get("time_sec")
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return None
+
+
+def _required_timed_shape_gates(beats: list[object]) -> list[dict]:
+    rows: list[dict] = []
+    for row in beats:
+        if not isinstance(row, dict):
+            continue
+        if row.get("kind") != REQUIRED_KIND:
+            continue
+        if _numeric_time(row) is None:
+            continue
+        rows.append(row)
+    rows.sort(key=lambda row: _numeric_time(row) or 0.0)
+    return rows
+
+
+def find_short_cross_lane_shape_jumps(
+    beats: list[object],
+    min_sec: float = DEFAULT_MIN_CROSS_LANE_JUMP_SEC,
+) -> list[tuple[dict, dict, float]]:
+    """Return adjacent required shape gates with unreachable 0<->2 swaps."""
+    violations: list[tuple[dict, dict, float]] = []
+    rows = _required_timed_shape_gates(beats)
+    for previous, current in zip(rows, rows[1:]):
+        previous_lane = previous.get("lane")
+        current_lane = current.get("lane")
+        if {previous_lane, current_lane} != FULL_CROSS_LANE_JUMP:
+            continue
+        if previous.get("shape") == current.get("shape"):
+            continue
+        dt = (_numeric_time(current) or 0.0) - (_numeric_time(previous) or 0.0)
+        if 0.0 < dt and dt < min_sec - 1e-9:
+            violations.append((previous, current, dt))
+    return violations
+
+
+def validate_beatmap(path: Path, min_sec: float = DEFAULT_MIN_CROSS_LANE_JUMP_SEC) -> list[str]:
+    beatmap = json.loads(path.read_text())
+    name = path.stem.replace("_beatmap", "")
+    findings: list[str] = []
+    for difficulty, payload in beatmap.get("difficulties", {}).items():
+        beats = payload.get("beats", []) or []
+        for previous, current, dt in find_short_cross_lane_shape_jumps(beats, min_sec):
+            findings.append(
+                f"{name} [{difficulty}]: beat {previous.get('beat')} "
+                f"(lane={previous.get('lane')}, shape={previous.get('shape')}, "
+                f"t={_numeric_time(previous):.3f}s) -> beat {current.get('beat')} "
+                f"(lane={current.get('lane')}, shape={current.get('shape')}, "
+                f"t={_numeric_time(current):.3f}s) is {dt:.3f}s < {min_sec:.3f}s (#819)"
+            )
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("files", nargs="*", help="Optional *_beatmap.json paths")
+    parser.add_argument("--min-sec", type=float, default=DEFAULT_MIN_CROSS_LANE_JUMP_SEC)
+    args = parser.parse_args(argv)
+
+    paths = [Path(raw) for raw in args.files] if args.files else sorted(DEFAULT_DIR.glob("*_beatmap.json"))
+    if not paths:
+        print(f"ERROR: no beatmaps found in {DEFAULT_DIR}", file=sys.stderr)
+        return 1
+
+    all_findings: list[str] = []
+    for path in paths:
+        all_findings.extend(validate_beatmap(path, args.min_sec))
+
+    if all_findings:
+        print("REQUIRED CROSS-LANE JUMP VIOLATIONS (#819):", file=sys.stderr)
+        for finding in all_findings:
+            print(f"  x {finding}", file=sys.stderr)
+        return 1
+
+    print(f"OK: no required 0<->2 lane shape jumps under {args.min_sec:.3f}s in {len(paths)} beatmap(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Adds a CTest-gated validator for time-authored required shape gates that flags adjacent 0<->2 lane + shape changes under 1.2s.
- Demotes the three offending shipped gates from required shape_gate rows to onset_marker rows, preserving onset metadata without requiring unreachable full-lane swaps.

## Root cause
Runtime schedules onset-authored rows by time_sec, while existing shape-gap checks only covered beat-index spacing. That left short real-time 0<->2 lane swaps in shipped content even when beat spacing appeared acceptable.

## Verification
- python3 tools/validate_required_cross_lane_jump_time.py
- python3 tools/validate_difficulty_ramp.py
- python3 tools/validate_loop2_content_gates.py --strict
- python3 tools/validate_no_simultaneous_shape_gates.py
- python3 tools/check_shape_change_gap.py
- python3 tools/validate_max_beat_gap.py
- python3 -m unittest discover -s tools -p 'test_*.py'
- cmake -B build -S . -Wno-dev && cmake --build build && ./build/shapeshifter_tests
- ctest --test-dir build --output-on-failure

Closes #819