### PR TITLE
Fix swipe touch release HUD shape presses

### DIFF
--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
@@ -349,7 +349,7 @@ void gameplay_hud_process_button_input(entt::registry& reg) {
     if (!(input.click || input.button_touch_up || input.touch_up)) return;
 
     static const GameplayHudLayoutState geometry_state = GameplayHudLayout_Init();
-    if (input.click || (input.touch_up && !input.button_touch_up)) {
+    if (input.click) {
         const Vector2 pointer = {input.end_x, input.end_y};
         gameplay_hud_apply_button_presses(
             reg,
@@ -357,6 +357,16 @@ void gameplay_hud_process_button_input(entt::registry& reg) {
             CheckCollisionPointRec(pointer, GameplayHudLayout_CircleButtonBounds(&geometry_state)),
             CheckCollisionPointRec(pointer, GameplayHudLayout_SquareButtonBounds(&geometry_state)),
             CheckCollisionPointRec(pointer, GameplayHudLayout_TriangleButtonBounds(&geometry_state)));
+    }
+
+    if (input.touch_up && !input.button_touch_up) {
+        const Vector2 pointer = {input.end_x, input.end_y};
+        gameplay_hud_apply_button_presses(
+            reg,
+            CheckCollisionPointRec(pointer, GameplayHudLayout_PauseButtonBounds(&geometry_state)),
+            false,
+            false,
+            false);
     }
 
     if (input.button_touch_up) {

--- a/tests/test_input_pipeline_behavior.cpp
+++ b/tests/test_input_pipeline_behavior.cpp
@@ -251,6 +251,31 @@ TEST_CASE("pipeline: mobile button-zone touch release is collected independently
     CHECK(lane.target == 2);
 }
 
+TEST_CASE("pipeline: swipe-zone touch release over shape HUD does not press shape",
+          "[input_pipeline][hud][mobile][issue986]") {
+    auto reg = make_rhythm_registry();
+    auto player = make_rhythm_player(reg);
+    auto& input = reg.ctx().get<InputState>();
+    auto& lane = reg.get<Lane>(player);
+    auto& sw = reg.get<ShapeWindow>(player);
+    REQUIRE(sw.phase == WindowPhase::Idle);
+    REQUIRE(lane.current == 1);
+    lane.target = lane.current;
+
+    const auto square_bounds = gameplay_hud_shape_input_bounds(GameplayHudShapeSlot::Square);
+    input.touch_up = true;
+    input.button_touch_up = false;
+    input.end_x = square_bounds.x + square_bounds.width * 0.5f;
+    input.end_y = square_bounds.y + square_bounds.height * 0.5f;
+    push_go(reg, Direction::Right);
+
+    gameplay_hud_process_button_input(reg);
+    run_pipeline(reg);
+
+    CHECK(sw.phase == WindowPhase::Idle);
+    CHECK(lane.target == 2);
+}
+
 TEST_CASE("pipeline: gameplay HUD pause release is collected before the fixed tick",
           "[input_pipeline][hud][issue833]") {
     auto reg = make_rhythm_registry();
@@ -259,6 +284,24 @@ TEST_CASE("pipeline: gameplay HUD pause release is collected before the fixed ti
     REQUIRE(gs.phase == GamePhase::Playing);
 
     input.click = true;
+    input.end_x = 660.0f;
+    input.end_y = 35.0f;
+
+    gameplay_hud_process_button_input(reg);
+    run_pipeline(reg);
+
+    CHECK(gs.phase == GamePhase::Paused);
+    CHECK_FALSE(gs.transition_pending);
+}
+
+TEST_CASE("pipeline: gameplay HUD touch release can pause before the fixed tick",
+          "[input_pipeline][hud][mobile][issue986]") {
+    auto reg = make_rhythm_registry();
+    auto& input = reg.ctx().get<InputState>();
+    auto& gs = reg.ctx().get<GameState>();
+    REQUIRE(gs.phase == GamePhase::Playing);
+
+    input.touch_up = true;
     input.end_x = 660.0f;
     input.end_y = 35.0f;
 


### PR DESCRIPTION
## Summary
- Prevent generic swipe-zone touch releases from activating shape HUD buttons.
- Keep desktop click behavior unchanged and preserve touch release pause handling.
- Add regression tests for issue #986 and touch pause behavior.

## Validation
- `cmake -B build -S . -Wno-dev && cmake --build build --parallel && ./build/shapeshifter_tests`

Fixes #986
