### PR TITLE
Handle selected beatmap load failure safely

### DIFF
--- a/app/session/play_session.cpp
+++ b/app/session/play_session.cpp
@@ -89,6 +89,13 @@ T& assign_or_emplace_ctx(entt::registry& reg, T value = T{}) {
     return reg.ctx().emplace<T>(std::move(value));
 }
 
+template <typename T>
+void erase_ctx_if_exists(entt::registry& reg) {
+    if (reg.ctx().find<T>()) {
+        reg.ctx().erase<T>();
+    }
+}
+
 } // namespace
 
 void setup_play_session(entt::registry& reg) {
@@ -110,7 +117,6 @@ void setup_play_session(entt::registry& reg) {
 
     // Reset singletons
     assign_or_emplace_ctx(reg, RNGState{});
-    assign_or_emplace_ctx(reg, ScoreState{});
 
     // Load beatmap from level selection. BeatMap is an entity singleton whose
     // cold asset data remains immutable for the duration of the play session.
@@ -119,8 +125,20 @@ void setup_play_session(entt::registry& reg) {
     beatmap = BeatMap{};
     lss.selected_level = content_config::level_index_or_default(lss.selected_level);
     lss.selected_difficulty = content_config::difficulty_index_or_default(lss.selected_difficulty);
+    std::string override_beatmap_path;
+    std::string override_difficulty_key;
     const char* beatmap_path = content_config::LEVELS[lss.selected_level].beatmap_path;
     const char* difficulty_key = content_config::DIFFICULTY_KEYS[lss.selected_difficulty];
+    if (const auto* override_content = reg.ctx().find<PlaySessionContentOverride>()) {
+        override_beatmap_path = override_content->beatmap_path;
+        override_difficulty_key = override_content->difficulty_key;
+        if (!override_beatmap_path.empty()) {
+            beatmap_path = override_beatmap_path.c_str();
+        }
+        if (!override_difficulty_key.empty()) {
+            difficulty_key = override_difficulty_key.c_str();
+        }
+    }
 
     std::vector<BeatMapError> load_errors;
     std::vector<BeatMapError> reported_load_errors;
@@ -144,9 +162,27 @@ void setup_play_session(entt::registry& reg) {
             TraceLog(LOG_WARNING, "Beatmap load error at beat %d: %s",
                      error.beat_index, error.message.c_str());
         }
+        runtime_system_scratch_init(reg);
+        if (auto* music = reg.ctx().find<MusicContext>()) {
+            music->release();
+        }
+        if (auto* hs = reg.ctx().find<HighScoreState>()) {
+            hs->current_key_hash = 0;
+        }
+        erase_ctx_if_exists<ScoreState>(reg);
+        erase_ctx_if_exists<SongState>(reg);
+        erase_ctx_if_exists<EnergyState>(reg);
+        erase_ctx_if_exists<SongResults>(reg);
+        erase_ctx_if_exists<GameOverState>(reg);
+        lss.confirmed = false;
+        auto& gs = reg.ctx().get<GameState>();
+        enter_phase(gs, GamePhase::LevelSelect);
+        return;
     }
     runtime_system_scratch_init(reg);
     runtime_system_scratch_reserve(reg, beatmap.beats.size());
+
+    assign_or_emplace_ctx(reg, ScoreState{});
 
     // Wire high score: derive song_id from beatmap filename and set current_key_hash.
     // The key string is built once in a stack buffer (no heap); ensure_entry pre-registers

--- a/app/session/play_session.h
+++ b/app/session/play_session.h
@@ -1,6 +1,12 @@
 #pragma once
 
 #include <entt/entt.hpp>
+#include <string>
+
+struct PlaySessionContentOverride {
+    std::string beatmap_path;
+    std::string difficulty_key;
+};
 
 // Sets up a fresh play session: clears entities, resets singletons,
 // creates the player entity. Called by game_state_system on transition

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -67,6 +67,30 @@ TEST_CASE("Play session: invalid level-select indices fall back before content l
         == high_score::make_key_hash("1_stomper", "medium"));
 }
 
+TEST_CASE("Play session: missing selected beatmap returns to level select without score session",
+          "[play_session][issue835]") {
+    auto reg = make_registry();
+    auto& gs = reg.ctx().get<GameState>();
+    auto& lss = reg.ctx().get<LevelSelectState>();
+    auto& high_scores = reg.ctx().get<HighScoreState>();
+    high_score::set_score(high_scores, "1_stomper|medium", 4321);
+    high_scores.current_key_hash = high_score::make_key_hash("1_stomper", "medium");
+    lss.confirmed = true;
+
+    reg.ctx().emplace<PlaySessionContentOverride>(
+        PlaySessionContentOverride{"content/beatmaps/does_not_exist_835.json", "medium"});
+
+    setup_play_session(reg);
+
+    CHECK(gs.phase == GamePhase::LevelSelect);
+    CHECK_FALSE(lss.confirmed);
+    CHECK(beat_map(reg).beats.empty());
+    CHECK(reg.view<PlayerTag>().empty());
+    CHECK(reg.ctx().find<ScoreState>() == nullptr);
+    CHECK(high_scores.current_key_hash == 0);
+    CHECK(high_scores.entry_count == 1);
+}
+
 TEST_CASE("Play session: SongResults total_notes excludes onset marker metadata",
           "[play_session][song_results][issue-773]") {
     bool saw_onset_marker = false;


### PR DESCRIPTION
Closes #835

## Summary
- return to Level Select when the selected beatmap cannot load or validate
- skip score/song/high-score session initialization and player spawn on failed loads
- add regression coverage for a missing selected beatmap path

## Verification
- cmake --build build
- ./build/shapeshifter_tests "[play_session][issue835]"
- ./build/shapeshifter_tests "[high_score][play_session]"
- ./build/shapeshifter_tests
- ./run.sh test