### PR TITLE
Refresh energy terminology in docs

### DIFF
--- a/docs/audio-pipeline-spec.md
+++ b/docs/audio-pipeline-spec.md
@@ -426,20 +426,20 @@ Current code (lines 133–139):
     song_state.bpm = 120.0f;
     song_state.playing = true;
     song_state_compute_derived(song_state);
-    reg.ctx().emplace<BeatMap>();
-    reg.ctx().emplace<HPState>();
+    create_beat_map_entity(reg);
+    reg.ctx().emplace<EnergyState>();
     reg.ctx().emplace<SongResults>();
 ```
 
 Replace with:
 ```cpp
     // ── Rhythm singletons ────────────────────────────────────
-    reg.ctx().emplace<HPState>();
+    reg.ctx().emplace<EnergyState>();
     reg.ctx().emplace<SongResults>();
 
     // Load beatmap from disk
     {
-        auto& beatmap = reg.ctx().emplace<BeatMap>();
+        auto& beatmap = beat_map(reg);
         std::vector<BeatMapError> load_errors;
 
         // Try path relative to executable first, then CWD
@@ -493,7 +493,7 @@ Replace with:
     // ── Load music stream ────────────────────────────────────
     {
         auto& music = reg.ctx().emplace<MusicContext>();
-        auto* beatmap = reg.ctx().find<BeatMap>();
+        auto* beatmap = find_beat_map(reg);
 
         if (beatmap && !beatmap->song_path.empty()) {
             // Try relative to exe first, then CWD
@@ -706,7 +706,7 @@ void song_playback_system(entt::registry& reg, float dt) {
 The existing `enter_playing()` on line 51-60 already handles the reset:
 ```cpp
 auto* song = reg.ctx().find<SongState>();
-auto* beatmap = reg.ctx().find<BeatMap>();
+auto* beatmap = find_beat_map(reg);
 bool has_chart = beatmap && !beatmap->beats.empty();
 if (song) {
     song->song_time      = 0.0f;
@@ -717,7 +717,7 @@ if (song) {
 }
 ```
 
-**Add music reset** inside `enter_playing()` (after line 60, before the HP reset on line 61):
+**Add music reset** inside `enter_playing()` before the energy/results reset:
 ```cpp
     auto* music = reg.ctx().find<MusicContext>();
     if (music && music->loaded) {

--- a/docs/testflight-readiness.md
+++ b/docs/testflight-readiness.md
@@ -58,7 +58,7 @@ Event set (v1):
 | `ftue_abandoned`   | run_index, last_step                               | Where new players drop                 |
 | `song_started`     | song_id, difficulty                                | Content selection                      |
 | `song_completed`   | song_id, difficulty, score, accuracy_pct           | Win-rate per song/difficulty           |
-| `song_failed`      | song_id, difficulty, hp_zero_at_song_pct           | Failure point analysis                 |
+| `song_failed`      | song_id, difficulty, energy_empty_at_song_pct      | Failure point analysis                 |
 | `pause_used`       | song_id, song_pct                                  | Pause behaviour                        |
 | `audio_interrupt`  | song_id, song_pct, source (call/siri/route)        | iOS audio-session correctness (#180)   |
 | `app_background`   | song_id?, song_pct?                                | Lifecycle correctness (#182)           |


### PR DESCRIPTION
## Summary
- replace stale HPState/HP telemetry wording with EnergyState/energy terminology
- update beat-map snippets to use create_beat_map_entity(), beat_map(), and find_beat_map() instead of ctx BeatMap access

Fixes #931

## Verification
- rg "HPState|hp_system\.cpp|hp_zero_at_song_pct|before the HP|\bHP\b|hp_" design-docs/beatmap-integration.md docs/audio-pipeline-spec.md docs/testflight-readiness.md