### PR TITLE
Fix shape gate target-lane collision

### DIFF
--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -39,19 +39,8 @@ bool player_matches_required_shape(const PlayerShape& p_shape,
     return p_window.phase != WindowPhase::Idle && p_window.target_shape == required;
 }
 
-bool shape_gate_lane_match(float obstacle_x,
-                           float player_x,
-                           const Lane& lane) {
-    if (CheckCollisionRecs(centered_hitbox_rect(player_x),
-                           centered_hitbox_rect(obstacle_x))) {
-        return true;
-    }
-
-    if (lane.target < 0 || lane.target >= constants::LANE_COUNT) {
-        return false;
-    }
-
-    return CheckCollisionRecs(centered_hitbox_rect(constants::LANE_X[lane.target]),
+bool shape_gate_lane_match(float obstacle_x, float player_x) {
+    return CheckCollisionRecs(centered_hitbox_rect(player_x),
                               centered_hitbox_rect(obstacle_x));
 }
 
@@ -139,7 +128,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
             for (auto [e, obstacle, wt, req, info] : rhythm_view.each()) {
                 (void)obstacle;
                 bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
-                bool lane_match = shape_gate_lane_match(wt.position.x, player_x, p_lane);
+                bool lane_match = shape_gate_lane_match(wt.position.x, player_x);
                 if (!lane_match) {
                     resolve(e, wt.position.y, false);
                     continue;
@@ -154,7 +143,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
             for (auto [e, obstacle, wt, req] : view.each()) {
                 (void)obstacle;
                 bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
-                bool lane_match = shape_gate_lane_match(wt.position.x, player_x, p_lane);
+                bool lane_match = shape_gate_lane_match(wt.position.x, player_x);
                 if (!lane_match) {
                     resolve(e, wt.position.y, false);
                     continue;
@@ -232,7 +221,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
             for (auto [e, obstacle, wt, req] : view.each()) {
                 (void)obstacle;
                 bool shape_match = player_matches_required_shape(p_shape, p_window, req.shape, rhythm_mode);
-                bool lane_match = shape_gate_lane_match(wt.position.x, player_x, p_lane);
+                bool lane_match = shape_gate_lane_match(wt.position.x, player_x);
                 if (!lane_match) {
                     resolve(e, wt.position.y, false);
                     continue;

--- a/tests/test_collision_extended.cpp
+++ b/tests/test_collision_extended.cpp
@@ -114,8 +114,8 @@ TEST_CASE("collision: rhythm mode assigns Perfect for on-time hit", "[collision]
     CHECK(reg.get<TimingGrade>(obs).tier == TimingTier::Perfect);
 }
 
-TEST_CASE("collision: on-beat shape press uses explicit target lane before interpolation",
-          "[collision][rhythm][issue850][issue874]") {
+TEST_CASE("collision: on-beat shape press requires player hitbox to reach target lane",
+          "[collision][rhythm][issue892]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& song = reg.ctx().get<SongState>();
@@ -143,9 +143,8 @@ TEST_CASE("collision: on-beat shape press uses explicit target lane before inter
     collision_system(reg, 0.016f);
 
     CHECK(reg.all_of<ScoredTag>(obs));
-    CHECK_FALSE(reg.all_of<MissTag>(obs));
-    REQUIRE(reg.all_of<TimingGrade>(obs));
-    CHECK(reg.get<TimingGrade>(obs).tier == TimingTier::Perfect);
+    CHECK(reg.all_of<MissTag>(obs));
+    CHECK_FALSE(reg.all_of<TimingGrade>(obs));
 }
 
 TEST_CASE("collision: rhythm mode assigns Bad for far-off hit", "[collision][rhythm]") {

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -52,8 +52,8 @@ TEST_CASE("collision: shape gate hitbox edge handling", "[collision][edge]") {
     }
 }
 
-TEST_CASE("collision: shape gate target-lane grace follows explicit lane target",
-          "[collision][issue874]") {
+TEST_CASE("collision: shape gate does not clear from target lane before strafe arrives",
+          "[collision][issue892]") {
     auto reg = make_registry();
     auto player = make_player(reg);
     auto& lane = reg.get<Lane>(player);
@@ -66,7 +66,7 @@ TEST_CASE("collision: shape gate target-lane grace follows explicit lane target"
     collision_system(reg, 0.016f);
 
     CHECK(reg.all_of<ScoredTag>(obs));
-    CHECK_FALSE(reg.all_of<MissTag>(obs));
+    CHECK(reg.all_of<MissTag>(obs));
 }
 
 TEST_CASE("collision: shape gate ignores shape-derived lane without explicit target",
@@ -81,6 +81,24 @@ TEST_CASE("collision: shape gate ignores shape-derived lane without explicit tar
 
     CHECK(reg.all_of<ScoredTag>(obs));
     CHECK(reg.all_of<MissTag>(obs));
+}
+
+TEST_CASE("collision: shape gate clears when interpolated player hitbox reaches lane",
+          "[collision][issue892]") {
+    auto reg = make_registry();
+    auto player = make_player(reg);
+    auto& lane = reg.get<Lane>(player);
+    auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
+
+    reg.get<WorldTransform>(obs).position.x = constants::LANE_X[0];
+    reg.get<WorldTransform>(player).position.x = constants::LANE_X[0];
+    lane.target = 0;
+    lane.lerp_t = 1.0f;
+
+    collision_system(reg, 0.016f);
+
+    CHECK(reg.all_of<ScoredTag>(obs));
+    CHECK_FALSE(reg.all_of<MissTag>(obs));
 }
 
 TEST_CASE("collision: lane block cleared when player in unblocked lane", "[collision]") {


### PR DESCRIPTION
## Summary
- Resolve shape-gate lane matching using only the player's actual/interpolated hitbox.
- Remove speculative target-lane matching during in-progress strafes.
- Update freeplay and rhythm regression coverage for #892.

## Verification
- `cmake -B build -S . -Wno-dev && cmake --build build --target shapeshifter_tests && ./build/shapeshifter_tests`
- `./run.sh test`

Fixes #892
