### PR TITLE
Fix high score saturation handling

### DIFF
--- a/app/session/play_session.cpp
+++ b/app/session/play_session.cpp
@@ -201,8 +201,8 @@ void setup_play_session(entt::registry& reg) {
         char key_buf[HighScoreState::KEY_CAP]{};
         high_score::make_key_str(key_buf, HighScoreState::KEY_CAP,
                                  stem.c_str(), beatmap.difficulty.c_str());
-        high_score::ensure_entry(*hs, key_buf);
         hs->current_key_hash = entt::hashed_string::value(static_cast<const char*>(key_buf));
+        high_score::ensure_entry(*hs, key_buf);
     }
 
     // Init song state

--- a/app/systems/game_state_terminal_phase_system.cpp
+++ b/app/systems/game_state_terminal_phase_system.cpp
@@ -26,29 +26,34 @@ void persist_dirty_high_scores(const HighScoreState& high_scores, HighScorePersi
 bool update_and_persist_high_score(entt::registry& reg) {
     auto& score = reg.ctx().get<ScoreState>();
     const int32_t previous_high_score = score.high_score;
-    const bool is_new_high_score = (score.score > score.high_score);
-    if (auto* result = reg.ctx().find<TerminalResultState>()) {
-        *result = TerminalResultState{is_new_high_score, previous_high_score};
-    } else {
-        reg.ctx().emplace<TerminalResultState>(TerminalResultState{is_new_high_score, previous_high_score});
-    }
+    const bool score_exceeds_high_score = (score.score > score.high_score);
+    bool recorded_new_high_score = score_exceeds_high_score;
 
     if (auto* hs = reg.ctx().find<HighScoreState>()) {
-        if (is_new_high_score) {
+        const bool has_active_high_score_key = (hs->current_key_hash != 0);
+        if (score_exceeds_high_score && has_active_high_score_key) {
+            recorded_new_high_score = high_score::update_if_higher(*hs, score.score);
+        }
+        if (score_exceeds_high_score && recorded_new_high_score) {
             score.high_score = score.score;
-            high_score::update_if_higher(*hs, score.score);
         }
         if (auto* hp = reg.ctx().find<HighScorePersistence>()) {
-            if (is_new_high_score) {
+            if (score_exceeds_high_score && recorded_new_high_score && has_active_high_score_key) {
                 hp->dirty = true;
             }
             persist_dirty_high_scores(*hs, *hp);
         }
-    } else if (is_new_high_score) {
+    } else if (score_exceeds_high_score) {
         score.high_score = score.score;
     }
 
-    return is_new_high_score;
+    if (auto* result = reg.ctx().find<TerminalResultState>()) {
+        *result = TerminalResultState{recorded_new_high_score, previous_high_score};
+    } else {
+        reg.ctx().emplace<TerminalResultState>(TerminalResultState{recorded_new_high_score, previous_high_score});
+    }
+
+    return recorded_new_high_score;
 }
 
 void emit_terminal_feedback(entt::registry& reg, GamePhase phase, bool is_new_high_score) {

--- a/app/util/high_score_persistence.cpp
+++ b/app/util/high_score_persistence.cpp
@@ -66,11 +66,11 @@ int32_t get_score_by_hash(const HighScoreState& state, entt::hashed_string::hash
     return 0;
 }
 
-void set_score(HighScoreState& state, const char* key, int32_t score) {
+bool set_score(HighScoreState& state, const char* key, int32_t score) {
     for (int32_t i = 0; i < state.entry_count; ++i) {
         if (std::strncmp(state.entries[i].key, key, HighScoreState::KEY_CAP) == 0) {
             state.entries[i].score = score;
-            return;
+            return true;
         }
     }
     if (state.entry_count < HighScoreState::MAX_ENTRIES) {
@@ -78,28 +78,37 @@ void set_score(HighScoreState& state, const char* key, int32_t score) {
         state.entries[state.entry_count].key[HighScoreState::KEY_CAP - 1] = '\0';
         state.entries[state.entry_count].score = score;
         ++state.entry_count;
+        return true;
     }
+    TraceLog(LOG_WARNING, "High score table full; dropping score for key '%s'", key);
+    return false;
 }
 
-void set_score_by_hash(HighScoreState& state, entt::hashed_string::hash_type hash, int32_t score) {
+bool set_score_by_hash(HighScoreState& state, entt::hashed_string::hash_type hash, int32_t score) {
     for (int32_t i = 0; i < state.entry_count; ++i) {
         if (entt::hashed_string::value(static_cast<const char*>(state.entries[i].key)) == hash) {
             state.entries[i].score = score;
-            return;
+            return true;
         }
     }
+    TraceLog(LOG_WARNING, "High score entry hash %u not found; score update skipped",
+             static_cast<unsigned int>(hash));
+    return false;
 }
 
-void ensure_entry(HighScoreState& state, const char* key) {
+bool ensure_entry(HighScoreState& state, const char* key) {
     for (int32_t i = 0; i < state.entry_count; ++i) {
-        if (std::strncmp(state.entries[i].key, key, HighScoreState::KEY_CAP) == 0) return;
+        if (std::strncmp(state.entries[i].key, key, HighScoreState::KEY_CAP) == 0) return true;
     }
     if (state.entry_count < HighScoreState::MAX_ENTRIES) {
         std::strncpy(state.entries[state.entry_count].key, key, HighScoreState::KEY_CAP - 1);
         state.entries[state.entry_count].key[HighScoreState::KEY_CAP - 1] = '\0';
         state.entries[state.entry_count].score = 0;
         ++state.entry_count;
+        return true;
     }
+    TraceLog(LOG_WARNING, "High score table full; cannot create entry for key '%s'", key);
+    return false;
 }
 
 int32_t get_current_high_score(const HighScoreState& state) {
@@ -168,7 +177,9 @@ bool high_score_state_from_json(const nlohmann::json& obj, HighScoreState& state
                 raw = std::numeric_limits<std::int32_t>::max();
             }
 
-            set_score(next, key.c_str(), static_cast<std::int32_t>(raw));
+            if (!set_score(next, key.c_str(), static_cast<std::int32_t>(raw))) {
+                return false;
+            }
         }
     }
 
@@ -237,13 +248,14 @@ persistence::Result save_high_scores(const HighScoreState& state, const std::fil
     return persistence::flush_persistence_writes(path);
 }
 
-void update_if_higher(HighScoreState& state, int32_t new_score) {
-    if (state.current_key_hash == 0) return;
+bool update_if_higher(HighScoreState& state, int32_t new_score) {
+    if (state.current_key_hash == 0) return false;
     if (new_score < 0) new_score = 0;
     int32_t stored = get_score_by_hash(state, state.current_key_hash);
     if (new_score > stored) {
-        set_score_by_hash(state, state.current_key_hash, new_score);
+        return set_score_by_hash(state, state.current_key_hash, new_score);
     }
+    return true;
 }
 
 }  // namespace high_score

--- a/app/util/high_score_persistence.h
+++ b/app/util/high_score_persistence.h
@@ -23,8 +23,9 @@ persistence::Result get_high_scores_file_path(
     const std::filesystem::path& root_override = {});
 
 // Update the stored score for state.current_key_hash if new_score is strictly higher.
-// Negative new_score is clamped to 0. No-op if current_key_hash is zero.
-void update_if_higher(HighScoreState& state, int32_t new_score);
+// Negative new_score is clamped to 0. Returns false when no active key exists
+// or the active key is missing from the fixed entry table.
+bool update_if_higher(HighScoreState& state, int32_t new_score);
 
 // Build "song_id|difficulty" into caller-supplied buf (no heap allocation).
 // Returns snprintf-style char count (excluding NUL), or -1 if cap is invalid.
@@ -40,14 +41,15 @@ int32_t get_score(const HighScoreState& state, const char* key);
 // Returns the stored score for a hash -- used on the session current-key path.
 int32_t get_score_by_hash(const HighScoreState& state, entt::hashed_string::hash_type hash);
 
-// Insert or update entry by string key. Silently drops if table is full.
-void set_score(HighScoreState& state, const char* key, int32_t score);
+// Insert or update entry by string key. Returns false if the table is full.
+bool set_score(HighScoreState& state, const char* key, int32_t score);
 
-// Update an existing entry's score by hash. No-op if hash is not found.
-void set_score_by_hash(HighScoreState& state, entt::hashed_string::hash_type hash, int32_t score);
+// Update an existing entry's score by hash. Returns false if hash is not found.
+bool set_score_by_hash(HighScoreState& state, entt::hashed_string::hash_type hash, int32_t score);
 
 // Ensure an entry exists for key with score 0 if not already present.
-void ensure_entry(HighScoreState& state, const char* key);
+// Returns false if the table is full.
+bool ensure_entry(HighScoreState& state, const char* key);
 
 // Returns the stored score for the current session key, or 0 if no session active.
 int32_t get_current_high_score(const HighScoreState& state);

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -271,6 +271,32 @@ TEST_CASE("High score integration: lower game-over score does not overwrite pers
     remove_path(file);
 }
 
+TEST_CASE("High score integration: missing active entry does not report new best",
+          "[high_score][gamestate][issue1004]") {
+    auto reg = make_registry();
+    auto& high_scores = reg.ctx().get<HighScoreState>();
+    for (int32_t i = 0; i < HighScoreState::MAX_ENTRIES; ++i) {
+        const std::string key = "song_" + std::to_string(i) + "|easy";
+        REQUIRE(high_score::set_score(high_scores, key.c_str(), i * 100));
+    }
+    high_scores.current_key_hash = high_score::make_key_hash("overflow", "hard");
+
+    auto& score = reg.ctx().get<ScoreState>();
+    score.high_score = 1000;
+    score.score = 2500;
+
+    auto& gs = reg.ctx().get<GameState>();
+    gs.transition_pending = true;
+    gs.next_phase = GamePhase::SongComplete;
+
+    game_state_system(reg, 0.016f);
+
+    CHECK(score.high_score == 1000);
+    CHECK_FALSE(reg.ctx().get<TerminalResultState>().new_best);
+    CHECK_FALSE(reg.ctx().get<HighScorePersistence>().dirty);
+    CHECK(high_score::get_score(high_scores, "overflow|hard") == 0);
+}
+
 TEST_CASE("High score integration: failed save keeps dirty state for retry",
           "[high_score][gamestate]") {
     const auto root = std::filesystem::path("test_high_score_retry_state");

--- a/tests/test_high_score_persistence.cpp
+++ b/tests/test_high_score_persistence.cpp
@@ -2,6 +2,7 @@
 #include <filesystem>
 #include <fstream>
 #include <limits>
+#include <string>
 #include <string_view>
 
 #include "components/high_score.h"
@@ -76,31 +77,51 @@ TEST_CASE("High score: current score lookup and update never lowers stored score
     CHECK(high_score::get_current_high_score(state) == 0);
 
     // ensure_entry + current_key_hash mirrors the production setup_play_session path.
-    high_score::ensure_entry(state, "song_001|easy");
+    REQUIRE(high_score::ensure_entry(state, "song_001|easy"));
     state.current_key_hash = high_score::make_key_hash("song_001", "easy");
     CHECK(high_score::get_current_high_score(state) == 0);
 
-    high_score::update_if_higher(state, 5000);
+    CHECK(high_score::update_if_higher(state, 5000));
     CHECK(high_score::get_current_high_score(state) == 5000);
 
-    high_score::update_if_higher(state, 1000);
+    CHECK(high_score::update_if_higher(state, 1000));
     CHECK(high_score::get_current_high_score(state) == 5000);
+}
+
+TEST_CASE("High score: saturated table reports insert and hash update failures", "[high_score][issue1004]") {
+    HighScoreState state;
+    for (int32_t i = 0; i < HighScoreState::MAX_ENTRIES; ++i) {
+        const std::string key = "song_" + std::to_string(i) + "|easy";
+        REQUIRE(high_score::set_score(state, key.c_str(), i * 100));
+    }
+
+    CHECK(state.entry_count == HighScoreState::MAX_ENTRIES);
+    CHECK_FALSE(high_score::set_score(state, "overflow|easy", 9000));
+    CHECK_FALSE(high_score::ensure_entry(state, "overflow|medium"));
+
+    state.current_key_hash = high_score::make_key_hash("overflow", "hard");
+    CHECK_FALSE(high_score::update_if_higher(state, 9000));
+    CHECK(high_score::get_score(state, "overflow|hard") == 0);
+
+    state.current_key_hash = high_score::make_key_hash("song_0", "easy");
+    CHECK(high_score::update_if_higher(state, 9000));
+    CHECK(high_score::get_score(state, "song_0|easy") == 9000);
 }
 
 TEST_CASE("High score: tracks songs and difficulties independently", "[high_score]") {
     HighScoreState state;
 
-    high_score::ensure_entry(state, "song_001|easy");
+    REQUIRE(high_score::ensure_entry(state, "song_001|easy"));
     state.current_key_hash = high_score::make_key_hash("song_001", "easy");
-    high_score::update_if_higher(state, 1000);
+    CHECK(high_score::update_if_higher(state, 1000));
 
-    high_score::ensure_entry(state, "song_001|hard");
+    REQUIRE(high_score::ensure_entry(state, "song_001|hard"));
     state.current_key_hash = high_score::make_key_hash("song_001", "hard");
-    high_score::update_if_higher(state, 2000);
+    CHECK(high_score::update_if_higher(state, 2000));
 
-    high_score::ensure_entry(state, "song_002|easy");
+    REQUIRE(high_score::ensure_entry(state, "song_002|easy"));
     state.current_key_hash = high_score::make_key_hash("song_002", "easy");
-    high_score::update_if_higher(state, 3000);
+    CHECK(high_score::update_if_higher(state, 3000));
 
     CHECK(high_score::get_score(state, "song_001|easy") == 1000);
     CHECK(high_score::get_score(state, "song_001|hard") == 2000);
@@ -198,6 +219,31 @@ TEST_CASE("High score persistence: invalid schema preserves state", "[high_score
         std::ofstream out(file);
         out << R"({"scores":{"song_001|easy":"not_a_number"}})";
     }
+
+    CHECK(high_score::load_high_scores(state, file).status == persistence::Status::CorruptData);
+    CHECK(high_score::get_score(state, "song_001|easy") == 500);
+
+    remove_path(dir);
+}
+
+TEST_CASE("High score persistence: oversized score map is corrupt", "[high_score][issue1004]") {
+    const auto dir = temp_high_score_path("shapeshifter_high_score_too_many_entries");
+    const auto file = dir / "too_many_scores.json";
+    remove_path(dir);
+    std::filesystem::create_directories(dir);
+
+    {
+        std::ofstream out(file);
+        out << R"({"scores":{)";
+        for (int32_t i = 0; i <= HighScoreState::MAX_ENTRIES; ++i) {
+            if (i > 0) out << ',';
+            out << R"("song_)" << i << R"(|easy":)" << i;
+        }
+        out << "}}";
+    }
+
+    HighScoreState state;
+    REQUIRE(high_score::set_score(state, "song_001|easy", 500));
 
     CHECK(high_score::load_high_scores(state, file).status == persistence::Status::CorruptData);
     CHECK(high_score::get_score(state, "song_001|easy") == 500);


### PR DESCRIPTION
## Summary
- make high-score entry creation and hash updates report success/failure
- keep active session hashes even when the fixed table is saturated so terminal flow can detect failed updates
- prevent terminal "new best" feedback and dirty persistence flags when no active entry was updated
- reject oversized persisted high-score maps instead of silently truncating

## Verification
- cmake -B build -S . -Wno-dev
- cmake --build build
- ./build/shapeshifter_tests

Closes #1004