### PR TITLE
Add web persistence retry regression

### DIFF
--- a/tests/test_settings_persistence.cpp
+++ b/tests/test_settings_persistence.cpp
@@ -3,8 +3,27 @@
 #include "entities/settings.h"
 #include <filesystem>
 #include <fstream>
+#include <sstream>
+#include <string>
 
 using Catch::Matchers::WithinAbs;
+
+namespace {
+
+std::filesystem::path persistence_policy_source_path() {
+    return std::filesystem::path{SHAPESHIFTER_SOURCE_DIR} / "app/util/persistence_policy.cpp";
+}
+
+std::string load_persistence_policy_source() {
+    std::ifstream file(persistence_policy_source_path());
+    if (!file.is_open()) return {};
+
+    std::ostringstream buffer;
+    buffer << file.rdbuf();
+    return buffer.str();
+}
+
+}  // namespace
 
 TEST_CASE("Settings: audio_offset_seconds() converts milliseconds correctly", "[settings]") {
     SettingsState state;
@@ -303,6 +322,38 @@ TEST_CASE("Persistence sync seams skip paths outside the web persistence root", 
     const std::filesystem::path current_dir_file = "settings_current_dir_tmp.json";
     CHECK(persistence::prepare_for_persistence_read(current_dir_file).ok());
     CHECK(persistence::flush_persistence_writes(current_dir_file).ok());
+}
+
+TEST_CASE("Web persistence initialization failures remain retryable",
+          "[settings][persistence][issue-970]") {
+    const std::string source = load_persistence_policy_source();
+    INFO("Expected persistence_policy.cpp at " << persistence_policy_source_path().string());
+    REQUIRE_FALSE(source.empty());
+
+    const auto function_begin = source.find("Result ensure_web_persistence_ready()");
+    REQUIRE(function_begin != std::string::npos);
+    const auto function_end = source.find("bool path_uses_web_persistence", function_begin);
+    REQUIRE(function_end != std::string::npos);
+    const std::string function_source =
+        source.substr(function_begin, function_end - function_begin);
+
+    CHECK(function_source.find("static bool initialized = false;") != std::string::npos);
+    CHECK(function_source.find("static Result") == std::string::npos);
+
+    const auto mount_failure = function_source.find("if (mount_status != 0)");
+    const auto sync_result = function_source.find("const auto init_result");
+    const auto success_guard = function_source.find("if (init_result.ok())");
+    REQUIRE(mount_failure != std::string::npos);
+    REQUIRE(sync_result != std::string::npos);
+    REQUIRE(success_guard != std::string::npos);
+    CHECK(mount_failure < sync_result);
+
+    const auto initialized_assignment =
+        function_source.find("initialized = true", success_guard);
+    REQUIRE(initialized_assignment != std::string::npos);
+    CHECK(success_guard < initialized_assignment);
+    CHECK(function_source.find("initialized = true", initialized_assignment + 1)
+        == std::string::npos);
 }
 
 TEST_CASE("Settings persistence helper: file path resolution reports failure without CWD fallback", "[settings]") {


### PR DESCRIPTION
## Summary\n- add a source-contract regression test for the web persistence initialization path\n- verify transient mount/init sync failures are not cached as terminal success or failure, while successful initialization remains cached\n\nFixes #970\n\n## Verification\n- cmake --build build -- -j2\n- ./build/shapeshifter_tests "Web persistence initialization failures remain retryable" --success\n- ./build/shapeshifter_tests --success