### PR TITLE
Correct energy bar system docs

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -591,9 +591,11 @@ system in the same frame (unidirectional data flow).
  │  │  8. popup_display_system  Tick ScorePopup.remaining.   │
  │  │                           Fade and destroy popups.     │
  │  │                                                        │
- │  │  9. energy_system         Apply pending energy changes.│
+ │  │  9. energy_system         Apply pending energy changes │
+ │  │                           and smooth displayed energy. │
  │  │                                                        │
- │  │ 10. energy_bar_system     Smooth displayed energy.     │
+ │  │ 10. energy_bar_system     Prepare energy bar visual    │
+ │  │                           animation state.             │
  │  │                                                        │
  │  │ 11. particle_system       Tick ParticleData.remaining. │
  │  │                           Destroy expired particles.   │


### PR DESCRIPTION
## Summary
- Fixes #886
- Clarifies that `energy_system` smooths displayed energy
- Clarifies that `energy_bar_system` prepares energy bar visual animation state

## Verification
- Documentation-only change
