### PR TITLE
Fix MSVC overlay config and README drift

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -165,11 +165,16 @@ jobs:
       - name: Configure
         run: |
           cmake -B build-msvc -S . -G "Visual Studio 17 2022" -A x64 -Wno-dev ^
-            "-DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%/scripts/buildsystems/vcpkg.cmake"
+            "-DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%/scripts/buildsystems/vcpkg.cmake" ^
+            "-DVCPKG_OVERLAY_PORTS=%GITHUB_WORKSPACE%/vcpkg-overlay"
         shell: cmd
 
       - name: Build
         run: cmake --build build-msvc --config Release
+        shell: cmd
+
+      - name: Validate raylib overlay audio stub path
+        run: cmake -P tools/validate_raylib_overlay_audio_stub_path.cmake
         shell: cmd
 
       - name: Install Python tool test dependencies

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ shape_window_system -> miss_detection_system -> scoring_system
 
 - **Rhythm positions derived from song_time**, not accumulated dt — prevents beat drift
 - **Shape windows** are song-time-anchored with phase transitions (MorphIn -> Active -> MorphOut -> Idle)
-- **Single-pass collision** dispatches by obstacle kind via switch, not multiple EnTT views
-- **Section pattern reuse** — verse 1 and verse 2 share the same obstacle pattern
+- **Collision dispatch** uses per-kind EnTT structural views for obstacle-specific component sets
+- **Section labels** guide beatmap structure and intensity; obstacle patterns are authored per section
 
 ### Project Layout
 


### PR DESCRIPTION
## Summary
- pass the raylib vcpkg overlay to the Windows MSVC configure step
- run the existing raylib overlay audio stub path validation in MSVC CI
- refresh README key design bullets for current collision dispatch and section metadata behavior

Closes #944
Closes #945

## Verification
- `cmake -P tools/validate_raylib_overlay_audio_stub_path.cmake`
- `./run.sh test`