### PR TITLE
Fix FTUE tutorial routing

### DIFF
--- a/app/input/game_state_routing.cpp
+++ b/app/input/game_state_routing.cpp
@@ -4,6 +4,7 @@
 #include "../components/input_events.h"
 #include "../components/audio_events.h"
 #include "../components/haptics.h"
+#include "../entities/settings.h"
 #include "../constants.h"
 
 namespace {
@@ -70,6 +71,20 @@ void game_state_handle_press(entt::registry& reg, const ButtonPressEvent& evt) {
     }
 
     if (game_state_handle_end_screen_press(reg, evt)) {
+        return;
+    }
+
+    if (gs.phase == GamePhase::Tutorial) {
+        if (gs.phase_timer <= constants::UI_ENTRY_DEBOUNCE) return;
+        if (evt.menu_action != MenuActionKind::Confirm) return;
+        if (auto* settings_state = find_settings_state(reg)) {
+            settings::mark_ftue_complete(*settings_state);
+            if (auto* persistence = find_settings_persistence(reg)) {
+                settings::mark_dirty_and_save(*persistence, *settings_state);
+            }
+        }
+        gs.transition_pending = true;
+        gs.next_phase = GamePhase::Playing;
         return;
     }
 

--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -138,9 +138,9 @@ void game_state_system(entt::registry& reg, float dt) {
         auto& lss = reg.ctx().get<LevelSelectState>();
         if (lss.confirmed) {
             lss.confirmed = false;
-            const auto* settings_state = find_settings_state(reg);
+            const auto* settings_ptr = find_settings_state(reg);
             gs.transition_pending = true;
-            gs.next_phase = settings_state && !settings::ftue_complete(*settings_state)
+            gs.next_phase = settings_ptr && !settings::ftue_complete(*settings_ptr)
                 ? GamePhase::Tutorial
                 : GamePhase::Playing;
         }

--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -7,6 +7,7 @@
 #include "../components/input_events.h"
 #include "../components/player.h"
 #include "../components/rhythm.h"
+#include "../entities/settings.h"
 #include "../constants.h"
 #if defined(__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)
 #include <emscripten/emscripten.h>
@@ -137,8 +138,11 @@ void game_state_system(entt::registry& reg, float dt) {
         auto& lss = reg.ctx().get<LevelSelectState>();
         if (lss.confirmed) {
             lss.confirmed = false;
+            const auto* settings_state = find_settings_state(reg);
             gs.transition_pending = true;
-            gs.next_phase = GamePhase::Playing;
+            gs.next_phase = settings_state && !settings::ftue_complete(*settings_state)
+                ? GamePhase::Tutorial
+                : GamePhase::Playing;
         }
     }
 

--- a/app/ui/screen_controllers/tutorial_screen_controller.cpp
+++ b/app/ui/screen_controllers/tutorial_screen_controller.cpp
@@ -53,10 +53,10 @@ void init_tutorial_screen_ui() {
 }
 
 void tutorial_screen_continue(entt::registry& reg) {
-    if (auto* settings_state = find_settings_state(reg)) {
-        settings::mark_ftue_complete(*settings_state);
+    if (auto* settings_ptr = find_settings_state(reg)) {
+        settings::mark_ftue_complete(*settings_ptr);
         if (auto* persistence = find_settings_persistence(reg)) {
-            settings::mark_dirty_and_save(*persistence, *settings_state);
+            settings::mark_dirty_and_save(*persistence, *settings_ptr);
         }
     }
 

--- a/app/ui/screen_controllers/tutorial_screen_controller.cpp
+++ b/app/ui/screen_controllers/tutorial_screen_controller.cpp
@@ -1,6 +1,7 @@
 // Tutorial screen controller - renders raygui layout and dispatches start action.
 
 #include "../../components/game_state.h"
+#include "../../components/input.h"
 #include "../../constants.h"
 #include "../../entities/settings.h"
 #include "../../systems/web_input_policy.h"
@@ -33,6 +34,18 @@ bool tutorial_prefer_touch_hint(const entt::registry& reg) {
 #endif
 }
 
+Rectangle tutorial_continue_button_bounds(Vector2 anchor) {
+    return offset_rect(anchor, 180, 1075, 360, 102);
+}
+
+bool tutorial_continue_tapped(const entt::registry& reg, Rectangle bounds) {
+    const auto* input = reg.ctx().find<InputState>();
+    if (!input || !(input->click || input->touch_up)) {
+        return false;
+    }
+    return CheckCollisionPointRec({input->end_x, input->end_y}, bounds);
+}
+
 } // anonymous namespace
 
 void init_tutorial_screen_ui() {
@@ -62,7 +75,8 @@ void render_tutorial_screen_ui(entt::registry& reg) {
 
     auto& gs = reg.ctx().get<GameState>();
     if (gs.phase_timer <= constants::UI_ENTRY_DEBOUNCE) return;
-    if (controller.state().ContinueButtonPressed) {
+    if (controller.state().ContinueButtonPressed ||
+        tutorial_continue_tapped(reg, tutorial_continue_button_bounds(controller.state().Anchor01))) {
         tutorial_screen_continue(reg);
     }
 }

--- a/app/ui/screen_controllers/tutorial_screen_controller.cpp
+++ b/app/ui/screen_controllers/tutorial_screen_controller.cpp
@@ -2,6 +2,7 @@
 
 #include "../../components/game_state.h"
 #include "../../constants.h"
+#include "../../entities/settings.h"
 #include "../../systems/web_input_policy.h"
 #include "../tutorial_dodge_hint.h"
 #include "screen_controller_base.h"
@@ -38,6 +39,19 @@ void init_tutorial_screen_ui() {
     // Controller state is registry-owned and initialized lazily in render.
 }
 
+void tutorial_screen_continue(entt::registry& reg) {
+    if (auto* settings_state = find_settings_state(reg)) {
+        settings::mark_ftue_complete(*settings_state);
+        if (auto* persistence = find_settings_persistence(reg)) {
+            settings::mark_dirty_and_save(*persistence, *settings_state);
+        }
+    }
+
+    auto& gs = reg.ctx().get<GameState>();
+    gs.transition_pending = true;
+    gs.next_phase = GamePhase::Playing;
+}
+
 void render_tutorial_screen_ui(entt::registry& reg) {
     auto& controller = screen_controller<TutorialController>(reg);
     controller.render();
@@ -48,9 +62,7 @@ void render_tutorial_screen_ui(entt::registry& reg) {
 
     auto& gs = reg.ctx().get<GameState>();
     if (gs.phase_timer <= constants::UI_ENTRY_DEBOUNCE) return;
-
     if (controller.state().ContinueButtonPressed) {
-        gs.transition_pending = true;
-        gs.next_phase = GamePhase::Playing;
+        tutorial_screen_continue(reg);
     }
 }

--- a/app/ui/screen_controllers/tutorial_screen_controller.h
+++ b/app/ui/screen_controllers/tutorial_screen_controller.h
@@ -2,5 +2,6 @@
 
 #include <entt/entt.hpp>
 
+void tutorial_screen_continue(entt::registry& reg);
 void init_tutorial_screen_ui();
 void render_tutorial_screen_ui(entt::registry& reg);

--- a/design-docs/game-flow.md
+++ b/design-docs/game-flow.md
@@ -104,15 +104,10 @@
                           (back to Title)
 ```
 
-> **Tutorial phase — defined but unreachable today.** `GamePhase::Tutorial`
-> exists in `game_state.h` and is wired into render/state systems, but
-> no screen controller currently issues `next_phase = GamePhase::Tutorial`
-> (`grep -rnE "next_phase = GamePhase::Tutorial" app/` returns no hits).
-> The "FTUE CHECK" branch shown in earlier revisions of this map is
-> **not shipped**: `Settings::ftue_run_count` is persisted but never
-> read by gameplay/UI systems. The wired-up FTUE/Tutorial flow is
-> tracked in #76 (FTUE not implemented); reinstate the FTUE-check
-> decision node only once a controller transitions into Tutorial.
+> **Tutorial phase.** `GamePhase::Tutorial` is reached from Level Select
+> when `SettingsState::ftue_run_count == 0`. Pressing START on the
+> tutorial marks FTUE complete, persists settings, and starts gameplay.
+> Completed FTUE profiles skip Tutorial and go directly to Playing.
 
 ### State Enumeration (for ECS implementation)
 
@@ -128,9 +123,7 @@
       GameOver     = 4,   // results screen
       SongComplete = 5,   // song finished successfully
       Settings     = 6,   // settings screen (entered from Title gear)
-      Tutorial     = 7    // FTUE/tutorial run — defined but
-                          // currently unreachable; no controller
-                          // issues a transition into it (see #76)
+      Tutorial     = 7    // FTUE/tutorial run before first gameplay
   };
 ```
 
@@ -139,7 +132,8 @@ Shipped transitions, by controller, as of Round 6 audit:
 - `Title → LevelSelect` — body tap (`title_screen_controller.cpp:62-72`).
 - `Title → Settings` — gear-icon tap (same controller).
 - `Settings → Title` — back action (`ui_render_system.cpp:117-122`).
-- `LevelSelect → Playing` — song selection.
+- `LevelSelect → Tutorial` — song selection when FTUE is incomplete.
+- `LevelSelect → Playing` — song selection after FTUE is complete.
 - `Playing ↔ Paused` — pause button / resume.
 - `Paused → Title` — quit action.
 - `Playing → GameOver` — energy reaches zero.
@@ -147,7 +141,7 @@ Shipped transitions, by controller, as of Round 6 audit:
 - `GameOver | SongComplete → Playing` — restart action.
 - `GameOver | SongComplete → LevelSelect` — level-select action.
 - `GameOver | SongComplete → Title` — main-menu action.
-- `* → Tutorial` — **none today** (see #76).
+- `Tutorial → Playing` — START marks FTUE complete and begins the run.
 
 ---
 

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include "test_helpers.h"
+#include "ui/screen_controllers/tutorial_screen_controller.h"
 
 // ── game_state_system: SongComplete transitions ──────────────
 
@@ -236,19 +237,58 @@ TEST_CASE("game_state: transition to Title sets phase and resets timer", "[games
     CHECK(gs.phase_timer == 0.0f);
 }
 
-TEST_CASE("game_state: level select confirmed triggers playing transition", "[gamestate]") {
+TEST_CASE("game_state: level select confirmed starts tutorial when FTUE is incomplete", "[gamestate][ftue][issue882]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
     gs.phase = GamePhase::LevelSelect;
     gs.phase_timer = 0.5f;  // past 0.2s guard
     auto& lss = reg.ctx().get<LevelSelectState>();
     lss.confirmed = true;
+    settings_state(reg).ftue_run_count = 0;
+
+    game_state_system(reg, 0.016f);
+
+    CHECK(gs.transition_pending);
+    CHECK(gs.next_phase == GamePhase::Tutorial);
+    CHECK_FALSE(lss.confirmed);
+}
+
+TEST_CASE("game_state: level select confirmed triggers playing when FTUE is complete",
+          "[gamestate][ftue][issue882]") {
+    auto reg = make_registry();
+    auto& gs = reg.ctx().get<GameState>();
+    gs.phase = GamePhase::LevelSelect;
+    gs.phase_timer = 0.5f;  // past 0.2s guard
+    auto& lss = reg.ctx().get<LevelSelectState>();
+    lss.confirmed = true;
+    settings_state(reg).ftue_run_count = 1;
 
     game_state_system(reg, 0.016f);
 
     CHECK(gs.transition_pending);
     CHECK(gs.next_phase == GamePhase::Playing);
     CHECK_FALSE(lss.confirmed);
+}
+
+TEST_CASE("tutorial: continue marks FTUE complete and requests gameplay",
+          "[gamestate][ftue][issue882]") {
+    auto reg = make_registry();
+    auto& gs = reg.ctx().get<GameState>();
+    gs.phase = GamePhase::Tutorial;
+
+    auto& settings = settings_state(reg);
+    settings.ftue_run_count = 0;
+    auto& persistence = settings_persistence(reg);
+    persistence.path.clear();
+    persistence.dirty = false;
+
+    tutorial_screen_continue(reg);
+
+    CHECK(settings::ftue_complete(settings));
+    CHECK(persistence.dirty);
+    CHECK(persistence.last_save.status == persistence::Status::PathUnavailable);
+    CHECK(gs.transition_pending);
+    CHECK(gs.next_phase == GamePhase::Playing);
 }
 
 TEST_CASE("game_state: level select ignores confirmed during delay", "[gamestate]") {

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -291,6 +291,32 @@ TEST_CASE("tutorial: continue marks FTUE complete and requests gameplay",
     CHECK(gs.next_phase == GamePhase::Playing);
 }
 
+TEST_CASE("tutorial: menu confirm marks FTUE complete and requests gameplay",
+          "[gamestate][ftue][input][issue882]") {
+    auto reg = make_registry();
+    auto& gs = reg.ctx().get<GameState>();
+    gs.phase = GamePhase::Tutorial;
+    gs.phase_timer = 0.5f;
+
+    auto& settings = settings_state(reg);
+    settings.ftue_run_count = 0;
+    auto& persistence = settings_persistence(reg);
+    persistence.path.clear();
+    persistence.dirty = false;
+
+    reg.ctx().get<entt::dispatcher>().enqueue<ButtonPressEvent>({
+        ButtonPressKind::Menu, Shape::Circle, MenuActionKind::Confirm, 0});
+    game_state_system(reg, 0.016f);
+
+    const auto& saved_settings = settings_state(reg);
+    const auto& saved_persistence = settings_persistence(reg);
+    CHECK(settings::ftue_complete(saved_settings));
+    CHECK(saved_persistence.dirty);
+    CHECK(saved_persistence.last_save.status == persistence::Status::PathUnavailable);
+    CHECK_FALSE(gs.transition_pending);
+    CHECK(gs.phase == GamePhase::Playing);
+}
+
 TEST_CASE("game_state: level select ignores confirmed during delay", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();

--- a/tests/wasm_runtime_smoke.cjs
+++ b/tests/wasm_runtime_smoke.cjs
@@ -424,6 +424,7 @@ async function main() {
       const beforeTutorialStartHash = sha256(await page.screenshot());
       let afterTutorialStartHash = beforeTutorialStartHash;
       for (let i = 0; i < 3 && afterTutorialStartHash === beforeTutorialStartHash; i += 1) {
+        await page.keyboard.press('Enter');
         await clickCanvasAt(0.5, 0.88);
         afterTutorialStartHash = await waitForVisualChange(beforeTutorialStartHash, 3500);
       }

--- a/tests/wasm_runtime_smoke.cjs
+++ b/tests/wasm_runtime_smoke.cjs
@@ -419,6 +419,18 @@ async function main() {
     if (afterLevelSelectClickHash === afterHash) {
       fatal.push('no-visual-response-after-enter');
     }
+    if (await waitForTitlePhase('Tutorial', 1500)) {
+      await page.waitForTimeout(500);
+      const beforeTutorialStartHash = sha256(await page.screenshot());
+      let afterTutorialStartHash = beforeTutorialStartHash;
+      for (let i = 0; i < 3 && afterTutorialStartHash === beforeTutorialStartHash; i += 1) {
+        await clickCanvasAt(0.5, 0.88);
+        afterTutorialStartHash = await waitForVisualChange(beforeTutorialStartHash, 3500);
+      }
+      if (beforeTutorialStartHash === afterTutorialStartHash) {
+        fatal.push('no-visual-response-after-tutorial-start');
+      }
+    }
     if (!(await waitForTitlePhase('Playing', 4500))) {
       fatal.push(`missing-playing-phase-marker:${await page.title()}`);
     }


### PR DESCRIPTION
## Summary
- Route first-time level confirmations through `GamePhase::Tutorial` when FTUE is incomplete.
- Mark FTUE complete and persist settings from the tutorial START action before entering gameplay.
- Update game-flow docs and add regression coverage for incomplete/complete FTUE paths.

## Verification
- `cmake -B build -S . -Wno-dev && cmake --build build && ./build/shapeshifter_tests`
- `./run.sh test`

Closes #882
