### PR TITLE
Validate blocked lanes before rejection

### DIFF
--- a/app/entities/beat_map.cpp
+++ b/app/entities/beat_map.cpp
@@ -118,6 +118,35 @@ bool read_optional_int(const json& object,
     return read_int_value(object[field], field, out, errors, beat_index);
 }
 
+bool validate_blocked_lanes_field(const json& object,
+                                  std::vector<BeatMapError>& errors,
+                                  const int beat_index) {
+    if (!object.contains("blocked")) return true;
+
+    const auto& blocked = object["blocked"];
+    if (!blocked.is_array()) {
+        push_type_error(errors, beat_index, "blocked", "an array", blocked);
+        return false;
+    }
+
+    bool ok = true;
+    for (const auto& lane_json : blocked) {
+        int lane = 0;
+        if (!read_int_value(lane_json, "blocked[]", lane, errors, beat_index)) {
+            ok = false;
+            continue;
+        }
+        if (lane < 0 || lane > 2) {
+            errors.push_back({beat_index,
+                "'blocked[]' lane must be in range [0, 2] at beat "
+                + std::to_string(beat_index)});
+            ok = false;
+        }
+    }
+
+    return ok;
+}
+
 std::optional<int> max_derived_beat_for_metadata(const float bpm, const float duration) {
     if (!std::isfinite(bpm) || !std::isfinite(duration) || bpm <= 0.0f || duration < 0.0f) {
         return std::nullopt;
@@ -486,6 +515,10 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
             }
         }
 
+        if (!validate_blocked_lanes_field(b, errors, entry.beat_index)) {
+            parse_ok = false;
+            continue;
+        }
         if (b.contains("blocked")) {
             errors.push_back({entry.beat_index,
                 "'blocked' is not supported by active beatmap obstacle kinds at beat "

--- a/tests/test_beat_map_validation.cpp
+++ b/tests/test_beat_map_validation.cpp
@@ -902,6 +902,50 @@ TEST_CASE("parse: blocked lane arrays are rejected from active beatmaps", "[pars
     CHECK(errors[0].message.find("'blocked' is not supported") != std::string::npos);
 }
 
+TEST_CASE("parse: invalid blocked lane values fail before narrowing", "[parse][blocked_mask][issue994]") {
+    const char* invalid_blocked_lanes[] = {"-1", "3", "257", "4294967297"};
+
+    for (const char* lane : invalid_blocked_lanes) {
+        BeatMap map;
+        std::vector<BeatMapError> errors;
+        const std::string json = std::string(R"({
+            "song_id": "blocked_lane_test",
+            "bpm": 120,
+            "offset": 0.0,
+            "lead_beats": 4,
+            "duration_sec": 60.0,
+            "beats": [
+                { "beat": 2, "kind": "shape_gate", "shape": "circle", "lane": 1, "blocked": [)") + lane + R"(] }
+            ]
+        })";
+
+        INFO("blocked lane: " << lane);
+        CHECK_FALSE(parse_beat_map(json, map, errors));
+        REQUIRE_FALSE(errors.empty());
+        CHECK(errors[0].message.find("blocked[]") != std::string::npos);
+        CHECK(errors[0].message.find("'blocked' is not supported") == std::string::npos);
+    }
+}
+
+TEST_CASE("parse: valid blocked lane values reach unsupported-field rejection unchanged", "[parse][blocked_mask][issue994]") {
+    BeatMap map;
+    std::vector<BeatMapError> errors;
+    std::string json = R"({
+        "song_id": "blocked_lane_test",
+        "bpm": 120,
+        "offset": 0.0,
+        "lead_beats": 4,
+        "duration_sec": 60.0,
+        "beats": [
+            { "beat": 2, "kind": "shape_gate", "shape": "circle", "lane": 1, "blocked": [0, 1, 2] }
+        ]
+    })";
+
+    CHECK_FALSE(parse_beat_map(json, map, errors));
+    REQUIRE_FALSE(errors.empty());
+    CHECK(errors[0].message.find("'blocked' is not supported") != std::string::npos);
+}
+
 TEST_CASE("parse: invalid scalar lane values fail before narrowing", "[parse][lane]") {
     const char* invalid_lanes[] = {"-1", "3", "257", "2147483648"};
 


### PR DESCRIPTION
## Summary
- range-check `blocked[]` entries with the same safe integer path used by scalar beatmap fields before any narrowing
- keep active beatmap behavior unchanged: valid `blocked` arrays still fail as unsupported, while malformed signed/unsigned lanes now report validation errors first
- add regression coverage for oversized `4294967297` and valid lanes `0`, `1`, `2`

## Root cause
Current active beatmap parsing rejected `blocked` fields without inspecting array contents, so malformed `blocked[]` lane values were not validated before the unsupported-field rejection path.

## Verification
- `./run.sh test --output-on-failure`
- `./build/shapeshifter_tests "[parse][blocked_mask]" --reporter compact`

Closes #994