### PR TITLE
Limit beatmaps to active obstacle kinds

### DIFF
--- a/app/entities/beat_map.cpp
+++ b/app/entities/beat_map.cpp
@@ -11,7 +11,6 @@
 
 using json = nlohmann::json;
 namespace {
-constexpr uint8_t kLaneBitsMask = 0x07;
 constexpr const char* kValidationConstantsPath = "content/constants.json";
 
 std::string constants_path_for_app_dir(const std::string& app_dir) {
@@ -25,29 +24,16 @@ std::string constants_path_for_app_dir(const std::string& app_dir) {
     return app_dir + "/" + kValidationConstantsPath;
 }
 
-bool has_only_lane_bits(const uint8_t mask) {
-    return (mask & static_cast<uint8_t>(~kLaneBitsMask)) == 0;
-}
-
-int lane_bit_count(const uint8_t mask) {
-    int count = 0;
-    for (int lane = 0; lane < 3; ++lane) {
-        if (((mask >> lane) & 1U) != 0U) {
-            ++count;
-        }
-    }
-    return count;
-}
-
 bool kind_requires_shape(const ObstacleKind kind) {
-    return kind == ObstacleKind::ShapeGate ||
-           kind == ObstacleKind::ComboGate ||
-           kind == ObstacleKind::SplitPath;
+    return kind == ObstacleKind::ShapeGate;
 }
 
 bool kind_requires_lane(const ObstacleKind kind) {
-    return kind == ObstacleKind::ShapeGate ||
-           kind == ObstacleKind::SplitPath;
+    return kind == ObstacleKind::ShapeGate;
+}
+
+bool is_supported_beatmap_kind(const ObstacleKind kind) {
+    return kind == ObstacleKind::ShapeGate || kind == ObstacleKind::OnsetMarker;
 }
 
 std::string type_error_message(const char* field, const char* expected, const json& value) {
@@ -252,9 +238,6 @@ ValidationConstants load_validation_constants(const std::string& app_dir) {
 
 static std::optional<ObstacleKind> parse_kind(const std::string& s) {
     if (s == "shape_gate")       return ObstacleKind::ShapeGate;
-    if (s == "lane_block")       return ObstacleKind::LaneBlock;
-    if (s == "combo_gate")       return ObstacleKind::ComboGate;
-    if (s == "split_path")       return ObstacleKind::SplitPath;
     if (s == "onset_marker")     return ObstacleKind::OnsetMarker;
     return std::nullopt;
 }
@@ -483,32 +466,11 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
         }
 
         if (b.contains("blocked")) {
-            if (!b["blocked"].is_array()) {
-                errors.push_back({entry.beat_index,
-                    "'blocked' must be an array at beat " + std::to_string(entry.beat_index)});
-                parse_ok = false;
-                continue;
-            }
-            entry.blocked_mask = 0;
-            bool blocked_ok = true;
-            for (const auto& lane_idx : b["blocked"]) {
-                int lane = 0;
-                if (!read_int_value(lane_idx, "blocked[]", lane, errors, entry.beat_index)) {
-                    parse_ok = false;
-                    blocked_ok = false;
-                    break;
-                }
-                if (lane < 0 || lane > 2) {
-                    errors.push_back({entry.beat_index,
-                        "'blocked' lane index must be in range [0, 2] at beat "
-                        + std::to_string(entry.beat_index)});
-                    parse_ok = false;
-                    blocked_ok = false;
-                    break;
-                }
-                entry.blocked_mask |= static_cast<uint8_t>(1 << lane);
-            }
-            if (!blocked_ok) continue;
+            errors.push_back({entry.beat_index,
+                "'blocked' is not supported by active beatmap obstacle kinds at beat "
+                + std::to_string(entry.beat_index)});
+            parse_ok = false;
+            continue;
         }
 
         out.beats.push_back(entry);
@@ -709,33 +671,15 @@ bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors,
             valid = false;
         }
 
-        // Rule 5: shape_gate / split_path must have lane 0-2
-        if ((entry.kind == ObstacleKind::ShapeGate || entry.kind == ObstacleKind::SplitPath) &&
-            (entry.lane < 0 || entry.lane > 2)) {
+        if (!is_supported_beatmap_kind(entry.kind)) {
+            errors.push_back({entry.beat_index, "Unsupported active beatmap obstacle kind"});
+            valid = false;
+        }
+
+        // Rule 5: shape_gate must have lane 0-2
+        if (entry.kind == ObstacleKind::ShapeGate && (entry.lane < 0 || entry.lane > 2)) {
             errors.push_back({entry.beat_index, "Lane must be 0-2"});
             valid = false;
-        }
-
-        if ((entry.kind == ObstacleKind::LaneBlock || entry.kind == ObstacleKind::ComboGate) &&
-            !has_only_lane_bits(entry.blocked_mask)) {
-            errors.push_back({entry.beat_index, "blocked_mask must only use lane bits 0..2"});
-            valid = false;
-        }
-
-        if (entry.kind == ObstacleKind::LaneBlock && lane_bit_count(entry.blocked_mask) != 1) {
-            errors.push_back({entry.beat_index, "LaneBlock blocked_mask must contain exactly one lane bit"});
-            valid = false;
-        }
-
-        // Rule 5b: combo_gate blocked_mask must block at least one lane and leave at least one open
-        if (entry.kind == ObstacleKind::ComboGate) {
-            if (entry.blocked_mask == 0) {
-                errors.push_back({entry.beat_index, "ComboGate must block at least one lane"});
-                valid = false;
-            } else if (entry.blocked_mask == 0x07) {
-                errors.push_back({entry.beat_index, "ComboGate must leave at least one lane open"});
-                valid = false;
-            }
         }
 
         if (entry.has_time_sec) {

--- a/app/systems/beat_scheduler_system.cpp
+++ b/app/systems/beat_scheduler_system.cpp
@@ -28,6 +28,12 @@ void beat_scheduler_system(entt::registry& reg, float /*dt*/) {
             song->next_spawn_idx++;
             continue;
         }
+        if (entry.kind != ObstacleKind::ShapeGate) {
+            TraceLog(LOG_WARNING, "Skipping unsupported active beatmap obstacle kind %d",
+                     static_cast<int>(entry.kind));
+            song->next_spawn_idx++;
+            continue;
+        }
 
         float beat_time = song->offset + entry.beat_index * song->beat_period;
         if (!entry.has_time_sec &&
@@ -66,22 +72,13 @@ void beat_scheduler_system(entt::registry& reg, float /*dt*/) {
                 - (max_start_y - constants::SPAWN_Y) / song->scroll_speed;
         }
 
-        // Compute x: LaneBlock derives it from blocked_mask; lane-based kinds
-        // use entry.lane directly; bar/gate types default to center lane.
+        // Shape gates use the authored lane directly.
         float x_pos = constants::LANE_X[1];
-        if (entry.kind == ObstacleKind::ShapeGate || entry.kind == ObstacleKind::SplitPath) {
-            const int lane = static_cast<int>(entry.lane);
-            if (lane >= 0 && lane < constants::LANE_COUNT) {
-                x_pos = constants::LANE_X[lane];
-            } else {
-                TraceLog(LOG_WARNING, "Invalid lane-based obstacle lane %d; defaulting to center lane", lane);
-            }
-        } else if (entry.kind == ObstacleKind::LaneBlock) {
-            int display_lane = 1;
-            for (int l = 0; l < 3; ++l) {
-                if ((entry.blocked_mask >> l) & 1) { display_lane = l; break; }
-            }
-            x_pos = constants::LANE_X[display_lane];
+        const int lane = static_cast<int>(entry.lane);
+        if (lane >= 0 && lane < constants::LANE_COUNT) {
+            x_pos = constants::LANE_X[lane];
+        } else {
+            TraceLog(LOG_WARNING, "Invalid shape_gate lane %d; defaulting to center lane", lane);
         }
 
         const BeatInfo bi{entry.beat_index, calibrated_arrival_time, effective_spawn_time};

--- a/tests/test_beat_map_parser_unknown_fields.cpp
+++ b/tests/test_beat_map_parser_unknown_fields.cpp
@@ -92,21 +92,22 @@ TEST_CASE("parse: unknown shape does not silently become Circle", "[parse][shape
 
 // ── Valid beatmaps remain error-free ──────────────────────────
 
-TEST_CASE("parse: all valid kinds parse without errors", "[parse][kind]") {
+TEST_CASE("parse: all active kinds parse without errors", "[parse][kind][issue873]") {
     const std::vector<std::string> valid_kinds = {
-        "shape_gate", "lane_block",
-        "combo_gate", "split_path"
+        "shape_gate", "onset_marker"
     };
 
     for (const auto& kind : valid_kinds) {
         BeatMap map;
         std::vector<BeatMapError> errors;
-        const bool requires_shape = kind == "shape_gate" || kind == "combo_gate" || kind == "split_path";
+        const bool requires_shape = kind == "shape_gate";
+        const bool requires_lane = kind == "shape_gate";
         const std::string shape = requires_shape ? R"(, "shape": "circle")" : "";
+        const std::string lane = requires_lane ? R"(, "lane": 1)" : "";
         std::string json = R"({
             "bpm": 120, "offset": 0.0, "lead_beats": 4, "duration_sec": 60.0,
             "beats": [
-                { "beat": 4, "kind": ")" + kind + R"(", "lane": 1)" + shape + R"( }
+                { "beat": 4, "kind": ")" + kind + R"(")" + shape + lane + R"( }
             ]
         })";
         INFO("Testing kind: " << kind);
@@ -258,7 +259,7 @@ TEST_CASE("parse: missing shape gate lane is rejected", "[parse][lane][required]
     CHECK(map.beats.empty());
 }
 
-TEST_CASE("parse: missing split path lane is rejected", "[parse][lane][required][issue757]") {
+TEST_CASE("parse: unshipped obstacle kinds are rejected", "[parse][kind][issue873]") {
     BeatMap map;
     std::vector<BeatMapError> errors;
     std::string json = R"({
@@ -271,7 +272,7 @@ TEST_CASE("parse: missing split path lane is rejected", "[parse][lane][required]
     CHECK_FALSE(parse_beat_map(json, map, errors));
     REQUIRE_FALSE(errors.empty());
     CHECK(errors[0].beat_index == 8);
-    CHECK(errors[0].message.find("lane") != std::string::npos);
+    CHECK(errors[0].message.find("Unknown obstacle kind") != std::string::npos);
     CHECK(map.beats.empty());
 }
 

--- a/tests/test_beat_map_validation.cpp
+++ b/tests/test_beat_map_validation.cpp
@@ -278,18 +278,6 @@ TEST_CASE("validate: shape_gate invalid lane fails", "[validate]") {
     CHECK_FALSE(validate_beat_map(map, errors));
 }
 
-TEST_CASE("validate: split_path invalid lane fails", "[validate]") {
-    BeatMap map;
-    map.bpm = 120.0f;
-    map.offset = 0.0f;
-    map.lead_beats = 4;
-    map.duration = 60.0f;
-    map.beats.push_back({0, ObstacleKind::SplitPath, Shape::Circle, -1, 0});
-
-    std::vector<BeatMapError> errors;
-    CHECK_FALSE(validate_beat_map(map, errors));
-}
-
 // ── validate_beat_map: multiple errors ───────────────────────
 
 TEST_CASE("validate: multiple errors accumulated", "[validate]") {
@@ -305,101 +293,30 @@ TEST_CASE("validate: multiple errors accumulated", "[validate]") {
     CHECK(errors.size() >= 3);
 }
 
-// ── validate_beat_map: ComboGate blocked_mask rules ──────────
+// ── validate_beat_map: active obstacle kind rules ─────────────
 
-TEST_CASE("validate: combo_gate blocked_mask 0 fails", "[validate][combo_gate]") {
-    BeatMap map;
-    map.bpm = 120.0f;
-    map.offset = 0.0f;
-    map.lead_beats = 4;
-    map.duration = 60.0f;
-    map.beats.push_back({4, ObstacleKind::ComboGate, Shape::Circle, 1, 0x00});
+TEST_CASE("validate: unshipped obstacle kinds are rejected from active beatmaps",
+          "[validate][kind][issue873]") {
+    constexpr ObstacleKind kinds[] = {
+        ObstacleKind::LaneBlock,
+        ObstacleKind::ComboGate,
+        ObstacleKind::SplitPath,
+    };
 
-    std::vector<BeatMapError> errors;
-    CHECK_FALSE(validate_beat_map(map, errors));
-    REQUIRE_FALSE(errors.empty());
-    CHECK(errors[0].message.find("block at least one lane") != std::string::npos);
-}
+    for (const auto kind : kinds) {
+        BeatMap map;
+        map.bpm = 120.0f;
+        map.offset = 0.0f;
+        map.lead_beats = 4;
+        map.duration = 60.0f;
+        map.beats.push_back({4, kind, Shape::Circle, 1, 0x01});
 
-TEST_CASE("validate: combo_gate blocked_mask 0x07 fails", "[validate][combo_gate]") {
-    BeatMap map;
-    map.bpm = 120.0f;
-    map.offset = 0.0f;
-    map.lead_beats = 4;
-    map.duration = 60.0f;
-    map.beats.push_back({4, ObstacleKind::ComboGate, Shape::Circle, 1, 0x07});
-
-    std::vector<BeatMapError> errors;
-    CHECK_FALSE(validate_beat_map(map, errors));
-    REQUIRE_FALSE(errors.empty());
-    CHECK(errors[0].message.find("leave at least one lane open") != std::string::npos);
-}
-
-TEST_CASE("validate: combo_gate blocked_mask 0x01 passes", "[validate][combo_gate]") {
-    BeatMap map;
-    map.bpm = 120.0f;
-    map.offset = 0.0f;
-    map.lead_beats = 4;
-    map.duration = 60.0f;
-    map.beats.push_back({4, ObstacleKind::ComboGate, Shape::Circle, 1, 0x01});
-
-    std::vector<BeatMapError> errors;
-    CHECK(validate_beat_map(map, errors));
-    CHECK(errors.empty());
-}
-
-TEST_CASE("validate: combo_gate blocked_mask 0x06 passes", "[validate][combo_gate]") {
-    BeatMap map;
-    map.bpm = 120.0f;
-    map.offset = 0.0f;
-    map.lead_beats = 4;
-    map.duration = 60.0f;
-    map.beats.push_back({4, ObstacleKind::ComboGate, Shape::Circle, 1, 0x06});
-
-    std::vector<BeatMapError> errors;
-    CHECK(validate_beat_map(map, errors));
-    CHECK(errors.empty());
-}
-
-TEST_CASE("validate: combo_gate blocked_mask 0x05 passes", "[validate][combo_gate]") {
-    BeatMap map;
-    map.bpm = 120.0f;
-    map.offset = 0.0f;
-    map.lead_beats = 4;
-    map.duration = 60.0f;
-    map.beats.push_back({4, ObstacleKind::ComboGate, Shape::Circle, 1, 0x05});
-
-    std::vector<BeatMapError> errors;
-    CHECK(validate_beat_map(map, errors));
-    CHECK(errors.empty());
-}
-
-TEST_CASE("validate: lane_block blocked_mask must use exactly one lane bit", "[validate][lane_block]") {
-    BeatMap map;
-    map.bpm = 120.0f;
-    map.offset = 0.0f;
-    map.lead_beats = 4;
-    map.duration = 60.0f;
-    map.beats.push_back({4, ObstacleKind::LaneBlock, Shape::Circle, 1, 0x03});
-
-    std::vector<BeatMapError> errors;
-    CHECK_FALSE(validate_beat_map(map, errors));
-    REQUIRE_FALSE(errors.empty());
-    CHECK(errors[0].message.find("exactly one lane bit") != std::string::npos);
-}
-
-TEST_CASE("validate: blocked_mask lane bits outside 0..2 fail", "[validate][blocked_mask]") {
-    BeatMap map;
-    map.bpm = 120.0f;
-    map.offset = 0.0f;
-    map.lead_beats = 4;
-    map.duration = 60.0f;
-    map.beats.push_back({4, ObstacleKind::ComboGate, Shape::Circle, 1, 0x09});
-
-    std::vector<BeatMapError> errors;
-    CHECK_FALSE(validate_beat_map(map, errors));
-    REQUIRE_FALSE(errors.empty());
-    CHECK(errors[0].message.find("bits 0..2") != std::string::npos);
+        std::vector<BeatMapError> errors;
+        INFO("kind=" << static_cast<int>(kind));
+        CHECK_FALSE(validate_beat_map(map, errors));
+        REQUIRE_FALSE(errors.empty());
+        CHECK(errors[0].message.find("Unsupported active beatmap obstacle kind") != std::string::npos);
+    }
 }
 
 // ── init_song_state ──────────────────────────────────────────
@@ -817,47 +734,23 @@ TEST_CASE("parse: non-numeric time_sec fails", "[parse][beat_times][time_sec]") 
     CHECK(errors[0].message.find("'time_sec'") != std::string::npos);
 }
 
-TEST_CASE("parse: shape-bearing obstacles require explicit shape", "[parse][shape][issue224]") {
-    const char* shape_bearing_kinds[] = {"shape_gate", "combo_gate", "split_path"};
-
-    for (const char* kind : shape_bearing_kinds) {
-        BeatMap map;
-        std::vector<BeatMapError> errors;
-        const std::string blocked = std::string(kind) == "combo_gate" ? R"(, "blocked": [1])" : "";
-        const std::string json = std::string(R"({
-            "song_id": "missing_shape_test",
-            "bpm": 120,
-            "offset": 0.0,
-            "lead_beats": 4,
-            "duration_sec": 60.0,
-            "beats": [
-                { "beat": 2, "kind": ")") + kind + R"(")" + blocked + R"( }
-            ]
-        })";
-
-        CHECK_FALSE(parse_beat_map(json, map, errors));
-        REQUIRE_FALSE(errors.empty());
-        CHECK(errors[0].message.find("Missing required shape") != std::string::npos);
-    }
-}
-
-TEST_CASE("parse: lane_block does not require shape", "[parse][shape][issue224]") {
+TEST_CASE("parse: shape_gate requires explicit shape", "[parse][shape][issue224]") {
     BeatMap map;
     std::vector<BeatMapError> errors;
     std::string json = R"({
-        "song_id": "lane_block_test",
+        "song_id": "missing_shape_test",
         "bpm": 120,
         "offset": 0.0,
         "lead_beats": 4,
         "duration_sec": 60.0,
         "beats": [
-            { "beat": 2, "kind": "lane_block", "blocked": [1] }
+            { "beat": 2, "kind": "shape_gate" }
         ]
     })";
 
-    CHECK(parse_beat_map(json, map, errors));
-    REQUIRE(map.beats.size() == 1);
-    CHECK(map.beats[0].kind == ObstacleKind::LaneBlock);
+    CHECK_FALSE(parse_beat_map(json, map, errors));
+    REQUIRE_FALSE(errors.empty());
+    CHECK(errors[0].message.find("Missing required shape") != std::string::npos);
 }
 
 TEST_CASE("parse: same beat_index entries are ordered by resolved time_sec", "[parse][beat_times][ordering]") {
@@ -905,7 +798,7 @@ TEST_CASE("parse: same beat_index entries keep authored order for identical timi
     CHECK(map.beats[1].shape == Shape::Triangle);
 }
 
-TEST_CASE("parse: invalid blocked lane index fails", "[parse][blocked_mask]") {
+TEST_CASE("parse: blocked lane arrays are rejected from active beatmaps", "[parse][blocked_mask][issue873]") {
     BeatMap map;
     std::vector<BeatMapError> errors;
     std::string json = R"({
@@ -915,58 +808,13 @@ TEST_CASE("parse: invalid blocked lane index fails", "[parse][blocked_mask]") {
         "lead_beats": 4,
         "duration_sec": 60.0,
         "beats": [
-            { "beat": 2, "kind": "lane_block", "blocked": [0, 3] }
+            { "beat": 2, "kind": "shape_gate", "shape": "circle", "lane": 1, "blocked": [0] }
         ]
     })";
 
     CHECK_FALSE(parse_beat_map(json, map, errors));
     REQUIRE_FALSE(errors.empty());
-    CHECK(errors[0].message.find("range [0, 2]") != std::string::npos);
-}
-
-TEST_CASE("parse: blocked lane index must fit before narrowing", "[parse][blocked_mask]") {
-    BeatMap map;
-    std::vector<BeatMapError> errors;
-    std::string json = R"({
-        "song_id": "timing_test",
-        "bpm": 120,
-        "offset": 0.0,
-        "lead_beats": 4,
-        "duration_sec": 60.0,
-        "beats": [
-            { "beat": 2, "kind": "combo_gate", "shape": "circle", "blocked": [4294967297] }
-        ]
-    })";
-
-    CHECK_FALSE(parse_beat_map(json, map, errors));
-    REQUIRE_FALSE(errors.empty());
-    CHECK(errors[0].message.find("blocked[]") != std::string::npos);
-    CHECK(errors[0].message.find("fit") != std::string::npos);
-}
-
-TEST_CASE("parse: valid blocked lane arrays remain accepted", "[parse][blocked_mask]") {
-    const char* blocked_arrays[] = {"[0]", "[1]", "[2]", "[0, 2]"};
-
-    for (const char* blocked : blocked_arrays) {
-        BeatMap map;
-        std::vector<BeatMapError> errors;
-        const std::string json = std::string(R"({
-            "song_id": "timing_test",
-            "bpm": 120,
-            "offset": 0.0,
-            "lead_beats": 4,
-            "duration_sec": 60.0,
-            "beats": [
-                { "beat": 2, "kind": "combo_gate", "shape": "circle", "blocked": )") + blocked + R"( }
-            ]
-        })";
-
-        INFO("blocked lanes: " << blocked);
-        CHECK(parse_beat_map(json, map, errors));
-        REQUIRE(map.beats.size() == 1);
-        CHECK(map.beats[0].blocked_mask != 0);
-        CHECK((map.beats[0].blocked_mask & static_cast<uint8_t>(~0x07U)) == 0);
-    }
+    CHECK(errors[0].message.find("'blocked' is not supported") != std::string::npos);
 }
 
 TEST_CASE("parse: invalid scalar lane values fail before narrowing", "[parse][lane]") {

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -264,8 +264,9 @@ TEST_CASE("beat_scheduler: spawns multiple beats when time is past all", "[beat_
     auto& map = beat_map(reg);
 
     map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
-    map.beats.push_back({2, ObstacleKind::LaneBlock, Shape::Circle, 1, 0b001});
-    map.beats.push_back({4, ObstacleKind::ComboGate, Shape::Square, 1, 0b100});
+    map.beats.push_back({2, ObstacleKind::ShapeGate, Shape::Square, 1, 0});
+    map.beats.push_back({4, ObstacleKind::OnsetMarker, Shape::Circle, 1, 0});
+    map.beats.push_back({6, ObstacleKind::ShapeGate, Shape::Triangle, 2, 0});
 
     song.song_time = 30.0f;  // Well past all spawn times
     song.next_spawn_idx = 0;
@@ -275,12 +276,12 @@ TEST_CASE("beat_scheduler: spawns multiple beats when time is past all", "[beat_
     int count = 0;
     for (auto e : reg.view<ObstacleTag>()) { ++count; (void)e; }
     CHECK(count == 3);
-    CHECK(song.next_spawn_idx == 3);
+    CHECK(song.next_spawn_idx == 4);
 }
 
 // ── beat_scheduler: obstacle types ───────────────────────────
 
-TEST_CASE("beat_scheduler: spawns LaneBlock with blocked_mask", "[beat_scheduler]") {
+TEST_CASE("beat_scheduler: skips unsupported active beatmap obstacle kinds", "[beat_scheduler][issue873]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
@@ -291,13 +292,9 @@ TEST_CASE("beat_scheduler: spawns LaneBlock with blocked_mask", "[beat_scheduler
 
     beat_scheduler_system(reg, 0.016f);
 
-    auto view = reg.view<ObstacleTag, Obstacle, BlockedLanes>();
-    for (auto [e, obs, bl] : view.each()) {
-        (void)obs;
-        CHECK_FALSE(reg.all_of<RequiredShape>(e));
-        CHECK_FALSE(reg.all_of<RequiredLane>(e));
-        CHECK(bl.mask == 0b010);
-    }
+    auto view = reg.view<ObstacleTag>();
+    CHECK(view.begin() == view.end());
+    CHECK(song.next_spawn_idx == 1);
 }
 
 TEST_CASE("beat_scheduler: spawns all queued beats from BeatMap entries", "[beat_scheduler]") {
@@ -305,9 +302,9 @@ TEST_CASE("beat_scheduler: spawns all queued beats from BeatMap entries", "[beat
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.beats.push_back({0, ObstacleKind::LaneBlock, Shape::Circle, 1, 0b010});
-    map.beats.push_back({0, ObstacleKind::ComboGate, Shape::Triangle, 1, 0b001});
     map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Square, 1, 0});
+    map.beats.push_back({0, ObstacleKind::OnsetMarker, Shape::Circle, 1, 0});
+    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Triangle, 2, 0});
     song.song_time = 10.0f;
     song.next_spawn_idx = 0;
 
@@ -319,59 +316,11 @@ TEST_CASE("beat_scheduler: spawns all queued beats from BeatMap entries", "[beat
     for (auto [e, obs] : obstacle_view.each()) {
         (void)obs;
         ++obstacle_count;
-        const ObstacleKind kind = obstacle_kind_from_components(
-            reg.all_of<RequiredShape>(e),
-            reg.all_of<BlockedLanes>(e),
-            reg.all_of<RequiredLane>(e));
-        if (kind == ObstacleKind::ShapeGate) ++shape_gate_count;
+        if (reg.all_of<RequiredShape>(e)) ++shape_gate_count;
     }
-    CHECK(obstacle_count == 3);
-    CHECK(shape_gate_count == 1);
+    CHECK(obstacle_count == 2);
+    CHECK(shape_gate_count == 2);
     CHECK(song.next_spawn_idx == 3);
-}
-
-TEST_CASE("beat_scheduler: spawns ComboGate with shape and blocked lanes", "[beat_scheduler]") {
-    auto reg = make_rhythm_registry();
-    auto& song = reg.ctx().get<SongState>();
-    auto& map = beat_map(reg);
-
-    map.beats.push_back({0, ObstacleKind::ComboGate, Shape::Triangle, 1, 0b101});
-    song.song_time = 10.0f;
-    song.next_spawn_idx = 0;
-
-    beat_scheduler_system(reg, 0.016f);
-
-    auto view = reg.view<ObstacleTag, Obstacle, RequiredShape, BlockedLanes>();
-    for (auto [e, obs, rs, bl] : view.each()) {
-        (void)obs;
-        CHECK_FALSE(reg.all_of<RequiredLane>(e));
-        CHECK(rs.shape == Shape::Triangle);
-        CHECK(bl.mask == 0b101);
-    }
-}
-
-TEST_CASE("beat_scheduler: spawns SplitPath with shape and required lane", "[beat_scheduler]") {
-    auto reg = make_rhythm_registry();
-    auto& song = reg.ctx().get<SongState>();
-    auto& map = beat_map(reg);
-
-    map.beats.push_back({0, ObstacleKind::SplitPath, Shape::Square, 2, 0});
-    song.song_time = 10.0f;
-    song.next_spawn_idx = 0;
-
-    beat_scheduler_system(reg, 0.016f);
-
-    auto view = reg.view<ObstacleTag, Obstacle, RequiredShape, RequiredLane, WorldTransform>();
-    int count = 0;
-    for (auto [e, obs, rs, rl, wt] : view.each()) {
-        (void)obs;
-        ++count;
-        CHECK_FALSE(reg.all_of<BlockedLanes>(e));
-        CHECK(rs.shape == Shape::Square);
-        CHECK(rl.lane == 2);
-        CHECK_THAT(wt.position.x, Catch::Matchers::WithinAbs(constants::LANE_X[2], 0.01f));
-    }
-    CHECK(count == 1);
 }
 
 TEST_CASE("beat_scheduler: all spawned obstacles have BeatInfo", "[beat_scheduler]") {

--- a/tests/test_rhythm_system.cpp
+++ b/tests/test_rhythm_system.cpp
@@ -38,28 +38,21 @@ TEST_CASE("beatmap: parse minimal valid JSON", "[rhythm][beatmap]") {
     CHECK(map.beats[1].shape == Shape::Triangle);
 }
 
-TEST_CASE("beatmap: parse all obstacle kinds", "[rhythm][beatmap]") {
+TEST_CASE("beatmap: parse active obstacle kinds", "[rhythm][beatmap][issue873]") {
     BeatMap map;
     std::vector<BeatMapError> errors;
     std::string json = R"({
         "bpm": 120, "offset": 0, "lead_beats": 4, "duration_sec": 60,
         "beats": [
             { "beat": 4,  "kind": "shape_gate",  "shape": "circle",   "lane": 1 },
-            { "beat": 8,  "kind": "lane_block",   "blocked": [0, 2] },
-                    { "beat": 20, "kind": "combo_gate",  "shape": "square", "blocked": [0, 1] },
-            { "beat": 24, "kind": "split_path",  "shape": "triangle", "lane": 2 }
+            { "beat": 8,  "kind": "onset_marker", "time_sec": 4.0 }
         ]
     })";
 
     REQUIRE(parse_beat_map(json, map, errors));
-    REQUIRE(map.beats.size() == 4);
+    REQUIRE(map.beats.size() == 2);
     CHECK(map.beats[0].kind == ObstacleKind::ShapeGate);
-    CHECK(map.beats[1].kind == ObstacleKind::LaneBlock);
-    CHECK(map.beats[1].blocked_mask == 0b101);
-    CHECK(map.beats[2].kind == ObstacleKind::ComboGate);
-    CHECK(map.beats[2].blocked_mask == 0b011);
-    CHECK(map.beats[3].kind == ObstacleKind::SplitPath);
-    CHECK(map.beats[3].lane == 2);
+    CHECK(map.beats[1].kind == ObstacleKind::OnsetMarker);
 }
 
 TEST_CASE("beatmap: tempo_changes in JSON are ignored", "[rhythm][beatmap]") {
@@ -313,19 +306,6 @@ TEST_CASE("beat_scheduler: rhythm obstacles use BeatInfo without MotionVelocity"
     }
     auto invalid_view = reg.view<ObstacleTag, BeatInfo, MotionVelocity>();
     CHECK(std::distance(invalid_view.begin(), invalid_view.end()) == 0);
-}
-
-TEST_CASE("beat_scheduler: spawns lane_block with blocked mask", "[rhythm][scheduler]") {
-    auto reg = make_rhythm_registry();
-    auto& song = reg.ctx().get<SongState>();
-    auto& map = beat_map(reg);
-    BeatEntry entry; entry.beat_index = 4; entry.kind = ObstacleKind::LaneBlock; entry.blocked_mask = 0b101;
-    map.beats.push_back(entry);
-    song.playing = true; song.song_time = 0.1f;
-    beat_scheduler_system(reg, 0.016f);
-    auto view = reg.view<ObstacleTag, BlockedLanes>();
-    REQUIRE(std::distance(view.begin(), view.end()) == 1);
-    for (auto [e, bl] : view.each()) { CHECK(bl.mask == 0b101); }
 }
 
 // Shape Window System

--- a/tools/validate_no_simultaneous_shape_gates.py
+++ b/tools/validate_no_simultaneous_shape_gates.py
@@ -33,15 +33,13 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_DIR = REPO_ROOT / "content" / "beatmaps"
 
 PROTECTED_CROSS_LAYER_SEC = 0.050
-REQUIRED_ACTION_KINDS = {"shape_gate", "combo_gate", "split_path"}
+REQUIRED_ACTION_KINDS = {"shape_gate"}
 
 
 def required_action_key(beat: dict) -> tuple[object, object] | None:
     kind = beat.get("kind", "shape_gate")
     if kind not in REQUIRED_ACTION_KINDS:
         return None
-    if kind == "combo_gate":
-        return (tuple(beat.get("blocked", ())), beat.get("shape"))
     return (beat.get("lane"), beat.get("shape"))
 
 


### PR DESCRIPTION
## Summary
- Limit active beatmap parsing to shipped/current kinds: shape_gate and onset_marker.
- Reject blocked lane arrays and validate manually-built future obstacle entries as unsupported active content.
- Make the scheduler skip unsupported active beatmap entries and update parser/validation/scheduler tests around the supported set.

## Root cause
Future obstacle kinds remained accepted by parser, validation, and scheduler tests even though shipped beatmaps only use shape_gate plus non-blocking onset_marker metadata.

## Verification
- cmake -B build -S . -Wno-dev
- cmake --build build
- ./build/shapeshifter_tests

Fixes #873