### PR TITLE
Add WASM difficulty selection smoke regression

### DIFF
--- a/tests/wasm_runtime_smoke.cjs
+++ b/tests/wasm_runtime_smoke.cjs
@@ -399,24 +399,35 @@ async function main() {
     // The title transition above covers the browser click path; using keyboard
     // here avoids depending on CSS-to-virtual-coordinate details for card rows.
     await page.keyboard.press('ArrowDown');
-    const afterLevelSelectClickHash = await waitForVisualChange(afterStartHash, 2500);
-    if (afterStartHash === afterLevelSelectClickHash) {
+    const afterLevelSelectNavigationHash = await waitForVisualChange(afterStartHash, 2500);
+    if (afterStartHash === afterLevelSelectNavigationHash) {
       fatal.push('no-visual-response-after-level-select-navigation');
     }
     if (!(await waitForTitlePhase('LevelSelect', 1500))) {
       fatal.push(`unexpected-phase-after-level-select-navigation:${await page.title()}`);
     }
 
+    // Regression coverage for #934: selecting a difficulty before confirming
+    // must not leave the browser build in a frozen/scattered gameplay frame.
+    await page.keyboard.press('ArrowRight');
+    const afterDifficultyNavigationHash = await waitForVisualChange(afterLevelSelectNavigationHash, 2500);
+    if (afterLevelSelectNavigationHash === afterDifficultyNavigationHash) {
+      fatal.push('no-visual-response-after-difficulty-navigation');
+    }
+    if (!(await waitForTitlePhase('LevelSelect', 1500))) {
+      fatal.push(`unexpected-phase-after-difficulty-navigation:${await page.title()}`);
+    }
+
     // Start the selected level. The controller intentionally ignores instant
     // confirm presses for the first 0.2s after entering Level Select, so wait
     // a frame budget before sending confirm.
     await page.waitForTimeout(500);
-    let afterHash = afterLevelSelectClickHash;
-    for (let i = 0; i < 3 && afterHash === afterLevelSelectClickHash; i += 1) {
+    let afterHash = afterDifficultyNavigationHash;
+    for (let i = 0; i < 3 && afterHash === afterDifficultyNavigationHash; i += 1) {
       await page.keyboard.press('Enter');
-      afterHash = await waitForVisualChange(afterLevelSelectClickHash, 3500);
+      afterHash = await waitForVisualChange(afterDifficultyNavigationHash, 3500);
     }
-    if (afterLevelSelectClickHash === afterHash) {
+    if (afterDifficultyNavigationHash === afterHash) {
       fatal.push('no-visual-response-after-enter');
     }
     if (await waitForTitlePhase('Tutorial', 1500)) {
@@ -438,6 +449,11 @@ async function main() {
     const laneBeforeSwipe = await waitForPlayingLane(() => true, 2500);
     if (laneBeforeSwipe === null) {
       fatal.push(`missing-playing-lane-marker:${await page.title()}`);
+    }
+    const playingHash = sha256(await page.screenshot());
+    const afterPlayingAdvanceHash = await waitForVisualChange(playingHash, 3000);
+    if (playingHash === afterPlayingAdvanceHash) {
+      fatal.push('no-visual-response-after-playing-start');
     }
 
     const beforeSwipeHash = sha256(await page.screenshot());


### PR DESCRIPTION
## Summary\n- extend the WASM Playwright smoke through difficulty selection before confirming play\n- assert gameplay keeps visually advancing after entering Playing, before touch input\n\nFixes #934\n\n## Verification\n- emcmake cmake -B build-web -S . -DCMAKE_BUILD_TYPE=Release -Wno-dev ... -DVCPKG_TARGET_TRIPLET=wasm32-emscripten -DSHAPESHIFTER_WASM_SMOKE_MARKERS=ON\n- cmake --build build-web -- -j10\n- cd build-web && ctest --verbose --output-on-failure\n- node tests/wasm_runtime_smoke.cjs --build-dir build-web --seed-stale-build-cache http://127.0.0.1:4173/index.html\n- node tests/wasm_runtime_smoke.cjs https://yashasg.github.io/friendly-parakeet/