### PR TITLE
Fix on-beat shape hits during morph-in

### DIFF
--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -29,7 +29,16 @@ bool player_matches_required_shape(const PlayerShape& p_shape,
         return false;
     }
 
-    if (rhythm_mode && p_window.phase != WindowPhase::Active) {
+    if (rhythm_mode) {
+        switch (p_window.phase) {
+            case WindowPhase::MorphIn:
+                return p_window.press_time >= 0.0f && p_window.target_shape == required;
+            case WindowPhase::Active:
+                return p_shape.current == required || p_window.target_shape == required;
+            case WindowPhase::Idle:
+            case WindowPhase::MorphOut:
+                return false;
+        }
         return false;
     }
 

--- a/tests/test_collision_extended.cpp
+++ b/tests/test_collision_extended.cpp
@@ -114,6 +114,34 @@ TEST_CASE("collision: rhythm mode assigns Perfect for on-time hit", "[collision]
     CHECK(reg.get<TimingGrade>(obs).tier == TimingTier::Perfect);
 }
 
+TEST_CASE("collision: on-beat rhythm press clears matching gate during MorphIn",
+          "[collision][rhythm][issue955]") {
+    auto reg = make_rhythm_registry();
+    auto player = make_rhythm_player(reg);
+    auto& ps = reg.get<PlayerShape>(player);
+    auto& sw = reg.get<ShapeWindow>(player);
+    auto& song = reg.ctx().get<SongState>();
+
+    song.song_time = 5.0f;
+    auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
+    reg.emplace<BeatInfo>(obs, 0, song.song_time, song.song_time - song.lead_time);
+
+    auto btn = make_shape_button(reg, Shape::Circle);
+    press_button(reg, btn);
+    reg.ctx().get<entt::dispatcher>().update<ButtonPressEvent>();
+
+    REQUIRE(ps.current == Shape::Hexagon);
+    REQUIRE(sw.phase == WindowPhase::MorphIn);
+    REQUIRE(sw.target_shape == Shape::Circle);
+
+    collision_system(reg, 0.016f);
+
+    CHECK(reg.all_of<ScoredTag>(obs));
+    CHECK_FALSE(reg.all_of<MissTag>(obs));
+    REQUIRE(reg.all_of<TimingGrade>(obs));
+    CHECK(reg.get<TimingGrade>(obs).tier == TimingTier::Perfect);
+}
+
 TEST_CASE("collision: on-beat shape press requires player hitbox to reach target lane",
           "[collision][rhythm][issue892]") {
     auto reg = make_rhythm_registry();


### PR DESCRIPTION
## Summary
- allow rhythm shape gates to match the pressed target shape during MorphIn
- keep Idle and MorphOut ineligible in rhythm mode
- add a regression for an on-beat press clearing and grading Perfect before visual morph-in completes

## Verification
- cmake -B build -S . -Wno-dev >/tmp/bullethell-cmake.log && cmake --build build && ./build/shapeshifter_tests

Fixes #955