### PR TITLE
Fix invalid lane normalization

### DIFF
--- a/app/constants.h
+++ b/app/constants.h
@@ -14,8 +14,13 @@ constexpr float SCREEN_H_F        = static_cast<float>(SCREEN_H);
 
 // ── Lanes ─────────────────────────────────────────
 constexpr int   LANE_COUNT        = 3;
+constexpr int   DEFAULT_LANE      = 1;
 constexpr float LANE_X[3]         = { 60.0f, 360.0f, 660.0f };
 constexpr float LANE_SWITCH_SPEED = 12.0f;
+
+constexpr bool is_valid_lane(int lane) {
+    return lane >= 0 && lane < LANE_COUNT;
+}
 
 // ── Player ────────────────────────────────────────
 constexpr float PLAYER_Y          = 920.0f;

--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -9,6 +9,7 @@
 #include "../components/song_state.h"
 #include "../components/gameplay_intents.h"
 #include "../constants.h"
+#include "../util/lane_utils.h"
 #include <raylib.h>
 #include <cmath>
 
@@ -53,6 +54,8 @@ void collision_system(entt::registry& reg, float /*dt*/) {
     auto player_entity = *player_view.begin();
     auto [p_transform, p_shape, p_window, p_lane, p_vstate] =
         player_view.get<WorldTransform, PlayerShape, ShapeWindow, Lane, VerticalState>(player_entity);
+    lane_utils::normalize(p_lane, &p_transform);
+    const int player_lane = p_lane.current;
 
     auto& song = reg.ctx().get<SongState>();
     const bool rhythm_mode = song.playing;
@@ -115,7 +118,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
             entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredShape>);
         for (auto [e, obstacle, wt, blocked] : view.each()) {
             (void)obstacle;
-            resolve(e, wt.position.y, !((blocked.mask >> p_lane.current) & 1));
+            resolve(e, wt.position.y, !((blocked.mask >> player_lane) & 1));
         }
     }
 
@@ -158,7 +161,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
                 entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredLane>);
             for (auto [e, obstacle, wt, req, blocked, info] : rhythm_view.each()) {
                 (void)obstacle;
-                bool lane_ok  = !((blocked.mask >> p_lane.current) & 1);
+                bool lane_ok  = !((blocked.mask >> player_lane) & 1);
                 if (!lane_ok) {
                     resolve(e, wt.position.y, false);
                     continue;
@@ -173,7 +176,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
                 entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredLane, BeatInfo>);
             for (auto [e, obstacle, wt, req, blocked] : view.each()) {
                 (void)obstacle;
-                bool lane_ok  = !((blocked.mask >> p_lane.current) & 1);
+                bool lane_ok  = !((blocked.mask >> player_lane) & 1);
                 if (!lane_ok) {
                     resolve(e, wt.position.y, false);
                     continue;
@@ -189,7 +192,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
                 entt::exclude<ScoredTag, ResolvedObstacleTag>);
             for (auto [e, obstacle, wt, req, rlane, info] : rhythm_view.each()) {
                 (void)obstacle;
-                bool lane_ok  = (p_lane.current == rlane.lane);
+                bool lane_ok  = (player_lane == rlane.lane);
                 if (!lane_ok) {
                     resolve(e, wt.position.y, false);
                     continue;
@@ -204,7 +207,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
                 entt::exclude<ScoredTag, ResolvedObstacleTag, BeatInfo>);
             for (auto [e, obstacle, wt, req, rlane] : view.each()) {
                 (void)obstacle;
-                bool lane_ok  = (p_lane.current == rlane.lane);
+                bool lane_ok  = (player_lane == rlane.lane);
                 if (!lane_ok) {
                     resolve(e, wt.position.y, false);
                     continue;
@@ -236,7 +239,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
                 entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredLane>);
             for (auto [e, obstacle, wt, req, blocked] : view.each()) {
                 (void)obstacle;
-                bool lane_ok  = !((blocked.mask >> p_lane.current) & 1);
+                bool lane_ok  = !((blocked.mask >> player_lane) & 1);
                 if (!lane_ok) {
                     resolve(e, wt.position.y, false);
                     continue;
@@ -252,7 +255,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
                 entt::exclude<ScoredTag, ResolvedObstacleTag>);
             for (auto [e, obstacle, wt, req, rlane] : view.each()) {
                 (void)obstacle;
-                bool lane_ok  = (p_lane.current == rlane.lane);
+                bool lane_ok  = (player_lane == rlane.lane);
                 if (!lane_ok) {
                     resolve(e, wt.position.y, false);
                     continue;

--- a/app/systems/player_input_system.cpp
+++ b/app/systems/player_input_system.cpp
@@ -8,6 +8,7 @@
 #include "../components/rhythm.h"
 #include "../entities/settings.h"
 #include "../constants.h"
+#include "../util/lane_utils.h"
 
 namespace {
 
@@ -27,6 +28,7 @@ void player_input_handle_go(entt::registry& reg, const GoEvent& evt) {
     if (!gameplay_input_enabled(reg)) return;
     auto view = reg.view<PlayerTag, PlayerShape, ShapeWindow, Lane, VerticalState>();
     for (auto [entity, pshape, swindow, lane, vstate] : view.each()) {
+        lane_utils::normalize(lane);
         int8_t delta = 0;
         if (evt.dir == Direction::Left  && lane.current > 0)
             delta = -1;

--- a/app/systems/player_movement_system.cpp
+++ b/app/systems/player_movement_system.cpp
@@ -6,6 +6,7 @@
 #include "../components/audio_events.h"
 #include "../components/haptics.h"
 #include "../constants.h"
+#include "../util/lane_utils.h"
 #include <raymath.h>
 
 void player_movement_system(entt::registry& reg, float dt) {
@@ -14,6 +15,7 @@ void player_movement_system(entt::registry& reg, float dt) {
 
     auto view = reg.view<PlayerTag, WorldTransform, PlayerShape, Lane, VerticalState>();
     for (auto [entity, transform, pshape, lane, vstate] : view.each()) {
+        lane_utils::normalize(lane, &transform);
 
         // Morph animation — freeplay only.
         // In rhythm mode shape_window_system owns morph_t (derives from song_time);
@@ -24,11 +26,11 @@ void player_movement_system(entt::registry& reg, float dt) {
 
         // Lane transition
         if (lane.target == lane.current) {
-            lane.target = -1;
+            lane.target = lane_utils::kNoTargetLane;
             lane.lerp_t = 1.0f;
             transform.position.x = constants::LANE_X[lane.current];
         }
-        if (lane.target >= 0 && lane.target != lane.current) {
+        if (lane_utils::is_valid(lane.target) && lane.target != lane.current) {
             lane.lerp_t += dt * constants::LANE_SWITCH_SPEED;
             float from_x = constants::LANE_X[lane.current];
             float to_x   = constants::LANE_X[lane.target];
@@ -36,7 +38,7 @@ void player_movement_system(entt::registry& reg, float dt) {
 
             if (lane.lerp_t >= 1.0f) {
                 lane.current = lane.target;
-                lane.target  = -1;
+                lane.target  = lane_utils::kNoTargetLane;
                 lane.lerp_t  = 1.0f;
                 transform.position.x = constants::LANE_X[lane.current];
             }

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -9,6 +9,7 @@
 #include "../components/rhythm.h"
 #include "../components/scoring.h"
 #include "../util/session_logger.h"
+#include "../util/lane_utils.h"
 #include "../constants.h"
 
 #include <raylib.h>
@@ -74,7 +75,7 @@ static bool test_player_needs_shape(const TestPlayerAction& action) {
 }
 
 static bool test_player_needs_lane(const TestPlayerAction& action) {
-    return action.target_lane >= 0 && !test_player_lane_done(action);
+    return lane_utils::is_valid(action.target_lane) && !test_player_lane_done(action);
 }
 
 static bool test_player_needs_vertical(const TestPlayerAction& action) {
@@ -84,7 +85,7 @@ static bool test_player_needs_vertical(const TestPlayerAction& action) {
 static bool test_player_action_done(const TestPlayerAction& action) {
     const bool shape_done = (action.target_shape == Shape::Hexagon) ||
                             test_player_shape_done(action);
-    const bool lane_done = (action.target_lane < 0) ||
+    const bool lane_done = !lane_utils::is_valid(action.target_lane) ||
                            test_player_lane_done(action);
     const bool vertical_done = (action.target_vertical == VMode::Grounded) ||
                                test_player_vertical_done(action);
@@ -110,6 +111,8 @@ static void test_player_remove_action(TestPlayerState& state, int idx) {
 
 // Find nearest unblocked lane to current position.
 static int8_t nearest_unblocked_lane(uint8_t blocked_mask, int8_t current) {
+    current = lane_utils::valid_or_default(current);
+
     // Try current lane first
     if (!((blocked_mask >> current) & 1)) return current;
 
@@ -175,7 +178,7 @@ static TestPlayerAction determine_action(
 
     // Lane requirement (RequiredLane — exact lane)
     auto* req_lane = reg.try_get<RequiredLane>(entity);
-    if (req_lane && req_lane->lane != player_lane) {
+    if (req_lane && lane_utils::is_valid(req_lane->lane) && req_lane->lane != player_lane) {
         action.target_lane = req_lane->lane;
     }
 
@@ -263,14 +266,16 @@ void test_player_system(entt::registry& reg, float dt) {
     auto player_entity = *player_view.begin();
     auto [p_transform, p_shape, p_window, p_lane, p_vstate] =
         player_view.get<WorldTransform, PlayerShape, ShapeWindow, Lane, VerticalState>(player_entity);
+    lane_utils::normalize(p_lane, &p_transform);
 
     // ── PERCEIVE: scan obstacles in vision range ─────────────
     // Compute the "effective lane" — where the player will be after
     // all pending lane changes in the action queue execute.
     int8_t effective_lane = p_lane.current;
-    if (p_lane.target >= 0) effective_lane = p_lane.target;
+    if (lane_utils::is_valid(p_lane.target)) effective_lane = p_lane.target;
     for (int i = 0; i < state->action_count; ++i) {
-        if (state->actions[i].target_lane >= 0 && !test_player_lane_done(state->actions[i])) {
+        if (lane_utils::is_valid(state->actions[i].target_lane) &&
+            !test_player_lane_done(state->actions[i])) {
             effective_lane = state->actions[i].target_lane;
         }
     }
@@ -291,7 +296,7 @@ void test_player_system(entt::registry& reg, float dt) {
         // Pro player aims for Perfect timing on SHAPE PRESSES.
         // Lane dodges and vertical-only actions react ASAP — no delay.
         bool has_shape = (action.target_shape != Shape::Hexagon);
-        bool has_lane_or_vertical = (action.target_lane >= 0 ||
+        bool has_lane_or_vertical = (lane_utils::is_valid(action.target_lane) ||
                                      action.target_vertical != VMode::Grounded);
 
         if (cfg.aim_perfect && has_shape) {
@@ -337,7 +342,7 @@ void test_player_system(entt::registry& reg, float dt) {
             session_log_write(*log, song_time, "PLAYER",
                 "PLAN action=%.*s%s%s react=%.3fs arrival=%.3fs",
                 static_cast<int>(action_shape_name.size()), action_shape_name.data(),
-                action.target_lane >= 0 ? "+lane" : "",
+                lane_utils::is_valid(action.target_lane) ? "+lane" : "",
                 action.target_vertical != VMode::Grounded ?
                     (action.target_vertical == VMode::Jumping ? "+jump" : "+slide") : "",
                 action.timer, action.arrival_time);
@@ -484,7 +489,8 @@ void test_player_system(entt::registry& reg, float dt) {
             }
         }
 
-        if (test_player_needs_lane(action) && p_lane.target < 0 && state->swipe_cooldown_timer <= 0.0f
+        if (test_player_needs_lane(action) && !lane_utils::is_valid(p_lane.target) &&
+            state->swipe_cooldown_timer <= 0.0f
             && !zone_blocked && !blocked_by_shape && !move_would_fail_closer) {
             if (action.target_lane < p_lane.current) {
                 disp.enqueue<GoEvent>({Direction::Left});

--- a/app/util/lane_utils.h
+++ b/app/util/lane_utils.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "../components/player.h"
+#include "../components/transform.h"
+#include "../constants.h"
+
+#include <cstdint>
+
+namespace lane_utils {
+
+inline constexpr int8_t kNoTargetLane = -1;
+inline constexpr int8_t kDefaultLane = static_cast<int8_t>(constants::DEFAULT_LANE);
+
+inline bool is_valid(int lane) {
+    return constants::is_valid_lane(lane);
+}
+
+inline int8_t valid_or_default(int8_t lane) {
+    return is_valid(lane) ? lane : kDefaultLane;
+}
+
+inline void snap_to_current_lane(const Lane& lane, WorldTransform& transform) {
+    transform.position.x = constants::LANE_X[lane.current];
+}
+
+inline bool normalize(Lane& lane, WorldTransform* transform = nullptr) {
+    if (!is_valid(lane.current)) {
+        lane.current = kDefaultLane;
+        lane.target = kNoTargetLane;
+        lane.lerp_t = 1.0f;
+        if (transform) {
+            snap_to_current_lane(lane, *transform);
+        }
+        return true;
+    }
+
+    if (lane.target != kNoTargetLane && !is_valid(lane.target)) {
+        lane.target = kNoTargetLane;
+        lane.lerp_t = 1.0f;
+        if (transform) {
+            snap_to_current_lane(lane, *transform);
+        }
+        return true;
+    }
+
+    return false;
+}
+
+}  // namespace lane_utils

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -128,6 +128,28 @@ TEST_CASE("collision: lane block drains energy when player in blocked lane", "[c
     CHECK(energy.flash_timer > 0.0f);
 }
 
+TEST_CASE("collision: invalid player lane is normalized before lane checks",
+          "[collision][issue900]") {
+    auto reg = make_registry();
+    auto player = make_player(reg);
+    auto& lane = reg.get<Lane>(player);
+    auto& transform = reg.get<WorldTransform>(player);
+    lane.current = -1;
+    lane.target = constants::LANE_COUNT;
+    lane.lerp_t = 0.0f;
+    transform.position.x = -999.0f;
+    auto obs = make_lane_block(reg, 0b010, constants::PLAYER_Y);
+
+    collision_system(reg, 0.016f);
+
+    CHECK(lane.current == constants::DEFAULT_LANE);
+    CHECK(lane.target == -1);
+    CHECK(lane.lerp_t == 1.0f);
+    CHECK(transform.position.x == constants::LANE_X[constants::DEFAULT_LANE]);
+    CHECK(reg.all_of<ScoredTag>(obs));
+    CHECK(reg.all_of<MissTag>(obs));
+}
+
 
 
 

--- a/tests/test_player_systems.cpp
+++ b/tests/test_player_systems.cpp
@@ -192,6 +192,42 @@ TEST_CASE("player_movement: clears stale lane target when target equals current"
     CHECK(transform.position.x == constants::LANE_X[1]);
 }
 
+TEST_CASE("player_movement: normalizes invalid current lane", "[player][issue900]") {
+    auto reg = make_registry();
+    auto p = make_player(reg);
+    auto& lane = reg.get<Lane>(p);
+    auto& transform = reg.get<WorldTransform>(p);
+    lane.current = -1;
+    lane.target = 0;
+    lane.lerp_t = 0.0f;
+    transform.position.x = -999.0f;
+
+    player_movement_system(reg, 0.016f);
+
+    CHECK(lane.current == constants::DEFAULT_LANE);
+    CHECK(lane.target == -1);
+    CHECK(lane.lerp_t == 1.0f);
+    CHECK(transform.position.x == constants::LANE_X[constants::DEFAULT_LANE]);
+}
+
+TEST_CASE("player_movement: normalizes invalid target lane", "[player][issue900]") {
+    auto reg = make_registry();
+    auto p = make_player(reg);
+    auto& lane = reg.get<Lane>(p);
+    auto& transform = reg.get<WorldTransform>(p);
+    lane.current = 1;
+    lane.target = constants::LANE_COUNT;
+    lane.lerp_t = 0.0f;
+    transform.position.x = (constants::LANE_X[1] + constants::LANE_X[2]) * 0.5f;
+
+    player_movement_system(reg, 0.016f);
+
+    CHECK(lane.current == 1);
+    CHECK(lane.target == -1);
+    CHECK(lane.lerp_t == 1.0f);
+    CHECK(transform.position.x == constants::LANE_X[1]);
+}
+
 TEST_CASE("player_movement: jump creates negative y_offset", "[player]") {
     auto reg = make_registry();
     auto p = make_player(reg);


### PR DESCRIPTION
## Summary
- Add shared lane validation/normalization for malformed `Lane` component values.
- Normalize player lane state before movement, input, collision, and test-player planning use lane indices.
- Add regression coverage for invalid current and target lane values.

## Root cause
Several systems assumed `Lane::current` and `Lane::target` were always in `[0, LANE_COUNT)`, then used them for `LANE_X` indexing or `BlockedLanes` bit shifts. Malformed ECS state could therefore cause out-of-bounds access or shift undefined behavior.

## Verification
- `cmake -B build -S . -Wno-dev && cmake --build build && ./build/shapeshifter_tests`
- `./run.sh test`

Fixes #900
