### PR TITLE
Fix squad cycle diagnostics

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -168,3 +168,27 @@ jobs:
       - name: Build
         run: cmake --build build-msvc --config Release
         shell: cmd
+
+      - name: Install Python tool test dependencies
+        shell: bash
+        run: |
+          PYTHON_TOOL_TEST_EXE="$(grep '^_Python3_EXECUTABLE:INTERNAL=' build-msvc/CMakeCache.txt | cut -d= -f2-)"
+          "$PYTHON_TOOL_TEST_EXE" -m pip install --break-system-packages -r tools/python-tool-test-requirements.txt || \
+          "$PYTHON_TOOL_TEST_EXE" -m pip install -r tools/python-tool-test-requirements.txt
+
+      - name: Run tests
+        run: |
+          mkdir -p build-msvc/ci
+          ctest --test-dir build-msvc -C Release -N \
+            | sed -nE 's/^ *Test *#[0-9]+: (.*)$/\1/p' \
+            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
+            | tr -d '\r' \
+            | sort -u > build-msvc/ci/ctest-nonbench-catch.txt
+          ./build-msvc/Release/shapeshifter_tests.exe --list-tests "~[bench]" --verbosity quiet \
+            | tr -d '\r' \
+            | sort -u > build-msvc/ci/catch-nonbench.txt
+          diff -u build-msvc/ci/ctest-nonbench-catch.txt build-msvc/ci/catch-nonbench.txt
+          ./build-msvc/Release/shapeshifter_tests.exe "~[bench]"
+          ctest --test-dir build-msvc -C Release --output-on-failure -R "^startup_shutdown_smoke$"
+          ctest --test-dir build-msvc -C Release --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
+        shell: bash

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -178,12 +178,30 @@ jobs:
 
       - name: Run tests
         run: |
+          PYTHON_TOOL_TEST_EXE="$(grep '^_Python3_EXECUTABLE:INTERNAL=' build-msvc/CMakeCache.txt | cut -d= -f2-)"
           mkdir -p build-msvc/ci
-          ctest --test-dir build-msvc -C Release -N \
-            | sed -nE 's/^ *Test *#[0-9]+: (.*)$/\1/p' \
-            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
-            | tr -d '\r' \
-            | sort -u > build-msvc/ci/ctest-nonbench-catch.txt
+          ctest --test-dir build-msvc -C Release --show-only=json-v1 > build-msvc/ci/ctest-tests.json
+          "$PYTHON_TOOL_TEST_EXE" - <<'PY'
+          import json
+          import re
+
+          excluded = re.compile(
+              r"^Bench:|^(python_tool_tests|loop2_content_gates_strict|"
+              r"validate_loop1_diagnostics|validate_difficulty_ramp|"
+              r"validate_offset_semantics|validate_max_beat_gap|"
+              r"validate_no_simultaneous_shape_gates|check_shape_change_gap|"
+              r"beatmap_editor_node_tests|service_worker_cache_policy_node_tests|"
+              r"startup_shutdown_smoke)$"
+          )
+          with open("build-msvc/ci/ctest-tests.json", encoding="utf-8") as handle:
+              payload = json.load(handle)
+          names = sorted(
+              {test["name"] for test in payload["tests"] if not excluded.search(test["name"])}
+          )
+          with open("build-msvc/ci/ctest-nonbench-catch.txt", "w", encoding="utf-8", newline="\n") as handle:
+              handle.write("\n".join(names))
+              handle.write("\n")
+          PY
           ./build-msvc/Release/shapeshifter_tests.exe --list-tests "~[bench]" --verbosity quiet \
             | tr -d '\r' \
             | sort -u > build-msvc/ci/catch-nonbench.txt

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -189,14 +189,25 @@ jobs:
               r"^Bench:|^(python_tool_tests|loop2_content_gates_strict|"
               r"validate_loop1_diagnostics|validate_difficulty_ramp|"
               r"validate_offset_semantics|validate_max_beat_gap|"
-              r"validate_no_simultaneous_shape_gates|check_shape_change_gap|"
+              r"validate_no_simultaneous_shape_gates|"
+              r"validate_required_cross_lane_jump_time|check_shape_change_gap|"
               r"beatmap_editor_node_tests|service_worker_cache_policy_node_tests|"
               r"startup_shutdown_smoke)$"
           )
+          def normalize_ctest_name(name):
+              try:
+                  return name.encode("cp437").decode("utf-8")
+              except UnicodeError:
+                  return name
+
           with open("build-msvc/ci/ctest-tests.json", encoding="utf-8") as handle:
               payload = json.load(handle)
           names = sorted(
-              {test["name"] for test in payload["tests"] if not excluded.search(test["name"])}
+              {
+                  normalize_ctest_name(test["name"])
+                  for test in payload["tests"]
+                  if not excluded.search(test["name"])
+              }
           )
           with open("build-msvc/ci/ctest-nonbench-catch.txt", "w", encoding="utf-8", newline="\n") as handle:
               handle.write("\n".join(names))
@@ -208,5 +219,5 @@ jobs:
           diff -u build-msvc/ci/ctest-nonbench-catch.txt build-msvc/ci/catch-nonbench.txt
           ./build-msvc/Release/shapeshifter_tests.exe "~[bench]"
           ctest --test-dir build-msvc -C Release --output-on-failure -R "^startup_shutdown_smoke$"
-          ctest --test-dir build-msvc -C Release --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
+          ctest --test-dir build-msvc -C Release --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|validate_required_cross_lane_jump_time|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,10 +421,13 @@ if(FONT_FILES)
     )
 endif()
 
-# Copy beatmap JSON files next to the executable
-file(GLOB BEATMAP_FILES CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/content/beatmaps/*.json)
+# Copy runtime beatmap JSON files next to the executable. Analysis JSON files are
+# development/tooling artifacts and should not be bundled with the game.
+file(GLOB BEATMAP_FILES CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/content/beatmaps/*_beatmap.json)
 if(BEATMAP_FILES)
     add_custom_command(TARGET shapeshifter POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E rm -rf
+            "$<TARGET_FILE_DIR:shapeshifter>/content/beatmaps"
         COMMAND ${CMAKE_COMMAND} -E make_directory
             "$<TARGET_FILE_DIR:shapeshifter>/content/beatmaps"
         COMMAND ${CMAKE_COMMAND} -E copy_if_different

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -129,7 +129,8 @@ struct WorldTransform {
 };
 
 /// Movement vector in pixels/second for entities that integrate position.
-/// Iterated with WorldTransform by scroll_system every frame.
+/// Iterated with WorldTransform by motion_system every frame.
+/// Rhythm obstacles use BeatInfo and are positioned by scroll_system instead.
 struct MotionVelocity {
     glm::vec2 value = {0.0f, 0.0f};
 };


### PR DESCRIPTION
## Summary
- run the Windows MSVC test suite after the Release build
- bundle only runtime *_beatmap.json files and clear stale beatmap bundle outputs before copying
- correct architecture docs to identify motion_system as the MotionVelocity integrator

## Verification
- cmake -B build -S . -Wno-dev
- cmake --build build
- ./run.sh test
- runtime bundle check: build/content/beatmaps contains only *_beatmap.json files

Closes #904
Closes #905
Closes #906