### PR TITLE
Align shared beatmap constants with runtime parser

### DIFF
--- a/content/constants.json
+++ b/content/constants.json
@@ -1,19 +1,16 @@
 {
     "obstacle_kinds": [
         "shape_gate",
-        "combo_gate",
         "split_path",
         "onset_marker"
     ],
     "shapes": [
         "circle",
         "square",
-        "triangle",
-        "hexagon"
+        "triangle"
     ],
     "kinds_with_shape": [
         "shape_gate",
-        "combo_gate",
         "split_path"
     ],
     "lanes": [

--- a/design-docs/beatmap-editor.md
+++ b/design-docs/beatmap-editor.md
@@ -307,7 +307,7 @@ export const state = {
 };
 
 // ── Beat Entry shape ────────────────────────────────
-// { beat: int, kind: string, shape: string, lane: int, blocked?: int[] }
+// { beat: int, kind: string, shape: string, lane: int }
 
 // ── Exported mutation functions ─────────────────────
 export function getActiveBeats()                          → BeatEntry[]
@@ -481,14 +481,14 @@ export function downloadFile(filename, content)        → void  // triggers bro
 ```javascript
 // Runtime-supported kinds imported/exported by the editor. Defaults mirror
 // content/constants.json and are refreshed by loadSharedConstants().
-export let OBSTACLE_KINDS = ["shape_gate", "combo_gate", "split_path", "onset_marker"];
+export let OBSTACLE_KINDS = ["shape_gate", "split_path", "onset_marker"];
 // Active editor palette: runtime-supported, authorable kinds only.
 export const EDITOR_OBSTACLE_KINDS = ["shape_gate", "split_path"];
 // onset_marker is import/export metadata for shipped beatmaps, not palette-authorable.
 // Archived/future catalog entries such as low_bar/high_bar are intentionally not constants here.
 export const SHAPES = ["circle", "square", "triangle"];
 export const LANES = [0, 1, 2];
-export const KINDS_WITH_SHAPE = ["shape_gate", "combo_gate", "split_path"];
+export const KINDS_WITH_SHAPE = ["shape_gate", "split_path"];
 export const COLORS = { /* per-kind and per-shape colors */ };
 export const GLYPHS = { /* unicode/emoji per obstacle kind */ };
 export const DEFAULT_BPM = 120;

--- a/design-docs/beatmap-integration.md
+++ b/design-docs/beatmap-integration.md
@@ -182,8 +182,8 @@ The current obstacle components already match the beatmap schema:
 
 ```
   ObstacleKind::ShapeGate      → "shape_gate"       ✓  required shipped obstacle
-  ObstacleKind::LaneBlock      → "lane_block"       ✓  legacy/backward-compatible support
-  ObstacleKind::ComboGate      → "combo_gate"       ✓  runtime-supported, not generated today
+  ObstacleKind::LaneBlock      → "lane_block"       ✗  ECS-only/future; parser rejects
+  ObstacleKind::ComboGate      → "combo_gate"       ✗  ECS-only/future; parser rejects
   ObstacleKind::SplitPath      → "split_path"       ✓  runtime-supported, not generated today
   ObstacleKind::OnsetMarker    → "onset_marker"     ✓  non-blocking shipped metadata
 

--- a/tools/beatmap-editor/js/constants.js
+++ b/tools/beatmap-editor/js/constants.js
@@ -5,10 +5,10 @@
 // glyphs, zoom, layout) stay here.
 
 // ── Shared constants (populated by loadSharedConstants) ──────
-export let OBSTACLE_KINDS = ["shape_gate", "combo_gate", "split_path", "onset_marker"];
+export let OBSTACLE_KINDS = ["shape_gate", "split_path", "onset_marker"];
 export let SHAPES = ["circle", "square", "triangle"];
 export let LANES = [0, 1, 2];
-export let KINDS_WITH_SHAPE = ["shape_gate", "combo_gate", "split_path"];
+export let KINDS_WITH_SHAPE = ["shape_gate", "split_path"];
 export const DIFFICULTY_KEYS = Object.freeze(["easy", "medium", "hard"]);
 export const RHYTHM_LAYER_KEYS = Object.freeze(["percussive", "harmonic", "full-spectrum"]);
 export let VALIDATION = {
@@ -129,7 +129,6 @@ export function isEditorObstacleKind(kind) {
 
 export const KIND_LABELS = {
     shape_gate: "ShapeGate",
-    combo_gate: "ComboGate",
     split_path: "SplitPath",
 };
 
@@ -160,7 +159,6 @@ export const COLORS = {
 
     kind: {
         shape_gate: "#4fc3f7",
-        combo_gate: "#fff176",
         split_path: "#4dd0e1",
         onset_marker: "#ce93d8",
     },
@@ -174,7 +172,6 @@ export const COLORS = {
 
 export const GLYPHS = {
     shape_gate: "◆",
-    combo_gate: "◈",
     split_path: "⑂",
     onset_marker: "·",
 };

--- a/tools/beatmap-editor/js/context-menu.js
+++ b/tools/beatmap-editor/js/context-menu.js
@@ -12,7 +12,7 @@ import {
 } from './constants.js';
 
 let container = null;
-const AUTHORING_KINDS = EDITOR_OBSTACLE_KINDS.filter((kind) => kind !== 'combo_gate');
+const AUTHORING_KINDS = EDITOR_OBSTACLE_KINDS;
 
 // ── Helpers ─────────────────────────────────────────
 

--- a/tools/beatmap-editor/js/io.js
+++ b/tools/beatmap-editor/js/io.js
@@ -1,7 +1,7 @@
 // io.js — Beatmap file I/O and validation (pure functions, no DOM except downloadFile)
 
 import {
-    OBSTACLE_KINDS, SHAPES, LANES, KINDS_WITH_SHAPE, DIFFICULTY_KEYS, RHYTHM_LAYER_KEYS, VALIDATION,
+    OBSTACLE_KINDS, SHAPES, KINDS_WITH_SHAPE, DIFFICULTY_KEYS, RHYTHM_LAYER_KEYS, VALIDATION,
 } from './constants.js';
 
 const LEGACY_ONSET_LAYER_MAP = Object.freeze({
@@ -230,24 +230,9 @@ function normalizeBeat(b, path, errors) {
         valid = false;
     }
 
-    const blocked = normalizeBlockedArray(b.blocked, `${path}.blocked`, errors);
-    if (b.blocked !== undefined && blocked == null) {
+    if (b.blocked !== undefined) {
+        errors.push(`${path}.blocked is not supported by active beatmap obstacle kinds`);
         valid = false;
-    }
-    if (kind === 'combo_gate') {
-        if (!Array.isArray(blocked)) {
-            errors.push(`${path}.blocked must be an array of lane indices 0-2 for combo_gate`);
-            valid = false;
-        } else {
-            const blockedMask = blocked.reduce((mask, blockedLane) => mask | (1 << blockedLane), 0);
-            if (blockedMask === 0) {
-                errors.push(`${path}.blocked must block at least one lane for combo_gate`);
-                valid = false;
-            } else if (blockedMask === 0x07) {
-                errors.push(`${path}.blocked must leave at least one lane open for combo_gate`);
-                valid = false;
-            }
-        }
     }
 
     if (!valid) return null;
@@ -258,7 +243,6 @@ function normalizeBeat(b, path, errors) {
         kind,
         shape,
         lane,
-        blocked,
     };
 }
 
@@ -364,6 +348,10 @@ function exportBeatEntry(b, path) {
         return { error: `${path}.lane must be in range 0-2` };
     }
 
+    if (b.blocked !== undefined) {
+        return { error: `${path}.blocked is not supported by active beatmap obstacle kinds` };
+    }
+
     const entry = { ...b, beat: b.beat, kind: b.kind, lane: b.lane };
 
     if (KINDS_WITH_SHAPE.includes(b.kind)) {
@@ -373,21 +361,6 @@ function exportBeatEntry(b, path) {
         entry.shape = b.shape;
     }
 
-    if (b.kind === 'combo_gate') {
-        const blocked = normalizeBlockedArray(b.blocked, `${path}.blocked`, []);
-        if (!blocked) {
-            return { error: `${path}.blocked must be an array of lane indices 0-2 for combo_gate` };
-        }
-        const blockedMask = blocked.reduce((mask, lane) => mask | (1 << lane), 0);
-        if (blockedMask === 0) {
-            return { error: `${path}.blocked must block at least one lane for combo_gate` };
-        }
-        if (blockedMask === 0x07) {
-            return { error: `${path}.blocked must leave at least one lane open for combo_gate` };
-        }
-        entry.blocked = blocked;
-    }
-
     if (b.shape !== undefined && !KINDS_WITH_SHAPE.includes(b.kind)) {
         if (typeof b.shape !== 'string' || !isAllowedShape(b.shape)) {
             return { error: `${path}.shape must be one of: ${SHAPES.join(', ')}` };
@@ -395,24 +368,6 @@ function exportBeatEntry(b, path) {
     }
 
     return { entry };
-}
-
-function normalizeBlockedArray(blocked, path, errors) {
-    if (blocked === undefined) return undefined;
-    if (!Array.isArray(blocked)) {
-        errors.push(`${path} must be an array`);
-        return null;
-    }
-    const normalized = [];
-    for (let i = 0; i < blocked.length; i++) {
-        const lane = blocked[i];
-        if (!Number.isInteger(lane) || !LANES.includes(lane)) {
-            errors.push(`${path}[${i}] must be one of: ${LANES.join(', ')}`);
-            return null;
-        }
-        normalized.push(lane);
-    }
-    return normalized;
 }
 
 /**
@@ -665,46 +620,12 @@ export function validate(state) {
             }
         }
 
-        // Rule 7b: combo_gate blocked lanes parity with C++ validator
-        if (entry.kind === 'combo_gate') {
-            if (!Array.isArray(entry.blocked)) {
-                errors.push({
-                    beatIndex: entry.beat,
-                    message: 'ComboGate blocked must be an array of lane indices',
-                    severity: 'error',
-                });
-            } else {
-                let blockedMask = 0;
-                let blockedValid = true;
-                for (const lane of entry.blocked) {
-                    if (!Number.isInteger(lane) || lane < 0 || lane > 2) {
-                        errors.push({
-                            beatIndex: entry.beat,
-                            message: 'ComboGate blocked lanes must be in range 0-2',
-                            severity: 'error',
-                        });
-                        blockedValid = false;
-                        break;
-                    }
-                    blockedMask |= (1 << lane);
-                }
-                if (!blockedValid) {
-                    continue;
-                }
-                if (blockedMask === 0) {
-                    errors.push({
-                        beatIndex: entry.beat,
-                        message: 'ComboGate must block at least one lane',
-                        severity: 'error',
-                    });
-                } else if (blockedMask === 0x07) {
-                    errors.push({
-                        beatIndex: entry.beat,
-                        message: 'ComboGate must leave at least one lane open',
-                        severity: 'error',
-                    });
-                }
-            }
+        if (entry.blocked !== undefined) {
+            errors.push({
+                beatIndex: entry.beat,
+                message: 'blocked is not supported by active beatmap obstacle kinds',
+                severity: 'error',
+            });
         }
 
         // Rule 8: Different-shape gates must be ≥ 3 beats apart

--- a/tools/beatmap-editor/js/timeline.js
+++ b/tools/beatmap-editor/js/timeline.js
@@ -482,7 +482,6 @@ function renderLegend(ctx, w, h) {
         { glyph: SHAPE_GLYPHS.circle,      color: COLORS.shape.circle,          label: 'Circle' },
         { glyph: SHAPE_GLYPHS.square,      color: COLORS.shape.square,          label: 'Square' },
         { glyph: SHAPE_GLYPHS.triangle,    color: COLORS.shape.triangle,        label: 'Triangle' },
-        { glyph: GLYPHS.combo_gate,        color: COLORS.kind.combo_gate,       label: 'ComboGate' },
         { glyph: GLYPHS.split_path,        color: COLORS.kind.split_path,       label: 'SplitPath' },
     ];
 

--- a/tools/beatmap-editor/test/io-hardening.test.js
+++ b/tools/beatmap-editor/test/io-hardening.test.js
@@ -10,6 +10,7 @@ import {
   DEFAULT_LEVELS,
   EDITOR_OBSTACLE_KINDS,
   OBSTACLE_KINDS,
+  SHAPES,
   canAutoLoadBundledContent,
   getContentUrl,
 } from '../js/constants.js';
@@ -59,7 +60,7 @@ test('valid beatmap import/export round-trip still works', () => {
       },
       hard: {
         beats: [
-          { beat: 3, kind: 'combo_gate', shape: 'circle', lane: 1, blocked: [0, 2] },
+          { beat: 3, kind: 'split_path', shape: 'circle', lane: 1 },
           { beat: 6, kind: 'shape_gate', shape: 'triangle', lane: 0 },
         ],
       },
@@ -462,40 +463,26 @@ test('unexpected difficulty names are rejected', () => {
   );
 });
 
-test('combo_gate blocked mask: no blocked lanes is surfaced', () => {
-  const errors = validate(makeState([
-    { beat: 1, kind: 'combo_gate', shape: 'circle', lane: 1, blocked: [] },
-  ]));
-
-  assert.match(
-    errors.map((e) => e.message).join('\n'),
-    /combo.?gate.*block at least one lane|blocked/i,
-  );
-});
-
-test('combo_gate blocked mask: all lanes blocked is surfaced', () => {
-  const errors = validate(makeState([
-    { beat: 1, kind: 'combo_gate', shape: 'circle', lane: 1, blocked: [0, 1, 2] },
-  ]));
-
-  assert.match(
-    errors.map((e) => e.message).join('\n'),
-    /combo.?gate.*leave at least one lane open|all lanes/i,
-  );
-});
-
-test('combo_gate blocked mask: partial mask stays valid', () => {
+test('combo_gate is rejected by shared editor validation', () => {
   const errors = validate(makeState([
     { beat: 1, kind: 'combo_gate', shape: 'circle', lane: 1, blocked: [0, 2] },
   ]));
 
-  const comboErrors = errors.filter((e) => /combo.?gate|blocked lane|lane open/i.test(e.message));
-  assert.equal(comboErrors.length, 0);
+  assert.match(errors.map((e) => e.message).join('\n'), /kind must be one of|combo_gate/i);
+});
+
+test('blocked lanes are rejected for active obstacle kinds', () => {
+  const errors = validate(makeState([
+    { beat: 1, kind: 'shape_gate', shape: 'circle', lane: 1, blocked: [0, 2] },
+  ]));
+
+  assert.match(errors.map((e) => e.message).join('\n'), /blocked is not supported/i);
 });
 
 test('combo_gate is not exposed as an authoring kind', () => {
   assert.ok(Array.isArray(EDITOR_OBSTACLE_KINDS));
   assert.ok(!EDITOR_OBSTACLE_KINDS.includes('combo_gate'));
+  assert.ok(!OBSTACLE_KINDS.includes('combo_gate'));
 });
 
 test('combo_gate is absent from palette and context-menu authoring surfaces', () => {
@@ -527,4 +514,15 @@ test('bundled level list points at shipped beatmap and audio assets', () => {
   assert.ok(getContentUrl('content/constants.json').href.endsWith('/content/constants.json'));
   assert.ok(getContentUrl('content/beatmaps/1_stomper_beatmap.json').href.endsWith('/content/beatmaps/1_stomper_beatmap.json'));
   assert.equal(canAutoLoadBundledContent(), false);
+});
+
+test('shared constants expose only runtime-parseable beatmap shapes', () => {
+  assert.deepEqual(SHAPES, ['circle', 'square', 'triangle']);
+  assert.ok(!SHAPES.includes('hexagon'));
+});
+
+test('bundled shared constants mirror editor runtime defaults', () => {
+  const constants = JSON.parse(fs.readFileSync(path.resolve(TEST_DIR, '../../../content/constants.json'), 'utf8'));
+  assert.deepEqual(constants.obstacle_kinds, OBSTACLE_KINDS);
+  assert.deepEqual(constants.shapes, SHAPES);
 });


### PR DESCRIPTION
## Summary
- Remove unsupported `combo_gate` and `hexagon` from shared beatmap constants and editor fallback defaults.
- Reject `blocked` masks for active beatmap obstacle kinds so editor export/import matches the C++ loader.
- Refresh beatmap editor/integration docs and tests around active runtime schema.

## Root Cause
`content/constants.json` and editor defaults included future/ECS-only values that the C++ beatmap parser intentionally rejects, so editor-valid beatmaps could fail at runtime.

## Verification
- `cmake -B build -S . -Wno-dev && cmake --build build && ./build/shapeshifter_tests && node --test tools/beatmap-editor/test/*.test.js`
- `ctest --test-dir build --output-on-failure`

Fixes #980