### PR TITLE
Guard scroll system speed input

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ at runtime boundaries, without wrapper abstraction layers.
 
 ## Gameplay
 
-- **3 shapes** — Circle, Square, Triangle. Press shape buttons on the beat.
+- **4 shapes** — Circle, Square, Triangle, and Hexagon. Press shape buttons on the beat; Hexagon is the idle/default shape.
 - **3 lanes** — Swipe or press A/D to dodge lane blocks.
 - **Timing grades** — Perfect > Good > Ok > Bad. Closer to the beat = higher score.
 - **Rhythm windows** — Shape changes are temporary; match the shape before the window closes.

--- a/app/systems/scroll_system.cpp
+++ b/app/systems/scroll_system.cpp
@@ -5,6 +5,8 @@
 #include "../components/obstacle.h"
 #include "../constants.h"
 
+#include <cmath>
+
 void scroll_system(entt::registry& reg, float /*dt*/) {
     auto* song = reg.ctx().find<SongState>();
 
@@ -12,6 +14,10 @@ void scroll_system(entt::registry& reg, float /*dt*/) {
     // This prevents floating-point drift from desynchronizing collisions
     // with the beat grid. (See: "never use anything other than song position")
     if (song && (song->playing || song->finished)) {
+        if (!std::isfinite(song->scroll_speed) || song->scroll_speed <= 0.0f) {
+            TraceLog(LOG_WARNING, "scroll_system skipped: invalid scroll_speed %.3f", song->scroll_speed);
+            return;
+        }
 
         auto beat_view = reg.view<ObstacleTag, WorldTransform, BeatInfo>();
         for (auto [entity, wt, info] : beat_view.each()) {

--- a/tests/test_scroll_rhythm.cpp
+++ b/tests/test_scroll_rhythm.cpp
@@ -2,6 +2,9 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include "test_helpers.h"
 
+#include <cmath>
+#include <limits>
+
 // ── scroll_system: rhythm-mode BeatInfo positioning ──────────
 
 TEST_CASE("scroll: rhythm obstacles positioned from song_time and BeatInfo", "[scroll][rhythm]") {
@@ -75,4 +78,41 @@ TEST_CASE("scroll: BeatInfo position tracks song_time progression", "[scroll][rh
     CHECK(y2 > y1);
     float delta = y2 - y1;
     CHECK_THAT(delta, Catch::Matchers::WithinAbs(song.scroll_speed, 0.5f));
+}
+
+TEST_CASE("scroll: invalid scroll_speed preserves finite obstacle position", "[scroll][rhythm][issue929]") {
+    auto reg = make_rhythm_registry();
+    auto& song = reg.ctx().get<SongState>();
+    song.song_time = 2.0f;
+    song.scroll_speed = std::numeric_limits<float>::quiet_NaN();
+
+    auto obs = reg.create();
+    reg.emplace<ObstacleTag>(obs);
+    reg.emplace<WorldTransform>(obs, WorldTransform{{0.0f, 123.0f}});
+    reg.emplace<BeatInfo>(obs, 0, 4.0f, 0.0f);
+
+    scroll_system(reg, 0.016f);
+
+    const auto& transform = reg.get<WorldTransform>(obs);
+    CHECK(std::isfinite(transform.position.y));
+    CHECK_THAT(transform.position.y, Catch::Matchers::WithinAbs(123.0f, 0.001f));
+}
+
+TEST_CASE("scroll: non-positive scroll_speed skips position updates", "[scroll][rhythm][issue929]") {
+    auto reg = make_rhythm_registry();
+    auto& song = reg.ctx().get<SongState>();
+    song.song_time = 2.0f;
+    song.scroll_speed = 0.0f;
+
+    auto obs = reg.create();
+    reg.emplace<ObstacleTag>(obs);
+    reg.emplace<WorldTransform>(obs, WorldTransform{{0.0f, 234.0f}});
+    reg.emplace<BeatInfo>(obs, 0, 4.0f, 0.0f);
+
+    scroll_system(reg, 0.016f);
+    CHECK_THAT(reg.get<WorldTransform>(obs).position.y, Catch::Matchers::WithinAbs(234.0f, 0.001f));
+
+    song.scroll_speed = -100.0f;
+    scroll_system(reg, 0.016f);
+    CHECK_THAT(reg.get<WorldTransform>(obs).position.y, Catch::Matchers::WithinAbs(234.0f, 0.001f));
 }


### PR DESCRIPTION
## Summary\n- skip rhythm obstacle scroll updates when scroll_speed is non-finite or non-positive\n- add regression coverage for invalid, zero, and negative scroll speeds\n- update README gameplay shape count to include Hexagon idle/default state\n\nFixes #929\nPart of #930\n\n## Verification\n- cmake -B build -S . -Wno-dev\n- cmake --build build\n- ./build/shapeshifter_tests\n- ./run.sh test