### PR TITLE
Guard SongState timing divisions

### DIFF
--- a/app/systems/beat_scheduler_system.cpp
+++ b/app/systems/beat_scheduler_system.cpp
@@ -14,6 +14,10 @@ void beat_scheduler_system(entt::registry& reg, float /*dt*/) {
     auto* song = reg.ctx().find<SongState>();
     auto* map  = find_beat_map(reg);
     if (!song || !map || !song->playing) return;
+    if (song->scroll_speed <= 0.0f) {
+        TraceLog(LOG_WARNING, "beat_scheduler_system skipped: invalid scroll_speed %.3f", song->scroll_speed);
+        return;
+    }
 
     // Player calibration (#474). Positive audio_offset_ms delays beat timing:
     // we push spawn_time forward by the same delta so obstacles arrive at

--- a/app/systems/shape_window_system.cpp
+++ b/app/systems/shape_window_system.cpp
@@ -15,8 +15,11 @@ void shape_window_system(entt::registry& reg, float /*dt*/) {
     auto* song = reg.ctx().find<SongState>();
     if (!song) return;
 
+    const bool morph_duration_valid = song->morph_duration > 0.0f;
+
     auto view = reg.view<PlayerTag, PlayerShape, ShapeWindow, Color>();
     for (auto [entity, pshape, swindow, col] : view.each()) {
+        (void)col;
         // Derive window_timer from song_time instead of accumulating dt.
         // This keeps shape windows frame-rate independent and perfectly
         // synced to the audio clock, per the "only use song position" rule.
@@ -28,6 +31,17 @@ void shape_window_system(entt::registry& reg, float /*dt*/) {
 
             case WindowPhase::MorphIn: {
                 swindow.window_timer = elapsed;
+                if (!morph_duration_valid) {
+                    TraceLog(LOG_WARNING, "shape_window_system completed MorphIn immediately: invalid morph_duration %.3f",
+                             song->morph_duration);
+                    pshape.morph_t = 1.0f;
+                    swindow.phase = WindowPhase::Active;
+                    swindow.window_start = song->song_time;
+                    swindow.window_timer = 0.0f;
+                    pshape.current = swindow.target_shape;
+                    apply_shape_color(reg, entity, pshape.current);
+                    break;
+                }
                 pshape.morph_t = elapsed / song->morph_duration;
                 if (pshape.morph_t >= 1.0f) {
                     pshape.morph_t = 1.0f;
@@ -58,6 +72,21 @@ void shape_window_system(entt::registry& reg, float /*dt*/) {
             case WindowPhase::MorphOut: {
                 float morph_elapsed = song->song_time - swindow.window_start;
                 swindow.window_timer = morph_elapsed;
+                if (!morph_duration_valid) {
+                    TraceLog(LOG_WARNING, "shape_window_system completed MorphOut immediately: invalid morph_duration %.3f",
+                             song->morph_duration);
+                    pshape.morph_t = 1.0f;
+                    pshape.current = Shape::Hexagon;
+                    pshape.previous = Shape::Hexagon;
+                    swindow.target_shape = Shape::Hexagon;
+                    swindow.phase = WindowPhase::Idle;
+                    swindow.window_timer = 0.0f;
+                    swindow.press_time = -1.0f;
+                    swindow.window_scale = 1.0f;
+                    swindow.graded = false;
+                    apply_shape_color(reg, entity, Shape::Hexagon);
+                    break;
+                }
                 pshape.morph_t = morph_elapsed / song->morph_duration;
                 if (pshape.morph_t >= 1.0f) {
                     pshape.morph_t = 1.0f;

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -552,26 +552,25 @@ system in the same frame (unidirectional data flow).
  │  │     b. beat_scheduler_sys Spawn authored BeatMap notes │
  │  │                           whose spawn_time has arrived.│
  │  │                                                        │
- │  │     c. player_movement    Advance lane, jump/slide,    │
+ │  │     c. shape_window_sys   Advance active timing windows│
  │  │                           and morph interpolation.     │
  │  │                                                        │
- │  │     d. scroll_system      Derive rhythm-obstacle       │
+ │  │     d. player_movement    Advance lane and jump/slide. │
+ │  │                                                        │
+ │  │     e. scroll_system      Derive rhythm-obstacle       │
  │  │                           positions from SongState     │
  │  │                           song_time + BeatInfo.        │
  │  │                                                        │
- │  │     e. motion_system      For every (WorldTransform,   │
+ │  │     f. motion_system      For every (WorldTransform,   │
  │  │                           MotionVelocity):             │
  │  │                           position += velocity * dt.   │
  │  │                           Simple, tight inner loop.    │
  │  │                                                        │
- │  │     f. collision_system   For each obstacle near       │
+ │  │     g. collision_system   For each obstacle near       │
  │  │                           PLAYER_Y: test shape match,  │
  │  │                           lane match, vertical state.  │
  │  │                           On match: emplace TimingGrade│
  │  │                           and ScoredTag.               │
- │  │                                                        │
- │  │     g. shape_window_sys   Advance active timing windows│
- │  │                           for shape presses.           │
  │  │                                                        │
  │  │     h. miss_detection     Mark passed unresolved notes │
  │  │                           with MissTag/ScoredTag.      │
@@ -1239,7 +1238,7 @@ Obstacle pool:   [obs0] [obs1] [obs2] ... [obsM]          contiguous in memory
    roughly 20 bytes × 71 = 1.4 KB. There is no cache pressure that SoA would
    alleviate.
 
-2. **Iteration patterns are simple**. The hottest loop (`scroll_system`) reads
+2. **Iteration patterns are simple**. The hottest loop (`motion_system`) reads
    `WorldTransform` + `MotionVelocity` together — two tiny pools that are in L1
    after the first iteration.
 
@@ -1247,19 +1246,14 @@ Obstacle pool:   [obs0] [obs1] [obs2] ... [obsM]          contiguous in memory
    indirection overhead and code complexity for zero performance gain at these
    entity counts. SoA becomes beneficial at 10,000+ entities — we peak at 71.
 
-**EnTT groups** can ensure co-iterated component pools are sorted identically:
+The current implementation uses an EnTT view for the small dt-integrated set:
 
 ```cpp
-// In initialization — declare a full-owning group for WorldTransform + MotionVelocity.
-// This guarantees both pools are sorted in the same entity order,
-// so iterating the group produces perfectly sequential memory access.
-auto& group = reg.group<WorldTransform, MotionVelocity>();
-
-// scroll_system uses this group:
-void scroll_system(entt::registry& reg, float dt) {
-    auto group = reg.group<WorldTransform, MotionVelocity>();
-    for (auto [entity, transform, velocity] : group.each()) {
-        transform.position += velocity.value * dt;
+void motion_system(entt::registry& reg, float dt) {
+    auto motion_view = reg.view<WorldTransform, MotionVelocity>();
+    for (auto [entity, transform, velocity] : motion_view.each()) {
+        transform.position.x += velocity.value.x * dt;
+        transform.position.y += velocity.value.y * dt;
     }
 }
 ```
@@ -1475,11 +1469,11 @@ app/
 │   ├── game_state_system.cpp    ← phase transitions
 │   ├── song_playback_system.cpp ← music stream timing
 │   ├── beat_log_system.cpp      ← session beat telemetry
-│   ├── player_input_system.cpp  ← ButtonPressEvent/GoEvent listener callbacks
+│   ├── player_input_system.cpp  ← ButtonPressEvent/GoEvent dispatcher callbacks
 │   ├── test_player_system.cpp   ← automated test player (enqueues semantic events)
-│   ├── player_movement_system.cpp ← lane lerp, jump parabola, morph advance
+│   ├── player_movement_system.cpp ← lane lerp, jump parabola
 │   ├── beat_scheduler_system.cpp ← song-authored obstacle entities
-│   ├── scroll_system.cpp        ← pos += vel × dt
+│   ├── scroll_system.cpp        ← derive rhythm positions from song_time + BeatInfo
 │   ├── collision_system.cpp     ← obstacle vs player match test
 │   ├── miss_detection_system.cpp ← missed obstacles → miss events
 │   ├── scoring_system.cpp       ← bank points, chain, spawn popup
@@ -1525,29 +1519,26 @@ for (auto [entity, pos, obs] : view.each()) {
 }
 ```
 
-### A.3 Group for Hot Path
+### A.3 View for Hot Path
 
 ```cpp
-// Declared once at startup — ensures WorldTransform and MotionVelocity pools
-// maintain identical sort order for cache-optimal co-iteration.
-reg.group<WorldTransform, MotionVelocity>();
-
-// Used in scroll_system:
-auto group = reg.group<WorldTransform, MotionVelocity>();
-for (auto [entity, transform, velocity] : group.each()) {
-    transform.position += velocity.value * dt;
+// Used in motion_system for dt-integrated entities.
+auto motion_view = reg.view<WorldTransform, MotionVelocity>();
+for (auto [entity, transform, velocity] : motion_view.each()) {
+    transform.position.x += velocity.value.x * dt;
+    transform.position.y += velocity.value.y * dt;
 }
 ```
 
 ### A.4 Entity Creation (obstacle spawn)
 
 ```cpp
-entt::entity spawn_shape_gate(entt::registry& reg, Shape required,
-                               int8_t lane, float scroll_speed) {
+entt::entity spawn_rhythm_shape_gate(entt::registry& reg, Shape required,
+                                     int8_t lane, const BeatInfo& beat_info) {
     auto e = reg.create();
     reg.emplace<ObstacleTag>(e);
     reg.emplace<WorldTransform>(e, WorldTransform{{constants::LANE_X[lane], constants::SPAWN_Y}});
-    reg.emplace<MotionVelocity>(e, MotionVelocity{{0.0f, scroll_speed}});
+    reg.emplace<BeatInfo>(e, beat_info);
     reg.emplace<Obstacle>(e, int16_t{constants::PTS_SHAPE_GATE});
     reg.emplace<RequiredShape>(e, required);
     reg.emplace<Color>(e, shape_color(required));

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -496,3 +496,26 @@ TEST_CASE("beat_scheduler: clamped late-spawn stores adjusted spawn_time in Beat
         CHECK_THAT(recomputed_y, Catch::Matchers::WithinAbs(max_start_y, 0.01f));
     }
 }
+
+TEST_CASE("beat_scheduler: invalid scroll_speed skips late-spawn division", "[beat_scheduler][issue915]") {
+    auto reg = make_rhythm_registry();
+    auto& song = reg.ctx().get<SongState>();
+    auto& map = beat_map(reg);
+
+    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    song.song_time = 100.0f;
+    song.scroll_speed = 0.0f;
+    song.next_spawn_idx = 0;
+
+    beat_scheduler_system(reg, 0.016f);
+
+    CHECK(song.next_spawn_idx == 0);
+    CHECK(reg.view<ObstacleTag>().begin() == reg.view<ObstacleTag>().end());
+    CHECK(reg.view<ObstacleTag, BeatInfo>().begin() == reg.view<ObstacleTag, BeatInfo>().end());
+
+    song.scroll_speed = -1.0f;
+    beat_scheduler_system(reg, 0.016f);
+
+    CHECK(song.next_spawn_idx == 0);
+    CHECK(reg.view<ObstacleTag>().begin() == reg.view<ObstacleTag>().end());
+}

--- a/tests/test_shape_window_system.cpp
+++ b/tests/test_shape_window_system.cpp
@@ -2,6 +2,8 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include "test_helpers.h"
 
+#include <cmath>
+
 // ── shape_window_system: Idle phase ──────────────────────────
 
 TEST_CASE("shape_window: Idle phase does nothing", "[shape_window]") {
@@ -262,4 +264,49 @@ TEST_CASE("shape_window: Active stays Active if time not yet expired", "[shape_w
 
     CHECK(sw.phase == WindowPhase::Active);
     CHECK_THAT(sw.window_timer, Catch::Matchers::WithinAbs(half_window, 0.001f));
+}
+
+TEST_CASE("shape_window: invalid morph_duration completes MorphIn without non-finite progress", "[shape_window][issue915]") {
+    auto reg = make_rhythm_registry();
+    auto player = make_rhythm_player(reg);
+    auto& ps = reg.get<PlayerShape>(player);
+    auto& sw = reg.get<ShapeWindow>(player);
+    auto& song = reg.ctx().get<SongState>();
+
+    sw.phase = WindowPhase::MorphIn;
+    sw.target_shape = Shape::Square;
+    sw.window_start = song.song_time;
+    ps.morph_t = 0.0f;
+    song.morph_duration = 0.0f;
+
+    shape_window_system(reg, 0.016f);
+
+    CHECK(std::isfinite(ps.morph_t));
+    CHECK(ps.morph_t == 1.0f);
+    CHECK(sw.phase == WindowPhase::Active);
+    CHECK(ps.current == Shape::Square);
+}
+
+TEST_CASE("shape_window: invalid morph_duration completes MorphOut without non-finite progress", "[shape_window][issue915]") {
+    auto reg = make_rhythm_registry();
+    auto player = make_rhythm_player(reg);
+    auto& ps = reg.get<PlayerShape>(player);
+    auto& sw = reg.get<ShapeWindow>(player);
+    auto& song = reg.ctx().get<SongState>();
+
+    sw.phase = WindowPhase::MorphOut;
+    sw.target_shape = Shape::Triangle;
+    ps.current = Shape::Triangle;
+    ps.previous = Shape::Triangle;
+    sw.window_start = song.song_time;
+    ps.morph_t = 0.0f;
+    song.morph_duration = -0.1f;
+
+    shape_window_system(reg, 0.016f);
+
+    CHECK(std::isfinite(ps.morph_t));
+    CHECK(ps.morph_t == 1.0f);
+    CHECK(sw.phase == WindowPhase::Idle);
+    CHECK(ps.current == Shape::Hexagon);
+    CHECK(ps.previous == Shape::Hexagon);
 }


### PR DESCRIPTION
## Summary
- guard beat scheduler late-spawn adjustment when SongState.scroll_speed is invalid
- complete shape morph phases safely when SongState.morph_duration is invalid
- update architecture docs for current execution order and scroll/motion responsibilities

## Root cause
Runtime systems assumed derived SongState timing values were valid at use sites, and the architecture docs had drifted from the current system boundaries.

## Verification
- cmake -B build -S . -Wno-dev
- cmake --build build --parallel
- ./build/shapeshifter_tests "[beat_scheduler],[shape_window]"
- ./run.sh test

Closes #915
Closes #914