### PR TITLE
Write CTRF report under build artifacts

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -118,13 +118,13 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           name: ctrf-report-linux
-          path: ctrf-report.json
+          path: build/ctrf-report.json
 
       - name: Report test results
         if: always() && steps.run-tests.outcome != 'skipped'
         uses: ctrf-io/github-test-reporter@v1
         with:
-          report-path: 'ctrf-report.json'
+          report-path: 'build/ctrf-report.json'
           title: 'Test Results (Linux)'
           pull-request-report: true
           update-comment: true

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -122,13 +122,13 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           name: ctrf-report-macos
-          path: ctrf-report.json
+          path: build/ctrf-report.json
 
       - name: Report test results
         if: always() && steps.run-tests.outcome != 'skipped'
         uses: ctrf-io/github-test-reporter@v1
         with:
-          report-path: 'ctrf-report.json'
+          report-path: 'build/ctrf-report.json'
           title: 'Test Results (macOS)'
           pull-request-report: true
           update-comment: true

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -115,13 +115,13 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           name: ctrf-report-windows
-          path: ctrf-report.json
+          path: build/ctrf-report.json
 
       - name: Report test results
         if: always() && steps.run-tests.outcome != 'skipped'
         uses: ctrf-io/github-test-reporter@v1
         with:
-          report-path: 'ctrf-report.json'
+          report-path: 'build/ctrf-report.json'
           title: 'Test Results (Windows)'
           pull-request-report: true
           update-comment: true
@@ -237,13 +237,13 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           name: ctrf-report-windows-msvc
-          path: ctrf-report.json
+          path: build-msvc/ctrf-report.json
 
       - name: Report test results
         if: always() && steps.run-tests.outcome != 'skipped'
         uses: ctrf-io/github-test-reporter@v1
         with:
-          report-path: 'ctrf-report.json'
+          report-path: 'build-msvc/ctrf-report.json'
           title: 'Test Results (Windows MSVC)'
           pull-request-report: true
           update-comment: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -538,6 +538,7 @@ target_link_libraries(shapeshifter_tests PRIVATE
 )
 target_compile_definitions(shapeshifter_tests PRIVATE
     SHAPESHIFTER_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
+    SHAPESHIFTER_CTRF_REPORT_PATH="${CMAKE_BINARY_DIR}/ctrf-report.json"
 )
 
 # Apply platform definitions to tests (same as shapeshifter_lib)

--- a/tests/ctrf_reporter.cpp
+++ b/tests/ctrf_reporter.cpp
@@ -1,3 +1,2 @@
 // This translation unit registers the CTRF reporter as a Catch2 listener.
-// The reporter writes ctrf-report.json alongside the test binary.
 #include "ctrf_reporter.h"

--- a/tests/ctrf_reporter.h
+++ b/tests/ctrf_reporter.h
@@ -4,11 +4,14 @@
 #include <catch2/reporters/catch_reporter_registrars.hpp>
 #include <catch2/catch_test_case_info.hpp>
 
-#include <fstream>
-#include <string>
-#include <vector>
 #include <chrono>
 #include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 static std::string ctrf_json_escape(const std::string& s) {
     std::string out;
@@ -32,6 +35,19 @@ static int64_t ctrf_now_ms() {
     ).count();
 }
 
+static std::string ctrf_report_path() {
+    if (const char* path = std::getenv("SHAPESHIFTER_CTRF_REPORT_PATH")) {
+        if (path[0] != '\0') {
+            return path;
+        }
+    }
+#ifdef SHAPESHIFTER_CTRF_REPORT_PATH
+    return SHAPESHIFTER_CTRF_REPORT_PATH;
+#else
+    return "ctrf-report.json";
+#endif
+}
+
 struct CtrfTestResult {
     std::string name;
     std::string status;
@@ -47,7 +63,7 @@ public:
     using EventListenerBase::EventListenerBase;
 
     static std::string getDescription() {
-        return "Outputs test results in CTRF JSON format to ctrf-report.json";
+        return "Outputs test results in CTRF JSON format";
     }
 
     void testRunStarting(Catch::TestRunInfo const&) override {
@@ -112,7 +128,12 @@ public:
             else                            ++other;
         }
 
-        std::ofstream out("ctrf-report.json");
+        const std::string report_path = ctrf_report_path();
+        std::ofstream out(report_path);
+        if (!out) {
+            std::cerr << "Failed to open CTRF report path: " << report_path << "\n";
+            throw std::runtime_error("failed to open CTRF report path");
+        }
         out << "{\n";
         out << "  \"reportFormat\": \"CTRF\",\n";
         out << "  \"specVersion\": \"0.0.1\",\n";


### PR DESCRIPTION
## Summary
- Default the Catch2 CTRF reporter output to `${CMAKE_BINARY_DIR}/ctrf-report.json` instead of `ctrf-report.json` in the process working directory.
- Add `SHAPESHIFTER_CTRF_REPORT_PATH` as an explicit override for manual/CI runs that need a custom report location.
- Update native CI upload and reporter steps to consume the build artifact path, including `build-msvc/ctrf-report.json` for MSVC.

## Root cause
The CTRF listener opened `ctrf-report.json` as a relative path while Catch2 tests run from the repository root, dirtying the source tree by default.

## Verification
- `export VCPKG_ROOT="${VCPKG_ROOT:-$HOME/vcpkg}" && rm -f ctrf-report.json build/ctrf-report.json && ./build.sh && ./build/shapeshifter_tests "~[bench]" --reporter compact >/tmp/shapeshifter-ctrf-test.log && test ! -f ctrf-report.json && test -f build/ctrf-report.json && tail -20 /tmp/shapeshifter-ctrf-test.log`

Closes #983