### PR TITLE
Fix SplitPath lane positioning

### DIFF
--- a/app/systems/beat_scheduler_system.cpp
+++ b/app/systems/beat_scheduler_system.cpp
@@ -69,12 +69,12 @@ void beat_scheduler_system(entt::registry& reg, float /*dt*/) {
         // Compute x: LaneBlock derives it from blocked_mask; lane-based kinds
         // use entry.lane directly; bar/gate types default to center lane.
         float x_pos = constants::LANE_X[1];
-        if (entry.kind == ObstacleKind::ShapeGate) {
+        if (entry.kind == ObstacleKind::ShapeGate || entry.kind == ObstacleKind::SplitPath) {
             const int lane = static_cast<int>(entry.lane);
             if (lane >= 0 && lane < constants::LANE_COUNT) {
                 x_pos = constants::LANE_X[lane];
             } else {
-                TraceLog(LOG_WARNING, "Invalid ShapeGate lane %d; defaulting to center lane", lane);
+                TraceLog(LOG_WARNING, "Invalid lane-based obstacle lane %d; defaulting to center lane", lane);
             }
         } else if (entry.kind == ObstacleKind::LaneBlock) {
             int display_lane = 1;

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -361,13 +361,17 @@ TEST_CASE("beat_scheduler: spawns SplitPath with shape and required lane", "[bea
 
     beat_scheduler_system(reg, 0.016f);
 
-    auto view = reg.view<ObstacleTag, Obstacle, RequiredShape, RequiredLane>();
-    for (auto [e, obs, rs, rl] : view.each()) {
+    auto view = reg.view<ObstacleTag, Obstacle, RequiredShape, RequiredLane, WorldTransform>();
+    int count = 0;
+    for (auto [e, obs, rs, rl, wt] : view.each()) {
         (void)obs;
+        ++count;
         CHECK_FALSE(reg.all_of<BlockedLanes>(e));
         CHECK(rs.shape == Shape::Square);
         CHECK(rl.lane == 2);
+        CHECK_THAT(wt.position.x, Catch::Matchers::WithinAbs(constants::LANE_X[2], 0.01f));
     }
+    CHECK(count == 1);
 }
 
 TEST_CASE("beat_scheduler: all spawned obstacles have BeatInfo", "[beat_scheduler]") {


### PR DESCRIPTION
## Summary
- treat SplitPath as a lane-based obstacle in the beat scheduler
- add a regression assertion for SplitPath WorldTransform lane alignment

## Root cause
SplitPath carries RequiredLane and collision uses that lane, but the scheduler left its logical X position at the center-lane default because only ShapeGate used entry.lane for positioning.

## Verification
- cmake -B build -S . -Wno-dev && cmake --build build && ./build/shapeshifter_tests

Closes #858