### PR TITLE
Run local tests through CTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ export VCPKG_ROOT=/path/to/vcpkg
 
 ./build.sh           # Release build
 ./run.sh             # Build + run game
-./run.sh test        # Build + run tests (skips optional Node tests if node/npm is unavailable)
+./run.sh test        # Build + run CTest gates (skips optional Node tests if node/npm is unavailable)
 cmake --build build --target shapeshifter_benchmarks  # Run benchmarks on demand
 ```
 

--- a/run.sh
+++ b/run.sh
@@ -7,14 +7,7 @@ export VCPKG_ROOT="${VCPKG_ROOT:-$HOME/vcpkg}"
 
 if [[ "${1:-}" == "test" ]]; then
     shift
-    ./build/shapeshifter_tests "$@"
-    python3 -m unittest discover -s tools -p "test_*.py"
-    if command -v node >/dev/null 2>&1; then
-        (cd tools/beatmap-editor && node --test test/*.test.js)
-        node --test tests/service_worker_cache_policy.test.cjs
-    else
-        echo "SKIPPED: JavaScript tests (node executable not found)"
-    fi
+    ctest --test-dir build --output-on-failure "$@"
 elif [[ "${1:-}" == "bench" ]]; then
     shift
     ./build/shapeshifter_tests "[bench]" "$@"


### PR DESCRIPTION
## Summary
- Delegate `./run.sh test` to `ctest --test-dir build --output-on-failure` so local runs include Catch2 tests plus CTest-only validators and smoke gates.
- Update README quick-start wording to describe the CTest gate path.

## Root cause
`run.sh test` manually invoked the Catch2 binary, Python unittest discovery, and Node tests, bypassing standalone validators registered only in CTest.

## Verification
- `./run.sh test`
- CTest ran 884 tests, including `loop2_content_gates_strict` and `validate_required_cross_lane_jump_time`; 884/884 passed with `startup_shutdown_smoke` skipped by its configured skip return on this local environment.

Closes #982