### PR TITLE
Fix beatmap timing validation

### DIFF
--- a/app/entities/beat_map.cpp
+++ b/app/entities/beat_map.cpp
@@ -316,6 +316,23 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
     parse_ok &= read_optional_float(j, "duration_sec", out.duration, errors, -1);
     out.difficulty = difficulty;
 
+    if (!std::isfinite(out.bpm) || out.bpm <= 0.0f) {
+        errors.push_back({-1, "BPM must be finite and > 0 before deriving beat timing"});
+        return false;
+    }
+    if (!std::isfinite(out.offset)) {
+        errors.push_back({-1, "Offset must be finite before deriving beat timing"});
+        return false;
+    }
+    if (!std::isfinite(out.duration)) {
+        errors.push_back({-1, "duration_sec must be finite before deriving beat timing"});
+        return false;
+    }
+    if (out.lead_beats <= 0) {
+        errors.push_back({-1, "lead_beats must be > 0 before deriving song timing"});
+        return false;
+    }
+
     if (j.contains("beat_times")) {
         if (!j["beat_times"].is_array()) {
             push_type_error(errors, -1, "beat_times", "an array", j["beat_times"]);

--- a/app/util/rhythm_math.h
+++ b/app/util/rhythm_math.h
@@ -3,11 +3,16 @@
 #include "../components/rhythm.h"
 #include "../constants.h"
 
+#include <cmath>
+#include <raylib.h>
+
 constexpr float kTimingBpmCeiling = 180.0f;
 constexpr float kTimingPerfectSeconds = 0.050f;
 constexpr float kTimingGoodSeconds = 0.100f;
 constexpr float kTimingOkSeconds = 0.150f;
 constexpr float kTimingGradeEpsilonSeconds = 0.0005f;
+constexpr float kDefaultTimingBpm = 120.0f;
+constexpr int kDefaultTimingLeadBeats = 4;
 
 // Better timing -> smaller scale -> remaining Active window collapses sooner.
 // collision_system applies this via window_start adjustment (scale < 1.0 path).
@@ -41,8 +46,24 @@ inline TimingTier compute_timing_tier_from_delta(float delta_seconds_abs) {
 }
 
 inline void song_state_compute_derived(SongState& s) {
+    if (!std::isfinite(s.bpm) || s.bpm <= 0.0f) {
+        TraceLog(LOG_WARNING, "Invalid SongState bpm %.3f; using %.1f", s.bpm, kDefaultTimingBpm);
+        s.bpm = kDefaultTimingBpm;
+    }
+    if (s.lead_beats <= 0) {
+        TraceLog(LOG_WARNING, "Invalid SongState lead_beats %d; using %d", s.lead_beats, kDefaultTimingLeadBeats);
+        s.lead_beats = kDefaultTimingLeadBeats;
+    }
+
     s.beat_period     = 60.0f / s.bpm;
-    s.lead_time       = s.lead_beats * s.beat_period;
+    s.lead_time       = static_cast<float>(s.lead_beats) * s.beat_period;
+    if (!std::isfinite(s.lead_time) || s.lead_time <= 0.0f) {
+        TraceLog(LOG_WARNING, "Invalid derived lead_time %.3f; using default timing", s.lead_time);
+        s.bpm = kDefaultTimingBpm;
+        s.lead_beats = kDefaultTimingLeadBeats;
+        s.beat_period = 60.0f / s.bpm;
+        s.lead_time = static_cast<float>(s.lead_beats) * s.beat_period;
+    }
 
     s.scroll_speed    = constants::APPROACH_DIST / s.lead_time;
 

--- a/tests/test_beat_map_validation.cpp
+++ b/tests/test_beat_map_validation.cpp
@@ -471,6 +471,24 @@ TEST_CASE("song_state_compute_derived: scroll_speed calculation", "[rhythm_helpe
     CHECK_THAT(s.scroll_speed, Catch::Matchers::WithinAbs(constants::APPROACH_DIST / 2.0f, 1.0f));
 }
 
+TEST_CASE("song_state_compute_derived: invalid timing inputs fall back to finite defaults",
+          "[rhythm_helpers][issue1003]") {
+    SongState s;
+    s.bpm = 0.0f;
+    s.lead_beats = 0;
+
+    song_state_compute_derived(s);
+
+    CHECK(s.bpm == 120.0f);
+    CHECK(s.lead_beats == 4);
+    CHECK(std::isfinite(s.beat_period));
+    CHECK(std::isfinite(s.lead_time));
+    CHECK(std::isfinite(s.scroll_speed));
+    CHECK(s.beat_period > 0.0f);
+    CHECK(s.lead_time > 0.0f);
+    CHECK(s.scroll_speed > 0.0f);
+}
+
 // ── load_validation_constants: path resolution ───────────────
 
 TEST_CASE("load_validation_constants: default paths load shipped defaults", "[validate][constants]") {
@@ -649,6 +667,49 @@ TEST_CASE("parse: beat_times and per-obstacle time_sec are loaded", "[parse][bea
     REQUIRE(map.beat_times.size() == 3);
     CHECK_THAT(map.beats[0].time_sec, Catch::Matchers::WithinAbs(1.4f, 0.001f));
     CHECK(map.beats[0].has_time_sec);
+}
+
+TEST_CASE("parse: non-positive BPM is rejected before deriving beat timing",
+          "[parse][beat_times][issue1003]") {
+    BeatMap map;
+    std::vector<BeatMapError> errors;
+    std::string json = R"({
+        "song_id": "invalid_timing_test",
+        "bpm": 0,
+        "offset": 0.0,
+        "lead_beats": 4,
+        "duration_sec": 60.0,
+        "beat_times": [0.1],
+        "beats": [
+            { "beat": 0, "kind": "shape_gate", "shape": "circle", "lane": 1 }
+        ]
+    })";
+
+    CHECK_FALSE(parse_beat_map(json, map, errors));
+    REQUIRE_FALSE(errors.empty());
+    CHECK(errors[0].message.find("BPM") != std::string::npos);
+    CHECK(map.beats.empty());
+}
+
+TEST_CASE("parse: non-positive lead_beats is rejected before runtime timing",
+          "[parse][issue1003]") {
+    BeatMap map;
+    std::vector<BeatMapError> errors;
+    std::string json = R"({
+        "song_id": "invalid_timing_test",
+        "bpm": 120,
+        "offset": 0.0,
+        "lead_beats": 0,
+        "duration_sec": 60.0,
+        "beats": [
+            { "beat": 0, "kind": "shape_gate", "shape": "circle", "lane": 1 }
+        ]
+    })";
+
+    CHECK_FALSE(parse_beat_map(json, map, errors));
+    REQUIRE_FALSE(errors.empty());
+    CHECK(errors[0].message.find("lead_beats") != std::string::npos);
+    CHECK(map.beats.empty());
 }
 
 TEST_CASE("parse: beat without time_sec falls back to beat_times", "[parse][beat_times]") {


### PR DESCRIPTION
## Summary
- reject non-finite/non-positive beatmap timing metadata before parse-time beat timing derivation
- make SongState derived timing fall back to finite defaults if invalid timing input is constructed directly
- add regression coverage for invalid BPM and lead-beat inputs

Fixes #1003

## Verification
- cmake -B build -S . -Wno-dev
- cmake --build build --parallel
- ./build/shapeshifter_tests