### PR TITLE
Fix squad cycle packaging and ECS findings

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -111,7 +111,10 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           name: shapeshifter-linux
-          path: build/shapeshifter
+          path: |
+            build/shapeshifter
+            build/content
+          if-no-files-found: error
 
       - name: Upload CTRF report
         if: always() && steps.run-tests.outcome != 'skipped'

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -108,7 +108,10 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           name: shapeshifter-windows
-          path: build/shapeshifter.exe
+          path: |
+            build/shapeshifter.exe
+            build/content
+          if-no-files-found: error
 
       - name: Upload CTRF report
         if: always() && steps.run-tests.outcome != 'skipped'

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ The level designer uses song structure (intro/verse/chorus/bridge) to control de
 | glm | vcpkg | Math data and transforms |
 | [EnTT](https://github.com/skypjack/entt) | 3.16.0 | Entity Component System |
 | [nlohmann-json](https://github.com/nlohmann/json) | 3.12+ | Beatmap JSON parsing |
+| magic_enum | vcpkg | Compile-time enum introspection and naming |
 | [Catch2](https://github.com/catchorg/Catch2) | 3.13+ | Testing framework |
 
 ## CI/CD

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -285,12 +285,12 @@ void test_player_system(entt::registry& reg, float dt) {
         }
     }
 
-    auto obs_view = reg.view<ObstacleTag, WorldTransform, Obstacle>(entt::exclude<ScoredTag>);
+    auto obs_view = reg.view<ObstacleTag, WorldTransform, Obstacle>(
+        entt::exclude<ScoredTag, TestPlayerPlannedTag>);
     for (auto [entity, obs_wt, obs] : obs_view.each()) {
         (void)obs;
         float dist = p_transform.position.y - obs_wt.position.y;
         if (dist <= 0.0f || dist > cfg.vision_range) continue;
-        if (reg.any_of<TestPlayerPlannedTag>(entity)) continue;
 
         TestPlayerAction action = determine_action(reg, entity, effective_lane, *song);
 


### PR DESCRIPTION
## Summary
- Include `build/content` in Linux and Windows native artifacts, matching runtime asset loading requirements.
- Document required `magic_enum` dependency in README.
- Move the test-player planned-obstacle skip into the EnTT view exclusion.

## Verification
- `git diff --check`
- `cmake -B build -S . -Wno-dev`
- `cmake --build build`
- `./build/shapeshifter_tests`

Fixes #999
Fixes #1000
Fixes #1001
