### PR TITLE
Remove ignored obstacle kind constructor

### DIFF
--- a/app/components/obstacle.h
+++ b/app/components/obstacle.h
@@ -22,7 +22,6 @@ struct Obstacle {
 
     constexpr Obstacle() = default;
     constexpr explicit Obstacle(int16_t points) : base_points(points) {}
-    constexpr Obstacle(ObstacleKind, int16_t points) : base_points(points) {}
 };
 
 constexpr ObstacleKind obstacle_kind_from_components(bool has_required_shape,

--- a/benchmarks/bench_systems.cpp
+++ b/benchmarks/bench_systems.cpp
@@ -58,7 +58,7 @@ static void spawn_obstacles(entt::registry& reg, int count) {
         reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[i % 3], y}});
         reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, song.scroll_speed}});
         auto shape = static_cast<Shape>(i % 3);
-        reg.emplace<Obstacle>(obs, ObstacleKind::ShapeGate, int16_t{200});
+        reg.emplace<Obstacle>(obs, int16_t{200});
         reg.emplace<RequiredShape>(obs, shape);
         reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);
         reg.emplace<DrawLayer>(obs, Layer::Game);
@@ -76,7 +76,7 @@ static void spawn_scroll_obstacles(entt::registry& reg, int count) {
         float y = constants::SPAWN_Y + static_cast<float>(i) * 80.0f;
         reg.emplace<WorldTransform>(obs, WorldTransform{{0.0f, y}});
         reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, song.scroll_speed}});
-        reg.emplace<Obstacle>(obs, ObstacleKind::ShapeGate, int16_t{200});
+        reg.emplace<Obstacle>(obs, int16_t{200});
         reg.emplace<DrawLayer>(obs, Layer::Game);
     }
 }
@@ -126,7 +126,7 @@ TEST_CASE("Bench: collision_system", "[!benchmark][bench]") {
         reg.emplace<ObstacleTag>(obs);
         reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
         reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, 400.0f}});
-        reg.emplace<Obstacle>(obs, ObstacleKind::ShapeGate, int16_t{200});
+        reg.emplace<Obstacle>(obs, int16_t{200});
         reg.emplace<RequiredShape>(obs, Shape::Circle);
         meter.measure([&] {
             if (reg.all_of<ScoredTag>(obs)) reg.remove<ScoredTag>(obs);
@@ -160,7 +160,7 @@ TEST_CASE("Bench: scoring_system", "[!benchmark][bench]") {
             reg.emplace<ObstacleTag>(obs);
             reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
             reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, 400.0f}});
-            reg.emplace<Obstacle>(obs, ObstacleKind::ShapeGate, int16_t{200});
+            reg.emplace<Obstacle>(obs, int16_t{200});
             reg.emplace<ScoredTag>(obs);
             reg.emplace<DrawLayer>(obs, Layer::Game);
             reg.emplace<Color>(obs, Color{255, 255, 255, 255});

--- a/tests/test_collision_extended.cpp
+++ b/tests/test_collision_extended.cpp
@@ -70,7 +70,7 @@ TEST_CASE("collision: Hexagon fails even when matching gate shape", "[collision]
     reg.emplace<ObstacleTag>(obs);
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
     reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, 400.0f}});
-    reg.emplace<Obstacle>(obs, ObstacleKind::ShapeGate, int16_t{200});
+    reg.emplace<Obstacle>(obs, int16_t{200});
     reg.emplace<RequiredShape>(obs, Shape::Hexagon);
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);
     reg.emplace<DrawLayer>(obs, Layer::Game);

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -289,7 +289,7 @@ TEST_CASE("collision: combo gate requires shape AND lane", "[collision]") {
     reg.emplace<ObstacleTag>(obs);
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
     reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, song.scroll_speed}});
-    reg.emplace<Obstacle>(obs, ObstacleKind::ComboGate, int16_t{200});
+    reg.emplace<Obstacle>(obs, int16_t{200});
     reg.emplace<RequiredShape>(obs, Shape::Circle);
     // Block lanes 0 and 2, leave lane 1 open
     reg.emplace<BlockedLanes>(obs, uint8_t{0b101});
@@ -310,7 +310,7 @@ TEST_CASE("collision: combo gate fails with wrong shape", "[collision]") {
     reg.emplace<ObstacleTag>(obs);
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
     reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, song.scroll_speed}});
-    reg.emplace<Obstacle>(obs, ObstacleKind::ComboGate, int16_t{200});
+    reg.emplace<Obstacle>(obs, int16_t{200});
     reg.emplace<RequiredShape>(obs, Shape::Triangle);  // wrong shape
     reg.emplace<BlockedLanes>(obs, uint8_t{0b101});    // lane 1 open
     reg.emplace<DrawSize>(obs, 720.0f, 80.0f);

--- a/tests/test_death_model_unified.cpp
+++ b/tests/test_death_model_unified.cpp
@@ -106,7 +106,7 @@ TEST_CASE("death_model: close hit banks points without instant GameOver", "[deat
     reg.emplace<ObstacleTag>(obstacle);
     reg.emplace<WorldTransform>(obstacle, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
     reg.emplace<MotionVelocity>(obstacle, MotionVelocity{{0.0f, 0.0f}});
-    reg.emplace<Obstacle>(obstacle, ObstacleKind::ShapeGate, int16_t{constants::PTS_SHAPE_GATE});
+    reg.emplace<Obstacle>(obstacle, int16_t{constants::PTS_SHAPE_GATE});
     reg.emplace<RequiredShape>(obstacle, Shape::Circle);
 
     collision_system(reg, 0.016f);
@@ -125,7 +125,7 @@ TEST_CASE("death_model: close miss drains energy instead of instant GameOver", "
     reg.emplace<ObstacleTag>(obstacle);
     reg.emplace<WorldTransform>(obstacle, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
     reg.emplace<MotionVelocity>(obstacle, MotionVelocity{{0.0f, 0.0f}});
-    reg.emplace<Obstacle>(obstacle, ObstacleKind::ShapeGate, int16_t{constants::PTS_SHAPE_GATE});
+    reg.emplace<Obstacle>(obstacle, int16_t{constants::PTS_SHAPE_GATE});
     reg.emplace<RequiredShape>(obstacle, Shape::Triangle);
 
     collision_system(reg, 0.016f);
@@ -169,7 +169,7 @@ TEST_CASE("death_model: scroll-past miss drains energy and requests GameOver", "
     auto obstacle = reg.create();
     reg.emplace<ObstacleTag>(obstacle);
     reg.emplace<WorldTransform>(obstacle, WorldTransform{{0.0f, constants::DESTROY_Y + 10.0f}});
-    reg.emplace<Obstacle>(obstacle, ObstacleKind::ShapeGate, int16_t{constants::PTS_SHAPE_GATE});
+    reg.emplace<Obstacle>(obstacle, int16_t{constants::PTS_SHAPE_GATE});
 
     // miss_detection_system tags; scoring_system drains.
     miss_detection_system(reg, 0.016f);
@@ -203,7 +203,7 @@ TEST_CASE("death_model: scroll-past fatal miss triggers GameOver same frame", "[
     auto obstacle = reg.create();
     reg.emplace<ObstacleTag>(obstacle);
     reg.emplace<WorldTransform>(obstacle, WorldTransform{{0.0f, constants::DESTROY_Y + 10.0f}});
-    reg.emplace<Obstacle>(obstacle, ObstacleKind::ShapeGate, int16_t{constants::PTS_SHAPE_GATE});
+    reg.emplace<Obstacle>(obstacle, int16_t{constants::PTS_SHAPE_GATE});
 
     miss_detection_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
@@ -228,7 +228,7 @@ TEST_CASE("death_model: scroll-past miss does not double-drain", "[death_model]"
     auto obstacle = reg.create();
     reg.emplace<ObstacleTag>(obstacle);
     reg.emplace<WorldTransform>(obstacle, WorldTransform{{0.0f, constants::DESTROY_Y + 10.0f}});
-    reg.emplace<Obstacle>(obstacle, ObstacleKind::ShapeGate, int16_t{constants::PTS_SHAPE_GATE});
+    reg.emplace<Obstacle>(obstacle, int16_t{constants::PTS_SHAPE_GATE});
 
     miss_detection_system(reg, 0.016f);
     scoring_system(reg, 0.016f);

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -202,7 +202,7 @@ inline entt::entity make_shape_gate(entt::registry& reg, Shape shape, float y) {
     reg.emplace<ObstacleTag>(obs);
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], y}});
     reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, song.scroll_speed}});
-    reg.emplace<Obstacle>(obs, ObstacleKind::ShapeGate, int16_t{constants::PTS_SHAPE_GATE});
+    reg.emplace<Obstacle>(obs, int16_t{constants::PTS_SHAPE_GATE});
     reg.emplace<RequiredShape>(obs, shape);
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);
     reg.emplace<DrawLayer>(obs, Layer::Game);
@@ -218,7 +218,7 @@ inline entt::entity make_lane_block(entt::registry& reg, uint8_t mask, float y) 
     reg.emplace<ObstacleTag>(obs);
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], y}});
     reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, song.scroll_speed}});
-    reg.emplace<Obstacle>(obs, ObstacleKind::LaneBlock, int16_t{constants::PTS_LANE_BLOCK});
+    reg.emplace<Obstacle>(obs, int16_t{constants::PTS_LANE_BLOCK});
     reg.emplace<BlockedLanes>(obs, mask);
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W / 3), 80.0f);
     reg.emplace<DrawLayer>(obs, Layer::Game);
@@ -235,7 +235,7 @@ inline entt::entity make_combo_gate(entt::registry& reg, Shape shape, uint8_t bl
     reg.emplace<ObstacleTag>(obs);
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], y}});
     reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, song.scroll_speed}});
-    reg.emplace<Obstacle>(obs, ObstacleKind::ComboGate, int16_t{constants::PTS_COMBO_GATE});
+    reg.emplace<Obstacle>(obs, int16_t{constants::PTS_COMBO_GATE});
     reg.emplace<RequiredShape>(obs, shape);
     reg.emplace<BlockedLanes>(obs, blocked_mask);
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);
@@ -252,7 +252,7 @@ inline entt::entity make_split_path(entt::registry& reg, Shape shape, int8_t lan
     reg.emplace<ObstacleTag>(obs);
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], y}});
     reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, song.scroll_speed}});
-    reg.emplace<Obstacle>(obs, ObstacleKind::SplitPath, int16_t{constants::PTS_SPLIT_PATH});
+    reg.emplace<Obstacle>(obs, int16_t{constants::PTS_SPLIT_PATH});
     reg.emplace<RequiredShape>(obs, shape);
     reg.emplace<RequiredLane>(obs, lane);
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);

--- a/tests/test_miss_detection_regression.cpp
+++ b/tests/test_miss_detection_regression.cpp
@@ -18,8 +18,7 @@
 static entt::entity make_expired_obstacle(entt::registry& reg) {
     auto e = reg.create();
     reg.emplace<ObstacleTag>(e);
-    reg.emplace<Obstacle>(e, ObstacleKind::ShapeGate,
-                          static_cast<int16_t>(constants::PTS_SHAPE_GATE));
+    reg.emplace<Obstacle>(e, static_cast<int16_t>(constants::PTS_SHAPE_GATE));
     reg.emplace<WorldTransform>(e, WorldTransform{{0.0f, constants::DESTROY_Y + 10.0f}});
     return e;
 }
@@ -102,8 +101,7 @@ TEST_CASE("miss_detection: obstacles above DESTROY_Y are not tagged",
     // One obstacle still on-screen that must not be tagged.
     auto active = reg.create();
     reg.emplace<ObstacleTag>(active);
-    reg.emplace<Obstacle>(active, ObstacleKind::ShapeGate,
-                          static_cast<int16_t>(constants::PTS_SHAPE_GATE));
+    reg.emplace<Obstacle>(active, static_cast<int16_t>(constants::PTS_SHAPE_GATE));
     reg.emplace<WorldTransform>(active, WorldTransform{{0.0f, constants::PLAYER_Y - 100.0f}});
 
     miss_detection_system(reg, 0.016f);

--- a/tests/test_phase_runner.cpp
+++ b/tests/test_phase_runner.cpp
@@ -187,7 +187,7 @@ TEST_CASE("tick_fixed_systems: energy depletion requests GameOver before next Pl
     reg.emplace<ObstacleTag>(late_miss);
     reg.emplace<ScoredTag>(late_miss);
     reg.emplace<MissTag>(late_miss);
-    reg.emplace<Obstacle>(late_miss, ObstacleKind::ShapeGate, int16_t{constants::PTS_SHAPE_GATE});
+    reg.emplace<Obstacle>(late_miss, int16_t{constants::PTS_SHAPE_GATE});
 
     tick_fixed_systems(reg, 0.016f);
 

--- a/tests/test_redfoot_testflight_ui.cpp
+++ b/tests/test_redfoot_testflight_ui.cpp
@@ -96,11 +96,11 @@ void spawn_aligned_player(entt::registry& reg, float y) {
     reg.emplace<VerticalState>(p);
 }
 
-entt::entity spawn_obstacle(entt::registry& reg, ObstacleKind kind, float y) {
+entt::entity spawn_obstacle(entt::registry& reg, float y) {
     auto e = reg.create();
     reg.emplace<ObstacleTag>(e);
     reg.emplace<WorldTransform>(e, WorldTransform{{constants::LANE_X[1], y}});
-    reg.emplace<Obstacle>(e, kind, int16_t{0});
+    reg.emplace<Obstacle>(e, int16_t{0});
     return e;
 }
 }  // namespace
@@ -117,7 +117,7 @@ TEST_CASE("redfoot/#168: collision miss is non-terminal cause context",
     runtime_system_scratch_init(reg);
 
     spawn_aligned_player(reg, constants::PLAYER_Y);
-    auto gate = spawn_obstacle(reg, ObstacleKind::ShapeGate, constants::PLAYER_Y);
+    auto gate = spawn_obstacle(reg, constants::PLAYER_Y);
     reg.emplace<RequiredShape>(gate, Shape::Circle);
 
     collision_system(reg, 0.016f);

--- a/tests/test_rhythm_system.cpp
+++ b/tests/test_rhythm_system.cpp
@@ -688,7 +688,7 @@ TEST_CASE("scoring: timing_mult applied to scored obstacle", "[rhythm][scoring]"
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
-    reg.emplace<Obstacle>(obs, ObstacleKind::ShapeGate, int16_t{200});
+    reg.emplace<Obstacle>(obs, int16_t{200});
     reg.emplace<ScoredTag>(obs);
     reg.emplace<TimingGrade>(obs, TimingTier::Perfect, 1.0f);
     int prev = score.score;

--- a/tests/test_scoring_extended.cpp
+++ b/tests/test_scoring_extended.cpp
@@ -20,7 +20,7 @@ entt::entity make_zero_point_passive_obstacle(entt::registry& reg) {
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
-    reg.emplace<Obstacle>(obs, ObstacleKind::LaneBlock, int16_t{0});
+    reg.emplace<Obstacle>(obs, int16_t{0});
     reg.emplace<ScoredTag>(obs);
     return obs;
 }

--- a/tests/test_scoring_system.cpp
+++ b/tests/test_scoring_system.cpp
@@ -395,7 +395,7 @@ TEST_CASE("scoring: NonScorableTag entity cleared without scoring", "[scoring][n
     auto e = reg.create();
     reg.emplace<ObstacleTag>(e);
     reg.emplace<WorldTransform>(e, WorldTransform{{300.0f, constants::PLAYER_Y}});
-    reg.emplace<Obstacle>(e, ObstacleKind::ShapeGate, int16_t{999});
+    reg.emplace<Obstacle>(e, int16_t{999});
     reg.emplace<NonScorableTag>(e);
     reg.emplace<ScoredTag>(e);
 
@@ -425,7 +425,7 @@ TEST_CASE("scoring: missed NonScorableTag entity is resolved without effects",
     auto e = reg.create();
     reg.emplace<ObstacleTag>(e);
     reg.emplace<WorldTransform>(e, WorldTransform{{300.0f, constants::PLAYER_Y}});
-    reg.emplace<Obstacle>(e, ObstacleKind::OnsetMarker, int16_t{0});
+    reg.emplace<Obstacle>(e, int16_t{0});
     reg.emplace<NonScorableTag>(e);
     reg.emplace<ScoredTag>(e);
     reg.emplace<MissTag>(e);
@@ -454,7 +454,7 @@ TEST_CASE("scoring: missed obstacle drains energy without setting terminal death
     auto e = reg.create();
     reg.emplace<ObstacleTag>(e);
     reg.emplace<WorldTransform>(e, WorldTransform{{300.0f, constants::PLAYER_Y}});
-    reg.emplace<Obstacle>(e, ObstacleKind::ShapeGate, int16_t{200});
+    reg.emplace<Obstacle>(e, int16_t{200});
     reg.emplace<ScoredTag>(e);
     reg.emplace<MissTag>(e);
 

--- a/tests/test_test_player_system.cpp
+++ b/tests/test_test_player_system.cpp
@@ -280,7 +280,7 @@ TEST_CASE("test_player: invalid scroll speed treats undated closer obstacles as 
 
     auto closer = reg.create();
     reg.emplace<ObstacleTag>(closer);
-    reg.emplace<Obstacle>(closer, ObstacleKind::LaneBlock, int16_t{constants::PTS_LANE_BLOCK});
+    reg.emplace<Obstacle>(closer, int16_t{constants::PTS_LANE_BLOCK});
     reg.emplace<WorldTransform>(closer,
                                WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y - 300.0f}});
     reg.emplace<BlockedLanes>(closer, uint8_t{0b001});


### PR DESCRIPTION
## Summary\n- remove the Obstacle constructor overload that accepted and ignored ObstacleKind\n- update benchmark and test call sites to construct Obstacle with score data only\n- keep obstacle kind structurally derived from RequiredShape, BlockedLanes, and RequiredLane components\n\nFixes #974\n\n## Verification\n- cmake --build build -- -j2\n- ./build/shapeshifter_tests --success