### PR TITLE
Fix active obstacle queries and HUD timing cues

### DIFF
--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -129,9 +129,10 @@ void collision_system(entt::registry& reg, float /*dt*/) {
 
     // LaneBlock: BlockedLanes only (no RequiredShape)
     {
-        auto view = reg.view<ObstacleTag, WorldTransform, BlockedLanes>(
+        auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, BlockedLanes>(
             entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredShape>);
-        for (auto [e, wt, blocked] : view.each()) {
+        for (auto [e, obstacle, wt, blocked] : view.each()) {
+            (void)obstacle;
             resolve(e, wt.position.y, !((blocked.mask >> p_lane.current) & 1));
         }
     }
@@ -140,9 +141,10 @@ void collision_system(entt::registry& reg, float /*dt*/) {
     if (can_grade_shape) {
         // ShapeGate: RequiredShape only (no BlockedLanes, no RequiredLane)
         {
-            auto rhythm_view = reg.view<ObstacleTag, WorldTransform, RequiredShape, BeatInfo>(
+            auto rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, BeatInfo>(
                 entt::exclude<ScoredTag, ResolvedObstacleTag, BlockedLanes, RequiredLane>);
-            for (auto [e, wt, req, info] : rhythm_view.each()) {
+            for (auto [e, obstacle, wt, req, info] : rhythm_view.each()) {
+                (void)obstacle;
                 bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
                 bool lane_match = shape_gate_lane_match(wt.position.x, player_x, p_lane,
                                                         req.shape, shape_match);
@@ -155,9 +157,10 @@ void collision_system(entt::registry& reg, float /*dt*/) {
                 resolve(e, wt.position.y, cleared);
             }
 
-            auto view = reg.view<ObstacleTag, WorldTransform, RequiredShape>(
+            auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape>(
                 entt::exclude<ScoredTag, ResolvedObstacleTag, BlockedLanes, RequiredLane, BeatInfo>);
-            for (auto [e, wt, req] : view.each()) {
+            for (auto [e, obstacle, wt, req] : view.each()) {
+                (void)obstacle;
                 bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
                 bool lane_match = shape_gate_lane_match(wt.position.x, player_x, p_lane,
                                                         req.shape, shape_match);
@@ -171,9 +174,10 @@ void collision_system(entt::registry& reg, float /*dt*/) {
 
         // ComboGate: RequiredShape + BlockedLanes (no RequiredLane)
         {
-            auto rhythm_view = reg.view<ObstacleTag, WorldTransform, RequiredShape, BlockedLanes, BeatInfo>(
+            auto rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, BlockedLanes, BeatInfo>(
                 entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredLane>);
-            for (auto [e, wt, req, blocked, info] : rhythm_view.each()) {
+            for (auto [e, obstacle, wt, req, blocked, info] : rhythm_view.each()) {
+                (void)obstacle;
                 bool lane_ok  = !((blocked.mask >> p_lane.current) & 1);
                 if (!lane_ok) {
                     resolve(e, wt.position.y, false);
@@ -185,9 +189,10 @@ void collision_system(entt::registry& reg, float /*dt*/) {
                 resolve(e, wt.position.y, cleared);
             }
 
-            auto view = reg.view<ObstacleTag, WorldTransform, RequiredShape, BlockedLanes>(
+            auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, BlockedLanes>(
                 entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredLane, BeatInfo>);
-            for (auto [e, wt, req, blocked] : view.each()) {
+            for (auto [e, obstacle, wt, req, blocked] : view.each()) {
+                (void)obstacle;
                 bool lane_ok  = !((blocked.mask >> p_lane.current) & 1);
                 if (!lane_ok) {
                     resolve(e, wt.position.y, false);
@@ -200,9 +205,10 @@ void collision_system(entt::registry& reg, float /*dt*/) {
 
         // SplitPath: RequiredShape + RequiredLane
         {
-            auto rhythm_view = reg.view<ObstacleTag, WorldTransform, RequiredShape, RequiredLane, BeatInfo>(
+            auto rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, RequiredLane, BeatInfo>(
                 entt::exclude<ScoredTag, ResolvedObstacleTag>);
-            for (auto [e, wt, req, rlane, info] : rhythm_view.each()) {
+            for (auto [e, obstacle, wt, req, rlane, info] : rhythm_view.each()) {
+                (void)obstacle;
                 bool lane_ok  = (p_lane.current == rlane.lane);
                 if (!lane_ok) {
                     resolve(e, wt.position.y, false);
@@ -214,9 +220,10 @@ void collision_system(entt::registry& reg, float /*dt*/) {
                 resolve(e, wt.position.y, cleared);
             }
 
-            auto view = reg.view<ObstacleTag, WorldTransform, RequiredShape, RequiredLane>(
+            auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, RequiredLane>(
                 entt::exclude<ScoredTag, ResolvedObstacleTag, BeatInfo>);
-            for (auto [e, wt, req, rlane] : view.each()) {
+            for (auto [e, obstacle, wt, req, rlane] : view.each()) {
+                (void)obstacle;
                 bool lane_ok  = (p_lane.current == rlane.lane);
                 if (!lane_ok) {
                     resolve(e, wt.position.y, false);
@@ -229,9 +236,10 @@ void collision_system(entt::registry& reg, float /*dt*/) {
     } else {
         // ShapeGate: RequiredShape only (no BlockedLanes, no RequiredLane)
         {
-            auto view = reg.view<ObstacleTag, WorldTransform, RequiredShape>(
+            auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape>(
                 entt::exclude<ScoredTag, ResolvedObstacleTag, BlockedLanes, RequiredLane>);
-            for (auto [e, wt, req] : view.each()) {
+            for (auto [e, obstacle, wt, req] : view.each()) {
+                (void)obstacle;
                 bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
                 bool lane_match = shape_gate_lane_match(wt.position.x, player_x, p_lane,
                                                         req.shape, shape_match);
@@ -245,9 +253,10 @@ void collision_system(entt::registry& reg, float /*dt*/) {
 
         // ComboGate: RequiredShape + BlockedLanes (no RequiredLane)
         {
-            auto view = reg.view<ObstacleTag, WorldTransform, RequiredShape, BlockedLanes>(
+            auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, BlockedLanes>(
                 entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredLane>);
-            for (auto [e, wt, req, blocked] : view.each()) {
+            for (auto [e, obstacle, wt, req, blocked] : view.each()) {
+                (void)obstacle;
                 bool lane_ok  = !((blocked.mask >> p_lane.current) & 1);
                 if (!lane_ok) {
                     resolve(e, wt.position.y, false);
@@ -260,9 +269,10 @@ void collision_system(entt::registry& reg, float /*dt*/) {
 
         // SplitPath: RequiredShape + RequiredLane
         {
-            auto view = reg.view<ObstacleTag, WorldTransform, RequiredShape, RequiredLane>(
+            auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, RequiredLane>(
                 entt::exclude<ScoredTag, ResolvedObstacleTag>);
-            for (auto [e, wt, req, rlane] : view.each()) {
+            for (auto [e, obstacle, wt, req, rlane] : view.each()) {
+                (void)obstacle;
                 bool lane_ok  = (p_lane.current == rlane.lane);
                 if (!lane_ok) {
                     resolve(e, wt.position.y, false);

--- a/app/systems/miss_detection_system.cpp
+++ b/app/systems/miss_detection_system.cpp
@@ -8,9 +8,10 @@
 // Runs before scoring_system so that the MissTag is processed the same frame.
 // Energy drain and miss_count are handled exclusively by scoring_system's MissTag branch.
 void miss_detection_system(entt::registry& reg, float /*dt*/) {
-    auto view = reg.view<ObstacleTag, WorldTransform>(
+    auto view = reg.view<ObstacleTag, Obstacle, WorldTransform>(
         entt::exclude<ScoredTag, ResolvedObstacleTag, NonScorableTag>);
-    for (auto [entity, wt] : view.each()) {
+    for (auto [entity, obstacle, wt] : view.each()) {
+        (void)obstacle;
         if (wt.position.y <= constants::DESTROY_Y) continue;
 
         reg.get_or_emplace<MissTag>(entity);

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -434,8 +434,9 @@ void test_player_system(entt::registry& reg, float dt) {
                                  && pending_shape_obstacle != action.obstacle);
         bool zone_blocked = false;
         {
-            auto zone_view = reg.view<ObstacleTag, WorldTransform>(entt::exclude<ScoredTag>);
-            for (auto [ze, zwt] : zone_view.each()) {
+            auto zone_view = reg.view<ObstacleTag, Obstacle, WorldTransform>(entt::exclude<ScoredTag>);
+            for (auto [ze, obstacle, zwt] : zone_view.each()) {
+                (void)obstacle;
                 if (ze == action.obstacle) continue; // don't self-block
                 float zdist = p_transform.position.y - zwt.position.y + p_vstate.y_offset;
                 if (zdist >= -constants::COLLISION_MARGIN && zdist <= constants::COLLISION_MARGIN * 3.0f) {
@@ -454,8 +455,9 @@ void test_player_system(entt::registry& reg, float dt) {
             if (action.target_lane < next_lane) next_lane--;
             else if (action.target_lane > next_lane) next_lane++;
 
-            auto closer_view = reg.view<ObstacleTag, WorldTransform>(entt::exclude<ScoredTag>);
-            for (auto [oe, owt] : closer_view.each()) {
+            auto closer_view = reg.view<ObstacleTag, Obstacle, WorldTransform>(entt::exclude<ScoredTag>);
+            for (auto [oe, obstacle, owt] : closer_view.each()) {
+                (void)obstacle;
                 if (oe == action.obstacle) continue;
                 float odist = p_transform.position.y - owt.position.y + p_vstate.y_offset;
                 if (odist <= 0.0f) continue;
@@ -514,8 +516,9 @@ void test_player_system(entt::registry& reg, float dt) {
                                       && pending_shape_obstacle != action.obstacle);
         bool vert_zone_blocked = false;
         {
-            auto zone_view = reg.view<ObstacleTag, WorldTransform>(entt::exclude<ScoredTag>);
-            for (auto [ze, zwt] : zone_view.each()) {
+            auto zone_view = reg.view<ObstacleTag, Obstacle, WorldTransform>(entt::exclude<ScoredTag>);
+            for (auto [ze, obstacle, zwt] : zone_view.each()) {
+                (void)obstacle;
                 if (ze == action.obstacle) continue;
                 float zdist = p_transform.position.y - zwt.position.y + p_vstate.y_offset;
                 if (zdist >= -constants::COLLISION_MARGIN && zdist <= constants::COLLISION_MARGIN * 3.0f) {

--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
@@ -165,9 +165,10 @@ void render_shape_buttons(const entt::registry& reg,
     }
 
     std::array<float, 4> nearest_dist = {-1.0f, -1.0f, -1.0f, -1.0f};
-    for (auto [entity, obstacle_pos, required_shape] :
-         reg.view<ObstacleTag, WorldTransform, RequiredShape>(entt::exclude<ScoredTag>).each()) {
+    for (auto [entity, obstacle, obstacle_pos, required_shape] :
+         reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape>(entt::exclude<ScoredTag>).each()) {
         (void)entity;
+        (void)obstacle;
         int shape_index = static_cast<int>(required_shape.shape);
         if (shape_index < 0 || shape_index >= static_cast<int>(nearest_dist.size())) continue;
         float dist = constants::PLAYER_Y - obstacle_pos.position.y;
@@ -178,7 +179,8 @@ void render_shape_buttons(const entt::registry& reg,
 
     auto* song_state = reg.ctx().find<SongState>();
     float perfect_dist = gameplay_hud_perfect_distance(song_state);
-    float ring_appear_dist = constants::APPROACH_DIST;
+    float good_dist = gameplay_hud_good_distance(song_state);
+    float ring_appear_dist = gameplay_hud_ok_distance(song_state);
     float max_ring_radius = btn_radius * layout.approach_ring_max_radius_scale;
 
     // Reduce-motion (#534): suppress the continuous approach-ring lerp/fade
@@ -198,7 +200,10 @@ void render_shape_buttons(const entt::registry& reg,
 
         int shape_index = static_cast<int>(button.shape);
         if (shape_index < 0 || shape_index >= static_cast<int>(nearest_dist.size())) continue;
-        const auto cue = gameplay_hud_ring_cue(nearest_dist[shape_index], perfect_dist, ring_appear_dist);
+        const auto cue = gameplay_hud_ring_cue(nearest_dist[shape_index],
+                                               perfect_dist,
+                                               good_dist,
+                                               ring_appear_dist);
         if (cue == GameplayHudRingCue::Hidden) continue;
         float ratio = gameplay_hud_ring_ratio(nearest_dist[shape_index], perfect_dist, ring_appear_dist);
 
@@ -292,11 +297,27 @@ void render_energy_bar(const entt::registry& reg) {
 
 } // anonymous namespace
 
-float gameplay_hud_perfect_distance(const SongState* song_state) {
+namespace {
+
+float gameplay_hud_timing_distance(const SongState* song_state, float timing_seconds) {
     const float scroll_speed = (song_state && song_state->scroll_speed > 0.0f)
         ? song_state->scroll_speed
         : constants::BASE_SCROLL_SPEED;
-    return scroll_speed * kTimingPerfectSeconds;
+    return scroll_speed * timing_seconds;
+}
+
+} // anonymous namespace
+
+float gameplay_hud_perfect_distance(const SongState* song_state) {
+    return gameplay_hud_timing_distance(song_state, kTimingPerfectSeconds);
+}
+
+float gameplay_hud_good_distance(const SongState* song_state) {
+    return gameplay_hud_timing_distance(song_state, kTimingGoodSeconds);
+}
+
+float gameplay_hud_ok_distance(const SongState* song_state) {
+    return gameplay_hud_timing_distance(song_state, kTimingOkSeconds);
 }
 
 float gameplay_hud_ring_ratio(float nearest_dist, float perfect_dist, float ring_appear_dist) {
@@ -305,12 +326,13 @@ float gameplay_hud_ring_ratio(float nearest_dist, float perfect_dist, float ring
     return Clamp((nearest_dist - perfect_dist) / denom, 0.0f, 1.0f);
 }
 
-GameplayHudRingCue gameplay_hud_ring_cue(float nearest_dist, float perfect_dist, float ring_appear_dist) {
+GameplayHudRingCue gameplay_hud_ring_cue(float nearest_dist,
+                                         float perfect_dist,
+                                         float good_dist,
+                                         float ring_appear_dist) {
     if (nearest_dist <= 0.0f || nearest_dist >= ring_appear_dist) return GameplayHudRingCue::Hidden;
     if (nearest_dist <= perfect_dist) return GameplayHudRingCue::Perfect;
-
-    const float ratio = gameplay_hud_ring_ratio(nearest_dist, perfect_dist, ring_appear_dist);
-    return (ratio < 0.3f) ? GameplayHudRingCue::Near : GameplayHudRingCue::Far;
+    return (nearest_dist <= good_dist) ? GameplayHudRingCue::Near : GameplayHudRingCue::Far;
 }
 
 void init_gameplay_hud_screen_ui() {

--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.h
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.h
@@ -19,8 +19,13 @@ enum class GameplayHudRingCue {
 };
 
 float gameplay_hud_perfect_distance(const SongState* song_state);
+float gameplay_hud_good_distance(const SongState* song_state);
+float gameplay_hud_ok_distance(const SongState* song_state);
 float gameplay_hud_ring_ratio(float nearest_dist, float perfect_dist, float ring_appear_dist);
-GameplayHudRingCue gameplay_hud_ring_cue(float nearest_dist, float perfect_dist, float ring_appear_dist);
+GameplayHudRingCue gameplay_hud_ring_cue(float nearest_dist,
+                                         float perfect_dist,
+                                         float good_dist,
+                                         float ring_appear_dist);
 void init_gameplay_hud_screen_ui();
 void gameplay_hud_process_button_input(entt::registry& reg);
 void render_gameplay_hud_screen_ui(entt::registry& reg);

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -145,6 +145,22 @@ TEST_CASE("collision: resolved hit obstacle is not re-tagged after scoring clean
     CHECK_FALSE(reg.all_of<MissTag>(obs));
 }
 
+TEST_CASE("collision: visual obstacle leftovers without Obstacle payload are ignored",
+          "[collision][regression][issue865]") {
+    auto reg = make_registry();
+    make_player(reg);
+
+    auto visual_leftover = reg.create();
+    reg.emplace<ObstacleTag>(visual_leftover);
+    reg.emplace<WorldTransform>(visual_leftover, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
+    reg.emplace<RequiredShape>(visual_leftover, Shape::Triangle);
+
+    collision_system(reg, 0.016f);
+
+    CHECK_FALSE(reg.all_of<ScoredTag>(visual_leftover));
+    CHECK_FALSE(reg.all_of<MissTag>(visual_leftover));
+}
+
 TEST_CASE("collision: combo gate requires shape AND lane", "[collision]") {
     auto reg = make_registry();
     make_player(reg);

--- a/tests/test_input_pipeline_behavior.cpp
+++ b/tests/test_input_pipeline_behavior.cpp
@@ -316,12 +316,18 @@ TEST_CASE("pipeline: gameplay HUD proximity ring progresses through far near per
     CHECK(perfect_dist > 19.99f);
     CHECK(perfect_dist < 20.01f);
 
-    const float appear_dist = constants::APPROACH_DIST;
-    const float near_dist = perfect_dist + (appear_dist - perfect_dist) * 0.2f;
+    const float good_dist = gameplay_hud_good_distance(&song);
+    CHECK(good_dist > 39.99f);
+    CHECK(good_dist < 40.01f);
 
-    CHECK(gameplay_hud_ring_cue(900.0f, perfect_dist, appear_dist) == GameplayHudRingCue::Far);
-    CHECK(gameplay_hud_ring_cue(near_dist, perfect_dist, appear_dist) == GameplayHudRingCue::Near);
-    CHECK(gameplay_hud_ring_cue(perfect_dist, perfect_dist, appear_dist) == GameplayHudRingCue::Perfect);
+    const float appear_dist = gameplay_hud_ok_distance(&song);
+    CHECK(appear_dist > 59.99f);
+    CHECK(appear_dist < 60.01f);
+
+    CHECK(gameplay_hud_ring_cue(900.0f, perfect_dist, good_dist, appear_dist) == GameplayHudRingCue::Hidden);
+    CHECK(gameplay_hud_ring_cue(50.0f, perfect_dist, good_dist, appear_dist) == GameplayHudRingCue::Far);
+    CHECK(gameplay_hud_ring_cue(good_dist, perfect_dist, good_dist, appear_dist) == GameplayHudRingCue::Near);
+    CHECK(gameplay_hud_ring_cue(perfect_dist, perfect_dist, good_dist, appear_dist) == GameplayHudRingCue::Perfect);
 }
 
 TEST_CASE("pipeline: gameplay HUD raygui shape presses ignored outside Playing",

--- a/tests/test_miss_detection_regression.cpp
+++ b/tests/test_miss_detection_regression.cpp
@@ -153,6 +153,21 @@ TEST_CASE("miss_detection: resolved missed obstacle is not re-tagged after scori
     CHECK_FALSE(reg.all_of<MissTag>(obs));
 }
 
+TEST_CASE("miss_detection: visual obstacle leftovers without Obstacle payload are ignored",
+          "[miss_detection][regression][issue865]") {
+    auto reg = make_registry();
+
+    auto visual_leftover = reg.create();
+    reg.emplace<ObstacleTag>(visual_leftover);
+    reg.emplace<WorldTransform>(visual_leftover,
+                                WorldTransform{{0.0f, constants::DESTROY_Y + 10.0f}});
+
+    miss_detection_system(reg, 0.016f);
+
+    CHECK_FALSE(reg.all_of<ScoredTag>(visual_leftover));
+    CHECK_FALSE(reg.all_of<MissTag>(visual_leftover));
+}
+
 // ── Non-Playing phase: system is a no-op ────────────────────────────────────
 
 TEST_CASE("miss_detection: no-op when game phase is not Playing",

--- a/tests/test_rhythm_system.cpp
+++ b/tests/test_rhythm_system.cpp
@@ -538,6 +538,10 @@ TEST_CASE("collision: HUD perfect cue distance maps to PERFECT timing", "[rhythm
     const float cue_dist = gameplay_hud_perfect_distance(&song);
     const float cue_lead_seconds = cue_dist / song.scroll_speed;
     CHECK_THAT(cue_lead_seconds, WithinAbs(kTimingPerfectSeconds, 0.0001f));
+    CHECK_THAT(gameplay_hud_good_distance(&song) / song.scroll_speed,
+               WithinAbs(kTimingGoodSeconds, 0.0001f));
+    CHECK_THAT(gameplay_hud_ok_distance(&song) / song.scroll_speed,
+               WithinAbs(kTimingOkSeconds, 0.0001f));
 
     ps.current = Shape::Circle;
     sw.phase = WindowPhase::Active;

--- a/tests/test_test_player_system.cpp
+++ b/tests/test_test_player_system.cpp
@@ -148,6 +148,24 @@ TEST_CASE("test_player: pro executes lane before shape for shape+lane actions", 
     CHECK_FALSE(saw_shape_first);
 }
 
+TEST_CASE("test_player: ignores visual obstacle leftovers without Obstacle payload",
+          "[test_player][regression][issue865]") {
+    auto reg = make_test_player_registry(TestPlayerSkill::Pro);
+    make_rhythm_player(reg);
+
+    auto visual_leftover = reg.create();
+    reg.emplace<ObstacleTag>(visual_leftover);
+    reg.emplace<WorldTransform>(visual_leftover,
+                                WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y - 200.0f}});
+    reg.emplace<RequiredShape>(visual_leftover, Shape::Circle);
+
+    test_player_system(reg, 0.016f);
+
+    CHECK_FALSE(reg.all_of<TestPlayerPlannedTag>(visual_leftover));
+    CHECK(drain_press_events(reg).count == 0);
+    CHECK(drain_go_events(reg).count == 0);
+}
+
 // ── KEY FIX: shape gate then lane block in sequence ──────────
 
 TEST_CASE("test_player: shape gate then lane block sequential", "[test_player]") {


### PR DESCRIPTION
## Summary
- Require the Obstacle payload for unresolved gameplay queries while keeping ObstacleTag for visual/despawn ownership
- Ignore resolved visual leftovers in collision, miss detection, HUD approach rings, and test-player avoidance
- Map HUD Perfect/Near/Far cues to Perfect/Good/Ok timing windows

## Verification
- cmake -B build -S . -Wno-dev
- cmake --build build
- ./build/shapeshifter_tests

Closes #865
Closes #864