### PR TITLE
Fix play session recovery and shape collision order

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ energy_system -> energy_bar_system -> particle_system
 `tick_playing_systems` is gated to `GamePhase::Playing` and runs:
 
 ```
-beat_log_system -> beat_scheduler_system -> player_movement_system ->
-scroll_system -> motion_system -> collision_system -> shape_window_system ->
-miss_detection_system -> scoring_system
+beat_log_system -> beat_scheduler_system -> shape_window_activation_system ->
+player_movement_system -> scroll_system -> motion_system -> collision_system ->
+shape_window_system -> miss_detection_system -> scoring_system
 ```
 
 ### Key Design Decisions

--- a/app/session/play_session.cpp
+++ b/app/session/play_session.cpp
@@ -202,8 +202,7 @@ void setup_play_session(entt::registry& reg) {
     }
 
     // Init song state
-    auto& song = reg.ctx().get<SongState>();
-    song = SongState{};
+    auto& song = assign_or_emplace_ctx(reg, SongState{});
     if (!beatmap.beats.empty()) {
         init_song_state(song, beatmap);
     } else {

--- a/app/systems/all_systems.h
+++ b/app/systems/all_systems.h
@@ -19,6 +19,7 @@ void beat_log_system(entt::registry& reg, float dt);
 void beat_scheduler_system(entt::registry& reg, float dt);
 
 // Phase 4: Player
+void shape_window_activation_system(entt::registry& reg, float dt);
 void shape_window_system(entt::registry& reg, float dt);
 void player_movement_system(entt::registry& reg, float dt);
 

--- a/app/systems/playing_systems_runner.cpp
+++ b/app/systems/playing_systems_runner.cpp
@@ -7,6 +7,7 @@ void tick_playing_systems(entt::registry& reg, float dt) {
     if (reg.ctx().get<GameState>().phase != GamePhase::Playing) return;
     beat_log_system(reg, dt);
     beat_scheduler_system(reg, dt);
+    shape_window_activation_system(reg, dt);
     player_movement_system(reg, dt);
     scroll_system(reg, dt);
     motion_system(reg, dt);

--- a/app/systems/shape_window_system.cpp
+++ b/app/systems/shape_window_system.cpp
@@ -5,17 +5,62 @@
 #include "../components/rhythm.h"
 #include "../constants.h"
 
+namespace {
+
 static void apply_shape_color(entt::registry& reg, entt::entity entity, Shape shape) {
     auto si = static_cast<int>(shape);
     auto& sc = constants::SHAPE_COLORS[si];
     reg.replace<Color>(entity, sc);
 }
 
-void shape_window_system(entt::registry& reg, float /*dt*/) {
+void update_morph_in(entt::registry& reg,
+                     entt::entity entity,
+                     PlayerShape& pshape,
+                     ShapeWindow& swindow,
+                     const SongState& song) {
+    const float elapsed = song.song_time - swindow.window_start;
+    swindow.window_timer = elapsed;
+    if (song.morph_duration <= 0.0f) {
+        TraceLog(LOG_WARNING, "shape_window_system completed MorphIn immediately: invalid morph_duration %.3f",
+                 song.morph_duration);
+        pshape.morph_t = 1.0f;
+        swindow.phase = WindowPhase::Active;
+        swindow.window_start = song.song_time;
+        swindow.window_timer = 0.0f;
+        pshape.current = swindow.target_shape;
+        apply_shape_color(reg, entity, pshape.current);
+        return;
+    }
+
+    pshape.morph_t = elapsed / song.morph_duration;
+    if (pshape.morph_t >= 1.0f) {
+        pshape.morph_t = 1.0f;
+        swindow.phase = WindowPhase::Active;
+        swindow.window_start = swindow.window_start + song.morph_duration;
+        swindow.window_timer = 0.0f;
+        pshape.current = swindow.target_shape;
+        apply_shape_color(reg, entity, pshape.current);
+    }
+}
+
+}  // namespace
+
+void shape_window_activation_system(entt::registry& reg, float /*dt*/) {
     auto* song = reg.ctx().find<SongState>();
     if (!song) return;
 
-    const bool morph_duration_valid = song->morph_duration > 0.0f;
+    auto view = reg.view<PlayerTag, PlayerShape, ShapeWindow, Color>();
+    for (auto [entity, pshape, swindow, col] : view.each()) {
+        (void)col;
+        if (swindow.phase == WindowPhase::MorphIn) {
+            update_morph_in(reg, entity, pshape, swindow, *song);
+        }
+    }
+}
+
+void shape_window_system(entt::registry& reg, float /*dt*/) {
+    auto* song = reg.ctx().find<SongState>();
+    if (!song) return;
 
     auto view = reg.view<PlayerTag, PlayerShape, ShapeWindow, Color>();
     for (auto [entity, pshape, swindow, col] : view.each()) {
@@ -23,35 +68,12 @@ void shape_window_system(entt::registry& reg, float /*dt*/) {
         // Derive window_timer from song_time instead of accumulating dt.
         // This keeps shape windows frame-rate independent and perfectly
         // synced to the audio clock, per the "only use song position" rule.
-        float elapsed = song->song_time - swindow.window_start;
-
         switch (swindow.phase) {
             case WindowPhase::Idle:
                 break;
 
             case WindowPhase::MorphIn: {
-                swindow.window_timer = elapsed;
-                if (!morph_duration_valid) {
-                    TraceLog(LOG_WARNING, "shape_window_system completed MorphIn immediately: invalid morph_duration %.3f",
-                             song->morph_duration);
-                    pshape.morph_t = 1.0f;
-                    swindow.phase = WindowPhase::Active;
-                    swindow.window_start = song->song_time;
-                    swindow.window_timer = 0.0f;
-                    pshape.current = swindow.target_shape;
-                    apply_shape_color(reg, entity, pshape.current);
-                    break;
-                }
-                pshape.morph_t = elapsed / song->morph_duration;
-                if (pshape.morph_t >= 1.0f) {
-                    pshape.morph_t = 1.0f;
-                    swindow.phase = WindowPhase::Active;
-                    // Record the exact song_time when Active began for the next phase
-                    swindow.window_start = swindow.window_start + song->morph_duration;
-                    swindow.window_timer = 0.0f;
-                    pshape.current = swindow.target_shape;
-                    apply_shape_color(reg, entity, pshape.current);
-                }
+                update_morph_in(reg, entity, pshape, swindow, *song);
                 break;
             }
 
@@ -72,7 +94,7 @@ void shape_window_system(entt::registry& reg, float /*dt*/) {
             case WindowPhase::MorphOut: {
                 float morph_elapsed = song->song_time - swindow.window_start;
                 swindow.window_timer = morph_elapsed;
-                if (!morph_duration_valid) {
+                if (song->morph_duration <= 0.0f) {
                     TraceLog(LOG_WARNING, "shape_window_system completed MorphOut immediately: invalid morph_duration %.3f",
                              song->morph_duration);
                     pshape.morph_t = 1.0f;

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -553,30 +553,34 @@ system in the same frame (unidirectional data flow).
  │  │     b. beat_scheduler_sys Spawn authored BeatMap notes │
  │  │                           whose spawn_time has arrived.│
  │  │                                                        │
- │  │     c. player_movement    Advance lane and jump/slide. │
+ │  │     c. shape_window_activation                          │
+ │  │                           Promote completed MorphIn     │
+ │  │                           windows before collision.     │
  │  │                                                        │
- │  │     d. scroll_system      Derive rhythm-obstacle       │
+ │  │     d. player_movement    Advance lane and jump/slide. │
+ │  │                                                        │
+ │  │     e. scroll_system      Derive rhythm-obstacle       │
  │  │                           positions from SongState     │
  │  │                           song_time + BeatInfo.        │
  │  │                                                        │
- │  │     e. motion_system      For every (WorldTransform,   │
+ │  │     f. motion_system      For every (WorldTransform,   │
  │  │                           MotionVelocity):             │
  │  │                           position += velocity * dt.   │
  │  │                           Simple, tight inner loop.    │
  │  │                                                        │
- │  │     f. collision_system   For each obstacle near       │
+ │  │     g. collision_system   For each obstacle near       │
  │  │                           PLAYER_Y: test shape match,  │
  │  │                           lane match, vertical state.  │
  │  │                           On match: emplace TimingGrade│
  │  │                           and ScoredTag.               │
  │  │                                                        │
- │  │     g. shape_window_sys   Advance active timing windows│
+ │  │     h. shape_window_sys   Advance active timing windows│
  │  │                           and morph interpolation.     │
  │  │                                                        │
- │  │     h. miss_detection     Mark passed unresolved notes │
+ │  │     i. miss_detection     Mark passed unresolved notes │
  │  │                           with MissTag/ScoredTag.      │
  │  │                                                        │
- │  │     i. scoring_system     Process scored obstacles.    │
+ │  │     j. scoring_system     Process scored obstacles.    │
  │  │                           Apply timing multiplier and  │
  │  │                           chain bonus. Queue popup     │
  │  │                           requests. Update SongResults.│
@@ -975,6 +979,7 @@ int main(int argc, char* argv[]) {
 │ song_playback_system           │ Fixed    │ Timing   │
 │ beat_log_system                │ Fixed    │ Telemetry│
 │ beat_scheduler_system          │ Fixed    │ Logic    │
+│ shape_window_activation_system │ Fixed    │ Timing   │
 │ player_movement_system         │ Fixed    │ Physics  │
 │ scroll_system                  │ Fixed    │ Physics  │
 │ motion_system                  │ Fixed    │ Physics  │

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -105,6 +105,17 @@ TEST_CASE("Play session: missing selected beatmap returns to level select withou
     CHECK(reg.ctx().find<ScoreState>() == nullptr);
     CHECK(high_scores.current_key_hash == 0);
     CHECK(high_scores.entry_count == 1);
+
+    reg.ctx().erase<PlaySessionContentOverride>();
+    lss.selected_level = content_config::DEFAULT_LEVEL_INDEX;
+    lss.selected_difficulty = content_config::DEFAULT_DIFFICULTY_INDEX;
+    lss.confirmed = true;
+
+    REQUIRE_NOTHROW(setup_play_session(reg));
+    CHECK(reg.ctx().find<SongState>() != nullptr);
+    CHECK(reg.ctx().find<ScoreState>() != nullptr);
+    CHECK(gs.phase == GamePhase::Playing);
+    CHECK_FALSE(reg.view<PlayerTag>().empty());
 }
 
 TEST_CASE("Play session: high score key uses loaded fallback difficulty",

--- a/tests/test_phase_runner.cpp
+++ b/tests/test_phase_runner.cpp
@@ -84,6 +84,33 @@ TEST_CASE("tick_playing_systems: collision resolves before active window expiry"
     CHECK_THAT(sw.window_start, WithinAbs(10.0f + song.window_duration, 0.0001f));
 }
 
+TEST_CASE("tick_playing_systems: shape window activates before collision", "[phase_guard][integration][order_regression]") {
+    auto reg = make_rhythm_registry();
+    auto player = make_rhythm_player(reg);
+    auto& ps = reg.get<PlayerShape>(player);
+    auto& sw = reg.get<ShapeWindow>(player);
+    auto& song = reg.ctx().get<SongState>();
+
+    song.song_time = 10.0f;
+    ps.current = Shape::Hexagon;
+    sw.target_shape = Shape::Circle;
+    sw.phase = WindowPhase::MorphIn;
+    sw.window_start = song.song_time - song.morph_duration - 0.01f;
+    sw.window_timer = 0.0f;
+    sw.press_time = song.song_time;
+    sw.graded = false;
+
+    auto obstacle = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
+    reg.emplace<BeatInfo>(obstacle, 0, song.song_time, song.song_time - song.lead_time);
+
+    tick_playing_systems(reg, 0.016f);
+
+    CHECK(sw.phase == WindowPhase::Active);
+    CHECK(ps.current == Shape::Circle);
+    CHECK(reg.ctx().get<SongResults>().perfect_count == 1);
+    CHECK(reg.ctx().get<SongResults>().miss_count == 0);
+}
+
 // ── tick_fixed_systems: score-feedback chain wiring guard ────────────────────
 //
 // Verifies that popup_feedback_system and energy_system are wired in


### PR DESCRIPTION
## Summary
- Recreate SongState on successful play-session setup after missing/invalid beatmap failures
- Promote completed MorphIn windows before collision while preserving post-collision active-window expiry
- Add regression coverage for both P1 issues and update runner-order docs

Fixes #938
Fixes #939

## Verification
- VCPKG_ROOT=/Users/yashasgujjar/vcpkg ./run.sh test