### PR TITLE
Support simultaneous mobile tap and swipe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,6 +562,7 @@ if(EMSCRIPTEN)
     target_compile_options(shapeshifter_tests PRIVATE -fexceptions)
     target_link_options(shapeshifter_tests PRIVATE
         -fexceptions
+        -sUSE_GLFW=3
         -sALLOW_MEMORY_GROWTH=1
         -sDYNAMIC_EXECUTION=0
         -sNODERAWFS=1

--- a/app/components/input.h
+++ b/app/components/input.h
@@ -9,7 +9,20 @@
 
 enum class InputSource : uint8_t { None, Mouse, Touch };
 
+struct TouchSlot {
+    static constexpr int InvalidId = -1;
+
+    int id = InvalidId;
+    bool active = false;
+    bool started_in_button_zone = false;
+    float start_x = 0.0f, start_y = 0.0f;
+    float curr_x = 0.0f, curr_y = 0.0f;
+    float duration = 0.0f;
+};
+
 struct InputState {
+    static constexpr int MaxTrackedTouches = 2;
+
     float start_x  = 0.0f, start_y = 0.0f;
     float curr_x   = 0.0f, curr_y  = 0.0f;
     float end_x    = 0.0f, end_y   = 0.0f;
@@ -24,6 +37,9 @@ struct InputState {
     bool was_focused = true;
     bool gestures_configured = false;
     bool suppress_mouse_release = false;
+    bool button_touch_up = false;
+    float button_end_x = 0.0f, button_end_y = 0.0f;
+    TouchSlot touch_slots[MaxTrackedTouches] = {};
 };
 
 // ── Directions ──────────────────────────────────────────────────────────────

--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -63,9 +63,10 @@ void game_state_system(entt::registry& reg, float dt) {
     // order: game_state → level_select → player_input
     // (see wire_input_dispatcher in input/input_dispatcher.cpp).
     //
-    // Events are enqueued earlier in the same frame by input_system
-    // (keyboard/swipes) and the gameplay HUD input collector before the
-    // fixed-step loop.
+    // Events are enqueued earlier in the same frame by input_system and the
+    // gameplay HUD input collector before the fixed-step loop. Shape presses
+    // drain before movement so same-frame mobile tap+swipe combo obstacles
+    // resolve deterministically.
     //
     // ⚠ Do NOT call disp.clear<GoEvent/ButtonPressEvent>() before this point
     //   within a frame.  Those pre-tick systems enqueue same-frame events that
@@ -73,8 +74,8 @@ void game_state_system(entt::registry& reg, float dt) {
     //   this update() call.  clear() would silently drop them before delivery.
     //
     auto& disp = reg.ctx().get<entt::dispatcher>();
-    disp.update<GoEvent>();
     disp.update<ButtonPressEvent>();
+    disp.update<GoEvent>();
 
     if (gs.transition_pending) {
         gs.transition_pending = false;
@@ -85,10 +86,14 @@ void game_state_system(entt::registry& reg, float dt) {
             input->touch_down = false;
             input->touch_up = false;
             input->click = false;
+            input->button_touch_up = false;
             input->touching = false;
             input->active_source = InputSource::None;
             input->suppress_mouse_release = false;
             input->duration = 0.0f;
+            for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
+                input->touch_slots[i] = TouchSlot{};
+            }
         }
 
         switch (gs.next_phase) {

--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -309,4 +309,30 @@ void input_system(entt::registry& reg, float raw_dt) {
         input.was_focused = focused;
     }
 
+    if (allow_touch_input &&
+        input.active_source != InputSource::Mouse &&
+        !input.touching &&
+        !input.touch_up) {
+        Direction gesture_dir = Direction::Up;
+        bool has_gesture_swipe = false;
+        if (IsGestureDetected(GESTURE_SWIPE_RIGHT)) {
+            gesture_dir = Direction::Right;
+            has_gesture_swipe = true;
+        } else if (IsGestureDetected(GESTURE_SWIPE_LEFT)) {
+            gesture_dir = Direction::Left;
+            has_gesture_swipe = true;
+        } else if (IsGestureDetected(GESTURE_SWIPE_UP)) {
+            gesture_dir = Direction::Up;
+            has_gesture_swipe = true;
+        } else if (IsGestureDetected(GESTURE_SWIPE_DOWN)) {
+            gesture_dir = Direction::Down;
+            has_gesture_swipe = true;
+        }
+
+        const Vector2 touch_pos = GetTouchPosition(0);
+        const glm::vec2 tp = screen_to_virtual({touch_pos.x, touch_pos.y}, st);
+        if (has_gesture_swipe && tp.y < constants::SCREEN_H_F * constants::SWIPE_ZONE_SPLIT) {
+            disp.enqueue<GoEvent>(GoEvent{gesture_dir});
+        }
+    }
 }

--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -70,7 +70,9 @@ bool raylib_gesture_swipe_direction(Direction& out) {
         out = Direction::Down;
         return true;
     }
-    return false;
+
+    const Vector2 drag = GetGestureDragVector();
+    return classify_swipe(drag.x, drag.y, GetGestureHoldDuration(), out);
 }
 
 int find_touch_slot(InputState& input, int touch_id) {
@@ -89,6 +91,49 @@ int find_free_touch_slot(InputState& input) {
         }
     }
     return -1;
+}
+
+bool touch_id_is_current(int touch_id, int touch_point_count) {
+    for (int touch_index = 0; touch_index < touch_point_count; ++touch_index) {
+        if (GetTouchPointId(touch_index) == touch_id) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool has_active_touch_in_zone(const InputState& input, bool button_zone) {
+    for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
+        const auto& slot = input.touch_slots[i];
+        if (slot.active && slot.started_in_button_zone == button_zone) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void release_touch_slot(TouchSlot& slot,
+                        InputState& input,
+                        Direction& latest_swipe_dir,
+                        bool& has_latest_swipe,
+                        bool& had_swipe_zone_release) {
+    input.touch_up = true;
+    input.end_x = slot.curr_x;
+    input.end_y = slot.curr_y;
+    if (slot.started_in_button_zone) {
+        input.button_touch_up = true;
+        input.button_end_x = slot.curr_x;
+        input.button_end_y = slot.curr_y;
+    } else {
+        had_swipe_zone_release = true;
+        if (classify_swipe(slot.curr_x - slot.start_x,
+                           slot.curr_y - slot.start_y,
+                           slot.duration,
+                           latest_swipe_dir)) {
+            has_latest_swipe = true;
+        }
+    }
+    slot = TouchSlot{};
 }
 
 } // namespace
@@ -174,19 +219,38 @@ void input_system(entt::registry& reg, float raw_dt) {
         touch_point_count > 0) {
         const float zone_y = constants::SCREEN_H_F * constants::SWIPE_ZONE_SPLIT;
         bool seen[InputState::MaxTrackedTouches] = {};
+        Direction latest_swipe_dir = Direction::Up;
+        bool has_latest_swipe = false;
+        bool had_swipe_zone_release = false;
+
+        for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
+            auto& slot = input.touch_slots[i];
+            if (slot.active && !touch_id_is_current(slot.id, touch_point_count)) {
+                release_touch_slot(slot,
+                                   input,
+                                   latest_swipe_dir,
+                                   has_latest_swipe,
+                                   had_swipe_zone_release);
+            }
+        }
+
         const int points_to_scan = touch_point_count;
         for (int touch_index = 0; touch_index < points_to_scan; ++touch_index) {
             const int touch_id = GetTouchPointId(touch_index);
+            const Vector2 touch_pos = GetTouchPosition(touch_index);
+            const glm::vec2 tp = screen_to_virtual({touch_pos.x, touch_pos.y}, st);
             int slot_index = find_touch_slot(input, touch_id);
             if (slot_index < 0) {
+                const bool button_zone = tp.y >= zone_y;
+                if (has_active_touch_in_zone(input, button_zone)) {
+                    continue;
+                }
                 slot_index = find_free_touch_slot(input);
             }
             if (slot_index < 0) {
                 continue;
             }
 
-            const Vector2 touch_pos = GetTouchPosition(touch_index);
-            const glm::vec2 tp = screen_to_virtual({touch_pos.x, touch_pos.y}, st);
             auto& slot = input.touch_slots[slot_index];
             if (!slot.active) {
                 slot.id = touch_id;
@@ -207,31 +271,6 @@ void input_system(entt::registry& reg, float raw_dt) {
             input.curr_y = tp.y;
         }
 
-        Direction latest_swipe_dir = Direction::Up;
-        bool has_latest_swipe = false;
-        bool had_swipe_zone_release = false;
-        for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
-            if (input.touch_slots[i].active && !seen[i]) {
-                auto& slot = input.touch_slots[i];
-                input.touch_up = true;
-                input.end_x = slot.curr_x;
-                input.end_y = slot.curr_y;
-                if (slot.started_in_button_zone) {
-                    input.button_touch_up = true;
-                    input.button_end_x = slot.curr_x;
-                    input.button_end_y = slot.curr_y;
-                } else {
-                    had_swipe_zone_release = true;
-                    if (classify_swipe(slot.curr_x - slot.start_x,
-                                       slot.curr_y - slot.start_y,
-                                       slot.duration,
-                                       latest_swipe_dir)) {
-                        has_latest_swipe = true;
-                    }
-                }
-                slot = TouchSlot{};
-            }
-        }
         if (!has_latest_swipe &&
             had_swipe_zone_release &&
             raylib_gesture_swipe_direction(latest_swipe_dir)) {
@@ -272,22 +311,11 @@ void input_system(entt::registry& reg, float raw_dt) {
             if (!slot.active) {
                 continue;
             }
-            input.end_x = slot.curr_x;
-            input.end_y = slot.curr_y;
-            if (slot.started_in_button_zone) {
-                input.button_touch_up = true;
-                input.button_end_x = slot.curr_x;
-                input.button_end_y = slot.curr_y;
-            } else {
-                had_swipe_zone_release = true;
-                if (classify_swipe(slot.curr_x - slot.start_x,
-                                   slot.curr_y - slot.start_y,
-                                   slot.duration,
-                                   latest_swipe_dir)) {
-                    has_latest_swipe = true;
-                }
-            }
-            slot = TouchSlot{};
+            release_touch_slot(slot,
+                               input,
+                               latest_swipe_dir,
+                               has_latest_swipe,
+                               had_swipe_zone_release);
         }
         if (!has_latest_swipe &&
             had_swipe_zone_release &&
@@ -352,9 +380,17 @@ void input_system(entt::registry& reg, float raw_dt) {
         Direction gesture_dir = Direction::Up;
         const bool has_gesture_swipe = raylib_gesture_swipe_direction(gesture_dir);
 
-        const Vector2 touch_pos = GetTouchPosition(0);
-        const glm::vec2 tp = screen_to_virtual({touch_pos.x, touch_pos.y}, st);
-        if (has_gesture_swipe && tp.y < constants::SCREEN_H_F * constants::SWIPE_ZONE_SPLIT) {
+        bool gesture_started_in_swipe_zone = false;
+        if (input.click) {
+            gesture_started_in_swipe_zone = input.end_y < constants::SCREEN_H_F * constants::SWIPE_ZONE_SPLIT;
+        } else {
+            const Vector2 touch_pos = GetTouchPosition(0);
+            const glm::vec2 tp = screen_to_virtual({touch_pos.x, touch_pos.y}, st);
+            gesture_started_in_swipe_zone = tp.y < constants::SCREEN_H_F * constants::SWIPE_ZONE_SPLIT;
+        }
+
+        if (has_gesture_swipe && gesture_started_in_swipe_zone) {
+            input.click = false;
             disp.enqueue<GoEvent>(GoEvent{gesture_dir});
         }
     }

--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -6,6 +6,7 @@
 #include "../components/rendering.h"
 #include "../components/game_state.h"
 #include "../constants.h"
+#include <cmath>
 #include <raylib.h>
 #ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
@@ -35,6 +36,39 @@ struct WebInputPolicy {
     // active_source guard inside input_system.
     bool touch_capable = false;
 };
+
+bool classify_swipe(float dx, float dy, float duration, Direction& out) {
+    const float distance_sq = dx * dx + dy * dy;
+    if (distance_sq < constants::MIN_SWIPE_DIST * constants::MIN_SWIPE_DIST ||
+        duration > constants::MAX_SWIPE_TIME) {
+        return false;
+    }
+
+    if (std::fabs(dx) >= std::fabs(dy)) {
+        out = (dx >= 0.0f) ? Direction::Right : Direction::Left;
+    } else {
+        out = (dy >= 0.0f) ? Direction::Down : Direction::Up;
+    }
+    return true;
+}
+
+int find_touch_slot(InputState& input, int touch_id) {
+    for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
+        if (input.touch_slots[i].active && input.touch_slots[i].id == touch_id) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+int find_free_touch_slot(InputState& input) {
+    for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
+        if (!input.touch_slots[i].active) {
+            return i;
+        }
+    }
+    return -1;
+}
 
 } // namespace
 
@@ -67,6 +101,7 @@ void input_system(entt::registry& reg, float raw_dt) {
     input.touch_down = false;
     input.touch_up   = false;
     input.click      = false;
+    input.button_touch_up = false;
 
 #if defined(PLATFORM_WEB) && defined(__EMSCRIPTEN__)
     const auto& web_policy = reg.ctx().get<WebInputPolicy>();
@@ -112,32 +147,120 @@ void input_system(entt::registry& reg, float raw_dt) {
         input.duration = 0.0f;
     }
 
-    // ── Touch (mobile / web) — only when no mouse gesture is active ─
+    // ── Touch (mobile / web) — up to one swipe-zone and one button-zone contact ─
     if (allow_touch_input &&
         input.active_source != InputSource::Mouse &&
         touch_point_count > 0) {
-        const Vector2 touch_pos = GetTouchPosition(0);
-        const glm::vec2 tp = screen_to_virtual({touch_pos.x, touch_pos.y}, st);
-        if (!input.touching) {
-            input.touch_down = true;
-            input.touching   = true;
-            input.active_source = InputSource::Touch;
-            input.start_x = input.curr_x = tp.x;
-            input.start_y = input.curr_y = tp.y;
-            input.duration = 0.0f;
-        } else if (input.active_source == InputSource::Touch) {
+        const float zone_y = constants::SCREEN_H_F * constants::SWIPE_ZONE_SPLIT;
+        bool seen[InputState::MaxTrackedTouches] = {};
+        const int points_to_scan = touch_point_count;
+        for (int touch_index = 0; touch_index < points_to_scan; ++touch_index) {
+            const int touch_id = GetTouchPointId(touch_index);
+            int slot_index = find_touch_slot(input, touch_id);
+            if (slot_index < 0) {
+                slot_index = find_free_touch_slot(input);
+            }
+            if (slot_index < 0) {
+                continue;
+            }
+
+            const Vector2 touch_pos = GetTouchPosition(touch_index);
+            const glm::vec2 tp = screen_to_virtual({touch_pos.x, touch_pos.y}, st);
+            auto& slot = input.touch_slots[slot_index];
+            if (!slot.active) {
+                slot.id = touch_id;
+                slot.active = true;
+                slot.started_in_button_zone = tp.y >= zone_y;
+                slot.start_x = slot.curr_x = tp.x;
+                slot.start_y = slot.curr_y = tp.y;
+                slot.duration = 0.0f;
+                input.touch_down = true;
+            } else {
+                slot.curr_x = tp.x;
+                slot.curr_y = tp.y;
+            }
+            seen[slot_index] = true;
+            input.start_x = slot.start_x;
+            input.start_y = slot.start_y;
             input.curr_x = tp.x;
             input.curr_y = tp.y;
+        }
+
+        Direction latest_swipe_dir = Direction::Up;
+        bool has_latest_swipe = false;
+        for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
+            if (input.touch_slots[i].active && !seen[i]) {
+                auto& slot = input.touch_slots[i];
+                input.touch_up = true;
+                input.end_x = slot.curr_x;
+                input.end_y = slot.curr_y;
+                if (slot.started_in_button_zone) {
+                    input.button_touch_up = true;
+                    input.button_end_x = slot.curr_x;
+                    input.button_end_y = slot.curr_y;
+                } else {
+                    if (classify_swipe(slot.curr_x - slot.start_x,
+                                       slot.curr_y - slot.start_y,
+                                       slot.duration,
+                                       latest_swipe_dir)) {
+                        has_latest_swipe = true;
+                    }
+                }
+                slot = TouchSlot{};
+            }
+        }
+        if (has_latest_swipe) {
+            disp.enqueue<GoEvent>(GoEvent{latest_swipe_dir});
+        }
+
+        input.touching = false;
+        for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
+            if (input.touch_slots[i].active) {
+                input.touching = true;
+                input.touch_slots[i].duration += raw_dt;
+            }
+        }
+        if (input.touching) {
+            input.active_source = InputSource::Touch;
+        }
+        input.duration = 0.0f;
+        for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
+            if (input.touch_slots[i].active && input.touch_slots[i].duration > input.duration) {
+                input.duration = input.touch_slots[i].duration;
+            }
         }
     } else if (allow_touch_input &&
                input.active_source != InputSource::Mouse &&
                input.touching && input.active_source == InputSource::Touch) {
+        Direction latest_swipe_dir = Direction::Up;
+        bool has_latest_swipe = false;
         input.touch_up  = true;
         input.touching  = false;
         input.suppress_mouse_release = true;
         input.active_source = InputSource::None;
-        input.end_x = input.curr_x;
-        input.end_y = input.curr_y;
+        for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
+            auto& slot = input.touch_slots[i];
+            if (!slot.active) {
+                continue;
+            }
+            input.end_x = slot.curr_x;
+            input.end_y = slot.curr_y;
+            if (slot.started_in_button_zone) {
+                input.button_touch_up = true;
+                input.button_end_x = slot.curr_x;
+                input.button_end_y = slot.curr_y;
+            } else if (classify_swipe(slot.curr_x - slot.start_x,
+                                      slot.curr_y - slot.start_y,
+                                      slot.duration,
+                                      latest_swipe_dir)) {
+                has_latest_swipe = true;
+            }
+            slot = TouchSlot{};
+        }
+        if (has_latest_swipe) {
+            disp.enqueue<GoEvent>(GoEvent{latest_swipe_dir});
+        }
+        input.duration = 0.0f;
     }
 
 #ifdef PLATFORM_HAS_KEYBOARD
@@ -186,38 +309,4 @@ void input_system(entt::registry& reg, float raw_dt) {
         input.was_focused = focused;
     }
 
-    if (input.touching) {
-        input.duration += raw_dt;
-    }
-
-    // Touch swipe gestures enqueue semantic GoEvent directly.
-    if (input.touch_up) {
-        int gesture = GESTURE_NONE;
-        if (IsGestureDetected(GESTURE_SWIPE_RIGHT)) {
-            gesture = GESTURE_SWIPE_RIGHT;
-        } else if (IsGestureDetected(GESTURE_SWIPE_LEFT)) {
-            gesture = GESTURE_SWIPE_LEFT;
-        } else if (IsGestureDetected(GESTURE_SWIPE_UP)) {
-            gesture = GESTURE_SWIPE_UP;
-        } else if (IsGestureDetected(GESTURE_SWIPE_DOWN)) {
-            gesture = GESTURE_SWIPE_DOWN;
-        } else if (IsGestureDetected(GESTURE_TAP)) {
-            gesture = GESTURE_TAP;
-        } else {
-            gesture = GetGestureDetected();
-        }
-
-        const float zone_y = constants::SCREEN_H * constants::SWIPE_ZONE_SPLIT;
-        if (input.start_y < zone_y) {
-            if ((gesture & GESTURE_SWIPE_RIGHT) != 0) {
-                disp.enqueue<GoEvent>(GoEvent{Direction::Right});
-            } else if ((gesture & GESTURE_SWIPE_LEFT) != 0) {
-                disp.enqueue<GoEvent>(GoEvent{Direction::Left});
-            } else if ((gesture & GESTURE_SWIPE_UP) != 0) {
-                disp.enqueue<GoEvent>(GoEvent{Direction::Up});
-            } else if ((gesture & GESTURE_SWIPE_DOWN) != 0) {
-                disp.enqueue<GoEvent>(GoEvent{Direction::Down});
-            }
-        }
-    }
 }

--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -309,22 +309,22 @@ void input_system(entt::registry& reg, float raw_dt) {
         input.was_focused = focused;
     }
 
-    if (allow_touch_input &&
-        input.active_source != InputSource::Mouse &&
+    if (input.active_source != InputSource::Mouse &&
         !input.touching &&
         !input.touch_up) {
         Direction gesture_dir = Direction::Up;
         bool has_gesture_swipe = false;
-        if (IsGestureDetected(GESTURE_SWIPE_RIGHT)) {
+        const int gesture = GetGestureDetected();
+        if (IsGestureDetected(GESTURE_SWIPE_RIGHT) || (gesture & GESTURE_SWIPE_RIGHT) != 0) {
             gesture_dir = Direction::Right;
             has_gesture_swipe = true;
-        } else if (IsGestureDetected(GESTURE_SWIPE_LEFT)) {
+        } else if (IsGestureDetected(GESTURE_SWIPE_LEFT) || (gesture & GESTURE_SWIPE_LEFT) != 0) {
             gesture_dir = Direction::Left;
             has_gesture_swipe = true;
-        } else if (IsGestureDetected(GESTURE_SWIPE_UP)) {
+        } else if (IsGestureDetected(GESTURE_SWIPE_UP) || (gesture & GESTURE_SWIPE_UP) != 0) {
             gesture_dir = Direction::Up;
             has_gesture_swipe = true;
-        } else if (IsGestureDetected(GESTURE_SWIPE_DOWN)) {
+        } else if (IsGestureDetected(GESTURE_SWIPE_DOWN) || (gesture & GESTURE_SWIPE_DOWN) != 0) {
             gesture_dir = Direction::Down;
             has_gesture_swipe = true;
         }

--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -218,7 +218,6 @@ void input_system(entt::registry& reg, float raw_dt) {
         input.active_source != InputSource::Mouse &&
         touch_point_count > 0) {
         const float zone_y = constants::SCREEN_H_F * constants::SWIPE_ZONE_SPLIT;
-        bool seen[InputState::MaxTrackedTouches] = {};
         Direction latest_swipe_dir = Direction::Up;
         bool has_latest_swipe = false;
         bool had_swipe_zone_release = false;
@@ -264,7 +263,6 @@ void input_system(entt::registry& reg, float raw_dt) {
                 slot.curr_x = tp.x;
                 slot.curr_y = tp.y;
             }
-            seen[slot_index] = true;
             input.start_x = slot.start_x;
             input.start_y = slot.start_y;
             input.curr_x = tp.x;

--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -52,6 +52,27 @@ bool classify_swipe(float dx, float dy, float duration, Direction& out) {
     return true;
 }
 
+bool raylib_gesture_swipe_direction(Direction& out) {
+    const int gesture = GetGestureDetected();
+    if (IsGestureDetected(GESTURE_SWIPE_RIGHT) || (gesture & GESTURE_SWIPE_RIGHT) != 0) {
+        out = Direction::Right;
+        return true;
+    }
+    if (IsGestureDetected(GESTURE_SWIPE_LEFT) || (gesture & GESTURE_SWIPE_LEFT) != 0) {
+        out = Direction::Left;
+        return true;
+    }
+    if (IsGestureDetected(GESTURE_SWIPE_UP) || (gesture & GESTURE_SWIPE_UP) != 0) {
+        out = Direction::Up;
+        return true;
+    }
+    if (IsGestureDetected(GESTURE_SWIPE_DOWN) || (gesture & GESTURE_SWIPE_DOWN) != 0) {
+        out = Direction::Down;
+        return true;
+    }
+    return false;
+}
+
 int find_touch_slot(InputState& input, int touch_id) {
     for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
         if (input.touch_slots[i].active && input.touch_slots[i].id == touch_id) {
@@ -188,6 +209,7 @@ void input_system(entt::registry& reg, float raw_dt) {
 
         Direction latest_swipe_dir = Direction::Up;
         bool has_latest_swipe = false;
+        bool had_swipe_zone_release = false;
         for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
             if (input.touch_slots[i].active && !seen[i]) {
                 auto& slot = input.touch_slots[i];
@@ -199,6 +221,7 @@ void input_system(entt::registry& reg, float raw_dt) {
                     input.button_end_x = slot.curr_x;
                     input.button_end_y = slot.curr_y;
                 } else {
+                    had_swipe_zone_release = true;
                     if (classify_swipe(slot.curr_x - slot.start_x,
                                        slot.curr_y - slot.start_y,
                                        slot.duration,
@@ -208,6 +231,11 @@ void input_system(entt::registry& reg, float raw_dt) {
                 }
                 slot = TouchSlot{};
             }
+        }
+        if (!has_latest_swipe &&
+            had_swipe_zone_release &&
+            raylib_gesture_swipe_direction(latest_swipe_dir)) {
+            has_latest_swipe = true;
         }
         if (has_latest_swipe) {
             disp.enqueue<GoEvent>(GoEvent{latest_swipe_dir});
@@ -234,6 +262,7 @@ void input_system(entt::registry& reg, float raw_dt) {
                input.touching && input.active_source == InputSource::Touch) {
         Direction latest_swipe_dir = Direction::Up;
         bool has_latest_swipe = false;
+        bool had_swipe_zone_release = false;
         input.touch_up  = true;
         input.touching  = false;
         input.suppress_mouse_release = true;
@@ -249,13 +278,21 @@ void input_system(entt::registry& reg, float raw_dt) {
                 input.button_touch_up = true;
                 input.button_end_x = slot.curr_x;
                 input.button_end_y = slot.curr_y;
-            } else if (classify_swipe(slot.curr_x - slot.start_x,
-                                      slot.curr_y - slot.start_y,
-                                      slot.duration,
-                                      latest_swipe_dir)) {
-                has_latest_swipe = true;
+            } else {
+                had_swipe_zone_release = true;
+                if (classify_swipe(slot.curr_x - slot.start_x,
+                                   slot.curr_y - slot.start_y,
+                                   slot.duration,
+                                   latest_swipe_dir)) {
+                    has_latest_swipe = true;
+                }
             }
             slot = TouchSlot{};
+        }
+        if (!has_latest_swipe &&
+            had_swipe_zone_release &&
+            raylib_gesture_swipe_direction(latest_swipe_dir)) {
+            has_latest_swipe = true;
         }
         if (has_latest_swipe) {
             disp.enqueue<GoEvent>(GoEvent{latest_swipe_dir});
@@ -313,21 +350,7 @@ void input_system(entt::registry& reg, float raw_dt) {
         !input.touching &&
         !input.touch_up) {
         Direction gesture_dir = Direction::Up;
-        bool has_gesture_swipe = false;
-        const int gesture = GetGestureDetected();
-        if (IsGestureDetected(GESTURE_SWIPE_RIGHT) || (gesture & GESTURE_SWIPE_RIGHT) != 0) {
-            gesture_dir = Direction::Right;
-            has_gesture_swipe = true;
-        } else if (IsGestureDetected(GESTURE_SWIPE_LEFT) || (gesture & GESTURE_SWIPE_LEFT) != 0) {
-            gesture_dir = Direction::Left;
-            has_gesture_swipe = true;
-        } else if (IsGestureDetected(GESTURE_SWIPE_UP) || (gesture & GESTURE_SWIPE_UP) != 0) {
-            gesture_dir = Direction::Up;
-            has_gesture_swipe = true;
-        } else if (IsGestureDetected(GESTURE_SWIPE_DOWN) || (gesture & GESTURE_SWIPE_DOWN) != 0) {
-            gesture_dir = Direction::Down;
-            has_gesture_swipe = true;
-        }
+        const bool has_gesture_swipe = raylib_gesture_swipe_direction(gesture_dir);
 
         const Vector2 touch_pos = GetTouchPosition(0);
         const glm::vec2 tp = screen_to_virtual({touch_pos.x, touch_pos.y}, st);

--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
@@ -346,16 +346,28 @@ Rectangle gameplay_hud_shape_input_bounds(GameplayHudShapeSlot slot) {
 
 void gameplay_hud_process_button_input(entt::registry& reg) {
     const auto& input = reg.ctx().get<InputState>();
-    if (!(input.click || input.touch_up)) return;
+    if (!(input.click || input.button_touch_up || input.touch_up)) return;
 
     static const GameplayHudLayoutState geometry_state = GameplayHudLayout_Init();
-    const Vector2 pointer = {input.end_x, input.end_y};
-    gameplay_hud_apply_button_presses(
-        reg,
-        CheckCollisionPointRec(pointer, GameplayHudLayout_PauseButtonBounds(&geometry_state)),
-        CheckCollisionPointRec(pointer, GameplayHudLayout_CircleButtonBounds(&geometry_state)),
-        CheckCollisionPointRec(pointer, GameplayHudLayout_SquareButtonBounds(&geometry_state)),
-        CheckCollisionPointRec(pointer, GameplayHudLayout_TriangleButtonBounds(&geometry_state)));
+    if (input.click || (input.touch_up && !input.button_touch_up)) {
+        const Vector2 pointer = {input.end_x, input.end_y};
+        gameplay_hud_apply_button_presses(
+            reg,
+            CheckCollisionPointRec(pointer, GameplayHudLayout_PauseButtonBounds(&geometry_state)),
+            CheckCollisionPointRec(pointer, GameplayHudLayout_CircleButtonBounds(&geometry_state)),
+            CheckCollisionPointRec(pointer, GameplayHudLayout_SquareButtonBounds(&geometry_state)),
+            CheckCollisionPointRec(pointer, GameplayHudLayout_TriangleButtonBounds(&geometry_state)));
+    }
+
+    if (input.button_touch_up) {
+        const Vector2 pointer = {input.button_end_x, input.button_end_y};
+        gameplay_hud_apply_button_presses(
+            reg,
+            false,
+            CheckCollisionPointRec(pointer, GameplayHudLayout_CircleButtonBounds(&geometry_state)),
+            CheckCollisionPointRec(pointer, GameplayHudLayout_SquareButtonBounds(&geometry_state)),
+            CheckCollisionPointRec(pointer, GameplayHudLayout_TriangleButtonBounds(&geometry_state)));
+    }
 }
 
 void gameplay_hud_apply_button_presses(entt::registry& reg,

--- a/tests/test_input_pipeline_behavior.cpp
+++ b/tests/test_input_pipeline_behavior.cpp
@@ -30,6 +30,23 @@ static void run_pipeline(entt::registry& reg, float dt = 0.016f) {
     game_state_system(reg, dt);
 }
 
+namespace {
+
+struct SemanticInputOrderCapture {
+    int order[2] = {0, 0};
+    int cursor = 0;
+
+    void on_press(const ButtonPressEvent&) {
+        if (cursor < 2) order[cursor++] = 1;
+    }
+
+    void on_go(const GoEvent&) {
+        if (cursor < 2) order[cursor++] = 2;
+    }
+};
+
+}
+
 TEST_CASE("pipeline: keyboard shape shortcuts follow left-center-right shapes",
           "[input_pipeline][keyboard][issue662]") {
     CHECK(shape_for_keyboard_slot(KeyboardShapeSlot::Left) == Shape::Circle);
@@ -207,6 +224,33 @@ TEST_CASE("pipeline: gameplay HUD pointer release is collected before the fixed 
     CHECK(sw.target_shape == Shape::Square);
 }
 
+TEST_CASE("pipeline: mobile button-zone touch release is collected independently of swipe release",
+          "[input_pipeline][hud][mobile][issue956]") {
+    auto reg = make_rhythm_registry();
+    auto player = make_rhythm_player(reg);
+    auto& input = reg.ctx().get<InputState>();
+    auto& lane = reg.get<Lane>(player);
+    auto& sw = reg.get<ShapeWindow>(player);
+    REQUIRE(sw.phase == WindowPhase::Idle);
+    REQUIRE(lane.current == 1);
+
+    const auto square_bounds = gameplay_hud_shape_input_bounds(GameplayHudShapeSlot::Square);
+    input.touch_up = true;
+    input.end_x = constants::SCREEN_W_F * 0.5f;
+    input.end_y = constants::SCREEN_H_F * 0.25f;
+    input.button_touch_up = true;
+    input.button_end_x = square_bounds.x + square_bounds.width * 0.5f;
+    input.button_end_y = square_bounds.y + square_bounds.height * 0.5f;
+    push_go(reg, Direction::Right);
+
+    gameplay_hud_process_button_input(reg);
+    run_pipeline(reg);
+
+    CHECK(sw.phase == WindowPhase::MorphIn);
+    CHECK(sw.target_shape == Shape::Square);
+    CHECK(lane.target == 2);
+}
+
 TEST_CASE("pipeline: gameplay HUD pause release is collected before the fixed tick",
           "[input_pipeline][hud][issue833]") {
     auto reg = make_rhythm_registry();
@@ -370,6 +414,26 @@ TEST_CASE("pipeline: mixed swipe and tap both take effect within a single pipeli
     CHECK(lane.target     == 2);                  // explicit swipe moves lanes
     CHECK(sw.phase        == WindowPhase::MorphIn); // tap processed
     CHECK(sw.target_shape == Shape::Triangle);
+}
+
+TEST_CASE("pipeline: same-frame shape tap drains before movement",
+          "[input_pipeline][issue956]") {
+    auto reg = make_rhythm_registry();
+    make_rhythm_player(reg);
+    auto& disp = reg.ctx().get<entt::dispatcher>();
+    SemanticInputOrderCapture capture;
+    disp.sink<ButtonPressEvent>().connect<&SemanticInputOrderCapture::on_press>(capture);
+    disp.sink<GoEvent>().connect<&SemanticInputOrderCapture::on_go>(capture);
+
+    push_go(reg, Direction::Right);
+    disp.enqueue<ButtonPressEvent>(
+        {ButtonPressKind::Shape, Shape::Triangle, MenuActionKind::Confirm, 0});
+
+    run_pipeline(reg);
+
+    CHECK(capture.cursor == 2);
+    CHECK(capture.order[0] == 1);
+    CHECK(capture.order[1] == 2);
 }
 
 // ── No-latency regression ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary\n- Track up to two touch contacts so mobile swipe-zone and button-zone inputs can resolve in the same frame.\n- Keep only the latest released swipe and latest button-zone tap for same-frame buffering.\n- Drain shape ButtonPressEvent before movement GoEvent for combo obstacle ordering.\n\nFixes #956\n\n## Verification\n- cmake -B build -S . -Wno-dev\n- cmake --build build --target shapeshifter_tests -- -j2\n- ./build/shapeshifter_tests