### PR TITLE
Fix energy bar segment count guard

### DIFF
--- a/app/components/energy_bar.h
+++ b/app/components/energy_bar.h
@@ -23,3 +23,7 @@ struct EnergyBarVisual {
     float critical_intensity = 0.0f;
     int overflow_segments = 0;
 };
+
+[[nodiscard]] inline int effective_energy_bar_segment_count(const EnergyBarLayout& layout) {
+    return layout.segment_count < 1 ? 1 : layout.segment_count;
+}

--- a/app/systems/energy_bar_system.cpp
+++ b/app/systems/energy_bar_system.cpp
@@ -67,8 +67,9 @@ void energy_bar_system(entt::registry& reg, float /*dt*/) {
     auto view = reg.view<EnergyBarTag, EnergyBarLayout, EnergyBarVisual>();
     for (auto [entity, layout, visual] : view.each()) {
         (void)entity;
+        const int segment_count = effective_energy_bar_segment_count(layout);
         visual.fill = fill;
-        visual.visible_level = std::min(fill + bounce * (5.0f / static_cast<float>(layout.segment_count)), 1.0f);
+        visual.visible_level = std::min(fill + bounce * (5.0f / static_cast<float>(segment_count)), 1.0f);
         visual.flash_ratio = flash_ratio;
         visual.flash_overlay = flash_overlay;
         visual.critical_intensity = critical_intensity;

--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
@@ -224,9 +224,10 @@ void render_energy_bar(const entt::registry& reg) {
     for (auto [entity, layout, visual] : view.each()) {
         (void)entity;
 
+        const int segment_count = effective_energy_bar_segment_count(layout);
         const float bar_top = layout.bottom - layout.height;
-        const float seg_h = (layout.height - (layout.segment_count - 1) * layout.segment_gap)
-            / static_cast<float>(layout.segment_count);
+        const float seg_h = (layout.height - (segment_count - 1) * layout.segment_gap)
+            / static_cast<float>(segment_count);
 
         for (int i = 0; i < visual.overflow_segments; ++i) {
             float seg_y = bar_top - (i + 1) * (seg_h + layout.segment_gap);
@@ -237,12 +238,12 @@ void render_energy_bar(const entt::registry& reg) {
 
         DrawRectangleRec({layout.x, bar_top, layout.width, layout.height}, {15, 15, 25, 180});
 
-        int filled_segs = static_cast<int>(visual.fill * static_cast<float>(layout.segment_count) + 0.5f);
-        int visible_segs = static_cast<int>(visual.visible_level * static_cast<float>(layout.segment_count) + 0.5f);
+        int filled_segs = static_cast<int>(visual.fill * static_cast<float>(segment_count) + 0.5f);
+        int visible_segs = static_cast<int>(visual.visible_level * static_cast<float>(segment_count) + 0.5f);
 
-        for (int i = 0; i < layout.segment_count; ++i) {
+        for (int i = 0; i < segment_count; ++i) {
             float seg_y = layout.bottom - (i + 1) * (seg_h + layout.segment_gap) + layout.segment_gap;
-            float t = static_cast<float>(i) / static_cast<float>(layout.segment_count - 1);
+            float t = static_cast<float>(i) / static_cast<float>(segment_count > 1 ? segment_count - 1 : 1);
             unsigned char cr = 0, cg = 0, cb = 0;
             if (t < 0.33f) {
                 float s = t / 0.33f;

--- a/tests/test_reduce_motion.cpp
+++ b/tests/test_reduce_motion.cpp
@@ -5,6 +5,7 @@
 #include "components/energy_bar.h"
 #include "entities/energy_bar_entity.h"
 
+#include <cmath>
 #include <stdexcept>
 
 TEST_CASE("energy bar entity: factory creates singleton HUD entity",
@@ -80,4 +81,43 @@ TEST_CASE("energy_bar_system: reduce_motion pins critical pulse to a stable midp
     const auto entity = *reg.view<EnergyBarTag>().begin();
     const auto& visual = reg.get<EnergyBarVisual>(entity);
     CHECK_THAT(visual.critical_intensity, Catch::Matchers::WithinAbs(0.675f, 1e-5f));
+}
+
+TEST_CASE("energy bar layout: invalid segment counts use a safe rendering minimum",
+          "[energy_bar][issue886]") {
+    EnergyBarLayout layout;
+
+    layout.segment_count = 0;
+    CHECK(effective_energy_bar_segment_count(layout) == 1);
+
+    layout.segment_count = 1;
+    CHECK(effective_energy_bar_segment_count(layout) == 1);
+
+    layout.segment_count = 32;
+    CHECK(effective_energy_bar_segment_count(layout) == 32);
+}
+
+TEST_CASE("energy_bar_system: invalid segment counts keep visual levels finite",
+          "[energy_bar][issue886]") {
+    auto reg = make_registry();
+    const auto entity = create_energy_bar_entity(reg);
+    auto& layout = reg.get<EnergyBarLayout>(entity);
+    auto& energy = reg.ctx().get<EnergyState>();
+    auto& song = reg.ctx().get<SongState>();
+    song.playing = true;
+    song.song_time = 0.0f;
+    song.beat_period = 0.5f;
+    energy.display = 0.25f;
+
+    layout.segment_count = 0;
+    energy_bar_system(reg, 0.016f);
+    const auto& visual_zero = reg.get<EnergyBarVisual>(entity);
+    CHECK(std::isfinite(visual_zero.fill));
+    CHECK(std::isfinite(visual_zero.visible_level));
+
+    layout.segment_count = 1;
+    energy_bar_system(reg, 0.016f);
+    const auto& visual_one = reg.get<EnergyBarVisual>(entity);
+    CHECK(std::isfinite(visual_one.fill));
+    CHECK(std::isfinite(visual_one.visible_level));
 }


### PR DESCRIPTION
## Summary
- Fixes #888
- Clamp energy bar layout math to an effective minimum of one segment
- Use the same guard in HUD rendering and energy bar visual updates
- Add regression coverage for zero and one segment layouts

## Verification
- `cmake -B build -S . -Wno-dev`
- `cmake --build build`
- `./build/shapeshifter_tests "[energy_bar]"`
- `./build/shapeshifter_tests`
