### PR TITLE
Fix final energy depletion GameOver precedence

### DIFF
--- a/app/systems/energy_system.cpp
+++ b/app/systems/energy_system.cpp
@@ -45,7 +45,7 @@ void energy_system(entt::registry& reg, float dt) {
         pending.events.clear();
     }
 
-    if (song && song->playing && energy->energy <= 0.0f) {
+    if (song && energy->energy <= 0.0f) {
         request_energy_depleted_game_over(reg);
     }
 

--- a/design-docs/energy-bar.md
+++ b/design-docs/energy-bar.md
@@ -167,7 +167,7 @@ switch (timing->tier) {
 ## System Execution Order
 
 ```
-  game_state_system        ← checks energy <= 0 → GameOver
+  game_state_system        ← catches pre-existing energy <= 0 → GameOver
   song_playback_system
   tick_playing_systems
     collision_system       ← tags MISS / ScoredTag
@@ -175,14 +175,17 @@ switch (timing->tier) {
   obstacle_despawn_system
   popup_feedback_system
   popup_display_system
-  energy_system            ← applies queued effects, smooths display
+  energy_system            ← applies queued effects, requests GameOver on depletion, smooths display
   particle_system
 ```
 
 `collision_system` tags MISS/HIT outcomes and `scoring_system` enqueues
 timing-grade energy drain/recovery inside `tick_playing_systems()`. The
-`energy_system` then runs after popup updates in `tick_fixed_systems()`;
-this placement is a cache-locality choice, not a semantic dependency.
+`energy_system` then runs after popup updates in `tick_fixed_systems()`.
+Energy depletion always wins over song completion while the phase is Playing,
+including when playback has already marked the song finished in the same fixed
+tick. The popup/energy placement is a cache-locality choice, not a semantic
+dependency.
 
 ---
 

--- a/design-docs/rhythm-design.md
+++ b/design-docs/rhythm-design.md
@@ -435,9 +435,10 @@ Hexagon button/key.
 > **Legacy / superseded:** Earlier drafts of this section described an
 > instant-death "ONE miss ends the run, no HP" model. That model is
 > superseded by the energy bar shipped in `app/systems/energy_system.cpp`
-> and the game-over check in
-> [`app/systems/game_state_system.cpp:105`](../app/systems/game_state_system.cpp)
-> (`energy && song && song->playing && energy->energy <= 0.0f`). Do not
+> and the game-over checks in
+> [`app/systems/game_state_system.cpp`](../app/systems/game_state_system.cpp)
+> / [`app/systems/energy_system.cpp`](../app/systems/energy_system.cpp)
+> (`energy->energy <= 0.0f` while the phase is Playing). Do not
 > reintroduce instant-death framing in design docs without first
 > revisiting `energy-bar.md`.
 

--- a/tests/test_energy_system.cpp
+++ b/tests/test_energy_system.cpp
@@ -125,7 +125,7 @@ TEST_CASE("energy: no action when SongState not present", "[energy]") {
     CHECK_FALSE(gs.transition_pending);
 }
 
-TEST_CASE("energy: no action when song not playing", "[energy]") {
+TEST_CASE("energy: depleted energy requests game over when song is not playing", "[energy][issue961]") {
     auto reg = make_rhythm_registry();
     reg.ctx().get<SongState>().playing = false;
     auto& energy = reg.ctx().get<EnergyState>();
@@ -134,7 +134,9 @@ TEST_CASE("energy: no action when song not playing", "[energy]") {
     energy_system(reg, 0.016f);
 
     auto& gs = reg.ctx().get<GameState>();
-    CHECK_FALSE(gs.transition_pending);
+    CHECK(gs.transition_pending);
+    CHECK(gs.next_phase == GamePhase::GameOver);
+    CHECK(reg.ctx().get<GameOverState>().cause == DeathCause::EnergyDepleted);
 }
 
 TEST_CASE("energy: no action when EnergyState not present", "[energy]") {

--- a/tests/test_phase_runner.cpp
+++ b/tests/test_phase_runner.cpp
@@ -206,3 +206,27 @@ TEST_CASE("tick_fixed_systems: energy depletion requests GameOver before next Pl
     CHECK(drain_sfx_events(reg).count == 0);
     CHECK(drain_haptic_events(reg).count == 0);
 }
+
+TEST_CASE("tick_fixed_systems: fatal final drain wins after song finishes",
+          "[phase_guard][energy][regression][issue961]") {
+    auto reg = make_rhythm_registry();
+    auto& gs = reg.ctx().get<GameState>();
+    auto& song = reg.ctx().get<SongState>();
+    auto& energy = reg.ctx().get<EnergyState>();
+    auto& pending = reg.ctx().get<PendingEnergyEffects>();
+
+    song.song_time = song.duration_sec;
+    song.playing = true;
+    song.finished = false;
+    energy.energy = constants::ENERGY_DRAIN_MISS;
+    pending.events.push_back({-constants::ENERGY_DRAIN_MISS, true});
+
+    tick_fixed_systems(reg, 0.016f);
+
+    CHECK(song.finished);
+    CHECK_FALSE(song.playing);
+    REQUIRE(energy.energy == 0.0f);
+    REQUIRE(gs.transition_pending);
+    CHECK(gs.next_phase == GamePhase::GameOver);
+    CHECK(reg.ctx().get<GameOverState>().cause == DeathCause::EnergyDepleted);
+}


### PR DESCRIPTION
## Summary
- Request GameOver from `energy_system` whenever Playing-phase energy reaches zero, even if song playback already flipped `SongState::playing` false in the same fixed tick.
- Add regression coverage for fatal final drain coinciding with song finish.
- Update energy docs to document GameOver precedence over SongComplete.

## Verification
- `cmake -Wno-dev -B build -S . && cmake --build build && ./build/shapeshifter_tests`

Fixes #961