### PR TITLE
Align HUD perfect cue with scoring

### DIFF
--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
@@ -11,6 +11,7 @@
 #include "../../components/ui_layout_cache.h"
 #include "../../constants.h"
 #include "../../entities/settings.h"
+#include "../../util/rhythm_math.h"
 #include "screen_controller_base.h"
 #include "gameplay_hud_screen_controller.h"
 #include <entt/entt.hpp>
@@ -294,13 +295,7 @@ float gameplay_hud_perfect_distance(const SongState* song_state) {
     const float scroll_speed = (song_state && song_state->scroll_speed > 0.0f)
         ? song_state->scroll_speed
         : constants::BASE_SCROLL_SPEED;
-    const float morph_duration = (song_state && song_state->morph_duration > 0.0f)
-        ? song_state->morph_duration
-        : constants::MORPH_DURATION;
-    const float half_window = (song_state && song_state->half_window > 0.0f)
-        ? song_state->half_window
-        : 0.15f;
-    return scroll_speed * (morph_duration + half_window);
+    return scroll_speed * kTimingPerfectSeconds;
 }
 
 float gameplay_hud_ring_ratio(float nearest_dist, float perfect_dist, float ring_appear_dist) {

--- a/app/util/rhythm_math.h
+++ b/app/util/rhythm_math.h
@@ -7,6 +7,7 @@ constexpr float kTimingBpmCeiling = 180.0f;
 constexpr float kTimingPerfectSeconds = 0.050f;
 constexpr float kTimingGoodSeconds = 0.100f;
 constexpr float kTimingOkSeconds = 0.150f;
+constexpr float kTimingGradeEpsilonSeconds = 0.0005f;
 
 // Better timing -> smaller scale -> remaining Active window collapses sooner.
 // collision_system applies this via window_start adjustment (scale < 1.0 path).
@@ -33,9 +34,9 @@ inline float timing_multiplier(TimingTier tier) {
 
 
 inline TimingTier compute_timing_tier_from_delta(float delta_seconds_abs) {
-    if (delta_seconds_abs <= kTimingPerfectSeconds) return TimingTier::Perfect;
-    if (delta_seconds_abs <= kTimingGoodSeconds) return TimingTier::Good;
-    if (delta_seconds_abs <= kTimingOkSeconds) return TimingTier::Ok;
+    if (delta_seconds_abs <= kTimingPerfectSeconds + kTimingGradeEpsilonSeconds) return TimingTier::Perfect;
+    if (delta_seconds_abs <= kTimingGoodSeconds + kTimingGradeEpsilonSeconds) return TimingTier::Good;
+    if (delta_seconds_abs <= kTimingOkSeconds + kTimingGradeEpsilonSeconds) return TimingTier::Ok;
     return TimingTier::Bad;
 }
 

--- a/design-docs/game-flow.md
+++ b/design-docs/game-flow.md
@@ -876,7 +876,7 @@ shape closer to the beat gives a higher grade (Perfect > Good > Ok > Bad).
   WHAT PLAYER LEARNS:
   ───────────────────
   "The ring shrinks toward the button as the beat approaches"
-  "Pressing when the ring is tight = PERFECT"
+  "Pressing while the ring is tight = PERFECT"
   "Earlier or later = lower grade"
   "Changing shape on the beat is fine even if no obstacle is here"
 ```
@@ -926,7 +926,7 @@ shape closer to the beat gives a higher grade (Perfect > Good > Ok > Bad).
   ║      press NOW for PERFECT.           ║
   ╚══════════════════════════════════════╝
 
-  The ring is the live timing cue: tight = on the beat.
+  The ring is the live timing cue: tight = inside the PERFECT timing window.
   No "fill the meter" — earlier presses are not penalised
   more than later ones.
 ```

--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -507,8 +507,8 @@ The proximity ring is the core visual feedback for rhythm timing. It replaces th
   │  • Appears when an obstacle spawns (nearest_dist < APPROACH_DIST)
   │  • Starts at max_ring_radius = btn_radius * 2.0            │
   │  • Shrinks toward btn_radius as obstacle approaches         │
-  │  • Ring = btn_radius when obstacle is at "perfect press"    │
-  │    distance (morph_duration + half_window ahead)            │
+  │  • Ring = btn_radius when obstacle enters the PERFECT       │
+  │    timing window (kTimingPerfectSeconds before arrival)     │
   │                                                             │
   │  Color states:                                              │
   │    blue-grey  → obstacle is far   (ratio > 0.3)            │

--- a/tests/test_input_pipeline_behavior.cpp
+++ b/tests/test_input_pipeline_behavior.cpp
@@ -275,8 +275,8 @@ TEST_CASE("pipeline: gameplay HUD proximity ring progresses through far near per
     song.half_window = 0.15f;
 
     const float perfect_dist = gameplay_hud_perfect_distance(&song);
-    CHECK(perfect_dist > 107.99f);
-    CHECK(perfect_dist < 108.01f);
+    CHECK(perfect_dist > 19.99f);
+    CHECK(perfect_dist < 20.01f);
 
     const float appear_dist = constants::APPROACH_DIST;
     const float near_dist = perfect_dist + (appear_dist - perfect_dist) * 0.2f;

--- a/tests/test_rhythm_system.cpp
+++ b/tests/test_rhythm_system.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include "test_helpers.h"
+#include "ui/screen_controllers/gameplay_hud_screen_controller.h"
 #include "util/rhythm_math.h"
 #include "entities/beat_map.h"
 
@@ -522,6 +523,32 @@ TEST_CASE("collision: timing grade PERFECT on press-at-arrival", "[rhythm][colli
     // arrival_time == press_time -> Perfect
     reg.emplace<BeatInfo>(obs, 0, 5.0f, 5.0f - song.lead_time);
     collision_system(reg, 0.016f);
+    REQUIRE(reg.all_of<ScoredTag>(obs));
+    REQUIRE(reg.all_of<TimingGrade>(obs));
+    CHECK(reg.get<TimingGrade>(obs).tier == TimingTier::Perfect);
+}
+
+TEST_CASE("collision: HUD perfect cue distance maps to PERFECT timing", "[rhythm][collision][hud]") {
+    auto reg = make_rhythm_registry();
+    auto player = make_rhythm_player(reg);
+    auto& ps = reg.get<PlayerShape>(player);
+    auto& sw = reg.get<ShapeWindow>(player);
+    auto& song = reg.ctx().get<SongState>();
+
+    const float cue_dist = gameplay_hud_perfect_distance(&song);
+    const float cue_lead_seconds = cue_dist / song.scroll_speed;
+    CHECK_THAT(cue_lead_seconds, WithinAbs(kTimingPerfectSeconds, 0.0001f));
+
+    ps.current = Shape::Circle;
+    sw.phase = WindowPhase::Active;
+    sw.press_time = 5.0f;
+    song.song_time = sw.press_time + cue_lead_seconds;
+
+    auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
+    reg.emplace<BeatInfo>(obs, 0, song.song_time, song.song_time - song.lead_time);
+
+    collision_system(reg, 0.016f);
+
     REQUIRE(reg.all_of<ScoredTag>(obs));
     REQUIRE(reg.all_of<TimingGrade>(obs));
     CHECK(reg.get<TimingGrade>(obs).tier == TimingTier::Perfect);


### PR DESCRIPTION
## Summary\n- key the Gameplay HUD perfect ring distance to the actual PERFECT timing threshold\n- add a regression test proving the HUD perfect cue maps to a PERFECT collision grade\n- update rhythm docs/tutorial copy to describe the PERFECT timing window\n\n## Validation\n- cmake -B build -S . -Wno-dev\n- cmake --build build\n- ./build/shapeshifter_tests\n\nCloses #834