### PR TITLE
Fix screen input debounce timing

### DIFF
--- a/app/constants.h
+++ b/app/constants.h
@@ -69,6 +69,12 @@ constexpr float SWIPE_ZONE_SPLIT  = 0.80f;
 constexpr float MIN_SWIPE_DIST    = 50.0f;
 constexpr float MAX_SWIPE_TIME    = 0.3f;
 
+// ── Screen input timing ───────────────────────────
+constexpr float UI_ENTRY_DEBOUNCE              = 0.2f;
+constexpr float GAME_OVER_INPUT_DELAY          = 0.4f;
+constexpr float SONG_COMPLETE_INPUT_DELAY      = 0.5f;
+constexpr float TEST_PLAYER_AUTO_START_DELAY   = 0.5f;
+
 // ── UI Layout (pixel-space; retained to derive the NDC constants below and for tests) ────
 constexpr float BUTTON_Y          = 1140.0f;
 constexpr float BUTTON_W          = 140.0f;

--- a/app/input/game_state_routing.cpp
+++ b/app/input/game_state_routing.cpp
@@ -4,12 +4,19 @@
 #include "../components/input_events.h"
 #include "../components/audio_events.h"
 #include "../components/haptics.h"
+#include "../constants.h"
 
 namespace {
 bool game_state_handle_end_screen_press(entt::registry& reg, const ButtonPressEvent& evt) {
     auto& gs = reg.ctx().get<GameState>();
-    if ((gs.phase != GamePhase::GameOver && gs.phase != GamePhase::SongComplete) ||
-        gs.phase_timer <= 0.4f) {
+    if (gs.phase != GamePhase::GameOver && gs.phase != GamePhase::SongComplete) {
+        return false;
+    }
+
+    const float input_delay = (gs.phase == GamePhase::SongComplete)
+        ? constants::SONG_COMPLETE_INPUT_DELAY
+        : constants::GAME_OVER_INPUT_DELAY;
+    if (gs.phase_timer <= input_delay) {
         return false;
     }
 
@@ -37,6 +44,7 @@ bool game_state_handle_end_screen_press(entt::registry& reg, const ButtonPressEv
 void game_state_handle_go(entt::registry& reg, const GoEvent& /*evt*/) {
     auto& gs = reg.ctx().get<GameState>();
     if (gs.phase != GamePhase::Paused) return;
+    if (gs.phase_timer <= constants::UI_ENTRY_DEBOUNCE) return;
     // Deferred per #482 — let game_state_system perform the resume swap.
     gs.transition_pending = true;
     gs.next_phase = GamePhase::Playing;
@@ -66,6 +74,7 @@ void game_state_handle_press(entt::registry& reg, const ButtonPressEvent& evt) {
     }
 
     if (gs.phase == GamePhase::Paused) {
+        if (gs.phase_timer <= constants::UI_ENTRY_DEBOUNCE) return;
         // Deferred per #482 — see game_state_handle_go above.
         gs.transition_pending = true;
         gs.next_phase = GamePhase::Playing;

--- a/app/systems/game_state_end_screen_system.cpp
+++ b/app/systems/game_state_end_screen_system.cpp
@@ -1,5 +1,6 @@
 #include "all_systems.h"
 #include "../components/game_state.h"
+#include "../constants.h"
 
 namespace {
 
@@ -14,9 +15,9 @@ GamePhase resolve_end_screen_phase(EndScreenChoice choice) {
 void game_state_end_screen_system(entt::registry& reg, float /*dt*/) {
     auto& gs = reg.ctx().get<GameState>();
     const bool game_over_ready =
-        gs.phase == GamePhase::GameOver && gs.phase_timer > 0.4f;
+        gs.phase == GamePhase::GameOver && gs.phase_timer > constants::GAME_OVER_INPUT_DELAY;
     const bool song_complete_ready =
-        gs.phase == GamePhase::SongComplete && gs.phase_timer > 0.5f;
+        gs.phase == GamePhase::SongComplete && gs.phase_timer > constants::SONG_COMPLETE_INPUT_DELAY;
     if (!(game_over_ready || song_complete_ready) ||
         gs.end_choice == EndScreenChoice::None) {
         return;

--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -7,6 +7,7 @@
 #include "../components/input_events.h"
 #include "../components/player.h"
 #include "../components/rhythm.h"
+#include "../constants.h"
 #if defined(__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)
 #include <emscripten/emscripten.h>
 #include <string>
@@ -132,7 +133,7 @@ void game_state_system(entt::registry& reg, float dt) {
     }
 
     // LevelSelect input handling
-    if (gs.phase == GamePhase::LevelSelect && gs.phase_timer > 0.2f) {
+    if (gs.phase == GamePhase::LevelSelect && gs.phase_timer > constants::UI_ENTRY_DEBOUNCE) {
         auto& lss = reg.ctx().get<LevelSelectState>();
         if (lss.confirmed) {
             lss.confirmed = false;

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -199,7 +199,7 @@ void test_player_system(entt::registry& reg, float dt) {
     // ── AUTO-START ───────────────────────────────────────────
     if (gs.phase == GamePhase::Title || gs.phase == GamePhase::GameOver ||
         gs.phase == GamePhase::SongComplete) {
-        if (gs.phase_timer > 0.5f) {
+        if (gs.phase_timer > constants::TEST_PLAYER_AUTO_START_DELAY) {
             // On end screens, press Restart; on Title, press Confirm
             auto target_action = (gs.phase == GamePhase::GameOver ||
                                   gs.phase == GamePhase::SongComplete)
@@ -239,7 +239,7 @@ void test_player_system(entt::registry& reg, float dt) {
     }
 
     // Auto-confirm on LevelSelect (level/difficulty already set in main.cpp)
-    if (gs.phase == GamePhase::LevelSelect && gs.phase_timer > 0.2f) {
+    if (gs.phase == GamePhase::LevelSelect && gs.phase_timer > constants::UI_ENTRY_DEBOUNCE) {
         disp.enqueue<ButtonPressEvent>({ButtonPressKind::Menu, Shape::Circle,
                                        MenuActionKind::Confirm, 0});
         return;

--- a/app/ui/screen_controllers/game_over_screen_controller.cpp
+++ b/app/ui/screen_controllers/game_over_screen_controller.cpp
@@ -3,6 +3,7 @@
 #include "../../components/game_state.h"
 #include "../../components/scoring.h"
 #include "../../components/song_state.h"
+#include "../../constants.h"
 #include "screen_controller_base.h"
 #include "game_over_screen_controller.h"
 #include <entt/entt.hpp>
@@ -99,7 +100,7 @@ void render_game_over_screen_ui(entt::registry& reg) {
     draw_game_over_scoreboard(reg, controller.state());
 
     auto& gs = reg.ctx().get<GameState>();
-    if (gs.phase_timer <= 0.4f) return;
+    if (gs.phase_timer <= constants::GAME_OVER_INPUT_DELAY) return;
 
     dispatch_end_screen_choice(gs, controller.state());
 }

--- a/app/ui/screen_controllers/level_select_screen_controller.cpp
+++ b/app/ui/screen_controllers/level_select_screen_controller.cpp
@@ -5,6 +5,7 @@
 #include "../../content/level_content_config.h"
 #include "../../components/input.h"
 #include "../../components/rendering.h"
+#include "../../constants.h"
 #include "screen_controller_base.h"
 #include <entt/entt.hpp>
 #include <cstdio>
@@ -164,5 +165,5 @@ void render_level_select_screen_ui(entt::registry& reg) {
     
     GuiSetStyle(DEFAULT, TEXT_SIZE, saved_text_size);
 
-    if (state.StartButtonPressed && gs.phase_timer > 0.2f) lss.confirmed = true;
+    if (state.StartButtonPressed && gs.phase_timer > constants::UI_ENTRY_DEBOUNCE) lss.confirmed = true;
 }

--- a/app/ui/screen_controllers/paused_screen_controller.cpp
+++ b/app/ui/screen_controllers/paused_screen_controller.cpp
@@ -2,6 +2,7 @@
 
 #include "../../components/game_state.h"
 #include "../../components/input.h"
+#include "../../constants.h"
 #include "screen_controller_base.h"
 #include <entt/entt.hpp>
 
@@ -25,6 +26,7 @@ void render_paused_screen_ui(entt::registry& reg) {
     controller.render();
 
     auto& gs = reg.ctx().get<GameState>();
+    if (gs.phase_timer <= constants::UI_ENTRY_DEBOUNCE) return;
 
     if (controller.state().ResumeButtonPressed) {
         // Deferred per #482 — the canonical state-machine swap (game_state_system)

--- a/app/ui/screen_controllers/song_complete_screen_controller.cpp
+++ b/app/ui/screen_controllers/song_complete_screen_controller.cpp
@@ -3,6 +3,7 @@
 #include "../../components/game_state.h"
 #include "../../components/scoring.h"
 #include "../../components/song_state.h"
+#include "../../constants.h"
 #include "screen_controller_base.h"
 #include <entt/entt.hpp>
 
@@ -73,7 +74,7 @@ void render_song_complete_screen_ui(entt::registry& reg) {
     draw_song_complete_scoreboard(reg, controller.state());
 
     auto& gs = reg.ctx().get<GameState>();
-    if (gs.phase_timer <= 0.5f) return;
+    if (gs.phase_timer <= constants::SONG_COMPLETE_INPUT_DELAY) return;
 
     dispatch_end_screen_choice(gs, controller.state());
 }

--- a/app/ui/screen_controllers/tutorial_screen_controller.cpp
+++ b/app/ui/screen_controllers/tutorial_screen_controller.cpp
@@ -1,6 +1,7 @@
 // Tutorial screen controller - renders raygui layout and dispatches start action.
 
 #include "../../components/game_state.h"
+#include "../../constants.h"
 #include "../../systems/web_input_policy.h"
 #include "../tutorial_dodge_hint.h"
 #include "screen_controller_base.h"
@@ -45,8 +46,10 @@ void render_tutorial_screen_ui(entt::registry& reg) {
     GuiLabel(tutorial_dodge_hint_bounds(controller.state().Anchor01),
              tutorial_dodge_hint_text(prefer_touch));
 
+    auto& gs = reg.ctx().get<GameState>();
+    if (gs.phase_timer <= constants::UI_ENTRY_DEBOUNCE) return;
+
     if (controller.state().ContinueButtonPressed) {
-        auto& gs = reg.ctx().get<GameState>();
         gs.transition_pending = true;
         gs.next_phase = GamePhase::Playing;
     }

--- a/tests/test_phase_transition_canonical.cpp
+++ b/tests/test_phase_transition_canonical.cpp
@@ -258,6 +258,18 @@ TEST_CASE("phase_transition: enforcement catches non-UI/non-input direct callers
     REQUIRE(offenders == std::vector<std::string>{"app/systems/rogue_system.cpp"});
 }
 
+TEST_CASE("phase_transition: Tutorial and Paused controllers guard entry input",
+          "[phase_transition][ui]") {
+    const fs::path root = find_repo_root();
+    const std::string tutorial =
+        read_file(root / "app/ui/screen_controllers/tutorial_screen_controller.cpp");
+    const std::string paused =
+        read_file(root / "app/ui/screen_controllers/paused_screen_controller.cpp");
+
+    REQUIRE(tutorial.find("constants::UI_ENTRY_DEBOUNCE") != std::string::npos);
+    REQUIRE(paused.find("constants::UI_ENTRY_DEBOUNCE") != std::string::npos);
+}
+
 TEST_CASE("phase_transition matcher catches whitespace variants and ignores strings/comments",
           "[phase_transition][architecture]") {
     const std::string direct_call = R"cpp(

--- a/tests/test_world_systems.cpp
+++ b/tests/test_world_systems.cpp
@@ -146,7 +146,7 @@ TEST_CASE("game_state: song complete keyboard confirm routes to restart", "[game
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
     gs.phase = GamePhase::SongComplete;
-    gs.phase_timer = 0.6f;
+    gs.phase_timer = constants::SONG_COMPLETE_INPUT_DELAY + 0.1f;
 
     reg.ctx().get<entt::dispatcher>().enqueue<ButtonPressEvent>(
         {ButtonPressKind::Menu, Shape::Circle, MenuActionKind::Confirm, 0});
@@ -157,17 +157,63 @@ TEST_CASE("game_state: song complete keyboard confirm routes to restart", "[game
     CHECK(gs.next_phase == GamePhase::Playing);
 }
 
+TEST_CASE("game_state: song complete keyboard confirm waits for button debounce",
+          "[gamestate][input][regression]") {
+    auto reg = make_registry();
+    auto& gs = reg.ctx().get<GameState>();
+    gs.phase = GamePhase::SongComplete;
+    gs.phase_timer = 0.45f;
+
+    reg.ctx().get<entt::dispatcher>().enqueue<ButtonPressEvent>(
+        {ButtonPressKind::Menu, Shape::Circle, MenuActionKind::Confirm, 0});
+
+    game_state_system(reg, 0.0f);
+
+    CHECK_FALSE(gs.transition_pending);
+    CHECK(gs.end_choice == EndScreenChoice::None);
+}
+
 TEST_CASE("game_state: game over ignores touch during delay", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
     gs.phase = GamePhase::GameOver;
-    gs.phase_timer = 0.2f;  // within 0.4s delay
+    gs.phase_timer = 0.2f;  // within GAME_OVER_INPUT_DELAY
     auto btn = make_menu_button(reg, MenuActionKind::Confirm);
     press_button(reg, btn);
 
     game_state_system(reg, 0.016f);
 
     CHECK_FALSE(gs.transition_pending);
+}
+
+TEST_CASE("game_state: paused menu input waits for entry debounce", "[gamestate][input]") {
+    auto reg = make_registry();
+    auto& gs = reg.ctx().get<GameState>();
+    gs.phase = GamePhase::Paused;
+    gs.phase_timer = constants::UI_ENTRY_DEBOUNCE + 0.1f;
+    gs.phase_timer = 0.1f;
+
+    reg.ctx().get<entt::dispatcher>().enqueue<ButtonPressEvent>(
+        {ButtonPressKind::Menu, Shape::Circle, MenuActionKind::Confirm, 0});
+
+    game_state_system(reg, 0.0f);
+
+    CHECK_FALSE(gs.transition_pending);
+}
+
+TEST_CASE("game_state: paused menu input resumes after entry debounce", "[gamestate][input]") {
+    auto reg = make_registry();
+    auto& gs = reg.ctx().get<GameState>();
+    gs.phase = GamePhase::Paused;
+    gs.phase_timer = constants::UI_ENTRY_DEBOUNCE + 0.1f;
+
+    reg.ctx().get<entt::dispatcher>().enqueue<ButtonPressEvent>(
+        {ButtonPressKind::Menu, Shape::Circle, MenuActionKind::Confirm, 0});
+
+    game_state_system(reg, 0.0f);
+
+    CHECK(gs.phase == GamePhase::Playing);
+    CHECK(gs.phase_timer == 0.0f);
 }
 
 TEST_CASE("game_state: phase timer increments", "[gamestate]") {
@@ -263,6 +309,7 @@ TEST_CASE("game_state: paused to playing on touch", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
     gs.phase = GamePhase::Paused;
+    gs.phase_timer = constants::UI_ENTRY_DEBOUNCE + 0.1f;
     auto btn = make_menu_button(reg, MenuActionKind::Confirm);
     press_button(reg, btn);
 
@@ -276,6 +323,7 @@ TEST_CASE("game_state: paused resume preserves active play session state", "[gam
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
     gs.phase = GamePhase::Paused;
+    gs.phase_timer = constants::UI_ENTRY_DEBOUNCE + 0.1f;
 
     auto player = make_player(reg);
     auto obstacle = reg.create();


### PR DESCRIPTION
## Summary
- Synchronize SongComplete keyboard/menu input with the existing 0.5s button/end-screen debounce.
- Add entry debounce protection to Paused routing/controllers and Tutorial controller input.
- Centralize screen input timing constants and add regression coverage.

Fixes #879
Fixes #880

## Verification
- `cmake -B build -S . -Wno-dev`
- `cmake --build build`
- `./build/shapeshifter_tests`