### PR TITLE
Use maybe_unused for unused system dt parameters

### DIFF
--- a/.squad/decisions-archive.md
+++ b/.squad/decisions-archive.md
@@ -244,7 +244,7 @@ The `Position.y` path on line 29 (`pos.y > constants::DESTROY_Y`) is correct and
 
 **Required fix:**
 ```cpp
-void obstacle_despawn_system(entt::registry& reg, float /*dt*/) {
+void obstacle_despawn_system(entt::registry& reg, [[maybe_unused]] float dt) {
     static std::vector<entt::entity> to_destroy;
     to_destroy.clear();
 

--- a/app/systems/beat_log_system.cpp
+++ b/app/systems/beat_log_system.cpp
@@ -6,7 +6,7 @@
 
 // Observes SongState::current_beat and emits BEAT log entries.
 // Keeps last_logged_beat in SessionLog so playback has no logging branch.
-void beat_log_system(entt::registry& reg, float /*dt*/) {
+void beat_log_system(entt::registry& reg, [[maybe_unused]] float dt) {
     auto* log = reg.ctx().find<SessionLog>();
     if (!log || !log->file) return;
 

--- a/app/systems/beat_scheduler_system.cpp
+++ b/app/systems/beat_scheduler_system.cpp
@@ -12,7 +12,7 @@
 
 #include <cmath>
 
-void beat_scheduler_system(entt::registry& reg, float /*dt*/) {
+void beat_scheduler_system(entt::registry& reg, [[maybe_unused]] float dt) {
     auto* song = reg.ctx().find<SongState>();
     auto* map  = find_beat_map(reg);
     if (!song || !map || !song->playing) return;

--- a/app/systems/camera_system.cpp
+++ b/app/systems/camera_system.cpp
@@ -245,7 +245,7 @@ static glm::mat4 make_shape_matrix(uint8_t mesh_index, float cx, float y_3d, flo
 
 // ── game_camera_system: model-to-world transforms for all 3D renderables ────
 
-void game_camera_system(entt::registry& reg, float /*dt*/) {
+void game_camera_system(entt::registry& reg, [[maybe_unused]] float dt) {
     const auto& mesh_config = reg.ctx().get<ShapeMeshConfig>();
 
 
@@ -360,7 +360,7 @@ void compute_screen_transform(entt::registry& reg) {
 
 // ── ui_camera_system: screen-space transforms for UI layer ──────────────────
 
-void ui_camera_system(entt::registry& reg, float /*dt*/) {
+void ui_camera_system(entt::registry& reg, [[maybe_unused]] float dt) {
     // ScreenTransform is computed once per frame by game_loop_frame (before
     // input_system) and stored in the registry context.  Reading it here is
     // sufficient; do NOT call compute_screen_transform again (#241).

--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -56,7 +56,7 @@ bool shape_gate_lane_match(float obstacle_x, float player_x) {
 
 }  // namespace
 
-void collision_system(entt::registry& reg, float /*dt*/) {
+void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
     auto player_view = reg.view<PlayerTag, WorldTransform, PlayerShape, ShapeWindow, Lane, VerticalState>();
     if (player_view.begin() == player_view.end()) return;
 

--- a/app/systems/energy_bar_system.cpp
+++ b/app/systems/energy_bar_system.cpp
@@ -31,7 +31,7 @@ float flash_overlay_strength(float flash_ratio, bool reduce_motion) {
 
 } // namespace
 
-void energy_bar_system(entt::registry& reg, float /*dt*/) {
+void energy_bar_system(entt::registry& reg, [[maybe_unused]] float dt) {
     if (reg.ctx().get<GameState>().phase != GamePhase::Playing) return;
 
     const auto* energy = reg.ctx().find<EnergyState>();

--- a/app/systems/game_state_end_screen_system.cpp
+++ b/app/systems/game_state_end_screen_system.cpp
@@ -12,7 +12,7 @@ GamePhase resolve_end_screen_phase(EndScreenChoice choice) {
 
 }  // namespace
 
-void game_state_end_screen_system(entt::registry& reg, float /*dt*/) {
+void game_state_end_screen_system(entt::registry& reg, [[maybe_unused]] float dt) {
     auto& gs = reg.ctx().get<GameState>();
     const bool game_over_ready =
         gs.phase == GamePhase::GameOver && gs.phase_timer > constants::GAME_OVER_INPUT_DELAY;

--- a/app/systems/miss_detection_system.cpp
+++ b/app/systems/miss_detection_system.cpp
@@ -7,7 +7,7 @@
 // Pure tagger: marks unscored obstacles that have scrolled past DESTROY_Y.
 // Runs before scoring_system so that the MissTag is processed the same frame.
 // Energy drain and miss_count are handled exclusively by scoring_system's MissTag branch.
-void miss_detection_system(entt::registry& reg, float /*dt*/) {
+void miss_detection_system(entt::registry& reg, [[maybe_unused]] float dt) {
     auto view = reg.view<ObstacleTag, Obstacle, WorldTransform>(
         entt::exclude<ScoredTag, ResolvedObstacleTag, NonScorableTag>);
     for (auto [entity, obstacle, wt] : view.each()) {

--- a/app/systems/obstacle_despawn_system.cpp
+++ b/app/systems/obstacle_despawn_system.cpp
@@ -13,7 +13,7 @@ ObstacleDespawnScratch& despawn_scratch_for(entt::registry& reg) {
 }  // namespace
 
 // Destroys obstacle entities that have scrolled past the despawn boundary.
-void obstacle_despawn_system(entt::registry& reg, float /*dt*/) {
+void obstacle_despawn_system(entt::registry& reg, [[maybe_unused]] float dt) {
     // Per-registry scratch retains capacity across frames without sharing mutable
     // state between registries.
     auto& to_destroy = despawn_scratch_for(reg).to_destroy;

--- a/app/systems/popup_feedback_system.cpp
+++ b/app/systems/popup_feedback_system.cpp
@@ -6,7 +6,7 @@
 #include "../entities/popup_entity.h"
 #include <optional>
 
-void popup_feedback_system(entt::registry& reg, float /*dt*/) {
+void popup_feedback_system(entt::registry& reg, [[maybe_unused]] float dt) {
     if (reg.ctx().get<GameState>().phase != GamePhase::Playing) return;
     auto& queue = reg.ctx().get<ScorePopupRequestQueue>();
     if (queue.requests.empty()) return;

--- a/app/systems/scroll_system.cpp
+++ b/app/systems/scroll_system.cpp
@@ -7,7 +7,7 @@
 
 #include <cmath>
 
-void scroll_system(entt::registry& reg, float /*dt*/) {
+void scroll_system(entt::registry& reg, [[maybe_unused]] float dt) {
     auto* song = reg.ctx().find<SongState>();
 
     // Rhythm obstacles: position derived from song_time, not accumulated dt.

--- a/app/systems/shape_window_system.cpp
+++ b/app/systems/shape_window_system.cpp
@@ -45,7 +45,7 @@ void update_morph_in(entt::registry& reg,
 
 }  // namespace
 
-void shape_window_activation_system(entt::registry& reg, float /*dt*/) {
+void shape_window_activation_system(entt::registry& reg, [[maybe_unused]] float dt) {
     auto* song = reg.ctx().find<SongState>();
     if (!song) return;
 
@@ -58,7 +58,7 @@ void shape_window_activation_system(entt::registry& reg, float /*dt*/) {
     }
 }
 
-void shape_window_system(entt::registry& reg, float /*dt*/) {
+void shape_window_system(entt::registry& reg, [[maybe_unused]] float dt) {
     auto* song = reg.ctx().find<SongState>();
     if (!song) return;
 


### PR DESCRIPTION
## Summary\n- replace comment-based unused `dt` suppression in system definitions with C++20 `[[maybe_unused]] float dt`\n- update the tracked squad doc sample to use the current convention\n- confirm no tracked `float /*dt*/` patterns remain\n\nFixes #1016\n\n## Verification\n- `cmake -B build -S . -Wno-dev`\n- `cmake --build build`\n- `./build/shapeshifter_tests`