### PR TITLE
Decouple shape input from lane targeting

### DIFF
--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -6,7 +6,6 @@
 #include "../components/game_state.h"
 #include "../components/rhythm.h"
 #include "../util/rhythm_math.h"
-#include "../util/shape_lane_mapping.h"
 #include "../components/song_state.h"
 #include "../components/gameplay_intents.h"
 #include "../constants.h"
@@ -42,24 +41,17 @@ bool player_matches_required_shape(const PlayerShape& p_shape,
 
 bool shape_gate_lane_match(float obstacle_x,
                            float player_x,
-                           const Lane& lane,
-                           Shape required,
-                           bool shape_match) {
+                           const Lane& lane) {
     if (CheckCollisionRecs(centered_hitbox_rect(player_x),
                            centered_hitbox_rect(obstacle_x))) {
         return true;
     }
 
-    if (!shape_match) {
+    if (lane.target < 0 || lane.target >= constants::LANE_COUNT) {
         return false;
     }
 
-    const int8_t required_lane = lane_for_shape(required);
-    if (required_lane < 0 || lane.target != required_lane) {
-        return false;
-    }
-
-    return CheckCollisionRecs(centered_hitbox_rect(constants::LANE_X[required_lane]),
+    return CheckCollisionRecs(centered_hitbox_rect(constants::LANE_X[lane.target]),
                               centered_hitbox_rect(obstacle_x));
 }
 
@@ -147,8 +139,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
             for (auto [e, obstacle, wt, req, info] : rhythm_view.each()) {
                 (void)obstacle;
                 bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
-                bool lane_match = shape_gate_lane_match(wt.position.x, player_x, p_lane,
-                                                        req.shape, shape_match);
+                bool lane_match = shape_gate_lane_match(wt.position.x, player_x, p_lane);
                 if (!lane_match) {
                     resolve(e, wt.position.y, false);
                     continue;
@@ -163,8 +154,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
             for (auto [e, obstacle, wt, req] : view.each()) {
                 (void)obstacle;
                 bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
-                bool lane_match = shape_gate_lane_match(wt.position.x, player_x, p_lane,
-                                                        req.shape, shape_match);
+                bool lane_match = shape_gate_lane_match(wt.position.x, player_x, p_lane);
                 if (!lane_match) {
                     resolve(e, wt.position.y, false);
                     continue;
@@ -242,8 +232,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
             for (auto [e, obstacle, wt, req] : view.each()) {
                 (void)obstacle;
                 bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
-                bool lane_match = shape_gate_lane_match(wt.position.x, player_x, p_lane,
-                                                        req.shape, shape_match);
+                bool lane_match = shape_gate_lane_match(wt.position.x, player_x, p_lane);
                 if (!lane_match) {
                     resolve(e, wt.position.y, false);
                     continue;

--- a/app/systems/player_input_system.cpp
+++ b/app/systems/player_input_system.cpp
@@ -8,7 +8,6 @@
 #include "../components/rhythm.h"
 #include "../entities/settings.h"
 #include "../constants.h"
-#include "../util/shape_lane_mapping.h"
 
 namespace {
 
@@ -59,7 +58,6 @@ void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt)
     const bool rhythm_mode = (song != nullptr && (song->playing || song->finished));
 
     auto pressed_shape = evt.shape;
-    auto shape_lane = lane_for_shape(pressed_shape);
 
     auto begin_shape_window = [&](PlayerShape& ps, ShapeWindow& sw) {
         Shape previous_shape = ps.current;
@@ -81,15 +79,6 @@ void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt)
 
     auto view = reg.view<PlayerTag, PlayerShape, ShapeWindow, Lane>();
     for (auto [entity, pshape, swindow, lane] : view.each()) {
-        const bool not_in_shape_lane = (lane.current != shape_lane);
-        const bool conflicting_in_flight_target =
-            (lane.current == shape_lane && lane.target >= 0 && lane.target != shape_lane);
-        if (shape_lane >= 0 && lane.target != shape_lane &&
-            (not_in_shape_lane || conflicting_in_flight_target)) {
-            lane.target = shape_lane;
-            lane.lerp_t = 0.0f;
-            push_haptic(reg, HapticEvent::LaneSwitch);
-        }
         if (rhythm_mode) {
             auto phase = swindow.phase;
             if (phase == WindowPhase::Idle) {
@@ -113,5 +102,6 @@ void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt)
                 push_haptic(reg, HapticEvent::ShapeShift);
             }
         }
+        (void)lane;
     }
 }

--- a/app/util/shape_lane_mapping.h
+++ b/app/util/shape_lane_mapping.h
@@ -4,8 +4,8 @@
 
 #include <cstdint>
 
-// Canonical shape→lane pairing authored by shipped beatmaps and HUD buttons.
-// Keep runtime input auto-targeting aligned with this helper.
+// Historical content motif used by shipped beatmap audits. Runtime input must
+// not use this helper to move lanes; lane changes come from explicit movement.
 inline constexpr int8_t lane_for_shape(Shape shape) noexcept {
     switch (shape) {
         case Shape::Circle:   return 0;

--- a/design-docs/game.md
+++ b/design-docs/game.md
@@ -60,27 +60,17 @@ The screen is divided into two zones:
 
   The currently active playable shape button is highlighted/glowing. There is no Hexagon button: Hexagon is a visible rest silhouette only, restored automatically by the shape-window system.
 
-- **Keyboard fallback** mirrors lane layout for shipped beatmaps: `Z`/`1` selects the left-lane shape, `X`/`2` selects center, and `C`/`3` selects right.
+- **Keyboard fallback** mirrors the HUD button order: `Z`/`1` selects Circle, `X`/`2` selects Square, and `C`/`3` selects Triangle. Shape keys never change lanes; use explicit left/right movement input for lane changes.
 
 ### Lanes
 
 3 lanes: left, center, right. Player starts in center.
 
-> ⚠️ **Current shipped behavior — see issue #441.** Across all 3 shipped
-> beatmaps / 9 difficulty arrays (**924 obstacles total** as of the current
-> content audit; see
-> the per-difficulty table in `rhythm-design.md` §8), shape and lane
-> are fused 1:1 by
-> `tools/level_designer.py:ONSET_CLASS_TO_OBSTACLE` — every circle is
-> on lane 0, every square on lane 1, every triangle on lane 2. As a
-> result, **strafing input is currently redundant**: choosing the
-> correct shape implies the correct lane, and a player who never strafes
-> still passes 100% of shape gates. The Controls section above and the
-> Split Path entry in the Obstacle Types table reflect the intended
-> design space, not shipped content. The shape↔lane decoupling vs.
-> intentional-collapse design call is tracked in #441 and must be
-> resolved before lane-as-a-skill claims are reinstated; until then,
-> treat lane variety as a known limitation of shipped beatmaps.
+Shipped beatmaps still use a simple readability motif where Circle gates appear
+in the left lane, Square gates in center, and Triangle gates on the right. This
+is content authoring only: shape input and lane movement are independent runtime
+skills, so the player must explicitly strafe to the gate lane and press the
+matching shape.
 
 ---
 

--- a/tests/test_collision_extended.cpp
+++ b/tests/test_collision_extended.cpp
@@ -114,8 +114,8 @@ TEST_CASE("collision: rhythm mode assigns Perfect for on-time hit", "[collision]
     CHECK(reg.get<TimingGrade>(obs).tier == TimingTier::Perfect);
 }
 
-TEST_CASE("collision: on-beat shape press uses target lane before interpolation",
-          "[collision][rhythm][issue850]") {
+TEST_CASE("collision: on-beat shape press uses explicit target lane before interpolation",
+          "[collision][rhythm][issue850][issue874]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& song = reg.ctx().get<SongState>();
@@ -125,13 +125,16 @@ TEST_CASE("collision: on-beat shape press uses target lane before interpolation"
     reg.get<WorldTransform>(obs).position.x = constants::LANE_X[0];
     reg.emplace<BeatInfo>(obs, 0, song.song_time, song.song_time - song.lead_time);
 
+    auto& lane = reg.get<Lane>(player);
+    lane.target = 0;
+    lane.lerp_t = 0.0f;
+
     auto btn = make_shape_button(reg, Shape::Circle);
     press_button(reg, btn);
     reg.ctx().get<entt::dispatcher>().update<ButtonPressEvent>();
     song.song_time += song.morph_duration + 0.001f;
     shape_window_system(reg, song.morph_duration + 0.001f);
 
-    const auto& lane = reg.get<Lane>(player);
     const auto& transform = reg.get<WorldTransform>(player);
     REQUIRE(lane.current == 1);
     REQUIRE(lane.target == 0);

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -52,6 +52,37 @@ TEST_CASE("collision: shape gate hitbox edge handling", "[collision][edge]") {
     }
 }
 
+TEST_CASE("collision: shape gate target-lane grace follows explicit lane target",
+          "[collision][issue874]") {
+    auto reg = make_registry();
+    auto player = make_player(reg);
+    auto& lane = reg.get<Lane>(player);
+    auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
+
+    reg.get<WorldTransform>(obs).position.x = constants::LANE_X[0];
+    lane.target = 0;
+    lane.lerp_t = 0.0f;
+
+    collision_system(reg, 0.016f);
+
+    CHECK(reg.all_of<ScoredTag>(obs));
+    CHECK_FALSE(reg.all_of<MissTag>(obs));
+}
+
+TEST_CASE("collision: shape gate ignores shape-derived lane without explicit target",
+          "[collision][issue874]") {
+    auto reg = make_registry();
+    make_player(reg);
+    auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
+
+    reg.get<WorldTransform>(obs).position.x = constants::LANE_X[0];
+
+    collision_system(reg, 0.016f);
+
+    CHECK(reg.all_of<ScoredTag>(obs));
+    CHECK(reg.all_of<MissTag>(obs));
+}
+
 TEST_CASE("collision: lane block cleared when player in unblocked lane", "[collision]") {
     auto reg = make_registry();
     make_player(reg);

--- a/tests/test_input_pipeline_behavior.cpp
+++ b/tests/test_input_pipeline_behavior.cpp
@@ -24,18 +24,17 @@
 #include "input/keyboard_shape_mapping.h"
 #include "test_helpers.h"
 #include "ui/screen_controllers/gameplay_hud_screen_controller.h"
-#include "util/shape_lane_mapping.h"
 
 // Runs the fixed-tick input path.
 static void run_pipeline(entt::registry& reg, float dt = 0.016f) {
     game_state_system(reg, dt);
 }
 
-TEST_CASE("pipeline: keyboard shape shortcuts follow left-center-right lanes",
+TEST_CASE("pipeline: keyboard shape shortcuts follow left-center-right shapes",
           "[input_pipeline][keyboard][issue662]") {
-    CHECK(lane_for_shape(shape_for_keyboard_slot(KeyboardShapeSlot::Left)) == 0);
-    CHECK(lane_for_shape(shape_for_keyboard_slot(KeyboardShapeSlot::Center)) == 1);
-    CHECK(lane_for_shape(shape_for_keyboard_slot(KeyboardShapeSlot::Right)) == 2);
+    CHECK(shape_for_keyboard_slot(KeyboardShapeSlot::Left) == Shape::Circle);
+    CHECK(shape_for_keyboard_slot(KeyboardShapeSlot::Center) == Shape::Square);
+    CHECK(shape_for_keyboard_slot(KeyboardShapeSlot::Right) == Shape::Triangle);
 }
 
 // ── Swipe → lane change ───────────────────────────────────────────────────
@@ -145,25 +144,26 @@ TEST_CASE("pipeline: semantic shape press triggers shape change in same pipeline
     CHECK(sw.target_shape == Shape::Square);
 }
 
-TEST_CASE("pipeline: semantic shape press remaps lane target to shape lane",
-          "[input_pipeline]") {
+TEST_CASE("pipeline: semantic shape press does not change lane target",
+          "[input_pipeline][issue874]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& lane = reg.get<Lane>(player);
     REQUIRE(lane.current == 1);
+    lane.target = lane.current;
 
     reg.ctx().get<entt::dispatcher>().enqueue<ButtonPressEvent>(
         {ButtonPressKind::Shape, Shape::Circle, MenuActionKind::Confirm, 0});
     run_pipeline(reg);
 
-    CHECK(lane.target == 0);
+    CHECK(lane.target == 1);
 }
 
-TEST_CASE("pipeline: desktop keyboard slot mapping keeps Z left and C right lanes",
+TEST_CASE("pipeline: desktop keyboard slot mapping keeps Z/X/C shape order",
           "[input_pipeline]") {
-    CHECK(lane_for_shape(kKeyboardShapeLeft) == 0);
-    CHECK(lane_for_shape(kKeyboardShapeCenter) == 1);
-    CHECK(lane_for_shape(kKeyboardShapeRight) == 2);
+    CHECK(kKeyboardShapeLeft == Shape::Circle);
+    CHECK(kKeyboardShapeCenter == Shape::Square);
+    CHECK(kKeyboardShapeRight == Shape::Triangle);
 }
 
 TEST_CASE("pipeline: gameplay HUD raygui shape press triggers player shape input",
@@ -171,7 +171,10 @@ TEST_CASE("pipeline: gameplay HUD raygui shape press triggers player shape input
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& sw = reg.get<ShapeWindow>(player);
+    auto& lane = reg.get<Lane>(player);
     REQUIRE(sw.phase == WindowPhase::Idle);
+    REQUIRE(lane.current == 1);
+    lane.target = lane.current;
     gameplay_hud_apply_button_presses(reg,
                                       false,
                                       false,
@@ -181,6 +184,7 @@ TEST_CASE("pipeline: gameplay HUD raygui shape press triggers player shape input
 
     CHECK(sw.phase == WindowPhase::MorphIn);
     CHECK(sw.target_shape == Shape::Square);
+    CHECK(lane.target == 1);
 }
 
 TEST_CASE("pipeline: gameplay HUD pointer release is collected before the fixed tick",
@@ -363,7 +367,7 @@ TEST_CASE("pipeline: mixed swipe and tap both take effect within a single pipeli
 
     run_pipeline(reg);
 
-    CHECK(lane.target     == 2);                  // shape auto-target wins
+    CHECK(lane.target     == 2);                  // explicit swipe moves lanes
     CHECK(sw.phase        == WindowPhase::MorphIn); // tap processed
     CHECK(sw.target_shape == Shape::Triangle);
 }

--- a/tests/test_player_input_rhythm_extended.cpp
+++ b/tests/test_player_input_rhythm_extended.cpp
@@ -91,20 +91,21 @@ TEST_CASE("player_input_rhythm: shape change pushes ShapeShift SFX", "[player][r
     CHECK(sfx_cap.buf[0] == SFX::ShapeShift);
 }
 
-TEST_CASE("player_input_rhythm: shape press auto-target follows shipped mapping", "[player][rhythm][issue531]") {
+TEST_CASE("player_input_rhythm: shape press does not target authored motif lane", "[player][rhythm][issue874]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& lane = reg.get<Lane>(player);
     REQUIRE(lane.current == 1);
+    lane.target = lane.current;
 
     auto btn = make_shape_button(reg, Shape::Triangle);
     press_button(reg, btn);
     run_semantic_input_tick(reg);
 
-    CHECK(lane.target == 2);
+    CHECK(lane.target == 1);
 }
 
-TEST_CASE("player_input_rhythm: shape press does not set stale target when already in shipped lane",
+TEST_CASE("player_input_rhythm: shape press does not set stale target when already in authored motif lane",
           "[player][rhythm][issue531]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
@@ -119,8 +120,8 @@ TEST_CASE("player_input_rhythm: shape press does not set stale target when alrea
     CHECK(lane.target == -1);
 }
 
-TEST_CASE("player_input_rhythm: shape press cancels conflicting in-flight lane target",
-          "[player][rhythm]") {
+TEST_CASE("player_input_rhythm: shape press preserves in-flight lane target",
+          "[player][rhythm][issue874]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& lane = reg.get<Lane>(player);
@@ -132,8 +133,8 @@ TEST_CASE("player_input_rhythm: shape press cancels conflicting in-flight lane t
     press_button(reg, btn);
     run_semantic_input_tick(reg);
 
-    CHECK(lane.target == 1);
-    CHECK(lane.lerp_t == 0.0f);
+    CHECK(lane.target == 2);
+    CHECK(lane.lerp_t == 0.5f);
 }
 
 TEST_CASE("player_input_rhythm: lane change works in rhythm mode", "[player][rhythm]") {


### PR DESCRIPTION
## Summary
- Remove shape-button auto lane targeting from player input.
- Make shape-gate target-lane collision grace depend on the explicit lane target, not the required shape.
- Update regression tests and design docs to describe shape/lane independence while preserving shipped beatmap motif coverage.

## Root cause
Shape button handling used lane_for_shape() to mutate Lane::target, and shape-gate collision used the same shape-derived lane fallback. That made shape selection implicitly perform lane targeting.

## Verification
- cmake -B build -S . -Wno-dev
- cmake --build build
- ./build/shapeshifter_tests

Fixes #874