### PR TITLE
Skip optional Node tests when unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ at runtime boundaries, without wrapper abstraction layers.
 - C++20 compiler (Clang 20 recommended)
 - CMake 3.20+
 - [vcpkg](https://vcpkg.io)
-- Node.js 22+ (optional, enables beatmap editor Node test suite during `ctest`)
+- Node.js 22+ with npm (optional, enables beatmap editor Node test suite during `ctest` and `./run.sh test`)
 
 ### Quick Start
 
@@ -37,7 +37,7 @@ export VCPKG_ROOT=/path/to/vcpkg
 
 ./build.sh           # Release build
 ./run.sh             # Build + run game
-./run.sh test        # Build + run tests
+./run.sh test        # Build + run tests (skips optional Node tests if node/npm is unavailable)
 cmake --build build --target shapeshifter_benchmarks  # Run benchmarks on demand
 ```
 

--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,11 @@ if [[ "${1:-}" == "test" ]]; then
     shift
     ./build/shapeshifter_tests "$@"
     python3 -m unittest discover -s tools -p "test_*.py"
-    npm --prefix tools/beatmap-editor test
+    if command -v node >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
+        npm --prefix tools/beatmap-editor test
+    else
+        echo "SKIPPED: beatmap-editor Node tests (node/npm executable not found)"
+    fi
 elif [[ "${1:-}" == "bench" ]]; then
     shift
     ./build/shapeshifter_tests "[bench]" "$@"


### PR DESCRIPTION
## Summary
- Skip beatmap-editor Node tests in `./run.sh test` when `node` or `npm` is unavailable.
- Document that the optional Node test suite is skipped when node/npm is missing.

## Verification
- `bash -n run.sh && cmake -B build -S . -Wno-dev && cmake --build build && ./run.sh test`
- Simulated missing node/npm with a temporary runner fixture and confirmed the skip message.

Closes #898