### PR TITLE
Fix test-player default level

### DIFF
--- a/app/game_loop.h
+++ b/app/game_loop.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <cstdint>
 #include <entt/entt.hpp>
+#include "content/level_content_config.h"
 
 // Forward-declare to avoid including test_player.h in the header.
 enum class TestPlayerSkill : uint8_t;
@@ -11,7 +12,7 @@ bool game_loop_init(entt::registry& reg,
                     bool test_player_mode = false,
                     TestPlayerSkill test_skill = {},
                     const char* difficulty = "medium",
-                    int selected_level = 1);
+                    int selected_level = content_config::DEFAULT_LEVEL_INDEX);
 
 // Run the game loop (blocks until quit). Handles Emscripten vs native.
 void game_loop_run(entt::registry& reg);

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char* argv[]) {
     TestPlayerSkill test_skill = TestPlayerSkill::Pro;
     bool test_player_mode = false;
     const char* difficulty = "medium";
-    int selected_level = 1;
+    int selected_level = content_config::DEFAULT_LEVEL_INDEX;
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "--test-player") == 0 && i + 1 < argc) {
             test_player_mode = true;

--- a/app/session/test_player_session.cpp
+++ b/app/session/test_player_session.cpp
@@ -16,25 +16,25 @@ struct TestPlayerSessionSignals {
     bool wired = false;
 };
 
+int valid_level_or_default(int selected_level) noexcept {
+    return content_config::level_index_or_default(selected_level);
+}
+
 int difficulty_index_or_default(const char* difficulty) {
     for (int d = 0; d < content_config::DIFFICULTY_COUNT; ++d) {
         if (std::strcmp(content_config::DIFFICULTY_KEYS[d], difficulty) == 0) {
             return d;
         }
     }
-    return 1;
+    return content_config::DEFAULT_DIFFICULTY_INDEX;
 }
-}
-
-int test_player_level_or_default(int selected_level) noexcept {
-    return content_config::level_index_or_default(selected_level);
 }
 
 void test_player_init(entt::registry& reg, TestPlayerSkill skill,
                       const char* difficulty,
                       int selected_level) {
     auto& lss = reg.ctx().get<LevelSelectState>();
-    lss.selected_level = test_player_level_or_default(selected_level);
+    lss.selected_level = valid_level_or_default(selected_level);
     lss.selected_difficulty = difficulty_index_or_default(difficulty);
 
     auto* session_state = reg.ctx().find<TestPlayerSessionState>();

--- a/app/session/test_player_session.cpp
+++ b/app/session/test_player_session.cpp
@@ -16,13 +16,6 @@ struct TestPlayerSessionSignals {
     bool wired = false;
 };
 
-int valid_level_or_default(int selected_level) {
-    if (selected_level >= 0 && selected_level < content_config::LEVEL_COUNT) {
-        return selected_level;
-    }
-    return 1;
-}
-
 int difficulty_index_or_default(const char* difficulty) {
     for (int d = 0; d < content_config::DIFFICULTY_COUNT; ++d) {
         if (std::strcmp(content_config::DIFFICULTY_KEYS[d], difficulty) == 0) {
@@ -33,11 +26,15 @@ int difficulty_index_or_default(const char* difficulty) {
 }
 }
 
+int test_player_level_or_default(int selected_level) noexcept {
+    return content_config::level_index_or_default(selected_level);
+}
+
 void test_player_init(entt::registry& reg, TestPlayerSkill skill,
                       const char* difficulty,
                       int selected_level) {
     auto& lss = reg.ctx().get<LevelSelectState>();
-    lss.selected_level = valid_level_or_default(selected_level);
+    lss.selected_level = test_player_level_or_default(selected_level);
     lss.selected_difficulty = difficulty_index_or_default(difficulty);
 
     auto* session_state = reg.ctx().find<TestPlayerSessionState>();

--- a/app/session/test_player_session.h
+++ b/app/session/test_player_session.h
@@ -17,5 +17,3 @@ struct TestPlayerSessionState {
 void test_player_init(entt::registry& reg, TestPlayerSkill skill,
                       const char* difficulty,
                       int selected_level = content_config::DEFAULT_LEVEL_INDEX);
-
-[[nodiscard]] int test_player_level_or_default(int selected_level) noexcept;

--- a/app/session/test_player_session.h
+++ b/app/session/test_player_session.h
@@ -3,6 +3,7 @@
 #include <entt/entt.hpp>
 #include <cstdint>
 #include "../components/test_player.h"
+#include "../content/level_content_config.h"
 
 struct TestPlayerSessionState {
     // Deterministic by default; callers may opt into runtime variability.
@@ -15,4 +16,6 @@ struct TestPlayerSessionState {
 
 void test_player_init(entt::registry& reg, TestPlayerSkill skill,
                       const char* difficulty,
-                      int selected_level = 1);
+                      int selected_level = content_config::DEFAULT_LEVEL_INDEX);
+
+[[nodiscard]] int test_player_level_or_default(int selected_level) noexcept;

--- a/tests/test_test_player_system.cpp
+++ b/tests/test_test_player_system.cpp
@@ -52,6 +52,7 @@ static void tick_systems(entt::registry& reg, int frames, float dt = 1.0f / 60.0
     }
 }
 
+#ifndef __EMSCRIPTEN__
 TEST_CASE("test_player: init level fallback uses canonical default", "[test_player][issue-947]") {
     auto reg = make_test_player_registry();
     reg.ctx().emplace<SessionLog>();
@@ -70,6 +71,7 @@ TEST_CASE("test_player: init level fallback uses canonical default", "[test_play
 
     session_log_close(reg.ctx().get<SessionLog>());
 }
+#endif
 
 static bool survived(entt::registry& reg) {
     auto& gs = reg.ctx().get<GameState>();

--- a/tests/test_test_player_system.cpp
+++ b/tests/test_test_player_system.cpp
@@ -52,13 +52,23 @@ static void tick_systems(entt::registry& reg, int frames, float dt = 1.0f / 60.0
     }
 }
 
-TEST_CASE("test_player: level fallback uses canonical default", "[test_player][issue-947]") {
-    CHECK(test_player_level_or_default(content_config::DEFAULT_LEVEL_INDEX)
-          == content_config::DEFAULT_LEVEL_INDEX);
-    CHECK(test_player_level_or_default(1) == 1);
-    CHECK(test_player_level_or_default(-1) == content_config::DEFAULT_LEVEL_INDEX);
-    CHECK(test_player_level_or_default(content_config::LEVEL_COUNT)
-          == content_config::DEFAULT_LEVEL_INDEX);
+TEST_CASE("test_player: init level fallback uses canonical default", "[test_player][issue-947]") {
+    auto reg = make_test_player_registry();
+    reg.ctx().emplace<SessionLog>();
+
+    test_player_init(reg, TestPlayerSkill::Pro, "medium", content_config::DEFAULT_LEVEL_INDEX);
+    CHECK(reg.ctx().get<LevelSelectState>().selected_level == content_config::DEFAULT_LEVEL_INDEX);
+
+    test_player_init(reg, TestPlayerSkill::Pro, "medium", 1);
+    CHECK(reg.ctx().get<LevelSelectState>().selected_level == 1);
+
+    test_player_init(reg, TestPlayerSkill::Pro, "medium", -1);
+    CHECK(reg.ctx().get<LevelSelectState>().selected_level == content_config::DEFAULT_LEVEL_INDEX);
+
+    test_player_init(reg, TestPlayerSkill::Pro, "medium", content_config::LEVEL_COUNT);
+    CHECK(reg.ctx().get<LevelSelectState>().selected_level == content_config::DEFAULT_LEVEL_INDEX);
+
+    session_log_close(reg.ctx().get<SessionLog>());
 }
 
 static bool survived(entt::registry& reg) {

--- a/tests/test_test_player_system.cpp
+++ b/tests/test_test_player_system.cpp
@@ -1,6 +1,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include "test_helpers.h"
 #include "components/test_player.h"
+#include "content/level_content_config.h"
+#include "session/test_player_session.h"
 #include "util/session_logger.h"
 #include <cstdio>
 #include <string>
@@ -48,6 +50,15 @@ static void tick_systems(entt::registry& reg, int frames, float dt = 1.0f / 60.0
         // Stop early if game over
         if (reg.ctx().get<GameState>().transition_pending) break;
     }
+}
+
+TEST_CASE("test_player: level fallback uses canonical default", "[test_player][issue-947]") {
+    CHECK(test_player_level_or_default(content_config::DEFAULT_LEVEL_INDEX)
+          == content_config::DEFAULT_LEVEL_INDEX);
+    CHECK(test_player_level_or_default(1) == 1);
+    CHECK(test_player_level_or_default(-1) == content_config::DEFAULT_LEVEL_INDEX);
+    CHECK(test_player_level_or_default(content_config::LEVEL_COUNT)
+          == content_config::DEFAULT_LEVEL_INDEX);
 }
 
 static bool survived(entt::registry& reg) {


### PR DESCRIPTION
Fixes #947.\n\nRoot cause: the test-player/native CLI path still hard-coded level index 1 while the canonical content default is content_config::DEFAULT_LEVEL_INDEX (0). Invalid test-player level fallback used the same stale hard-coded value.\n\nChanges:\n- Default game_loop_init/test_player_init/native CLI selected level to content_config::DEFAULT_LEVEL_INDEX.\n- Route test-player level fallback through content_config::level_index_or_default.\n- Add regression coverage for valid/default/invalid test-player level fallback.\n\nVerification:\n- cmake -B build -S . -Wno-dev\n- cmake --build build\n- ./run.sh test