### PR TITLE
Fix high score key after difficulty fallback

### DIFF
--- a/app/session/play_session.cpp
+++ b/app/session/play_session.cpp
@@ -195,7 +195,8 @@ void setup_play_session(entt::registry& reg) {
             stem.erase(stem.size() - BEATMAP_SUFFIX.size());
         }
         char key_buf[HighScoreState::KEY_CAP]{};
-        high_score::make_key_str(key_buf, HighScoreState::KEY_CAP, stem.c_str(), difficulty_key);
+        high_score::make_key_str(key_buf, HighScoreState::KEY_CAP,
+                                 stem.c_str(), beatmap.difficulty.c_str());
         high_score::ensure_entry(*hs, key_buf);
         hs->current_key_hash = entt::hashed_string::value(static_cast<const char*>(key_buf));
     }

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -20,6 +20,22 @@ void remove_path(const std::filesystem::path& path) {
     std::filesystem::remove_all(path, ec);
 }
 
+struct TempBeatMapFile {
+    explicit TempBeatMapFile(const char* name, const std::string& json)
+        : path(std::filesystem::temp_directory_path() / name) {
+        std::filesystem::remove(path);
+        std::ofstream out(path);
+        REQUIRE(out.good());
+        out << json;
+    }
+
+    ~TempBeatMapFile() {
+        std::filesystem::remove(path);
+    }
+
+    std::filesystem::path path;
+};
+
 int count_result_notes(const BeatMap& beatmap) {
     int total = 0;
     for (const BeatEntry& beat : beatmap.beats) {
@@ -89,6 +105,39 @@ TEST_CASE("Play session: missing selected beatmap returns to level select withou
     CHECK(reg.ctx().find<ScoreState>() == nullptr);
     CHECK(high_scores.current_key_hash == 0);
     CHECK(high_scores.entry_count == 1);
+}
+
+TEST_CASE("Play session: high score key uses loaded fallback difficulty",
+          "[play_session][high_score][issue847]") {
+    const TempBeatMapFile beatmap("shapeshifter_issue847_beatmap.json", R"json({
+        "song_id": "issue847",
+        "title": "Issue 847",
+        "bpm": 120,
+        "offset": 0,
+        "lead_beats": 4,
+        "duration": 8,
+        "difficulties": {
+            "medium": {
+                "beats": [
+                    {"beat": 4, "kind": "shape_gate", "shape": "circle", "lane": 1}
+                ]
+            }
+        }
+    })json");
+
+    auto reg = make_registry();
+    auto& high_scores = reg.ctx().get<HighScoreState>();
+    high_score::set_score(high_scores, "shapeshifter_issue847|medium", 4321);
+    high_score::set_score(high_scores, "shapeshifter_issue847|hard", 9999);
+    reg.ctx().emplace<PlaySessionContentOverride>(
+        PlaySessionContentOverride{beatmap.path.string(), "hard"});
+
+    setup_play_session(reg);
+
+    CHECK(beat_map(reg).difficulty == "medium");
+    CHECK(reg.ctx().get<HighScoreState>().current_key_hash
+        == high_score::make_key_hash("shapeshifter_issue847", "medium"));
+    CHECK(reg.ctx().get<ScoreState>().high_score == 4321);
 }
 
 TEST_CASE("Play session: SongResults total_notes excludes onset marker metadata",


### PR DESCRIPTION
## Summary\n- key active high-score lookup by the loaded beatmap difficulty instead of the requested difficulty\n- add a regression test for hard -> medium fallback content\n\n## Validation\n- cmake -B build -S . -Wno-dev -DCMAKE_TOOLCHAIN_FILE=/Users/yashasgujjar/vcpkg/scripts/buildsystems/vcpkg.cmake\n- cmake --build build\n- ./build/shapeshifter_tests "[play_session]"\n- ./build/shapeshifter_tests\n\nFixes #847