### PR TITLE
Fix collision-before-window-expiry ordering

### DIFF
--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -110,7 +110,8 @@ void collision_system(entt::registry& reg, float /*dt*/) {
 
         if (!p_window.graded) {
             float scale = window_scale_for_tier(tier);
-            float remaining = song.window_duration - p_window.window_timer;
+            const float active_elapsed = song.song_time - p_window.window_start;
+            float remaining = song.window_duration - active_elapsed;
             if (remaining > 0.0f && scale < 1.0f) {
                 // Adjust window_start backward so the song-time-derived
                 // elapsed time is naturally larger on subsequent ticks,

--- a/app/systems/playing_systems_runner.cpp
+++ b/app/systems/playing_systems_runner.cpp
@@ -7,11 +7,11 @@ void tick_playing_systems(entt::registry& reg, float dt) {
     if (reg.ctx().get<GameState>().phase != GamePhase::Playing) return;
     beat_log_system(reg, dt);
     beat_scheduler_system(reg, dt);
-    shape_window_system(reg, dt);
     player_movement_system(reg, dt);
     scroll_system(reg, dt);
     motion_system(reg, dt);
     collision_system(reg, dt);
+    shape_window_system(reg, dt);
     miss_detection_system(reg, dt);
     scoring_system(reg, dt);
 }

--- a/design-docs/energy-bar.md
+++ b/design-docs/energy-bar.md
@@ -105,9 +105,7 @@ constexpr float ENERGY_CRITICAL_THRESH  = 0.25f;   // below this → bar pulses 
   ┌──────────────────────────────────────────────────────┐
   │                   ENERGY SYSTEM                       │
   │                                                      │
-  │  Runs after scoring_system, reads EnergyState        │
-  │                                                      │
-  │  if energy <= 0  ──► GamePhase::GameOver              │
+  │  Runs after scoring_system, applies queued effects   │
   │                                                      │
   │  Smooth display toward energy (lerp)                 │
   │  Tick flash_timer countdown                          │
@@ -130,38 +128,37 @@ constexpr float ENERGY_CRITICAL_THRESH  = 0.25f;   // below this → bar pulses 
 
 ## Energy Modification Points
 
-Energy is modified in **two places** only:
+Energy deltas are enqueued by gameplay systems and applied by
+`energy_system` through `PendingEnergyEffects`.  Gameplay systems should not
+mutate `EnergyState::energy` directly.
 
 ### 1. collision_system.cpp — on MISS
 
 Current shipped behavior:
 
 ```
-MISS:    enqueue energy delta -ENERGY_DRAIN_MISS
-GameOver: energy_system transitions only when energy reaches 0
-         energy.flash_timer = ENERGY_FLASH_DURATION;
+MISS: enqueue_energy_effect(reg, -ENERGY_DRAIN_MISS, true)
 ```
 
-The miss no longer kills the player directly.  The `energy_system`
-handles the GameOver transition when energy reaches zero.
+The miss no longer kills the player directly.  `game_state_system` owns the
+energy-depleted `GamePhase::GameOver` transition after queued effects have
+been applied by a prior fixed tick.
 
 Miss still increments `results->miss_count` and still emplaces
 `ScoredTag` (obstacle is consumed, not re-triggered).
 
 ### 2. scoring_system.cpp — on scored obstacle with TimingGrade
 
-After computing points, apply energy delta based on timing tier:
+After computing points, enqueue an energy delta based on timing tier:
 
 ```
 switch (timing->tier) {
-    case TimingTier::Perfect: energy.energy += ENERGY_RECOVER_PERFECT; break;
-    case TimingTier::Good:    energy.energy += ENERGY_RECOVER_GOOD;    break;
-    case TimingTier::Ok:      energy.energy += ENERGY_RECOVER_OK;      break;
-    case TimingTier::Bad:     energy.energy -= ENERGY_DRAIN_BAD;
-                              energy.flash_timer = ENERGY_FLASH_DURATION;
+    case TimingTier::Perfect: enqueue_energy_effect(reg, ENERGY_RECOVER_PERFECT); break;
+    case TimingTier::Good:    enqueue_energy_effect(reg, ENERGY_RECOVER_GOOD);    break;
+    case TimingTier::Ok:      enqueue_energy_effect(reg, ENERGY_RECOVER_OK);      break;
+    case TimingTier::Bad:     enqueue_energy_effect(reg, -ENERGY_DRAIN_BAD, true);
                               break;
 }
-energy.energy = clamp(energy.energy, 0.0f, ENERGY_MAX);
 ```
 
 
@@ -170,18 +167,19 @@ energy.energy = clamp(energy.energy, 0.0f, ENERGY_MAX);
 ## System Execution Order
 
 ```
-  game_state_system
+  game_state_system        ← checks energy <= 0 → GameOver
   song_playback_system
   tick_playing_systems
-    → playing systems include collision_system and scoring_system
+    collision_system       ← tags MISS / ScoredTag
+    scoring_system         ← enqueues energy effects
   obstacle_despawn_system
   popup_feedback_system
   popup_display_system
-  energy_system       ← checks depletion → GameOver, smooths display
+  energy_system            ← applies queued effects, smooths display
   particle_system
 ```
 
-`collision_system` tags MISS/HIT outcomes and `scoring_system` applies the
+`collision_system` tags MISS/HIT outcomes and `scoring_system` enqueues
 timing-grade energy drain/recovery inside `tick_playing_systems()`. The
 `energy_system` then runs after popup updates in `tick_fixed_systems()`;
 this placement is a cache-locality choice, not a semantic dependency.

--- a/tests/test_phase_runner.cpp
+++ b/tests/test_phase_runner.cpp
@@ -1,5 +1,8 @@
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include "test_helpers.h"
+
+using Catch::Matchers::WithinAbs;
 
 // ── tick_playing_systems: phase-gate integration ─────────────────────────────
 //
@@ -53,6 +56,32 @@ TEST_CASE("tick_playing_systems: no-op when phase is GameOver", "[phase_guard]")
     CHECK(energy.energy == energy_before);
     CHECK_FALSE(reg.all_of<MissTag>(obs));
     CHECK_FALSE(reg.all_of<ScoredTag>(obs));
+}
+
+TEST_CASE("tick_playing_systems: collision resolves before active window expiry", "[phase_guard][integration][order_regression]") {
+    auto reg = make_rhythm_registry();
+    auto player = make_rhythm_player(reg);
+    auto& ps = reg.get<PlayerShape>(player);
+    auto& sw = reg.get<ShapeWindow>(player);
+    auto& song = reg.ctx().get<SongState>();
+
+    song.song_time = 10.0f + song.window_duration;
+    ps.current = Shape::Circle;
+    sw.target_shape = Shape::Circle;
+    sw.phase = WindowPhase::Active;
+    sw.window_start = 10.0f;
+    sw.window_timer = 0.0f;
+    sw.press_time = song.song_time;
+    sw.graded = false;
+
+    auto obstacle = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
+    reg.emplace<BeatInfo>(obstacle, 0, song.song_time, song.song_time - song.lead_time);
+
+    tick_playing_systems(reg, 0.016f);
+
+    CHECK(reg.ctx().get<SongResults>().perfect_count == 1);
+    CHECK(sw.phase == WindowPhase::MorphOut);
+    CHECK_THAT(sw.window_start, WithinAbs(10.0f + song.window_duration, 0.0001f));
 }
 
 // ── tick_fixed_systems: score-feedback chain wiring guard ────────────────────


### PR DESCRIPTION
## Summary
- Run collision resolution before shape-window advancement so boundary-frame hits use the active shape before expiry
- Compute post-grade remaining window time from song-time elapsed state instead of stale window_timer
- Align energy-bar docs with queued PendingEnergyEffects and game_state_system GameOver ownership

Fixes #871
Closes #872

## Verification
- cmake -B build -S . -Wno-dev && cmake --build build && ./build/shapeshifter_tests
- ./build/shapeshifter_tests "tick_playing_systems: collision resolves before active window expiry"
- ./build/shapeshifter_tests "player_input_rhythm: same shape in Active is no-op"