### PR TITLE
Fix shape gate target-lane collision

### DIFF
--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -6,6 +6,7 @@
 #include "../components/game_state.h"
 #include "../components/rhythm.h"
 #include "../util/rhythm_math.h"
+#include "../util/shape_lane_mapping.h"
 #include "../components/song_state.h"
 #include "../components/gameplay_intents.h"
 #include "../constants.h"
@@ -37,6 +38,29 @@ bool player_matches_required_shape(const PlayerShape& p_shape,
     }
 
     return p_window.phase != WindowPhase::Idle && p_window.target_shape == required;
+}
+
+bool shape_gate_lane_match(float obstacle_x,
+                           float player_x,
+                           const Lane& lane,
+                           Shape required,
+                           bool shape_match) {
+    if (CheckCollisionRecs(centered_hitbox_rect(player_x),
+                           centered_hitbox_rect(obstacle_x))) {
+        return true;
+    }
+
+    if (!shape_match) {
+        return false;
+    }
+
+    const int8_t required_lane = lane_for_shape(required);
+    if (required_lane < 0 || lane.target != required_lane) {
+        return false;
+    }
+
+    return CheckCollisionRecs(centered_hitbox_rect(constants::LANE_X[required_lane]),
+                              centered_hitbox_rect(obstacle_x));
 }
 
 }  // namespace
@@ -100,11 +124,6 @@ void collision_system(entt::registry& reg, float /*dt*/) {
         }
     };
 
-    const Rectangle player_hitbox = centered_hitbox_rect(player_x);
-    auto hitboxes_overlap = [player_hitbox](float obstacle_x) -> bool {
-        return CheckCollisionRecs(player_hitbox, centered_hitbox_rect(obstacle_x));
-    };
-
     // Per-kind structural views — each loop touches only entities that actually
     // carry the required components, eliminating per-entity try_get branches.
 
@@ -124,12 +143,13 @@ void collision_system(entt::registry& reg, float /*dt*/) {
             auto rhythm_view = reg.view<ObstacleTag, WorldTransform, RequiredShape, BeatInfo>(
                 entt::exclude<ScoredTag, BlockedLanes, RequiredLane>);
             for (auto [e, wt, req, info] : rhythm_view.each()) {
-                bool lane_match  = hitboxes_overlap(wt.position.x);
+                bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
+                bool lane_match = shape_gate_lane_match(wt.position.x, player_x, p_lane,
+                                                        req.shape, shape_match);
                 if (!lane_match) {
                     resolve(e, wt.position.y, false);
                     continue;
                 }
-                bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
                 bool cleared = shape_match;
                 if (cleared) grade_shape_timing(e, info.arrival_time);
                 resolve(e, wt.position.y, cleared);
@@ -138,12 +158,13 @@ void collision_system(entt::registry& reg, float /*dt*/) {
             auto view = reg.view<ObstacleTag, WorldTransform, RequiredShape>(
                 entt::exclude<ScoredTag, BlockedLanes, RequiredLane, BeatInfo>);
             for (auto [e, wt, req] : view.each()) {
-                bool lane_match  = hitboxes_overlap(wt.position.x);
+                bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
+                bool lane_match = shape_gate_lane_match(wt.position.x, player_x, p_lane,
+                                                        req.shape, shape_match);
                 if (!lane_match) {
                     resolve(e, wt.position.y, false);
                     continue;
                 }
-                bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
                 resolve(e, wt.position.y, shape_match);
             }
         }
@@ -211,12 +232,13 @@ void collision_system(entt::registry& reg, float /*dt*/) {
             auto view = reg.view<ObstacleTag, WorldTransform, RequiredShape>(
                 entt::exclude<ScoredTag, BlockedLanes, RequiredLane>);
             for (auto [e, wt, req] : view.each()) {
-                bool lane_match  = hitboxes_overlap(wt.position.x);
+                bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
+                bool lane_match = shape_gate_lane_match(wt.position.x, player_x, p_lane,
+                                                        req.shape, shape_match);
                 if (!lane_match) {
                     resolve(e, wt.position.y, false);
                     continue;
                 }
-                bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
                 resolve(e, wt.position.y, shape_match);
             }
         }

--- a/tests/test_collision_extended.cpp
+++ b/tests/test_collision_extended.cpp
@@ -114,6 +114,37 @@ TEST_CASE("collision: rhythm mode assigns Perfect for on-time hit", "[collision]
     CHECK(reg.get<TimingGrade>(obs).tier == TimingTier::Perfect);
 }
 
+TEST_CASE("collision: on-beat shape press uses target lane before interpolation",
+          "[collision][rhythm][issue850]") {
+    auto reg = make_rhythm_registry();
+    auto player = make_rhythm_player(reg);
+    auto& song = reg.ctx().get<SongState>();
+    song.song_time = 5.0f;
+
+    auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
+    reg.get<WorldTransform>(obs).position.x = constants::LANE_X[0];
+    reg.emplace<BeatInfo>(obs, 0, song.song_time, song.song_time - song.lead_time);
+
+    auto btn = make_shape_button(reg, Shape::Circle);
+    press_button(reg, btn);
+    reg.ctx().get<entt::dispatcher>().update<ButtonPressEvent>();
+    song.song_time += song.morph_duration + 0.001f;
+    shape_window_system(reg, song.morph_duration + 0.001f);
+
+    const auto& lane = reg.get<Lane>(player);
+    const auto& transform = reg.get<WorldTransform>(player);
+    REQUIRE(lane.current == 1);
+    REQUIRE(lane.target == 0);
+    REQUIRE(transform.position.x == constants::LANE_X[1]);
+
+    collision_system(reg, 0.016f);
+
+    CHECK(reg.all_of<ScoredTag>(obs));
+    CHECK_FALSE(reg.all_of<MissTag>(obs));
+    REQUIRE(reg.all_of<TimingGrade>(obs));
+    CHECK(reg.get<TimingGrade>(obs).tier == TimingTier::Perfect);
+}
+
 TEST_CASE("collision: rhythm mode assigns Bad for far-off hit", "[collision][rhythm]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);


### PR DESCRIPTION
## Summary
- Treat a matching shape press target lane as valid for shape-gate collision while lane interpolation is still in flight
- Keep combo/split lane checks tied to actual lane state
- Add regression coverage for issue #850

## Verification
- cmake -B build -S . -Wno-dev
- cmake --build build
- ./build/shapeshifter_tests "[issue850]"
- ./build/shapeshifter_tests

Fixes #850