### PR TITLE
Fix SplitPath beatmap lane scheduling

### DIFF
--- a/app/entities/beat_map.cpp
+++ b/app/entities/beat_map.cpp
@@ -25,15 +25,17 @@ std::string constants_path_for_app_dir(const std::string& app_dir) {
 }
 
 bool kind_requires_shape(const ObstacleKind kind) {
-    return kind == ObstacleKind::ShapeGate;
+    return kind == ObstacleKind::ShapeGate || kind == ObstacleKind::SplitPath;
 }
 
 bool kind_requires_lane(const ObstacleKind kind) {
-    return kind == ObstacleKind::ShapeGate;
+    return kind == ObstacleKind::ShapeGate || kind == ObstacleKind::SplitPath;
 }
 
 bool is_supported_beatmap_kind(const ObstacleKind kind) {
-    return kind == ObstacleKind::ShapeGate || kind == ObstacleKind::OnsetMarker;
+    return kind == ObstacleKind::ShapeGate ||
+           kind == ObstacleKind::SplitPath ||
+           kind == ObstacleKind::OnsetMarker;
 }
 
 std::string type_error_message(const char* field, const char* expected, const json& value) {
@@ -238,6 +240,7 @@ ValidationConstants load_validation_constants(const std::string& app_dir) {
 
 static std::optional<ObstacleKind> parse_kind(const std::string& s) {
     if (s == "shape_gate")       return ObstacleKind::ShapeGate;
+    if (s == "split_path")       return ObstacleKind::SplitPath;
     if (s == "onset_marker")     return ObstacleKind::OnsetMarker;
     return std::nullopt;
 }
@@ -676,8 +679,8 @@ bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors,
             valid = false;
         }
 
-        // Rule 5: shape_gate must have lane 0-2
-        if (entry.kind == ObstacleKind::ShapeGate && (entry.lane < 0 || entry.lane > 2)) {
+        // Rule 5: lane-bound obstacles must have lane 0-2
+        if (kind_requires_lane(entry.kind) && (entry.lane < 0 || entry.lane > 2)) {
             errors.push_back({entry.beat_index, "Lane must be 0-2"});
             valid = false;
         }

--- a/app/systems/beat_scheduler_system.cpp
+++ b/app/systems/beat_scheduler_system.cpp
@@ -34,7 +34,7 @@ void beat_scheduler_system(entt::registry& reg, float /*dt*/) {
             song->next_spawn_idx++;
             continue;
         }
-        if (entry.kind != ObstacleKind::ShapeGate) {
+        if (entry.kind != ObstacleKind::ShapeGate && entry.kind != ObstacleKind::SplitPath) {
             TraceLog(LOG_WARNING, "Skipping unsupported active beatmap obstacle kind %d",
                      static_cast<int>(entry.kind));
             song->next_spawn_idx++;
@@ -78,13 +78,13 @@ void beat_scheduler_system(entt::registry& reg, float /*dt*/) {
                 - (max_start_y - constants::SPAWN_Y) / song->scroll_speed;
         }
 
-        // Shape gates use the authored lane directly.
+        // Lane-bound obstacles use the authored lane directly.
         float x_pos = constants::LANE_X[1];
         const int lane = static_cast<int>(entry.lane);
         if (lane >= 0 && lane < constants::LANE_COUNT) {
             x_pos = constants::LANE_X[lane];
         } else {
-            TraceLog(LOG_WARNING, "Invalid shape_gate lane %d; defaulting to center lane", lane);
+            TraceLog(LOG_WARNING, "Invalid beatmap lane %d; defaulting to center lane", lane);
         }
 
         const BeatInfo bi{entry.beat_index, calibrated_arrival_time, effective_spawn_time};

--- a/tests/test_beat_map_parser_unknown_fields.cpp
+++ b/tests/test_beat_map_parser_unknown_fields.cpp
@@ -265,7 +265,7 @@ TEST_CASE("parse: unshipped obstacle kinds are rejected", "[parse][kind][issue87
     std::string json = R"({
         "bpm": 120, "offset": 0.0, "lead_beats": 4, "duration_sec": 60.0,
         "beats": [
-            { "beat": 8, "kind": "split_path", "shape": "triangle" }
+            { "beat": 8, "kind": "lane_block", "lane": 1 }
         ]
     })";
 

--- a/tests/test_beat_map_validation.cpp
+++ b/tests/test_beat_map_validation.cpp
@@ -278,6 +278,18 @@ TEST_CASE("validate: shape_gate invalid lane fails", "[validate]") {
     CHECK_FALSE(validate_beat_map(map, errors));
 }
 
+TEST_CASE("validate: split_path invalid lane fails", "[validate][issue932]") {
+    BeatMap map;
+    map.bpm = 120.0f;
+    map.offset = 0.0f;
+    map.lead_beats = 4;
+    map.duration = 60.0f;
+    map.beats.push_back({0, ObstacleKind::SplitPath, Shape::Circle, 5, 0});
+
+    std::vector<BeatMapError> errors;
+    CHECK_FALSE(validate_beat_map(map, errors));
+}
+
 // ── validate_beat_map: multiple errors ───────────────────────
 
 TEST_CASE("validate: multiple errors accumulated", "[validate]") {
@@ -300,7 +312,6 @@ TEST_CASE("validate: unshipped obstacle kinds are rejected from active beatmaps"
     constexpr ObstacleKind kinds[] = {
         ObstacleKind::LaneBlock,
         ObstacleKind::ComboGate,
-        ObstacleKind::SplitPath,
     };
 
     for (const auto kind : kinds) {
@@ -317,6 +328,18 @@ TEST_CASE("validate: unshipped obstacle kinds are rejected from active beatmaps"
         REQUIRE_FALSE(errors.empty());
         CHECK(errors[0].message.find("Unsupported active beatmap obstacle kind") != std::string::npos);
     }
+}
+
+TEST_CASE("validate: split_path is supported in active beatmaps", "[validate][kind][issue932]") {
+    BeatMap map;
+    map.bpm = 120.0f;
+    map.offset = 0.0f;
+    map.lead_beats = 4;
+    map.duration = 60.0f;
+    map.beats.push_back({4, ObstacleKind::SplitPath, Shape::Circle, 2, 0});
+
+    std::vector<BeatMapError> errors;
+    CHECK(validate_beat_map(map, errors));
 }
 
 // ── init_song_state ──────────────────────────────────────────
@@ -751,6 +774,27 @@ TEST_CASE("parse: shape_gate requires explicit shape", "[parse][shape][issue224]
     CHECK_FALSE(parse_beat_map(json, map, errors));
     REQUIRE_FALSE(errors.empty());
     CHECK(errors[0].message.find("Missing required shape") != std::string::npos);
+}
+
+TEST_CASE("parse: split_path loads required shape and lane", "[parse][issue932]") {
+    BeatMap map;
+    std::vector<BeatMapError> errors;
+    std::string json = R"({
+        "song_id": "split_path_test",
+        "bpm": 120,
+        "offset": 0.0,
+        "lead_beats": 4,
+        "duration_sec": 60.0,
+        "beats": [
+            { "beat": 2, "kind": "split_path", "shape": "triangle", "lane": 2 }
+        ]
+    })";
+
+    CHECK(parse_beat_map(json, map, errors));
+    REQUIRE(map.beats.size() == 1);
+    CHECK(map.beats[0].kind == ObstacleKind::SplitPath);
+    CHECK(map.beats[0].shape == Shape::Triangle);
+    CHECK(map.beats[0].lane == 2);
 }
 
 TEST_CASE("parse: same beat_index entries are ordered by resolved time_sec", "[parse][beat_times][ordering]") {

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -299,6 +299,28 @@ TEST_CASE("beat_scheduler: skips unsupported active beatmap obstacle kinds", "[b
     CHECK(song.next_spawn_idx == 1);
 }
 
+TEST_CASE("beat_scheduler: spawns SplitPath in authored lane", "[beat_scheduler][issue932]") {
+    auto reg = make_rhythm_registry();
+    auto& song = reg.ctx().get<SongState>();
+    auto& map = beat_map(reg);
+
+    map.beats.push_back({0, ObstacleKind::SplitPath, Shape::Triangle, 2, 0});
+    song.song_time = 10.0f;
+    song.next_spawn_idx = 0;
+
+    beat_scheduler_system(reg, 0.016f);
+
+    auto view = reg.view<ObstacleTag, WorldTransform, RequiredShape, RequiredLane>();
+    REQUIRE(view.size_hint() == 1);
+    for (auto [e, wt, shape, lane] : view.each()) {
+        (void)e;
+        CHECK_THAT(wt.position.x, Catch::Matchers::WithinAbs(constants::LANE_X[2], 0.01f));
+        CHECK(shape.shape == Shape::Triangle);
+        CHECK(lane.lane == 2);
+    }
+    CHECK(song.next_spawn_idx == 1);
+}
+
 TEST_CASE("beat_scheduler: spawns all queued beats from BeatMap entries", "[beat_scheduler]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();


### PR DESCRIPTION
## Summary
- allow active beatmaps to parse and validate split_path entries with required shape/lane data
- schedule SplitPath rhythm obstacles instead of skipping them as unsupported
- place SplitPath obstacles at their authored lane while preserving RequiredLane

Fixes #932

## Verification
- ./build/shapeshifter_tests "[issue932]"
- ./run.sh test