### PR TITLE
Guard shape enum indexing

### DIFF
--- a/app/components/shape_mesh.h
+++ b/app/components/shape_mesh.h
@@ -10,7 +10,7 @@ struct ShapeProps {
 };
 
 // Registry singleton config for mesh generation and transform scaling.
-// Indexed by Shape enum (Circle, Square, Triangle, Hexagon).
+// Indexed via shape_index() from util/shape_lane_mapping.h.
 struct ShapeMeshConfig {
     ShapeProps props[4] = {
         {0.5f, 0.6f},   // Circle:   cylinder

--- a/app/constants.h
+++ b/app/constants.h
@@ -147,7 +147,7 @@ constexpr float FLOOR_PULSE_DECAY    = 0.15f;   // seconds
 
 // ── Shape Colors ──────────────────────────────────
 // Used for both obstacles and player character.
-// Index by static_cast<int>(Shape).
+// Index via shape_index() from util/shape_lane_mapping.h.
 constexpr Color SHAPE_COLORS[] = {
     {  80, 200, 255, 255 },   // Circle   — cyan/blue
     { 255, 100, 100, 255 },   // Square   — red

--- a/app/entities/obstacle_entity.cpp
+++ b/app/entities/obstacle_entity.cpp
@@ -4,10 +4,22 @@
 #include "../components/rendering.h"
 #include "obstacle_render_entity.h"
 #include "../constants.h"
+#include "../util/shape_lane_mapping.h"
+#include <stdexcept>
 
 namespace {
 
+bool obstacle_kind_requires_shape(ObstacleKind kind) {
+    return kind == ObstacleKind::ShapeGate
+        || kind == ObstacleKind::ComboGate
+        || kind == ObstacleKind::SplitPath;
+}
+
 entt::entity spawn_obstacle_base(entt::registry& reg, const ObstacleSpawnParams& params) {
+    if (obstacle_kind_requires_shape(params.kind) && !is_valid_shape(params.shape)) {
+        throw std::logic_error("Invalid obstacle shape");
+    }
+
     auto e = reg.create();
     reg.emplace<WorldTransform>(e, WorldTransform{{params.x, params.y}});
     reg.emplace<DrawLayer>(e, Layer::Game);
@@ -18,8 +30,7 @@ entt::entity spawn_obstacle_base(entt::registry& reg, const ObstacleSpawnParams&
             reg.emplace<Obstacle>(e, int16_t{constants::PTS_SHAPE_GATE});
             reg.emplace<RequiredShape>(e, params.shape);
             reg.emplace<DrawSize>(e, constants::SCREEN_W_F, 80.0f);
-            const auto shape_index = static_cast<int>(params.shape);
-            reg.emplace<Color>(e, constants::SHAPE_COLORS[shape_index]);
+            reg.emplace<Color>(e, constants::SHAPE_COLORS[shape_index(params.shape)]);
             break;
         }
         case ObstacleKind::LaneBlock: {

--- a/app/entities/obstacle_render_entity.cpp
+++ b/app/entities/obstacle_render_entity.cpp
@@ -3,6 +3,7 @@
 #include "../components/transform.h"
 #include "../components/rendering.h"
 #include "../constants.h"
+#include "../util/shape_lane_mapping.h"
 #include <cstdint>
 #include <stdexcept>
 
@@ -14,18 +15,9 @@ struct ObstacleMeshLifetimeState {
 
 
 uint8_t checked_shape_mesh_index(Shape shape) {
-    switch (shape) {
-        case Shape::Circle:
-            return 0;
-        case Shape::Square:
-            return 1;
-        case Shape::Triangle:
-            return 2;
-        case Shape::Hexagon:
-            return 3;
-    }
-
-    throw std::logic_error("Invalid RequiredShape shape");
+    const int index = shape_index(shape);
+    if (index < 0) throw std::logic_error("Invalid RequiredShape shape");
+    return static_cast<uint8_t>(index);
 }
 
 int checked_lane_index(int8_t lane) {

--- a/app/systems/camera_system.cpp
+++ b/app/systems/camera_system.cpp
@@ -13,6 +13,7 @@
 #include "../constants.h"
 #include "../entities/settings.h"
 #include "../platform_display.h"
+#include "../util/shape_lane_mapping.h"
 #include <glm/mat4x4.hpp>
 #include <raylib.h>
 #include <raymath.h>
@@ -272,6 +273,12 @@ void game_camera_system(entt::registry& reg, [[maybe_unused]] float dt) {
                     ModelTransform{slab_matrix(mc.x, z, mc.width, mc.height, mc.depth),
                                     mc.tint, 0, MeshType::Slab};
             } else {
+                if (mc.mesh_index >= kShapeCount) {
+                    TraceLog(LOG_WARNING, "game_camera_system skipped invalid MeshChild shape index %u",
+                             static_cast<unsigned>(mc.mesh_index));
+                    reg.remove<ModelTransform>(entity);
+                    continue;
+                }
                 const auto& props = mesh_config.props[mc.mesh_index];
                 reg.get_or_emplace<ModelTransform>(entity) =
                     ModelTransform{make_shape_matrix(mc.mesh_index, mc.x, 0.0f, z,
@@ -293,12 +300,19 @@ void game_camera_system(entt::registry& reg, [[maybe_unused]] float dt) {
             float y_3d = -vstate.y_offset;
             float sz = constants::PLAYER_SIZE;
             if (vstate.mode == VMode::Sliding) sz *= 0.5f;
-            uint8_t shape_idx = static_cast<uint8_t>(pshape.current);
-                const auto& props = mesh_config.props[shape_idx];
-                reg.get_or_emplace<ModelTransform>(entity) =
-                    ModelTransform{make_shape_matrix(shape_idx, transform.position.x, y_3d,
-                                                     transform.position.y, sz, props.radius_scale),
-                                   col, shape_idx, MeshType::Shape};
+            const int shape_idx = shape_index(pshape.current);
+            if (shape_idx < 0) {
+                TraceLog(LOG_WARNING, "game_camera_system skipped invalid PlayerShape %d",
+                         static_cast<int>(pshape.current));
+                reg.remove<ModelTransform>(entity);
+                continue;
+            }
+            const auto mesh_index = static_cast<uint8_t>(shape_idx);
+            const auto& props = mesh_config.props[shape_idx];
+            reg.get_or_emplace<ModelTransform>(entity) =
+                ModelTransform{make_shape_matrix(mesh_index, transform.position.x, y_3d,
+                                                 transform.position.y, sz, props.radius_scale),
+                               col, mesh_index, MeshType::Shape};
         }
     }
 

--- a/app/systems/game_render_system.cpp
+++ b/app/systems/game_render_system.cpp
@@ -3,6 +3,7 @@
 #include "floor_render_system.h"
 #include "../components/rendering.h"
 #include "../components/game_state.h"
+#include "../util/shape_lane_mapping.h"
 #include "camera_system.h"
 #include <glm/mat4x4.hpp>
 #include <raylib.h>
@@ -27,6 +28,7 @@ static void draw_model_transform(const camera::ShapeMeshes& sm, const ModelTrans
             DrawMesh(sm.slab, mat, matrix);
             break;
         case MeshType::Shape:
+            if (mt.mesh_index >= kShapeCount) return;
             DrawMesh(sm.shapes[mt.mesh_index], mat, matrix);
             break;
         case MeshType::Quad:

--- a/app/systems/player_input_system.cpp
+++ b/app/systems/player_input_system.cpp
@@ -9,6 +9,7 @@
 #include "../entities/settings.h"
 #include "../constants.h"
 #include "../util/lane_utils.h"
+#include "../util/shape_lane_mapping.h"
 
 namespace {
 
@@ -60,6 +61,12 @@ void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt)
     const bool rhythm_mode = (song != nullptr && (song->playing || song->finished));
 
     auto pressed_shape = evt.shape;
+    const int pressed_shape_index = shape_index(pressed_shape);
+    if (pressed_shape_index < 0) {
+        TraceLog(LOG_WARNING, "player_input_system ignored invalid shape %d",
+                 static_cast<int>(pressed_shape));
+        return;
+    }
 
     auto begin_shape_window = [&](PlayerShape& ps, ShapeWindow& sw) {
         Shape previous_shape = ps.current;
@@ -95,8 +102,7 @@ void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt)
                 pshape.previous = pshape.current;
                 pshape.current  = pressed_shape;
                 pshape.morph_t  = 1.0f;
-                auto si = static_cast<int>(pressed_shape);
-                auto& sc = constants::SHAPE_COLORS[si];
+                const auto& sc = constants::SHAPE_COLORS[pressed_shape_index];
                 reg.replace<Color>(entity, sc);
                 if (auto* disp = reg.ctx().find<entt::dispatcher>()) {
                     disp->enqueue<PlaySfxEvent>({SFX::ShapeShift});

--- a/app/systems/shape_window_system.cpp
+++ b/app/systems/shape_window_system.cpp
@@ -4,13 +4,20 @@
 #include "../components/rendering.h"
 #include "../components/rhythm.h"
 #include "../constants.h"
+#include "../util/shape_lane_mapping.h"
 
 namespace {
 
-static void apply_shape_color(entt::registry& reg, entt::entity entity, Shape shape) {
-    auto si = static_cast<int>(shape);
-    auto& sc = constants::SHAPE_COLORS[si];
+static bool apply_shape_color(entt::registry& reg, entt::entity entity, Shape shape) {
+    const int si = shape_index(shape);
+    if (si < 0) {
+        TraceLog(LOG_WARNING, "shape_window_system rejected invalid shape %d",
+                 static_cast<int>(shape));
+        return false;
+    }
+    const auto& sc = constants::SHAPE_COLORS[si];
     reg.replace<Color>(entity, sc);
+    return true;
 }
 
 void update_morph_in(entt::registry& reg,
@@ -27,8 +34,13 @@ void update_morph_in(entt::registry& reg,
         swindow.phase = WindowPhase::Active;
         swindow.window_start = song.song_time;
         swindow.window_timer = 0.0f;
+        if (!apply_shape_color(reg, entity, swindow.target_shape)) {
+            pshape.current = Shape::Hexagon;
+            swindow.target_shape = Shape::Hexagon;
+            swindow.phase = WindowPhase::Idle;
+            return;
+        }
         pshape.current = swindow.target_shape;
-        apply_shape_color(reg, entity, pshape.current);
         return;
     }
 
@@ -38,8 +50,13 @@ void update_morph_in(entt::registry& reg,
         swindow.phase = WindowPhase::Active;
         swindow.window_start = swindow.window_start + song.morph_duration;
         swindow.window_timer = 0.0f;
+        if (!apply_shape_color(reg, entity, swindow.target_shape)) {
+            pshape.current = Shape::Hexagon;
+            swindow.target_shape = Shape::Hexagon;
+            swindow.phase = WindowPhase::Idle;
+            return;
+        }
         pshape.current = swindow.target_shape;
-        apply_shape_color(reg, entity, pshape.current);
     }
 }
 

--- a/app/util/shape_lane_mapping.h
+++ b/app/util/shape_lane_mapping.h
@@ -4,6 +4,22 @@
 
 #include <cstdint>
 
+inline constexpr int kShapeCount = 4;
+
+inline constexpr int shape_index(Shape shape) noexcept {
+    switch (shape) {
+        case Shape::Circle:   return 0;
+        case Shape::Square:   return 1;
+        case Shape::Triangle: return 2;
+        case Shape::Hexagon:  return 3;
+    }
+    return -1;
+}
+
+inline constexpr bool is_valid_shape(Shape shape) noexcept {
+    return shape_index(shape) >= 0;
+}
+
 // Historical content motif used by shipped beatmap audits. Runtime input must
 // not use this helper to move lanes; lane changes come from explicit movement.
 inline constexpr int8_t lane_for_shape(Shape shape) noexcept {

--- a/tests/test_obstacle_archetypes.cpp
+++ b/tests/test_obstacle_archetypes.cpp
@@ -202,6 +202,16 @@ TEST_CASE("entity: mesh factory rejects invalid RequiredLane before children", "
     }
 }
 
+TEST_CASE("entity: spawn_obstacle rejects invalid ShapeGate shape before indexing color",
+          "[archetype][validation]") {
+    entt::registry reg;
+    const Shape invalid_shape = static_cast<Shape>(255);
+
+    CHECK_THROWS_AS(spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f, invalid_shape}),
+                    std::logic_error);
+    CHECK(count_mesh_children(reg) == 0);
+}
+
 TEST_CASE("entity: ShapeGate Square - red color", "[archetype]") {
     entt::registry reg;
     auto e = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 60.0f, -120.0f, Shape::Square});

--- a/tests/test_perspective.cpp
+++ b/tests/test_perspective.cpp
@@ -2,6 +2,7 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <entt/entt.hpp>
 #include "constants.h"
+#include "components/player.h"
 #include "components/rendering.h"
 #include "components/shape_mesh.h"
 #include "components/transform.h"
@@ -128,4 +129,39 @@ TEST_CASE("game_camera_system drops stale MeshChild parents without crashing", "
 
     REQUIRE_NOTHROW(game_camera_system(reg, 0.0f));
     CHECK_FALSE(reg.valid(child));
+}
+
+TEST_CASE("game_camera_system rejects invalid MeshChild shape index", "[camera3d][mesh_child][validation]") {
+    entt::registry reg;
+    reg.ctx().emplace<ShapeMeshConfig>();
+    reg.ctx().emplace<FloorParams>();
+    auto parent = reg.create();
+    reg.emplace<WorldTransform>(parent, WorldTransform{{100.0f, 200.0f}});
+    auto child = reg.create();
+    reg.emplace<MeshChild>(
+        child,
+        MeshChild{parent, 10.0f, 0.0f, 20.0f, 30.0f, 40.0f, WHITE, 255, MeshType::Shape}
+    );
+    reg.emplace<ModelTransform>(child, ModelTransform{glm::mat4{1.0f}, WHITE, 255, MeshType::Shape});
+    reg.emplace<TagWorldPass>(child);
+
+    REQUIRE_NOTHROW(game_camera_system(reg, 0.0f));
+    CHECK_FALSE(reg.all_of<ModelTransform>(child));
+}
+
+TEST_CASE("game_camera_system rejects invalid PlayerShape before mesh lookup", "[camera3d][player][validation]") {
+    entt::registry reg;
+    reg.ctx().emplace<ShapeMeshConfig>();
+    reg.ctx().emplace<FloorParams>();
+    auto player = reg.create();
+    reg.emplace<PlayerTag>(player);
+    reg.emplace<WorldTransform>(player, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
+    reg.emplace<PlayerShape>(player, PlayerShape{static_cast<Shape>(255), Shape::Hexagon, 1.0f});
+    reg.emplace<VerticalState>(player);
+    reg.emplace<Color>(player, WHITE);
+    reg.emplace<ModelTransform>(player, ModelTransform{glm::mat4{1.0f}, WHITE, 255, MeshType::Shape});
+    reg.emplace<TagWorldPass>(player);
+
+    REQUIRE_NOTHROW(game_camera_system(reg, 0.0f));
+    CHECK_FALSE(reg.all_of<ModelTransform>(player));
 }

--- a/tests/test_shape_window_system.cpp
+++ b/tests/test_shape_window_system.cpp
@@ -63,6 +63,27 @@ TEST_CASE("shape_window: MorphIn completes and transitions to Active", "[shape_w
     CHECK(ps.current == Shape::Triangle);
 }
 
+TEST_CASE("shape_window: invalid MorphIn target resets safely", "[shape_window][validation]") {
+    auto reg = make_rhythm_registry();
+    auto player = make_rhythm_player(reg);
+    auto& ps = reg.get<PlayerShape>(player);
+    auto& sw = reg.get<ShapeWindow>(player);
+    auto& song = reg.ctx().get<SongState>();
+
+    sw.phase = WindowPhase::MorphIn;
+    sw.target_shape = static_cast<Shape>(255);
+    ps.current = Shape::Hexagon;
+    ps.morph_t = 0.0f;
+    sw.window_start = song.song_time;
+
+    song.song_time += song.morph_duration + 0.01f;
+
+    REQUIRE_NOTHROW(shape_window_system(reg, song.morph_duration + 0.01f));
+    CHECK(sw.phase == WindowPhase::Idle);
+    CHECK(ps.current == Shape::Hexagon);
+    CHECK(sw.target_shape == Shape::Hexagon);
+}
+
 TEST_CASE("shape_window: MorphIn morph_t proportional to timer", "[shape_window]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);


### PR DESCRIPTION
## Summary
- Adds shared shape validation/index helpers for shape-to-array lookups.
- Rejects invalid shape obstacle spawn data before creating entities.
- Skips invalid ECS render/player shape data before mesh/color indexing and adds regression coverage.

## Verification
- `cmake --build build`
- `./build/shapeshifter_tests "[validation],[shape_window],[camera3d],[archetype]"`
- `ctest --test-dir build --output-on-failure`

Closes #1026