### PR TITLE
Exclude benchmarks from default CTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -572,6 +572,12 @@ if(NOT EMSCRIPTEN AND NOT SHAPESHIFTER_IOS)
         TEST_SPEC "~[bench]"
         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     )
+    add_custom_target(shapeshifter_benchmarks
+        COMMAND $<TARGET_FILE:shapeshifter_tests> "[bench]"
+        DEPENDS shapeshifter_tests
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        COMMENT "Running Catch2 benchmark cases"
+    )
     add_test(
         NAME startup_shutdown_smoke
         COMMAND $<TARGET_FILE:shapeshifter_startup_shutdown_smoke> --frames 2 --cycles 2

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ export VCPKG_ROOT=/path/to/vcpkg
 ./build.sh           # Release build
 ./run.sh             # Build + run game
 ./run.sh test        # Build + run tests
+cmake --build build --target shapeshifter_benchmarks  # Run benchmarks on demand
 ```
 
 ### iOS TestFlight Archive (owner-driven signing)

--- a/benchmarks/bench_perspective.cpp
+++ b/benchmarks/bench_perspective.cpp
@@ -13,7 +13,7 @@
 // The remaining CPU cost is generating world-space vertex positions for
 // rlVertex3f calls.
 
-TEST_CASE("Bench: circle ring vertex generation (world-space)", "[bench][rendering]") {
+TEST_CASE("Bench: circle ring vertex generation (world-space)", "[!benchmark][bench][rendering]") {
     BENCHMARK("24-segment circle trig vertices") {
         constexpr int ring_segments = 24;
         constexpr float tau = 6.28318530717958647692f;
@@ -29,7 +29,7 @@ TEST_CASE("Bench: circle ring vertex generation (world-space)", "[bench][renderi
     };
 }
 
-TEST_CASE("Bench: floor position computation (3 lanes × 21 positions)", "[bench][rendering]") {
+TEST_CASE("Bench: floor position computation (3 lanes × 21 positions)", "[!benchmark][bench][rendering]") {
     BENCHMARK("3 lanes × 21 floor positions (world-space)") {
         float sum = 0.0f;
         for (int lane = 0; lane < 3; ++lane) {
@@ -46,7 +46,7 @@ TEST_CASE("Bench: floor position computation (3 lanes × 21 positions)", "[bench
     };
 }
 
-TEST_CASE("Bench: polygon vertex generation", "[bench][rendering]") {
+TEST_CASE("Bench: polygon vertex generation", "[!benchmark][bench][rendering]") {
     BENCHMARK("6-segment polygon trig vertices") {
         constexpr int sides = 6;
         constexpr float tau = 6.28318530717958647692f;

--- a/benchmarks/bench_systems.cpp
+++ b/benchmarks/bench_systems.cpp
@@ -100,7 +100,7 @@ static void spawn_particles(entt::registry& reg, int count) {
 
 constexpr float DT = 1.0f / 60.0f;
 
-TEST_CASE("Bench: scroll_system", "[bench]") {
+TEST_CASE("Bench: scroll_system", "[!benchmark][bench]") {
     BENCHMARK_ADVANCED("10 entities")(Catch::Benchmark::Chronometer meter) {
         auto reg = make_bench_registry();
         spawn_scroll_obstacles(reg, 10);
@@ -118,7 +118,7 @@ TEST_CASE("Bench: scroll_system", "[bench]") {
     };
 }
 
-TEST_CASE("Bench: collision_system", "[bench]") {
+TEST_CASE("Bench: collision_system", "[!benchmark][bench]") {
     BENCHMARK_ADVANCED("1 obstacle at player")(Catch::Benchmark::Chronometer meter) {
         auto reg = make_bench_registry();
         make_bench_player(reg);
@@ -145,7 +145,7 @@ TEST_CASE("Bench: collision_system", "[bench]") {
     };
 }
 
-TEST_CASE("Bench: scoring_system", "[bench]") {
+TEST_CASE("Bench: scoring_system", "[!benchmark][bench]") {
     BENCHMARK_ADVANCED("no scored obstacles")(Catch::Benchmark::Chronometer meter) {
         auto reg = make_bench_registry();
         make_bench_player(reg);
@@ -169,7 +169,7 @@ TEST_CASE("Bench: scoring_system", "[bench]") {
     };
 }
 
-TEST_CASE("Bench: player_input + movement", "[bench]") {
+TEST_CASE("Bench: player_input + movement", "[!benchmark][bench]") {
     BENCHMARK_ADVANCED("shape change + lane switch")(Catch::Benchmark::Chronometer meter) {
         auto reg = make_bench_registry();
         make_bench_player(reg);
@@ -182,7 +182,7 @@ TEST_CASE("Bench: player_input + movement", "[bench]") {
     };
 }
 
-TEST_CASE("Bench: particle_system", "[bench]") {
+TEST_CASE("Bench: particle_system", "[!benchmark][bench]") {
     BENCHMARK_ADVANCED("50 particles")(Catch::Benchmark::Chronometer meter) {
         auto reg = make_bench_registry();
         spawn_particles(reg, 50);
@@ -190,7 +190,7 @@ TEST_CASE("Bench: particle_system", "[bench]") {
     };
 }
 
-TEST_CASE("Bench: obstacle_despawn_system", "[bench]") {
+TEST_CASE("Bench: obstacle_despawn_system", "[!benchmark][bench]") {
     BENCHMARK_ADVANCED("10 obstacles (none past threshold)")(Catch::Benchmark::Chronometer meter) {
         auto reg = make_bench_registry();
         spawn_obstacles(reg, 10);
@@ -198,7 +198,7 @@ TEST_CASE("Bench: obstacle_despawn_system", "[bench]") {
     };
 }
 
-TEST_CASE("Bench: motion_system", "[bench]") {
+TEST_CASE("Bench: motion_system", "[!benchmark][bench]") {
     BENCHMARK_ADVANCED("10 entities")(Catch::Benchmark::Chronometer meter) {
         auto reg = make_bench_registry();
         spawn_obstacles(reg, 10);
@@ -216,7 +216,7 @@ TEST_CASE("Bench: motion_system", "[bench]") {
     };
 }
 
-TEST_CASE("Bench: full frame (typical)", "[bench]") {
+TEST_CASE("Bench: full frame (typical)", "[!benchmark][bench]") {
     BENCHMARK_ADVANCED("6 obstacles + 20 particles")(Catch::Benchmark::Chronometer meter) {
         auto reg = make_bench_registry();
         make_bench_player(reg);
@@ -235,7 +235,7 @@ TEST_CASE("Bench: full frame (typical)", "[bench]") {
     };
 }
 
-TEST_CASE("Bench: full frame (stress)", "[bench]") {
+TEST_CASE("Bench: full frame (stress)", "[!benchmark][bench]") {
     BENCHMARK_ADVANCED("50 obstacles + 50 particles")(Catch::Benchmark::Chronometer meter) {
         auto reg = make_bench_registry();
         make_bench_player(reg);


### PR DESCRIPTION
Fixes #824.

## Summary
- marks Catch2 benchmark cases with `[!benchmark][bench]` so they stay hidden from default runs
- keeps `catch_discover_tests(... TEST_SPEC "~[bench]")` for default CTest discovery
- adds `shapeshifter_benchmarks` custom target and documents it in README

## Verification
- `cmake -B build -S . -Wno-dev`
- `cmake --build build`
- `ctest --test-dir build -N` (838 default tests listed; no `Bench:` cases)
- `cmake --build build --target shapeshifter_benchmarks`
- `ctest --test-dir build --output-on-failure` (838/838 passed; startup_shutdown_smoke skipped by its configured skip code)