### PR TITLE
Fix HUD button input frame order

### DIFF
--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -24,6 +24,7 @@
 #include "systems/camera_system.h"
 #include "entities/beat_map.h"
 #include "entities/obstacle_render_entity.h"
+#include "ui/screen_controllers/gameplay_hud_screen_controller.h"
 #include "platform_display.h"
 #include "util/persistence_policy.h"
 #include "components/high_score.h"
@@ -265,6 +266,7 @@ void game_loop_frame(entt::registry& reg, float& accumulator) {
 
     compute_screen_transform(reg);
     input_system(reg, raw_dt);
+    gameplay_hud_process_button_input(reg);
     test_player_system(reg, raw_dt);
 
     while (accumulator >= FIXED_DT) {

--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -62,7 +62,7 @@ void game_state_system(entt::registry& reg, float dt) {
     // (see wire_input_dispatcher in input/input_dispatcher.cpp).
     //
     // Events are enqueued earlier in the same frame by input_system
-    // (keyboard/swipes) and raygui HUD controllers (buttons) before the
+    // (keyboard/swipes) and the gameplay HUD input collector before the
     // fixed-step loop.
     //
     // ⚠ Do NOT call disp.clear<GoEvent/ButtonPressEvent>() before this point

--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
@@ -2,6 +2,7 @@
 
 #include "../../components/game_state.h"
 #include "../../components/energy_bar.h"
+#include "../../components/input.h"
 #include "../../components/input_events.h"
 #include "../../components/obstacle.h"
 #include "../../components/player.h"
@@ -321,6 +322,20 @@ Rectangle gameplay_hud_shape_input_bounds(GameplayHudShapeSlot slot) {
     return shape_slot_bounds(geometry_state, slot);
 }
 
+void gameplay_hud_process_button_input(entt::registry& reg) {
+    const auto& input = reg.ctx().get<InputState>();
+    if (!(input.click || input.touch_up)) return;
+
+    static const GameplayHudLayoutState geometry_state = GameplayHudLayout_Init();
+    const Vector2 pointer = {input.end_x, input.end_y};
+    gameplay_hud_apply_button_presses(
+        reg,
+        CheckCollisionPointRec(pointer, GameplayHudLayout_PauseButtonBounds(&geometry_state)),
+        CheckCollisionPointRec(pointer, GameplayHudLayout_CircleButtonBounds(&geometry_state)),
+        CheckCollisionPointRec(pointer, GameplayHudLayout_SquareButtonBounds(&geometry_state)),
+        CheckCollisionPointRec(pointer, GameplayHudLayout_TriangleButtonBounds(&geometry_state)));
+}
+
 void gameplay_hud_apply_button_presses(entt::registry& reg,
                                        bool pause_pressed,
                                        bool circle_pressed,
@@ -413,9 +428,8 @@ void render_gameplay_hud_screen_ui(entt::registry& reg) {
 
     GuiSetStyle(DEFAULT, TEXT_SIZE, saved_text_size);
 
-    gameplay_hud_apply_button_presses(reg,
-                                      state.PauseButtonPressed,
-                                      state.CircleButtonPressed,
-                                      state.SquareButtonPressed,
-                                      state.TriangleButtonPressed);
+    state.PauseButtonPressed = false;
+    state.CircleButtonPressed = false;
+    state.SquareButtonPressed = false;
+    state.TriangleButtonPressed = false;
 }

--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.h
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.h
@@ -22,6 +22,7 @@ float gameplay_hud_perfect_distance(const SongState* song_state);
 float gameplay_hud_ring_ratio(float nearest_dist, float perfect_dist, float ring_appear_dist);
 GameplayHudRingCue gameplay_hud_ring_cue(float nearest_dist, float perfect_dist, float ring_appear_dist);
 void init_gameplay_hud_screen_ui();
+void gameplay_hud_process_button_input(entt::registry& reg);
 void render_gameplay_hud_screen_ui(entt::registry& reg);
 Rectangle gameplay_hud_shape_input_bounds(GameplayHudShapeSlot slot);
 void gameplay_hud_apply_button_presses(entt::registry& reg,

--- a/tests/test_input_pipeline_behavior.cpp
+++ b/tests/test_input_pipeline_behavior.cpp
@@ -183,6 +183,44 @@ TEST_CASE("pipeline: gameplay HUD raygui shape press triggers player shape input
     CHECK(sw.target_shape == Shape::Square);
 }
 
+TEST_CASE("pipeline: gameplay HUD pointer release is collected before the fixed tick",
+          "[input_pipeline][hud][issue833]") {
+    auto reg = make_rhythm_registry();
+    auto player = make_rhythm_player(reg);
+    auto& input = reg.ctx().get<InputState>();
+    auto& sw = reg.get<ShapeWindow>(player);
+    REQUIRE(sw.phase == WindowPhase::Idle);
+
+    const auto square_bounds = gameplay_hud_shape_input_bounds(GameplayHudShapeSlot::Square);
+    input.click = true;
+    input.end_x = square_bounds.x + square_bounds.width * 0.5f;
+    input.end_y = square_bounds.y + square_bounds.height * 0.5f;
+
+    gameplay_hud_process_button_input(reg);
+    run_pipeline(reg);
+
+    CHECK(sw.phase == WindowPhase::MorphIn);
+    CHECK(sw.target_shape == Shape::Square);
+}
+
+TEST_CASE("pipeline: gameplay HUD pause release is collected before the fixed tick",
+          "[input_pipeline][hud][issue833]") {
+    auto reg = make_rhythm_registry();
+    auto& input = reg.ctx().get<InputState>();
+    auto& gs = reg.ctx().get<GameState>();
+    REQUIRE(gs.phase == GamePhase::Playing);
+
+    input.click = true;
+    input.end_x = 660.0f;
+    input.end_y = 35.0f;
+
+    gameplay_hud_process_button_input(reg);
+    run_pipeline(reg);
+
+    CHECK(gs.phase == GamePhase::Paused);
+    CHECK_FALSE(gs.transition_pending);
+}
+
 TEST_CASE("pipeline: pending phase transition blocks queued shape input",
           "[input_pipeline][transition][issue823]") {
     auto reg = make_rhythm_registry();


### PR DESCRIPTION
Closes #833

## Summary
- collect Gameplay HUD shape/pause pointer releases immediately after raw input and before fixed gameplay ticks
- keep HUD render from replaying raygui press flags after the tick drain
- add regression tests for same-frame HUD shape and pause handling

## Verification
- cmake -B build -S . -Wno-dev
- cmake --build build
- ./build/shapeshifter_tests "[input_pipeline][hud]"
- ./build/shapeshifter_tests
- ./run.sh test