### PR TITLE
Fix lane collision during transitions

### DIFF
--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -55,7 +55,6 @@ void collision_system(entt::registry& reg, float /*dt*/) {
     auto [p_transform, p_shape, p_window, p_lane, p_vstate] =
         player_view.get<WorldTransform, PlayerShape, ShapeWindow, Lane, VerticalState>(player_entity);
     lane_utils::normalize(p_lane, &p_transform);
-    const int player_lane = p_lane.current;
 
     auto& song = reg.ctx().get<SongState>();
     const bool rhythm_mode = song.playing;
@@ -65,6 +64,7 @@ void collision_system(entt::registry& reg, float /*dt*/) {
     // Precomputing here avoids redundant addition + Vector2 construction per obstacle.
     const float player_timing_y = p_transform.position.y + p_vstate.y_offset;
     const float player_x        = p_transform.position.x;
+    const int player_lane       = lane_utils::nearest_lane_for_x(player_x);
 
     // resolve: tag entity as scored (cleared) or missed.
     // kind is passed by the caller — no try_get needed since each per-kind

--- a/app/util/lane_utils.h
+++ b/app/util/lane_utils.h
@@ -4,6 +4,7 @@
 #include "../components/transform.h"
 #include "../constants.h"
 
+#include <cmath>
 #include <cstdint>
 
 namespace lane_utils {
@@ -21,6 +22,21 @@ inline int8_t valid_or_default(int8_t lane) {
 
 inline void snap_to_current_lane(const Lane& lane, WorldTransform& transform) {
     transform.position.x = constants::LANE_X[lane.current];
+}
+
+inline int8_t nearest_lane_for_x(float x) {
+    int8_t nearest_lane = 0;
+    float nearest_distance = std::abs(x - constants::LANE_X[0]);
+
+    for (int lane = 1; lane < constants::LANE_COUNT; ++lane) {
+        const float distance = std::abs(x - constants::LANE_X[lane]);
+        if (distance < nearest_distance) {
+            nearest_distance = distance;
+            nearest_lane = static_cast<int8_t>(lane);
+        }
+    }
+
+    return nearest_lane;
 }
 
 inline bool normalize(Lane& lane, WorldTransform* transform = nullptr) {

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -150,6 +150,54 @@ TEST_CASE("collision: invalid player lane is normalized before lane checks",
     CHECK(reg.all_of<MissTag>(obs));
 }
 
+TEST_CASE("collision: lane block uses interpolated player lane during transitions",
+          "[collision][issue949]") {
+    constexpr struct {
+        float lerp_t;
+        bool missed;
+    } cases[] = {
+        {0.1f, true},
+        {0.9f, false},
+    };
+
+    for (const auto& tc : cases) {
+        auto reg = make_registry();
+        auto player = make_player(reg);
+        auto& lane = reg.get<Lane>(player);
+        auto& transform = reg.get<WorldTransform>(player);
+        lane.current = 1;
+        lane.target = 2;
+        lane.lerp_t = tc.lerp_t;
+        transform.position.x = constants::LANE_X[1] +
+            (constants::LANE_X[2] - constants::LANE_X[1]) * tc.lerp_t;
+        auto obs = make_lane_block(reg, 0b010, constants::PLAYER_Y);
+
+        collision_system(reg, 0.016f);
+
+        CHECK(reg.all_of<ScoredTag>(obs));
+        CHECK(reg.all_of<MissTag>(obs) == tc.missed);
+    }
+}
+
+TEST_CASE("collision: split path uses interpolated player lane during transitions",
+          "[collision][issue949]") {
+    auto reg = make_registry();
+    auto player = make_player(reg);
+    auto& lane = reg.get<Lane>(player);
+    auto& transform = reg.get<WorldTransform>(player);
+    lane.current = 1;
+    lane.target = 2;
+    lane.lerp_t = 0.9f;
+    transform.position.x = constants::LANE_X[1] +
+        (constants::LANE_X[2] - constants::LANE_X[1]) * lane.lerp_t;
+    auto obs = make_split_path(reg, Shape::Circle, 2, constants::PLAYER_Y);
+
+    collision_system(reg, 0.016f);
+
+    CHECK(reg.all_of<ScoredTag>(obs));
+    CHECK_FALSE(reg.all_of<MissTag>(obs));
+}
+
 
 
 


### PR DESCRIPTION
## Summary
- derive lane-based collision checks from the player's interpolated world X position
- add regression coverage for early/late strafe lane-block behavior and split-path late-transition behavior

## Root cause
LaneBlock, ComboGate, and SplitPath used `Lane.current` while `player_movement_system` rendered/collided the player at an interpolated X position during lane changes. This made late-transition collisions resolve against the previous lane.

## Verification
- `cmake --build build`
- `./run.sh test`

Fixes #949
