### PR TITLE
Avoid nullable shape text in session log

### DIFF
--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -338,7 +338,7 @@ void test_player_system(entt::registry& reg, float dt) {
                 action.target_lane, dist);
 
             const std::string_view action_shape_name =
-                action.target_shape != Shape::Hexagon ? shape_name : std::string_view{};
+                action.target_shape != Shape::Hexagon ? shape_name : std::string_view{""};
             session_log_write(*log, song_time, "PLAYER",
                 "PLAN action=%.*s%s%s react=%.3fs arrival=%.3fs",
                 static_cast<int>(action_shape_name.size()), action_shape_name.data(),

--- a/tests/test_test_player_system.cpp
+++ b/tests/test_test_player_system.cpp
@@ -248,6 +248,22 @@ TEST_CASE("test_player: swipe cooldown blocks immediate second swipe", "[test_pl
     CHECK_FALSE(has_go);
 }
 
+TEST_CASE("test_player: session log handles lane-only planned action",
+          "[test_player][session_logger][issue-899]") {
+    auto reg = make_test_player_registry();
+    make_rhythm_player(reg);
+    auto& log = reg.ctx().emplace<SessionLog>();
+    log.file = std::tmpfile();
+    REQUIRE(log.file != nullptr);
+
+    make_lane_block_at(reg, 0b010, constants::PLAYER_Y - 300.0f);
+
+    test_player_system(reg, 0.016f);
+
+    const std::string contents = read_session_log(log);
+    CHECK(contents.find("PLAN action=+lane") != std::string::npos);
+}
+
 // ── PRIORITY: don't move for far obstacle if it fails a closer one ──
 
 TEST_CASE("test_player: won't move for far obstacle if closer one blocks that lane", "[test_player]") {


### PR DESCRIPTION
## Summary
- Use a stable empty string for shape-less planned actions before passing text to `%.*s` session-log formatting.
- Add a regression test for lane-only planned actions with session logging enabled.

## Verification
- `cmake -B build -S . -Wno-dev && cmake --build build && ./build/shapeshifter_tests "[test_player][session_logger]" && ./build/shapeshifter_tests`
- `./run.sh test`

Closes #899