### PR TITLE
Fix Loop 2 max-shape-cluster exemption

### DIFF
--- a/content/beatmaps/2_drama_beatmap.json
+++ b/content/beatmaps/2_drama_beatmap.json
@@ -4865,7 +4865,7 @@
         },
         {
           "beat": 181,
-          "kind": "shape_gate",
+          "kind": "onset_marker",
           "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",

--- a/content/beatmaps/2_drama_beatmap.json
+++ b/content/beatmaps/2_drama_beatmap.json
@@ -4865,7 +4865,7 @@
         },
         {
           "beat": 181,
-          "kind": "onset_marker",
+          "kind": "shape_gate",
           "lane": 2,
           "shape": "triangle",
           "onset_class": "percussive",
@@ -4949,7 +4949,7 @@
           "beat_time_sec": 86.082
         },
         {
-          "beat": 188,
+          "beat": 189,
           "kind": "shape_gate",
           "lane": 2,
           "shape": "triangle",
@@ -4963,7 +4963,7 @@
           "timing_source": "onset",
           "onset_time_sec": 86.311,
           "subdivision_label": "eighth",
-          "beat_time_sec": 86.544
+          "beat_time_sec": 87.005
         },
         {
           "beat": 215,

--- a/content/beatmaps/2_drama_beatmap.json
+++ b/content/beatmaps/2_drama_beatmap.json
@@ -4864,23 +4864,6 @@
           "beat_time_sec": 82.843
         },
         {
-          "beat": 181,
-          "kind": "shape_gate",
-          "lane": 2,
-          "shape": "triangle",
-          "onset_class": "percussive",
-          "segment_idx": 6,
-          "segment_focus": "percussive",
-          "difficulty_inclusion": "medium",
-          "source_event_idx": 977,
-          "flux": 29.5129,
-          "time_sec": 83.548,
-          "timing_source": "onset",
-          "onset_time_sec": 83.548,
-          "subdivision_label": "eighth",
-          "beat_time_sec": 83.313
-        },
-        {
           "beat": 183,
           "kind": "shape_gate",
           "lane": 2,
@@ -4949,7 +4932,7 @@
           "beat_time_sec": 86.082
         },
         {
-          "beat": 189,
+          "beat": 188,
           "kind": "shape_gate",
           "lane": 2,
           "shape": "triangle",
@@ -4963,7 +4946,7 @@
           "timing_source": "onset",
           "onset_time_sec": 86.311,
           "subdivision_label": "eighth",
-          "beat_time_sec": 87.005
+          "beat_time_sec": 86.544
         },
         {
           "beat": 215,
@@ -6802,7 +6785,7 @@
           "beat_time_sec": 237.227
         }
       ],
-      "count": 169
+      "count": 168
     }
   },
   "structure": [

--- a/tools/diagnostics/2_drama_loop1/onset_timing_events.csv
+++ b/tools/diagnostics/2_drama_loop1/onset_timing_events.csv
@@ -247,7 +247,6 @@ hard,51,170,78.237,78.225,-12.0,onset,downbeat,915,harmonic,5,harmonic,,,,,,easy
 hard,52,171,78.698,78.919,-5.5,onset,eighth,922,harmonic,5,harmonic,,,,,,hard,hard
 hard,53,174,80.074,80.303,-6.0,onset,eighth,939,full-spectrum,5,harmonic,,,,,,hard,hard
 hard,54,180,82.843,83.069,-9.0,onset,eighth,973,percussive,6,percussive,,,,,,medium,medium
-hard,55,181,83.313,83.548,4.0,onset,eighth,977,percussive,6,percussive,,,,,,medium,medium
 hard,56,183,84.236,84.454,-8.5,onset,eighth,986,percussive,6,percussive,,,,,,easy,easy
 hard,57,185,85.159,85.153,-6.0,onset,downbeat,994,percussive,6,percussive,,,,,,medium,medium
 hard,58,186,85.612,85.838,-9.0,onset,eighth,999,percussive,6,percussive,,,,,,easy,easy

--- a/tools/diagnostics/2_drama_loop1/snap_diagnostics_summary.json
+++ b/tools/diagnostics/2_drama_loop1/snap_diagnostics_summary.json
@@ -558,7 +558,7 @@
     "obstacle_counts_by_difficulty": {
       "easy": 96,
       "medium": 97,
-      "hard": 169
+      "hard": 168
     }
   }
 }

--- a/tools/diagnostics/onset_spike/2_drama/onset_timing_events.csv
+++ b/tools/diagnostics/onset_spike/2_drama/onset_timing_events.csv
@@ -247,7 +247,6 @@ hard,51,170,78.237,78.225,-12.0,onset,downbeat,915,harmonic,5,harmonic,,,,,,easy
 hard,52,171,78.698,78.919,-5.5,onset,eighth,922,harmonic,5,harmonic,,,,,,hard,hard
 hard,53,174,80.074,80.303,-6.0,onset,eighth,939,full-spectrum,5,harmonic,,,,,,hard,hard
 hard,54,180,82.843,83.069,-9.0,onset,eighth,973,percussive,6,percussive,,,,,,medium,medium
-hard,55,181,83.313,83.548,4.0,onset,eighth,977,percussive,6,percussive,,,,,,medium,medium
 hard,56,183,84.236,84.454,-8.5,onset,eighth,986,percussive,6,percussive,,,,,,easy,easy
 hard,57,185,85.159,85.153,-6.0,onset,downbeat,994,percussive,6,percussive,,,,,,medium,medium
 hard,58,186,85.612,85.838,-9.0,onset,eighth,999,percussive,6,percussive,,,,,,easy,easy

--- a/tools/diagnostics/onset_spike/2_drama/snap_diagnostics_summary.json
+++ b/tools/diagnostics/onset_spike/2_drama/snap_diagnostics_summary.json
@@ -558,7 +558,7 @@
     "obstacle_counts_by_difficulty": {
       "easy": 96,
       "medium": 97,
-      "hard": 169
+      "hard": 168
     }
   }
 }

--- a/tools/diagnostics/onset_spike_smoke/onset_timing_events.csv
+++ b/tools/diagnostics/onset_spike_smoke/onset_timing_events.csv
@@ -247,7 +247,6 @@ hard,51,170,78.237,78.225,-12.0,onset,downbeat,915,harmonic,5,harmonic,,,,,,easy
 hard,52,171,78.698,78.919,-5.5,onset,eighth,922,harmonic,5,harmonic,,,,,,hard,hard
 hard,53,174,80.074,80.303,-6.0,onset,eighth,939,full-spectrum,5,harmonic,,,,,,hard,hard
 hard,54,180,82.843,83.069,-9.0,onset,eighth,973,percussive,6,percussive,,,,,,medium,medium
-hard,55,181,83.313,83.548,4.0,onset,eighth,977,percussive,6,percussive,,,,,,medium,medium
 hard,56,183,84.236,84.454,-8.5,onset,eighth,986,percussive,6,percussive,,,,,,easy,easy
 hard,57,185,85.159,85.153,-6.0,onset,downbeat,994,percussive,6,percussive,,,,,,medium,medium
 hard,58,186,85.612,85.838,-9.0,onset,eighth,999,percussive,6,percussive,,,,,,easy,easy

--- a/tools/diagnostics/onset_spike_smoke/snap_diagnostics_summary.json
+++ b/tools/diagnostics/onset_spike_smoke/snap_diagnostics_summary.json
@@ -558,7 +558,7 @@
     "obstacle_counts_by_difficulty": {
       "easy": 96,
       "medium": 97,
-      "hard": 169
+      "hard": 168
     }
   }
 }

--- a/tools/test_validate_loop2_content_gates.py
+++ b/tools/test_validate_loop2_content_gates.py
@@ -37,7 +37,7 @@ class TestLoop2MetricCalculations(unittest.TestCase):
         self.assertEqual(metrics["longest_same_shape_cluster_run"], 1)
         self.assertEqual(metrics["shape_cluster_count"], 3)
         self.assertEqual(metrics["max_shape_cluster_size"], 3)
-        self.assertEqual(metrics["max_unprotected_shape_cluster_size"], 3)
+        self.assertEqual(metrics["max_unexempt_shape_cluster_size"], 3)
         self.assertAlmostEqual(metrics["triangle_share"], 1 / 6)
         self.assertAlmostEqual(metrics["circle_share"], 2 / 6)
         self.assertIsNotNone(metrics["min_ioi_ms"])
@@ -175,7 +175,7 @@ class TestLoop2GateEvaluation(unittest.TestCase):
             "ioi_index_error": False,
         }
         findings = gates.evaluate_content_gates(metrics, "hard")
-        self.assertTrue(any("max shape cluster size" in f and "#532" in f for f in findings),
+        self.assertTrue(any("max unexempt shape cluster size" in f and "#532" in f for f in findings),
                         f"expected max-shape-cluster finding, got {findings}")
 
     def test_unrelated_protected_onset_pairs_do_not_exempt_cluster_size(self):
@@ -203,7 +203,7 @@ class TestLoop2GateEvaluation(unittest.TestCase):
 
         self.assertEqual(metrics["cross_layer_preserved_pairs"], 1)
         self.assertEqual(metrics["max_shape_cluster_size"], 6)
-        self.assertTrue(any("max shape cluster size 6 exceeds cap 5" in f for f in findings),
+        self.assertTrue(any("max unexempt shape cluster size 6 exceeds cap 5" in f for f in findings),
                         f"expected local max cluster finding, got {findings}")
 
     def test_onset_timed_charts_still_enforce_circle_and_lane0_floor(self):

--- a/tools/test_validate_loop2_content_gates.py
+++ b/tools/test_validate_loop2_content_gates.py
@@ -37,6 +37,7 @@ class TestLoop2MetricCalculations(unittest.TestCase):
         self.assertEqual(metrics["longest_same_shape_cluster_run"], 1)
         self.assertEqual(metrics["shape_cluster_count"], 3)
         self.assertEqual(metrics["max_shape_cluster_size"], 3)
+        self.assertEqual(metrics["max_unprotected_shape_cluster_size"], 3)
         self.assertAlmostEqual(metrics["triangle_share"], 1 / 6)
         self.assertAlmostEqual(metrics["circle_share"], 2 / 6)
         self.assertIsNotNone(metrics["min_ioi_ms"])
@@ -176,6 +177,34 @@ class TestLoop2GateEvaluation(unittest.TestCase):
         findings = gates.evaluate_content_gates(metrics, "hard")
         self.assertTrue(any("max shape cluster size" in f and "#532" in f for f in findings),
                         f"expected max-shape-cluster finding, got {findings}")
+
+    def test_unrelated_protected_onset_pairs_do_not_exempt_cluster_size(self):
+        beats = [
+            {"beat": 0, "kind": "shape_gate", "shape": "circle", "lane": 0,
+             "onset_class": "harmonic", "time_sec": 0.000, "timing_source": "onset"},
+            {"beat": 1, "kind": "shape_gate", "shape": "square", "lane": 1,
+             "onset_class": "full-spectrum", "time_sec": 0.020, "timing_source": "onset"},
+            {"beat": 10, "kind": "shape_gate", "shape": "triangle", "lane": 2,
+             "onset_class": "percussive", "time_sec": 4.000, "timing_source": "onset"},
+            {"beat": 11, "kind": "shape_gate", "shape": "triangle", "lane": 2,
+             "onset_class": "percussive", "time_sec": 4.500, "timing_source": "onset"},
+            {"beat": 12, "kind": "shape_gate", "shape": "triangle", "lane": 2,
+             "onset_class": "percussive", "time_sec": 5.000, "timing_source": "onset"},
+            {"beat": 13, "kind": "shape_gate", "shape": "triangle", "lane": 2,
+             "onset_class": "percussive", "time_sec": 5.500, "timing_source": "onset"},
+            {"beat": 14, "kind": "shape_gate", "shape": "triangle", "lane": 2,
+             "onset_class": "percussive", "time_sec": 6.000, "timing_source": "onset"},
+            {"beat": 15, "kind": "shape_gate", "shape": "triangle", "lane": 2,
+             "onset_class": "percussive", "time_sec": 6.500, "timing_source": "onset"},
+        ]
+
+        metrics = gates.calculate_content_metrics(beats, expected_count=len(beats))
+        findings = gates.evaluate_content_gates(metrics, "hard")
+
+        self.assertEqual(metrics["cross_layer_preserved_pairs"], 1)
+        self.assertEqual(metrics["max_shape_cluster_size"], 6)
+        self.assertTrue(any("max shape cluster size 6 exceeds cap 5" in f for f in findings),
+                        f"expected local max cluster finding, got {findings}")
 
     def test_onset_timed_charts_still_enforce_circle_and_lane0_floor(self):
         metrics = {

--- a/tools/validate_loop2_content_gates.py
+++ b/tools/validate_loop2_content_gates.py
@@ -113,6 +113,37 @@ def _longest_gap_one_run(gaps: list[int]) -> int:
 
 
 CROSS_LAYER_PRESERVATION_WINDOW_MS = 50.0
+PUBLIC_ONSET_CLASSES = {"percussive", "harmonic", "full-spectrum"}
+
+
+def _is_protected_obstacle_pair(left: dict, right: dict) -> bool:
+    left_class = left.get("source_onset_class") or left.get("onset_class")
+    right_class = right.get("source_onset_class") or right.get("onset_class")
+    if left_class not in PUBLIC_ONSET_CLASSES or right_class not in PUBLIC_ONSET_CLASSES:
+        return False
+    if left_class == right_class:
+        return False
+    try:
+        delta_ms = abs(float(left.get("time_sec", 0.0)) - float(right.get("time_sec", 0.0))) * 1000.0
+    except (TypeError, ValueError):
+        return False
+    return delta_ms <= CROSS_LAYER_PRESERVATION_WINDOW_MS
+
+
+def _is_protected_by_cluster_neighbor(obstacle: dict, cluster: list[dict]) -> bool:
+    return any(
+        other is not obstacle and _is_protected_obstacle_pair(obstacle, other)
+        for other in cluster
+    )
+
+
+def _max_unprotected_shape_cluster_size(clusters: list[list[dict]]) -> int:
+    sizes = [
+        len(cluster)
+        for cluster in clusters
+        if any(not _is_protected_by_cluster_neighbor(beat, cluster) for beat in cluster)
+    ]
+    return max(sizes) if sizes else 0
 
 
 def _all_onset_timed(beats: list[dict]) -> bool:
@@ -210,6 +241,7 @@ def calculate_content_metrics(
         "longest_same_shape_cluster_run": _longest_same_shape_cluster_run(shape_clusters) if shape_clusters else 0,
         "shape_cluster_count": len(shape_clusters),
         "max_shape_cluster_size": max(cluster_sizes) if cluster_sizes else 0,
+        "max_unprotected_shape_cluster_size": _max_unprotected_shape_cluster_size(shape_clusters),
         "shape_clusters_over_warn": 0,
         "triangle_share": (shape_counts.get("triangle", 0) / total_shape_gates) if total_shape_gates else 0.0,
         "circle_share": (shape_counts.get("circle", 0) / total_shape_gates) if total_shape_gates else 0.0,
@@ -265,7 +297,8 @@ def evaluate_content_gates(metrics: dict[str, float | int | bool | None], diffic
         )
     cluster_size_cap = MAX_SHAPE_CLUSTER_SIZE.get(difficulty)
     max_cluster = int(metrics.get("max_shape_cluster_size", 0))
-    if cluster_size_cap is not None and max_cluster > cluster_size_cap and not protected_onset_pairs:
+    max_unprotected_cluster = int(metrics.get("max_unprotected_shape_cluster_size", max_cluster))
+    if cluster_size_cap is not None and max_unprotected_cluster > cluster_size_cap:
         findings.append(
             f"max shape cluster size {max_cluster} exceeds cap {cluster_size_cap} (#532)"
         )

--- a/tools/validate_loop2_content_gates.py
+++ b/tools/validate_loop2_content_gates.py
@@ -128,7 +128,7 @@ def _is_protected_obstacle_pair(left: dict, right: dict) -> bool:
     if not isinstance(left_time, (int, float)) or not isinstance(right_time, (int, float)):
         return False
     delta_ms = abs(float(left_time) - float(right_time)) * 1000.0
-    return delta_ms < CROSS_LAYER_PRESERVATION_WINDOW_MS
+    return delta_ms <= CROSS_LAYER_PRESERVATION_WINDOW_MS
 
 
 def _is_protected_by_cluster_neighbor(obstacle: dict, cluster: list[dict]) -> bool:
@@ -205,7 +205,7 @@ def calculate_content_metrics(
                 and prev.get("onset_class") is not None
                 and current.get("onset_class") is not None
             )
-            if cross_layer and 0.0 <= dt_ms < CROSS_LAYER_PRESERVATION_WINDOW_MS:
+            if cross_layer and 0.0 <= dt_ms <= CROSS_LAYER_PRESERVATION_WINDOW_MS:
                 cross_layer_preserved_pairs += 1
                 prev = current
                 continue

--- a/tools/validate_loop2_content_gates.py
+++ b/tools/validate_loop2_content_gates.py
@@ -123,11 +123,12 @@ def _is_protected_obstacle_pair(left: dict, right: dict) -> bool:
         return False
     if left_class == right_class:
         return False
-    try:
-        delta_ms = abs(float(left.get("time_sec", 0.0)) - float(right.get("time_sec", 0.0))) * 1000.0
-    except (TypeError, ValueError):
+    left_time = left.get("time_sec")
+    right_time = right.get("time_sec")
+    if not isinstance(left_time, (int, float)) or not isinstance(right_time, (int, float)):
         return False
-    return delta_ms <= CROSS_LAYER_PRESERVATION_WINDOW_MS
+    delta_ms = abs(float(left_time) - float(right_time)) * 1000.0
+    return delta_ms < CROSS_LAYER_PRESERVATION_WINDOW_MS
 
 
 def _is_protected_by_cluster_neighbor(obstacle: dict, cluster: list[dict]) -> bool:
@@ -137,7 +138,7 @@ def _is_protected_by_cluster_neighbor(obstacle: dict, cluster: list[dict]) -> bo
     )
 
 
-def _max_unprotected_shape_cluster_size(clusters: list[list[dict]]) -> int:
+def _max_unexempt_shape_cluster_size(clusters: list[list[dict]]) -> int:
     sizes = [
         len(cluster)
         for cluster in clusters
@@ -241,7 +242,7 @@ def calculate_content_metrics(
         "longest_same_shape_cluster_run": _longest_same_shape_cluster_run(shape_clusters) if shape_clusters else 0,
         "shape_cluster_count": len(shape_clusters),
         "max_shape_cluster_size": max(cluster_sizes) if cluster_sizes else 0,
-        "max_unprotected_shape_cluster_size": _max_unprotected_shape_cluster_size(shape_clusters),
+        "max_unexempt_shape_cluster_size": _max_unexempt_shape_cluster_size(shape_clusters),
         "shape_clusters_over_warn": 0,
         "triangle_share": (shape_counts.get("triangle", 0) / total_shape_gates) if total_shape_gates else 0.0,
         "circle_share": (shape_counts.get("circle", 0) / total_shape_gates) if total_shape_gates else 0.0,
@@ -297,10 +298,11 @@ def evaluate_content_gates(metrics: dict[str, float | int | bool | None], diffic
         )
     cluster_size_cap = MAX_SHAPE_CLUSTER_SIZE.get(difficulty)
     max_cluster = int(metrics.get("max_shape_cluster_size", 0))
-    max_unprotected_cluster = int(metrics.get("max_unprotected_shape_cluster_size", max_cluster))
-    if cluster_size_cap is not None and max_unprotected_cluster > cluster_size_cap:
+    max_unexempt_cluster = int(metrics.get("max_unexempt_shape_cluster_size", max_cluster))
+    if cluster_size_cap is not None and max_unexempt_cluster > cluster_size_cap:
         findings.append(
-            f"max shape cluster size {max_cluster} exceeds cap {cluster_size_cap} (#532)"
+            f"max unexempt shape cluster size {max_unexempt_cluster} exceeds cap {cluster_size_cap} "
+            f"(#532; raw max={max_cluster})"
         )
 
     if not onset_timed:


### PR DESCRIPTION
Closes #821

## Root cause
`tools/validate_loop2_content_gates.py` used a difficulty-wide `cross_layer_preserved_pairs > 0` exemption for the max shape cluster cap. Any protected cross-layer pair anywhere in an onset-timed chart could hide an unrelated oversized local cluster, including 2_drama hard.

## Changes
- Scope protected-pair handling for max shape cluster validation to the cluster being evaluated.
- Require explicit numeric timestamps for protected pairs and keep the 50ms boundary aligned with the generator.
- Add regression coverage proving an unrelated protected onset pair cannot exempt an oversized cluster.
- Remove the lowest-flux gate from the 2_drama hard six-gate cluster, reducing the blocking cluster to the hard cap of 5.

## Verification
- `python3 tools/test_validate_loop2_content_gates.py`
- `python3 tools/validate_loop2_content_gates.py --strict`
- `python3 tools/validate_max_beat_gap.py`
- `python3 tools/check_shape_change_gap.py`
- `python3 tools/validate_difficulty_ramp.py`
- `python3 tools/validate_no_simultaneous_shape_gates.py content/beatmaps/2_drama_beatmap.json`
- `python3 tools/validate_required_cross_lane_jump_time.py`
- `python3 tools/validate_offset_semantics.py`
- `cmake -B build -S . -Wno-dev && cmake --build build && ./build/shapeshifter_tests`
- `ctest --test-dir build --output-on-failure`