### PR TITLE
Validate beat_times ordering

### DIFF
--- a/app/entities/beat_map.cpp
+++ b/app/entities/beat_map.cpp
@@ -292,13 +292,31 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
             push_type_error(errors, -1, "beat_times", "an array", j["beat_times"]);
             parse_ok = false;
         } else {
+            bool has_prev_beat_time = false;
+            float prev_beat_time = 0.0f;
+            size_t beat_time_index = 0;
             for (const auto& t : j["beat_times"]) {
                 if (!t.is_number()) {
                     push_type_error(errors, -1, "beat_times[]", "a number", t);
                     parse_ok = false;
+                    ++beat_time_index;
                     continue;
                 }
-                out.beat_times.push_back(t.get<float>());
+                const float beat_time = t.get<float>();
+                if (!std::isfinite(beat_time)) {
+                    errors.push_back({-1, "beat_times[" + std::to_string(beat_time_index) + "] must be finite"});
+                    parse_ok = false;
+                    ++beat_time_index;
+                    continue;
+                }
+                if (has_prev_beat_time && beat_time < prev_beat_time) {
+                    errors.push_back({-1, "beat_times must be non-decreasing"});
+                    parse_ok = false;
+                }
+                out.beat_times.push_back(beat_time);
+                prev_beat_time = beat_time;
+                has_prev_beat_time = true;
+                ++beat_time_index;
             }
         }
     }
@@ -611,6 +629,19 @@ bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors,
         } else {
             beat_period = 60.0f / map.bpm;
             max_beat = *max_derived_beat;
+        }
+    }
+
+    for (size_t i = 0; i < map.beat_times.size(); ++i) {
+        const float beat_time = map.beat_times[i];
+        if (!std::isfinite(beat_time)) {
+            errors.push_back({-1, "beat_times[" + std::to_string(i) + "] must be finite"});
+            valid = false;
+            continue;
+        }
+        if (i > 0 && beat_time < map.beat_times[i - 1]) {
+            errors.push_back({-1, "beat_times must be non-decreasing"});
+            valid = false;
         }
     }
 

--- a/tests/test_beat_map_validation.cpp
+++ b/tests/test_beat_map_validation.cpp
@@ -672,6 +672,47 @@ TEST_CASE("parse: beat without time_sec falls back to beat_times", "[parse][beat
     CHECK_THAT(map.beats[0].time_sec, Catch::Matchers::WithinAbs(1.4f, 0.001f));
 }
 
+TEST_CASE("parse: beat_times must be finite", "[parse][beat_times][issue995]") {
+    BeatMap map;
+    std::vector<BeatMapError> errors;
+    std::string json = R"({
+        "song_id": "timing_test",
+        "bpm": 120,
+        "offset": 0.0,
+        "lead_beats": 4,
+        "duration_sec": 60.0,
+        "beat_times": [0.1, 1e39],
+        "beats": [
+            { "beat": 0, "kind": "shape_gate", "shape": "circle", "lane": 1 }
+        ]
+    })";
+
+    CHECK_FALSE(parse_beat_map(json, map, errors));
+    REQUIRE_FALSE(errors.empty());
+    CHECK(errors[0].message.find("finite") != std::string::npos);
+}
+
+TEST_CASE("parse: beat_times must be non-decreasing", "[parse][beat_times][issue995]") {
+    BeatMap map;
+    std::vector<BeatMapError> errors;
+    std::string json = R"({
+        "song_id": "timing_test",
+        "bpm": 120,
+        "offset": 0.0,
+        "lead_beats": 4,
+        "duration_sec": 60.0,
+        "beat_times": [1.0, 0.5],
+        "beats": [
+            { "beat": 0, "kind": "shape_gate", "shape": "circle", "lane": 1 },
+            { "beat": 1, "kind": "shape_gate", "shape": "circle", "lane": 1 }
+        ]
+    })";
+
+    CHECK_FALSE(parse_beat_map(json, map, errors));
+    REQUIRE_FALSE(errors.empty());
+    CHECK(errors[0].message.find("non-decreasing") != std::string::npos);
+}
+
 TEST_CASE("parse: missing selected difficulty falls back to valid difficulty",
           "[parse][difficulty][issue859]") {
     BeatMap map;
@@ -994,4 +1035,35 @@ TEST_CASE("validate: beat index out of range for beat_times fails", "[validate][
     CHECK_FALSE(validate_beat_map(map, errors));
     REQUIRE_FALSE(errors.empty());
     CHECK(errors[0].message.find("out of range for beat_times") != std::string::npos);
+}
+
+TEST_CASE("validate: beat_times must be finite", "[validate][beat_times][issue995]") {
+    BeatMap map;
+    map.bpm = 120.0f;
+    map.offset = 0.0f;
+    map.lead_beats = 4;
+    map.duration = 60.0f;
+    map.beat_times = {0.0f, std::numeric_limits<float>::infinity()};
+    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+
+    std::vector<BeatMapError> errors;
+    CHECK_FALSE(validate_beat_map(map, errors));
+    REQUIRE_FALSE(errors.empty());
+    CHECK(errors[0].message.find("finite") != std::string::npos);
+}
+
+TEST_CASE("validate: beat_times must be non-decreasing", "[validate][beat_times][issue995]") {
+    BeatMap map;
+    map.bpm = 120.0f;
+    map.offset = 0.0f;
+    map.lead_beats = 4;
+    map.duration = 60.0f;
+    map.beat_times = {1.0f, 0.5f};
+    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.beats.push_back({1, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+
+    std::vector<BeatMapError> errors;
+    CHECK_FALSE(validate_beat_map(map, errors));
+    REQUIRE_FALSE(errors.empty());
+    CHECK(errors[0].message.find("non-decreasing") != std::string::npos);
 }


### PR DESCRIPTION
## Summary\n- Reject non-finite beat_times entries during parsing and validation.\n- Reject decreasing beat_times arrays before scheduler/playback can consume them.\n- Add parser and validator regressions for issue #995.\n\n## Root cause\nbeat_times[] values were stored as floats without a whole-array finite/nondecreasing pass, while playback and scheduling consume them in index order.\n\n## Verification\n- cmake --build build-nonunity -j \"10\" -- -s\n- ./build-nonunity/shapeshifter_tests "[beat_times]"\n- ctest --test-dir build-nonunity --output-on-failure\n\nCloses #995