### PR TITLE
Fix resolved obstacle re-tagging

### DIFF
--- a/app/components/obstacle.h
+++ b/app/components/obstacle.h
@@ -6,6 +6,9 @@
 
 struct ObstacleTag {};
 
+// Presence means scoring has consumed the obstacle's final hit/miss result.
+struct ResolvedObstacleTag {};
+
 enum class ObstacleKind : uint8_t {
     ShapeGate,
     LaneBlock,

--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -130,7 +130,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
     // LaneBlock: BlockedLanes only (no RequiredShape)
     {
         auto view = reg.view<ObstacleTag, WorldTransform, BlockedLanes>(
-            entt::exclude<ScoredTag, RequiredShape>);
+            entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredShape>);
         for (auto [e, wt, blocked] : view.each()) {
             resolve(e, wt.position.y, !((blocked.mask >> p_lane.current) & 1));
         }
@@ -141,7 +141,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
         // ShapeGate: RequiredShape only (no BlockedLanes, no RequiredLane)
         {
             auto rhythm_view = reg.view<ObstacleTag, WorldTransform, RequiredShape, BeatInfo>(
-                entt::exclude<ScoredTag, BlockedLanes, RequiredLane>);
+                entt::exclude<ScoredTag, ResolvedObstacleTag, BlockedLanes, RequiredLane>);
             for (auto [e, wt, req, info] : rhythm_view.each()) {
                 bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
                 bool lane_match = shape_gate_lane_match(wt.position.x, player_x, p_lane,
@@ -156,7 +156,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
             }
 
             auto view = reg.view<ObstacleTag, WorldTransform, RequiredShape>(
-                entt::exclude<ScoredTag, BlockedLanes, RequiredLane, BeatInfo>);
+                entt::exclude<ScoredTag, ResolvedObstacleTag, BlockedLanes, RequiredLane, BeatInfo>);
             for (auto [e, wt, req] : view.each()) {
                 bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
                 bool lane_match = shape_gate_lane_match(wt.position.x, player_x, p_lane,
@@ -172,7 +172,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
         // ComboGate: RequiredShape + BlockedLanes (no RequiredLane)
         {
             auto rhythm_view = reg.view<ObstacleTag, WorldTransform, RequiredShape, BlockedLanes, BeatInfo>(
-                entt::exclude<ScoredTag, RequiredLane>);
+                entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredLane>);
             for (auto [e, wt, req, blocked, info] : rhythm_view.each()) {
                 bool lane_ok  = !((blocked.mask >> p_lane.current) & 1);
                 if (!lane_ok) {
@@ -186,7 +186,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
             }
 
             auto view = reg.view<ObstacleTag, WorldTransform, RequiredShape, BlockedLanes>(
-                entt::exclude<ScoredTag, RequiredLane, BeatInfo>);
+                entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredLane, BeatInfo>);
             for (auto [e, wt, req, blocked] : view.each()) {
                 bool lane_ok  = !((blocked.mask >> p_lane.current) & 1);
                 if (!lane_ok) {
@@ -201,7 +201,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
         // SplitPath: RequiredShape + RequiredLane
         {
             auto rhythm_view = reg.view<ObstacleTag, WorldTransform, RequiredShape, RequiredLane, BeatInfo>(
-                entt::exclude<ScoredTag>);
+                entt::exclude<ScoredTag, ResolvedObstacleTag>);
             for (auto [e, wt, req, rlane, info] : rhythm_view.each()) {
                 bool lane_ok  = (p_lane.current == rlane.lane);
                 if (!lane_ok) {
@@ -215,7 +215,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
             }
 
             auto view = reg.view<ObstacleTag, WorldTransform, RequiredShape, RequiredLane>(
-                entt::exclude<ScoredTag, BeatInfo>);
+                entt::exclude<ScoredTag, ResolvedObstacleTag, BeatInfo>);
             for (auto [e, wt, req, rlane] : view.each()) {
                 bool lane_ok  = (p_lane.current == rlane.lane);
                 if (!lane_ok) {
@@ -230,7 +230,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
         // ShapeGate: RequiredShape only (no BlockedLanes, no RequiredLane)
         {
             auto view = reg.view<ObstacleTag, WorldTransform, RequiredShape>(
-                entt::exclude<ScoredTag, BlockedLanes, RequiredLane>);
+                entt::exclude<ScoredTag, ResolvedObstacleTag, BlockedLanes, RequiredLane>);
             for (auto [e, wt, req] : view.each()) {
                 bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
                 bool lane_match = shape_gate_lane_match(wt.position.x, player_x, p_lane,
@@ -246,7 +246,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
         // ComboGate: RequiredShape + BlockedLanes (no RequiredLane)
         {
             auto view = reg.view<ObstacleTag, WorldTransform, RequiredShape, BlockedLanes>(
-                entt::exclude<ScoredTag, RequiredLane>);
+                entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredLane>);
             for (auto [e, wt, req, blocked] : view.each()) {
                 bool lane_ok  = !((blocked.mask >> p_lane.current) & 1);
                 if (!lane_ok) {
@@ -261,7 +261,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
         // SplitPath: RequiredShape + RequiredLane
         {
             auto view = reg.view<ObstacleTag, WorldTransform, RequiredShape, RequiredLane>(
-                entt::exclude<ScoredTag>);
+                entt::exclude<ScoredTag, ResolvedObstacleTag>);
             for (auto [e, wt, req, rlane] : view.each()) {
                 bool lane_ok  = (p_lane.current == rlane.lane);
                 if (!lane_ok) {

--- a/app/systems/miss_detection_system.cpp
+++ b/app/systems/miss_detection_system.cpp
@@ -8,7 +8,8 @@
 // Runs before scoring_system so that the MissTag is processed the same frame.
 // Energy drain and miss_count are handled exclusively by scoring_system's MissTag branch.
 void miss_detection_system(entt::registry& reg, float /*dt*/) {
-    auto view = reg.view<ObstacleTag, WorldTransform>(entt::exclude<ScoredTag, NonScorableTag>);
+    auto view = reg.view<ObstacleTag, WorldTransform>(
+        entt::exclude<ScoredTag, ResolvedObstacleTag, NonScorableTag>);
     for (auto [entity, wt] : view.each()) {
         if (wt.position.y <= constants::DESTROY_Y) continue;
 

--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -147,6 +147,7 @@ void scoring_system(entt::registry& reg, float dt) {
         }
         // Apply structural removals after iteration — safe.
         for (auto& r : miss_buf) {
+            reg.get_or_emplace<ResolvedObstacleTag>(r.e);
             reg.remove<Obstacle>(r.e);
             reg.remove<ScoredTag>(r.e);
             reg.remove<MissTag>(r.e);
@@ -249,6 +250,7 @@ void scoring_system(entt::registry& reg, float dt) {
             spawn_score_particles(reg, r.popup_xy, score_particle_color(r));
 
             // Structural removals after all reads — safe.
+            reg.get_or_emplace<ResolvedObstacleTag>(r.e);
             reg.remove<Obstacle>(r.e);
             reg.remove<ScoredTag>(r.e);
             if (r.has_timing) reg.remove<TimingGrade>(r.e);
@@ -277,6 +279,7 @@ void scoring_system(entt::registry& reg, float dt) {
             cleanup_buf.push_back(r);
         }
         for (auto& r : cleanup_buf) {
+            reg.get_or_emplace<ResolvedObstacleTag>(r.e);
             reg.remove<Obstacle>(r.e);
             reg.remove<ScoredTag>(r.e);
         }

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -124,6 +124,27 @@ TEST_CASE("collision: already scored obstacles are skipped", "[collision]") {
     CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
 }
 
+TEST_CASE("collision: resolved hit obstacle is not re-tagged after scoring cleanup",
+          "[collision][regression][issue860]") {
+    auto reg = make_registry();
+    make_player(reg);
+    auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
+
+    collision_system(reg, 0.016f);
+    REQUIRE(reg.all_of<ScoredTag>(obs));
+
+    scoring_system(reg, 0.0f);
+    REQUIRE(reg.all_of<ResolvedObstacleTag>(obs));
+    REQUIRE_FALSE(reg.all_of<Obstacle>(obs));
+    REQUIRE_FALSE(reg.all_of<ScoredTag>(obs));
+    REQUIRE_FALSE(reg.all_of<MissTag>(obs));
+
+    collision_system(reg, 0.016f);
+
+    CHECK_FALSE(reg.all_of<ScoredTag>(obs));
+    CHECK_FALSE(reg.all_of<MissTag>(obs));
+}
+
 TEST_CASE("collision: combo gate requires shape AND lane", "[collision]") {
     auto reg = make_registry();
     make_player(reg);

--- a/tests/test_miss_detection_regression.cpp
+++ b/tests/test_miss_detection_regression.cpp
@@ -134,6 +134,25 @@ TEST_CASE("miss_detection: pre-scored obstacles are excluded from miss tagging",
     CHECK(reg.all_of<ScoredTag>(unscored));
 }
 
+TEST_CASE("miss_detection: resolved missed obstacle is not re-tagged after scoring cleanup",
+          "[miss_detection][regression][issue860]") {
+    auto reg = make_registry();
+    auto obs = make_expired_obstacle(reg);
+    reg.emplace<ScoredTag>(obs);
+    reg.emplace<MissTag>(obs);
+
+    scoring_system(reg, 0.0f);
+    REQUIRE(reg.all_of<ResolvedObstacleTag>(obs));
+    REQUIRE_FALSE(reg.all_of<Obstacle>(obs));
+    REQUIRE_FALSE(reg.all_of<ScoredTag>(obs));
+    REQUIRE_FALSE(reg.all_of<MissTag>(obs));
+
+    miss_detection_system(reg, 0.016f);
+
+    CHECK_FALSE(reg.all_of<ScoredTag>(obs));
+    CHECK_FALSE(reg.all_of<MissTag>(obs));
+}
+
 // ── Non-Playing phase: system is a no-op ────────────────────────────────────
 
 TEST_CASE("miss_detection: no-op when game phase is not Playing",


### PR DESCRIPTION
## Summary
- mark obstacles as resolved when scoring consumes hit, miss, or non-scorable outcomes
- exclude resolved obstacles from collision and miss-detection tagging passes
- add regression coverage for hit and miss cleanup paths

Fixes #860

## Verification
- cmake -B build -S . -Wno-dev && cmake --build build && ./build/shapeshifter_tests