### PR TITLE
Block gameplay input during pending transitions

### DIFF
--- a/app/systems/player_input_system.cpp
+++ b/app/systems/player_input_system.cpp
@@ -12,6 +12,11 @@
 
 namespace {
 
+bool gameplay_input_enabled(entt::registry& reg) {
+    const auto& gs = reg.ctx().get<GameState>();
+    return gs.phase == GamePhase::Playing && !gs.transition_pending;
+}
+
 void push_haptic(entt::registry& reg, HapticEvent event) {
     auto* disp = reg.ctx().find<entt::dispatcher>();
     if (disp) disp->enqueue<PlayHapticEvent>({event});
@@ -20,7 +25,7 @@ void push_haptic(entt::registry& reg, HapticEvent event) {
 }  // namespace
 
 void player_input_handle_go(entt::registry& reg, const GoEvent& evt) {
-    if (reg.ctx().get<GameState>().phase != GamePhase::Playing) return;
+    if (!gameplay_input_enabled(reg)) return;
     auto view = reg.view<PlayerTag, PlayerShape, ShapeWindow, Lane, VerticalState>();
     for (auto [entity, pshape, swindow, lane, vstate] : view.each()) {
         int8_t delta = 0;
@@ -49,7 +54,7 @@ void player_input_handle_go(entt::registry& reg, const GoEvent& evt) {
 
 void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt) {
     if (evt.kind != ButtonPressKind::Shape) return;  // ignore menu-button events
-    if (reg.ctx().get<GameState>().phase != GamePhase::Playing) return;
+    if (!gameplay_input_enabled(reg)) return;
     auto* song = reg.ctx().find<SongState>();
     bool rhythm_mode = (song != nullptr && song->playing);
 

--- a/tests/test_input_pipeline_behavior.cpp
+++ b/tests/test_input_pipeline_behavior.cpp
@@ -183,6 +183,61 @@ TEST_CASE("pipeline: gameplay HUD raygui shape press triggers player shape input
     CHECK(sw.target_shape == Shape::Square);
 }
 
+TEST_CASE("pipeline: pending phase transition blocks queued shape input",
+          "[input_pipeline][transition][issue823]") {
+    auto reg = make_rhythm_registry();
+    auto player = make_rhythm_player(reg);
+    auto& gs = reg.ctx().get<GameState>();
+    auto& sw = reg.get<ShapeWindow>(player);
+    auto& lane = reg.get<Lane>(player);
+
+    REQUIRE(gs.phase == GamePhase::Playing);
+    REQUIRE(sw.phase == WindowPhase::Idle);
+    REQUIRE(lane.current == 1);
+    lane.target = lane.current;
+    REQUIRE(lane.target == 1);
+
+    gs.transition_pending = true;
+    gs.next_phase = GamePhase::Paused;
+    reg.ctx().get<entt::dispatcher>().enqueue<ButtonPressEvent>(
+        {ButtonPressKind::Shape, Shape::Circle, MenuActionKind::Confirm, 0});
+
+    run_pipeline(reg);
+
+    CHECK(gs.phase == GamePhase::Paused);
+    CHECK_FALSE(gs.transition_pending);
+    CHECK(sw.phase == WindowPhase::Idle);
+    CHECK(sw.target_shape == Shape::Hexagon);
+    CHECK(lane.target == 1);
+}
+
+TEST_CASE("pipeline: pending phase transition blocks queued go input",
+          "[input_pipeline][transition][issue823]") {
+    auto reg = make_rhythm_registry();
+    auto player = make_rhythm_player(reg);
+    auto& gs = reg.ctx().get<GameState>();
+    auto& lane = reg.get<Lane>(player);
+    auto& vstate = reg.get<VerticalState>(player);
+
+    REQUIRE(gs.phase == GamePhase::Playing);
+    REQUIRE(lane.current == 1);
+    lane.target = lane.current;
+    REQUIRE(lane.target == 1);
+    REQUIRE(vstate.mode == VMode::Grounded);
+
+    gs.transition_pending = true;
+    gs.next_phase = GamePhase::Paused;
+    push_go(reg, Direction::Right);
+    push_go(reg, Direction::Up);
+
+    run_pipeline(reg);
+
+    CHECK(gs.phase == GamePhase::Paused);
+    CHECK_FALSE(gs.transition_pending);
+    CHECK(lane.target == 1);
+    CHECK(vstate.mode == VMode::Grounded);
+}
+
 TEST_CASE("pipeline: gameplay HUD shape tap uses slot rectangle bounds",
           "[input_pipeline][hud]") {
     const auto circle_input_bounds = gameplay_hud_shape_input_bounds(GameplayHudShapeSlot::Circle);


### PR DESCRIPTION
Closes #823

## Root cause
`game_state_system` drains queued GoEvent/ButtonPressEvent before applying an already-pending phase transition, while player input consumers only checked `phase == Playing`. That allowed queued gameplay input to mutate player lane/shape state during a pending transition.

## Changes
- Gate player input handlers on both `GamePhase::Playing` and `!transition_pending`.
- Add regressions for queued shape and go input while transitioning to Paused.

## Verification
- `./build/shapeshifter_tests "[issue823]"`
- `cmake -B build -S . -Wno-dev && cmake --build build && ./build/shapeshifter_tests`