### PR TITLE
Fix dirty high-score save retry

### DIFF
--- a/app/systems/game_state_terminal_phase_system.cpp
+++ b/app/systems/game_state_terminal_phase_system.cpp
@@ -9,6 +9,20 @@
 
 namespace {
 
+void persist_dirty_high_scores(const HighScoreState& high_scores, HighScorePersistence& persistence) {
+    if (!persistence.dirty) return;
+
+    if (persistence.path.empty()) {
+        persistence.last_save = persistence::Result{persistence::Status::PathUnavailable, {}};
+        return;
+    }
+
+    persistence.last_save = high_score::save_high_scores(high_scores, persistence.path);
+    if (persistence.last_save.ok()) {
+        persistence.dirty = false;
+    }
+}
+
 bool update_and_persist_high_score(entt::registry& reg) {
     auto& score = reg.ctx().get<ScoreState>();
     const int32_t previous_high_score = score.high_score;
@@ -18,22 +32,23 @@ bool update_and_persist_high_score(entt::registry& reg) {
     } else {
         reg.ctx().emplace<TerminalResultState>(TerminalResultState{is_new_high_score, previous_high_score});
     }
-    if (!is_new_high_score) return false;
 
-    score.high_score = score.score;
     if (auto* hs = reg.ctx().find<HighScoreState>()) {
-        high_score::update_if_higher(*hs, score.score);
-        if (auto* hp = reg.ctx().find<HighScorePersistence>()) {
-            hp->dirty = true;
-            if (hp->path.empty()) {
-                hp->last_save = persistence::Result{persistence::Status::PathUnavailable, {}};
-            } else {
-                hp->last_save = high_score::save_high_scores(*hs, hp->path);
-                if (hp->last_save.ok()) hp->dirty = false;
-            }
+        if (is_new_high_score) {
+            score.high_score = score.score;
+            high_score::update_if_higher(*hs, score.score);
         }
+        if (auto* hp = reg.ctx().find<HighScorePersistence>()) {
+            if (is_new_high_score) {
+                hp->dirty = true;
+            }
+            persist_dirty_high_scores(*hs, *hp);
+        }
+    } else if (is_new_high_score) {
+        score.high_score = score.score;
     }
-    return true;
+
+    return is_new_high_score;
 }
 
 void emit_terminal_feedback(entt::registry& reg, GamePhase phase, bool is_new_high_score) {

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -261,6 +261,23 @@ TEST_CASE("High score integration: failed save keeps dirty state for retry",
     CHECK(persistence_state.last_save.status == persistence::Status::DirectoryCreateFailed);
 
     remove_path(root);
+    const auto retry_file = root / "high_scores.json";
+    reg.ctx().get<HighScorePersistence>().path = retry_file.string();
+    score.score = 1000;
+    gs.transition_pending = true;
+    gs.next_phase = GamePhase::GameOver;
+
+    game_state_system(reg, 0.016f);
+
+    const auto& retried_persistence = reg.ctx().get<HighScorePersistence>();
+    CHECK_FALSE(retried_persistence.dirty);
+    CHECK(retried_persistence.last_save.status == persistence::Status::Success);
+
+    HighScoreState loaded;
+    REQUIRE(high_score::load_high_scores(loaded, retry_file).ok());
+    CHECK(high_score::get_score(loaded, "song_001|easy") == 2500);
+
+    remove_path(root);
 }
 
 TEST_CASE("High score bootstrap: persistence path is populated for save call sites",


### PR DESCRIPTION
## Summary
- Retry dirty high-score persistence on later terminal transitions even when the current run does not beat the in-memory high score.
- Keep dirty set until `save_high_scores` succeeds, including path-unavailable retries.
- Extend the high-score integration regression to cover failed save -> later retry -> persisted high score.

Fixes #919

## Verification
- `cmake --build build --target shapeshifter_tests && ./build/shapeshifter_tests "[high_score][gamestate]"`
- `./run.sh test`
