### PR TITLE
Fix WASM smoke lane marker registry state

### DIFF
--- a/app/components/system_scratch.h
+++ b/app/components/system_scratch.h
@@ -47,3 +47,7 @@ struct MeshChildCleanupScratch {
     std::vector<entt::entity> stale_children;
     uint32_t capacity_exceeded_count = 0;
 };
+
+struct WasmSmokeLaneMarkerState {
+    int last_lane = -1;
+};

--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -7,6 +7,7 @@
 #include "../components/input_events.h"
 #include "../components/player.h"
 #include "../components/rhythm.h"
+#include "../components/system_scratch.h"
 #include "../entities/settings.h"
 #include "../constants.h"
 #if defined(__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)
@@ -17,25 +18,36 @@
 #if defined(__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)
 namespace {
 
+WasmSmokeLaneMarkerState& wasm_smoke_lane_marker_state(entt::registry& reg) {
+    if (auto* state = reg.ctx().find<WasmSmokeLaneMarkerState>()) {
+        return *state;
+    }
+    return reg.ctx().emplace<WasmSmokeLaneMarkerState>();
+}
+
+void reset_web_playing_lane_marker(entt::registry& reg) {
+    wasm_smoke_lane_marker_state(reg).last_lane = -1;
+}
+
 void update_web_playing_lane_marker(entt::registry& reg, const GameState& gs) {
-    static int last_lane = -1;
+    auto& marker = wasm_smoke_lane_marker_state(reg);
     if (gs.phase != GamePhase::Playing) {
-        last_lane = -1;
+        marker.last_lane = -1;
         return;
     }
 
     auto player_view = reg.view<PlayerTag, Lane>();
     if (player_view.begin() == player_view.end()) {
-        last_lane = -1;
+        marker.last_lane = -1;
         return;
     }
 
     const auto player_entity = *player_view.begin();
     const int lane = static_cast<int>(player_view.get<Lane>(player_entity).current);
-    if (lane == last_lane) {
+    if (lane == marker.last_lane) {
         return;
     }
-    last_lane = lane;
+    marker.last_lane = lane;
 
     const std::string title = std::string("SHAPESHIFTER [Playing][Lane:")
         + std::to_string(lane) + "]";
@@ -135,6 +147,11 @@ void game_state_system(entt::registry& reg, float dt) {
                 enter_phase(gs, GamePhase::Tutorial);
                 break;
         }
+#if defined(__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)
+        if (gs.phase != GamePhase::Playing) {
+            reset_web_playing_lane_marker(reg);
+        }
+#endif
         return;
     }
 

--- a/app/systems/runtime_system_scratch.cpp
+++ b/app/systems/runtime_system_scratch.cpp
@@ -24,6 +24,7 @@ void runtime_system_scratch_init(entt::registry& reg) {
     reg.ctx().erase<PopupDisplayScratch>();
     reg.ctx().erase<ParticleSystemScratch>();
     reg.ctx().erase<MeshChildCleanupScratch>();
+    reg.ctx().erase<WasmSmokeLaneMarkerState>();
 
     reg.ctx().emplace<ScoringSystemScratch>();
     reg.ctx().emplace<PendingEnergyEffects>();
@@ -32,6 +33,7 @@ void runtime_system_scratch_init(entt::registry& reg) {
     reg.ctx().emplace<PopupDisplayScratch>();
     reg.ctx().emplace<ParticleSystemScratch>();
     reg.ctx().emplace<MeshChildCleanupScratch>();
+    reg.ctx().emplace<WasmSmokeLaneMarkerState>();
 
     runtime_system_scratch_reserve(reg, 0);
 }

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -234,6 +234,23 @@ TEST_CASE("game_state: Settings hides stale world renderables",
     CHECK_FALSE(game_render_should_draw_world_meshes(GamePhase::Tutorial));
 }
 
+TEST_CASE("wasm smoke lane marker state is registry-owned and reset with runtime scratch",
+          "[gamestate][wasm][regression][issue973]") {
+    auto first = make_registry();
+    auto second = make_registry();
+
+    auto& first_marker = first.ctx().get<WasmSmokeLaneMarkerState>();
+    auto& second_marker = second.ctx().get<WasmSmokeLaneMarkerState>();
+    first_marker.last_lane = 2;
+
+    CHECK(second_marker.last_lane == -1);
+
+    runtime_system_scratch_init(first);
+
+    CHECK(first.ctx().get<WasmSmokeLaneMarkerState>().last_lane == -1);
+    CHECK(second.ctx().get<WasmSmokeLaneMarkerState>().last_lane == -1);
+}
+
 TEST_CASE("game_state: transition clears in-flight pointer capture", "[gamestate][input]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include "components/system_scratch.h"
 #include "test_helpers.h"
 #include "ui/screen_controllers/tutorial_screen_controller.h"
 


### PR DESCRIPTION
## Summary
- Move the WASM smoke lane marker cache from function-static state into `entt::registry` context scratch.
- Reset the marker state when runtime scratch is reinitialized and when marker-enabled builds leave `Playing`.
- Add regression coverage that separate registries do not share marker state.

## Root cause
`update_web_playing_lane_marker()` used a function-static `last_lane`, so multiple registries in one process could share stale marker state under `SHAPESHIFTER_WASM_SMOKE_MARKERS`.

## Verification
- `cmake -B build -S . -Wno-dev`
- `cmake --build build --parallel`
- `./build/shapeshifter_tests "~[bench]"`

Closes #973