### PR TITLE
Retry web persistence after failed initialization

### DIFF
--- a/app/util/persistence_policy.cpp
+++ b/app/util/persistence_policy.cpp
@@ -50,10 +50,9 @@ Result sync_web_filesystem(const bool populate, const Status failure_status) {
 
 Result ensure_web_persistence_ready() {
     static bool initialized = false;
-    static Result init_result{};
 
     if (initialized) {
-        return init_result;
+        return Result{};
     }
 
     const int mount_status = EM_ASM_INT(
@@ -77,13 +76,13 @@ Result ensure_web_persistence_ready() {
         },
         kWebPersistenceMount);
     if (mount_status != 0) {
-        init_result = Result{Status::PathUnavailable, std::make_error_code(std::errc::io_error)};
-        initialized = true;
-        return init_result;
+        return Result{Status::PathUnavailable, std::make_error_code(std::errc::io_error)};
     }
 
-    init_result = sync_web_filesystem(true, Status::FileReadFailed);
-    initialized = true;
+    const auto init_result = sync_web_filesystem(true, Status::FileReadFailed);
+    if (init_result.ok()) {
+        initialized = true;
+    }
     return init_result;
 }
 

--- a/tests/test_wasm_beforeunload_lifecycle.cpp
+++ b/tests/test_wasm_beforeunload_lifecycle.cpp
@@ -94,3 +94,24 @@ TEST_CASE("wasm persistence uses explicit IDBFS policy and save flush hooks", "[
     CHECK(high_score_source.find("persistence::prepare_for_persistence_read(path)") != std::string::npos);
     CHECK(high_score_source.find("persistence::flush_persistence_writes(path)") != std::string::npos);
 }
+
+TEST_CASE("wasm persistence readiness retries after initialization failure",
+          "[persistence][architecture][issue887]") {
+    const fs::path root = find_repo_root();
+    const std::string policy_source = read_file(root / "app" / "util" / "persistence_policy.cpp");
+
+    const std::size_t mount_failure_return = policy_source.find(
+        "return Result{Status::PathUnavailable, std::make_error_code(std::errc::io_error)};");
+    const std::size_t sync_result = policy_source.find(
+        "const auto init_result = sync_web_filesystem(true, Status::FileReadFailed);");
+    const std::size_t success_guard = policy_source.find("if (init_result.ok()) {", sync_result);
+    const std::size_t initialized_true = policy_source.find("initialized = true;", success_guard);
+
+    REQUIRE(mount_failure_return != std::string::npos);
+    REQUIRE(sync_result != std::string::npos);
+    REQUIRE(success_guard != std::string::npos);
+    REQUIRE(initialized_true != std::string::npos);
+    CHECK(mount_failure_return < sync_result);
+    CHECK(sync_result < success_guard);
+    CHECK(success_guard < initialized_true);
+}


### PR DESCRIPTION
## Summary
- Fixes #887
- Cache successful web persistence readiness only
- Allow later persistence reads/writes to retry after mount or sync failures
- Add a wasm persistence source-contract regression

## Verification
- `cmake -B build -S . -Wno-dev`
- `cmake --build build`
- `./build/shapeshifter_tests "[persistence][architecture]"`
- `./build/shapeshifter_tests`
