### PR TITLE
Clarify shipped tutorial and obstacle docs

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -199,7 +199,7 @@ enum class ObstacleKind : uint8_t {
     LaneBlock,   // legacy value kept for backward compat
     ComboGate,   // shape + lane
     SplitPath,   // shape + specific lane
-    OnsetMarker, // virtual beat marker; scheduler does not spawn an obstacle
+    OnsetMarker, // visual beat marker
 };
 
 struct Obstacle {
@@ -209,6 +209,10 @@ struct Obstacle {
 // BlockedLanes, RequiredLane) via obstacle_kind_from_components().
 // Existential tag: presence means the obstacle has been cleared and awaits scoring.
 struct ScoredTag {};
+
+// Existential tag: obstacle does not participate in score popups or chains.
+// OnsetMarker obstacles carry this tag so beat markers remain visual-only.
+struct NonScorableTag {};
 ```
 
 ### 2.4 — WARM: Obstacle Specifics (read by collision/scoring, not by scroll)

--- a/design-docs/game-flow.md
+++ b/design-docs/game-flow.md
@@ -561,6 +561,11 @@ Terminal split:
 
 ## 3. FIRST-TIME USER EXPERIENCE (FTUE)
 
+> **Implementation status:** the shipped tutorial is the single-screen
+> **Quick Start** flow (`GamePhase::Tutorial`, `content/ui/screens/tutorial.rgl`).
+> The five-run adaptive FTUE design below is aspirational/archived and is not
+> routed by the current controllers.
+
 ### Design Philosophy
 
 ```
@@ -587,7 +592,7 @@ storage, but no shipped controller routes players through Tutorial Run 1-5.
 
 ---
 
-### TUTORIAL RUN 1 — "Match the Shape"
+### TUTORIAL RUN 1 — "Match the Shape" (unimplemented archived design)
 
 **Goal:** Teach shape matching. Only ■ gates appear. Only ■ button visible.
 

--- a/design-docs/game.md
+++ b/design-docs/game.md
@@ -105,12 +105,16 @@ See `rhythm-design.md` for the full timing-window grading table and `rhythm-spec
 | Obstacle        | Status          | Player Action Required    | Timed? | Base Points |
 |-----------------|-----------------|---------------------------|--------|-------------|
 | Shape Gate      | Shipped         | Tap correct shape button  | YES    | 200         |
+| Lane Block      | Legacy/back-compat | Avoid blocked lane     | NO     | 100 (unused legacy) |
 | Combo Gate      | Future design   | Shape + swipe (2 actions) | YES    | TBD         |
 | Split Path      | Future design   | Shape + correct lane      | YES    | TBD         |
 
 Shipped beatmaps currently use required `shape_gate` obstacles only. They may also include non-blocking `onset_marker` rows for authored onset metadata; runtime skips those rows and they do not score, block, or count as required obstacles.
 
-Vertical bars, Combo Gates, and Split Paths are archived/future-only design space and have no live base-point constants.
+Lane Block remains a legacy runtime enum/constant for backward compatibility
+(`PTS_LANE_BLOCK = 100`) but is not parsed from active beatmaps and is not
+current shipped content. Vertical bars, Combo Gates, and Split Paths are
+archived/future-only design space and have no live shipped content.
 
 ### Future Combo / Split-Path Obstacles
 


### PR DESCRIPTION
## Summary
- document OnsetMarker as a visual beat marker and note its NonScorableTag behavior
- mark the five-run FTUE design as archived/unimplemented while keeping shipped Quick Start status clear
- mark LaneBlock as legacy/back-compat and its 100-point value as unused legacy data

Closes #990
Closes #992
Closes #991

## Validation
- git diff --check
- CMake configure/build could not run locally because EnTT package configuration is unavailable in this environment (EnTTConfig.cmake/entt-config.cmake not found).