### PR TITLE
Guard invalid scroll speed divisions

### DIFF
--- a/app/systems/beat_scheduler_system.cpp
+++ b/app/systems/beat_scheduler_system.cpp
@@ -10,11 +10,13 @@
 #include "../constants.h"
 #include "../entities/settings.h"
 
+#include <cmath>
+
 void beat_scheduler_system(entt::registry& reg, float /*dt*/) {
     auto* song = reg.ctx().find<SongState>();
     auto* map  = find_beat_map(reg);
     if (!song || !map || !song->playing) return;
-    if (song->scroll_speed <= 0.0f) {
+    if (!std::isfinite(song->scroll_speed) || song->scroll_speed <= 0.0f) {
         TraceLog(LOG_WARNING, "beat_scheduler_system skipped: invalid scroll_speed %.3f", song->scroll_speed);
         return;
     }

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -14,6 +14,7 @@
 
 #include <raylib.h>
 #include <magic_enum/magic_enum.hpp>
+#include <cmath>
 #include <random>
 #include <string_view>
 
@@ -76,6 +77,10 @@ static bool test_player_needs_shape(const TestPlayerAction& action) {
 
 static bool test_player_needs_lane(const TestPlayerAction& action) {
     return lane_utils::is_valid(action.target_lane) && !test_player_lane_done(action);
+}
+
+static bool valid_scroll_speed(float scroll_speed) {
+    return std::isfinite(scroll_speed) && scroll_speed > 0.0f;
 }
 
 static bool test_player_needs_vertical(const TestPlayerAction& action) {
@@ -468,9 +473,12 @@ void test_player_system(entt::registry& reg, float dt) {
                 if (odist <= 0.0f) continue;
 
                 auto* obeat = reg.try_get<BeatInfo>(oe);
-                float o_arrival = obeat ? obeat->arrival_time
-                    : (song_time + odist / song->scroll_speed);
-                if (o_arrival >= action.arrival_time) continue; // farther, don't care
+                if (obeat) {
+                    if (obeat->arrival_time >= action.arrival_time) continue; // farther, don't care
+                } else if (valid_scroll_speed(song->scroll_speed)) {
+                    const float o_arrival = song_time + odist / song->scroll_speed;
+                    if (o_arrival >= action.arrival_time) continue; // farther, don't care
+                }
 
                 // Closer obstacle — check if proposed lane is safe for it
                 auto* oblocked = reg.try_get<BlockedLanes>(oe);

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -3,6 +3,8 @@
 #include "test_helpers.h"
 #include "entities/beat_map.h"
 
+#include <limits>
+
 // ── beat_scheduler_system: basic spawning ────────────────────
 
 TEST_CASE("beat_scheduler: no spawn when not Playing", "[beat_scheduler]") {
@@ -514,6 +516,12 @@ TEST_CASE("beat_scheduler: invalid scroll_speed skips late-spawn division", "[be
     CHECK(reg.view<ObstacleTag, BeatInfo>().begin() == reg.view<ObstacleTag, BeatInfo>().end());
 
     song.scroll_speed = -1.0f;
+    beat_scheduler_system(reg, 0.016f);
+
+    CHECK(song.next_spawn_idx == 0);
+    CHECK(reg.view<ObstacleTag>().begin() == reg.view<ObstacleTag>().end());
+
+    song.scroll_speed = std::numeric_limits<float>::quiet_NaN();
     beat_scheduler_system(reg, 0.016f);
 
     CHECK(song.next_spawn_idx == 0);

--- a/tests/test_test_player_system.cpp
+++ b/tests/test_test_player_system.cpp
@@ -248,6 +248,32 @@ TEST_CASE("test_player: swipe cooldown blocks immediate second swipe", "[test_pl
     CHECK_FALSE(has_go);
 }
 
+TEST_CASE("test_player: invalid scroll speed treats undated closer obstacles as blockers",
+          "[test_player][issue923]") {
+    auto reg = make_test_player_registry();
+    make_rhythm_player(reg);
+    auto& song = reg.ctx().get<SongState>();
+    song.scroll_speed = 0.0f;
+
+    auto closer = reg.create();
+    reg.emplace<ObstacleTag>(closer);
+    reg.emplace<Obstacle>(closer, ObstacleKind::LaneBlock, int16_t{constants::PTS_LANE_BLOCK});
+    reg.emplace<WorldTransform>(closer,
+                               WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y - 300.0f}});
+    reg.emplace<BlockedLanes>(closer, uint8_t{0b001});
+
+    auto& tp = reg.ctx().get<TestPlayerState>();
+    TestPlayerAction action;
+    action.timer = -1.0f;
+    action.arrival_time = song.song_time + 2.0f;
+    action.target_lane = 0;
+    tp.actions[tp.action_count++] = action;
+
+    test_player_system(reg, 0.016f);
+
+    CHECK(drain_go_events(reg).count == 0);
+}
+
 TEST_CASE("test_player: session log handles lane-only planned action",
           "[test_player][session_logger][issue-899]") {
     auto reg = make_test_player_registry();


### PR DESCRIPTION
## Summary
- guard beat scheduling against non-finite or non-positive scroll_speed before late-spawn division
- make test-player fallback arrival checks avoid invalid scroll_speed division and treat undated closer obstacles conservatively
- add focused regression coverage for zero/negative/NaN scroll_speed cases

## Verification
- ./build/shapeshifter_tests "[beat_scheduler],[test_player]"
- ./run.sh test

Fixes #923