### PR TITLE
Guard beat_log_system beat_times lookup

### DIFF
--- a/app/systems/beat_log_system.cpp
+++ b/app/systems/beat_log_system.cpp
@@ -17,7 +17,7 @@ void beat_log_system(entt::registry& reg, float /*dt*/) {
     if (song->current_beat > log->last_logged_beat) {
         for (int b = log->last_logged_beat + 1; b <= song->current_beat; ++b) {
             float expected = song->offset + b * song->beat_period;
-            if (map && !map->beat_times.empty()) {
+            if (map && b >= 0 && static_cast<size_t>(b) < map->beat_times.size()) {
                 expected = map->beat_times[static_cast<size_t>(b)];
             }
             session_log_write(*log, song->song_time, "GAME",

--- a/tests/test_beat_log_system.cpp
+++ b/tests/test_beat_log_system.cpp
@@ -113,6 +113,28 @@ TEST_CASE("beat_log: catches up multiple beats in one call", "[beat_log]") {
     CHECK(reg.ctx().get<SessionLog>().last_logged_beat == 5);
 }
 
+TEST_CASE("beat_log: falls back when authored beat_times are shorter than current beat", "[beat_log]") {
+    auto reg = make_rhythm_registry();
+    auto& song = reg.ctx().get<SongState>();
+    song.offset = 0.25f;
+    song.beat_period = 0.5f;
+    song.song_time = 1.75f;
+    song.current_beat = 3;
+
+    auto& map = beat_map(reg);
+    map.beat_times = {0.25f};
+
+    auto slog = make_open_log();
+    reg.ctx().emplace<SessionLog>(std::move(slog));
+
+    beat_log_system(reg, 0.0f);
+
+    auto& stored = reg.ctx().get<SessionLog>();
+    CHECK(stored.last_logged_beat == 3);
+    CHECK(stored.buffer.find("BEAT 0 expected=0.250") != std::string::npos);
+    CHECK(stored.buffer.find("BEAT 3 expected=1.750") != std::string::npos);
+}
+
 TEST_CASE("beat_log: does not re-log already-logged beats", "[beat_log]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();


### PR DESCRIPTION
## Summary
- bounds-check authored `BeatMap::beat_times` before using it in `beat_log_system`
- fall back to computed beat timing when authored timing for a beat is unavailable
- add a regression test for shorter `beat_times` than `SongState::current_beat`

Fixes #1009

## Validation
- `cmake -S . -B build -Wno-dev && cmake --build build && ./build/shapeshifter_tests`
