### PR TITLE
Fix squad cycle regressions

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -112,7 +112,10 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           name: shapeshifter-macos
-          path: build/shapeshifter
+          path: |
+            build/shapeshifter
+            build/content
+          if-no-files-found: error
 
       - name: Upload CTRF report
         if: always() && steps.run-tests.outcome != 'skipped'
@@ -253,6 +256,11 @@ jobs:
           mkdir -p "$APP_BUNDLE/Contents/MacOS" "$APP_BUNDLE/Contents/Resources"
           mv build/shapeshifter "$APP_BUNDLE/Contents/MacOS/SHAPESHIFTER"
           chmod +x "$APP_BUNDLE/Contents/MacOS/SHAPESHIFTER"
+          test -f build/content/constants.json
+          test -d build/content/fonts
+          test -d build/content/beatmaps
+          test -d build/content/audio
+          cp -R build/content "$APP_BUNDLE/Contents/MacOS/content"
 
           cat > "$APP_BUNDLE/Contents/Info.plist" <<'PLIST'
           <?xml version="1.0" encoding="UTF-8"?>

--- a/app/systems/runtime_systems.h
+++ b/app/systems/runtime_systems.h
@@ -4,7 +4,19 @@
 #include "components/game_state.h"
 
 [[nodiscard]] constexpr bool game_render_should_draw_world_meshes(GamePhase phase) noexcept {
-    return phase != GamePhase::Title && phase != GamePhase::LevelSelect;
+    switch (phase) {
+        case GamePhase::Playing:
+        case GamePhase::Paused:
+        case GamePhase::GameOver:
+        case GamePhase::SongComplete:
+            return true;
+        case GamePhase::Title:
+        case GamePhase::LevelSelect:
+        case GamePhase::Settings:
+        case GamePhase::Tutorial:
+            return false;
+    }
+    return false;
 }
 
 // Runtime-only systems require a live platform/audio/render context and are

--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -150,7 +150,7 @@ void scoring_system(entt::registry& reg, float dt) {
             reg.get_or_emplace<ResolvedObstacleTag>(r.e);
             reg.remove<Obstacle>(r.e);
             reg.remove<ScoredTag>(r.e);
-            reg.remove<MissTag>(r.e);
+            if (reg.all_of<MissTag>(r.e)) reg.remove<MissTag>(r.e);
             if (r.has_timing) reg.remove<TimingGrade>(r.e);
         }
     }
@@ -268,11 +268,11 @@ void scoring_system(entt::registry& reg, float dt) {
         auto& cleanup_buf = scratch.hit_buf;
         cleanup_buf.clear();
 
-        auto ns_view = reg.view<ObstacleTag, ScoredTag, NonScorableTag>(
-            entt::exclude<MissTag>);
+        auto ns_view = reg.view<ObstacleTag, ScoredTag, NonScorableTag>();
         for (auto e : ns_view) {
             HitRecord r;
             r.e = e;
+            r.has_timing = reg.all_of<TimingGrade>(e);
             if (cleanup_buf.size() >= cleanup_buf.capacity()) {
                 ++scratch.hit_capacity_exceeded_count;
             }
@@ -282,6 +282,8 @@ void scoring_system(entt::registry& reg, float dt) {
             reg.get_or_emplace<ResolvedObstacleTag>(r.e);
             reg.remove<Obstacle>(r.e);
             reg.remove<ScoredTag>(r.e);
+            if (reg.all_of<MissTag>(r.e)) reg.remove<MissTag>(r.e);
+            if (r.has_timing) reg.remove<TimingGrade>(r.e);
         }
     }
 

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -222,6 +222,18 @@ TEST_CASE("game_state: terminal to LevelSelect hides stale world renderables",
     CHECK_FALSE(game_render_should_draw_world_meshes(gs.phase));
 }
 
+TEST_CASE("game_state: Settings hides stale world renderables",
+          "[gamestate][render][regression][issue966]") {
+    CHECK(game_render_should_draw_world_meshes(GamePhase::Playing));
+    CHECK(game_render_should_draw_world_meshes(GamePhase::Paused));
+    CHECK(game_render_should_draw_world_meshes(GamePhase::GameOver));
+    CHECK(game_render_should_draw_world_meshes(GamePhase::SongComplete));
+    CHECK_FALSE(game_render_should_draw_world_meshes(GamePhase::Title));
+    CHECK_FALSE(game_render_should_draw_world_meshes(GamePhase::LevelSelect));
+    CHECK_FALSE(game_render_should_draw_world_meshes(GamePhase::Settings));
+    CHECK_FALSE(game_render_should_draw_world_meshes(GamePhase::Tutorial));
+}
+
 TEST_CASE("game_state: transition clears in-flight pointer capture", "[gamestate][input]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();

--- a/tests/test_scoring_system.cpp
+++ b/tests/test_scoring_system.cpp
@@ -412,6 +412,40 @@ TEST_CASE("scoring: NonScorableTag entity cleared without scoring", "[scoring][n
     CHECK_FALSE(reg.all_of<Obstacle>(e));
 }
 
+TEST_CASE("scoring: missed NonScorableTag entity is resolved without effects",
+          "[scoring][nonscorable][issue965]") {
+    auto reg = make_registry();
+    auto& score = reg.ctx().get<ScoreState>();
+    auto& energy = reg.ctx().get<EnergyState>();
+    auto& results = reg.ctx().get<SongResults>();
+    const int score_before = score.score;
+    const int chain_before = score.chain_count;
+    const float energy_before = energy.energy;
+
+    auto e = reg.create();
+    reg.emplace<ObstacleTag>(e);
+    reg.emplace<WorldTransform>(e, WorldTransform{{300.0f, constants::PLAYER_Y}});
+    reg.emplace<Obstacle>(e, ObstacleKind::OnsetMarker, int16_t{0});
+    reg.emplace<NonScorableTag>(e);
+    reg.emplace<ScoredTag>(e);
+    reg.emplace<MissTag>(e);
+    reg.emplace<TimingGrade>(e, TimingTier::Bad, 0.0f);
+
+    scoring_system(reg, 0.0f);
+    energy_system(reg, 0.0f);
+
+    CHECK(score.score == score_before);
+    CHECK(score.chain_count == chain_before);
+    CHECK(energy.energy == energy_before);
+    CHECK(results.miss_count == 0);
+    CHECK(reg.view<ScorePopup>().size() == 0);
+    CHECK(reg.all_of<ResolvedObstacleTag>(e));
+    CHECK_FALSE(reg.all_of<Obstacle>(e));
+    CHECK_FALSE(reg.all_of<ScoredTag>(e));
+    CHECK_FALSE(reg.all_of<MissTag>(e));
+    CHECK_FALSE(reg.all_of<TimingGrade>(e));
+}
+
 TEST_CASE("scoring: missed obstacle drains energy without setting terminal death cause", "[scoring]") {
     auto reg = make_registry();
     auto& gos = reg.ctx().get<GameOverState>();


### PR DESCRIPTION
## Summary
- Fix non-scorable missed obstacle cleanup so it resolves without scoring/energy effects.
- Make gameplay world rendering opt-in for gameplay/terminal phases so Settings/Tutorial do not show stale world meshes.
- Include `build/content` in the macOS artifact and copy it into the notarized `.app` bundle with missing-file preflights.

## Verification
- `cmake -B build -S . -Wno-dev`
- `cmake --build build`
- `./build/shapeshifter_tests "[issue965],[issue966]" --verbosity quiet`
- `./build/shapeshifter_tests`

Fixes #965
Fixes #966
Fixes #967