### PR TITLE
Align run.sh JavaScript tests with CMake

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ at runtime boundaries, without wrapper abstraction layers.
 - C++20 compiler (Clang 20 recommended)
 - CMake 3.20+
 - [vcpkg](https://vcpkg.io)
-- Node.js 22+ with npm (optional, enables beatmap editor Node test suite during `ctest` and `./run.sh test`)
+- Node.js 22+ (optional, enables JavaScript test suites during `ctest` and `./run.sh test`)
 
 ### Quick Start
 

--- a/run.sh
+++ b/run.sh
@@ -9,10 +9,11 @@ if [[ "${1:-}" == "test" ]]; then
     shift
     ./build/shapeshifter_tests "$@"
     python3 -m unittest discover -s tools -p "test_*.py"
-    if command -v node >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
-        npm --prefix tools/beatmap-editor test
+    if command -v node >/dev/null 2>&1; then
+        (cd tools/beatmap-editor && node --test test/*.test.js)
+        node --test tests/service_worker_cache_policy.test.cjs
     else
-        echo "SKIPPED: beatmap-editor Node tests (node/npm executable not found)"
+        echo "SKIPPED: JavaScript tests (node executable not found)"
     fi
 elif [[ "${1:-}" == "bench" ]]; then
     shift


### PR DESCRIPTION
## Summary
- replace the npm-based beatmap editor test path in run.sh with direct node --test commands matching CMake
- include the service worker Node test in run.sh test
- update README prerequisites to describe the Node-only JavaScript test requirement

## Verification
- bash -n run.sh
- ./run.sh test

Closes #916