### PR TITLE
Create persistence directories recursively

### DIFF
--- a/app/entities/settings.cpp
+++ b/app/entities/settings.cpp
@@ -8,8 +8,6 @@
 #include <system_error>
 #include <utility>
 
-#include <raylib.h>
-
 entt::entity create_settings_entity(entt::registry& reg,
                                     SettingsState state,
                                     SettingsPersistence persistence) {
@@ -121,14 +119,6 @@ void destroy_settings_entity(entt::registry& reg) {
 namespace settings {
 
 namespace {
-
-std::error_code ensure_directory_exists(const std::filesystem::path& dir) {
-    if (dir.empty()) return {};
-    const std::string dir_path = dir.string();
-    if (DirectoryExists(dir_path.c_str())) return {};
-    if (MakeDirectory(dir_path.c_str()) == 0 && DirectoryExists(dir_path.c_str())) return {};
-    return std::make_error_code(std::errc::io_error);
-}
 
 bool json_integer_to_i64(const nlohmann::json& value, std::int64_t& out) {
     if (!value.is_number_integer()) return false;
@@ -251,7 +241,7 @@ persistence::Result load_settings(SettingsState& state, const std::filesystem::p
 }
 
 persistence::Result save_settings(const SettingsState& state, const std::filesystem::path& path) {
-    const auto ensure_error = ensure_directory_exists(path.parent_path());
+    const auto ensure_error = persistence::ensure_directory_exists(path.parent_path());
     if (ensure_error) {
         return persistence::Result{persistence::Status::DirectoryCreateFailed, ensure_error};
     }

--- a/app/util/high_score_persistence.cpp
+++ b/app/util/high_score_persistence.cpp
@@ -118,14 +118,6 @@ int32_t get_current_high_score(const HighScoreState& state) {
 
 namespace {
 
-std::error_code ensure_directory_exists(const std::filesystem::path& dir) {
-    if (dir.empty()) return {};
-    const std::string dir_path = dir.string();
-    if (DirectoryExists(dir_path.c_str())) return {};
-    if (MakeDirectory(dir_path.c_str()) == 0 && DirectoryExists(dir_path.c_str())) return {};
-    return std::make_error_code(std::errc::io_error);
-}
-
 nlohmann::json high_score_state_to_json(const HighScoreState& state) {
     nlohmann::json result;
     nlohmann::json scores_obj;
@@ -225,7 +217,7 @@ persistence::Result load_high_scores(HighScoreState& state, const std::filesyste
 }
 
 persistence::Result save_high_scores(const HighScoreState& state, const std::filesystem::path& path) {
-    const auto ensure_error = ensure_directory_exists(path.parent_path());
+    const auto ensure_error = persistence::ensure_directory_exists(path.parent_path());
     if (ensure_error) {
         return persistence::Result{persistence::Status::DirectoryCreateFailed, ensure_error};
     }

--- a/app/util/persistence_policy.cpp
+++ b/app/util/persistence_policy.cpp
@@ -93,14 +93,6 @@ bool path_uses_web_persistence(const std::filesystem::path& path) {
 }
 #endif
 
-std::error_code ensure_directory_exists(const std::filesystem::path& dir) {
-    if (dir.empty()) return {};
-    const std::string dir_path = dir.string();
-    if (DirectoryExists(dir_path.c_str())) return {};
-    if (MakeDirectory(dir_path.c_str()) == 0 && DirectoryExists(dir_path.c_str())) return {};
-    return std::make_error_code(std::errc::io_error);
-}
-
 std::filesystem::path resolve_root_dir(const std::filesystem::path& root_override) {
     if (!root_override.empty()) {
         return root_override;
@@ -129,6 +121,25 @@ std::filesystem::path resolve_root_dir(const std::filesystem::path& root_overrid
 }
 
 }  // namespace
+
+std::error_code ensure_directory_exists(const std::filesystem::path& dir) {
+    if (dir.empty()) return {};
+
+    std::error_code ec;
+    const bool path_exists = std::filesystem::exists(dir, ec);
+    if (ec) return ec;
+    if (path_exists) {
+        if (std::filesystem::is_directory(dir, ec)) return {};
+        return ec ? ec : std::make_error_code(std::errc::not_a_directory);
+    }
+
+    if (std::filesystem::create_directories(dir, ec)) return {};
+    if (ec) return ec;
+
+    return std::filesystem::is_directory(dir, ec)
+        ? std::error_code{}
+        : (ec ? ec : std::make_error_code(std::errc::io_error));
+}
 
 Result resolve_paths(Paths& out_paths, const std::filesystem::path& root_override) {
 #if defined(__EMSCRIPTEN__)

--- a/app/util/persistence_policy.h
+++ b/app/util/persistence_policy.h
@@ -33,6 +33,8 @@ struct Paths {
 
 Result resolve_paths(Paths& out_paths, const std::filesystem::path& root_override = {});
 
+std::error_code ensure_directory_exists(const std::filesystem::path& dir);
+
 Result prepare_for_persistence_read(const std::filesystem::path& path);
 Result flush_persistence_writes(const std::filesystem::path& path);
 

--- a/tests/test_high_score_persistence.cpp
+++ b/tests/test_high_score_persistence.cpp
@@ -313,6 +313,24 @@ TEST_CASE("High score persistence: save reports unwritable parent path", "[high_
     remove_path(root);
 }
 
+TEST_CASE("High score persistence: save creates nested parent directories",
+          "[high_score][persistence][issue-1025]") {
+    const auto root = std::filesystem::path("test_high_score_nested_parent");
+    const auto file = root / "missing" / "parent" / "high_scores.json";
+    remove_path(root);
+
+    HighScoreState original;
+    high_score::set_score(original, "song_001|easy", 1000);
+    REQUIRE(high_score::save_high_scores(original, file).ok());
+    CHECK(std::filesystem::exists(file));
+
+    HighScoreState loaded;
+    REQUIRE(high_score::load_high_scores(loaded, file).ok());
+    CHECK(high_score::get_score(loaded, "song_001|easy") == 1000);
+
+    remove_path(root);
+}
+
 TEST_CASE("High score helper: file path resolution reports failure without CWD fallback", "[high_score]") {
     const auto root = std::filesystem::path("test_high_score_path_resolution_failure");
     const auto blocked_root = root / "blocked_root";

--- a/tests/test_settings_persistence.cpp
+++ b/tests/test_settings_persistence.cpp
@@ -318,6 +318,22 @@ TEST_CASE("Persistence paths: one shared policy resolves both settings and high-
     std::filesystem::remove_all(paths.root_dir);
 }
 
+TEST_CASE("Persistence paths: nested root override creates parent directories recursively",
+          "[settings][persistence][issue-1025]") {
+    const auto root = std::filesystem::path("test_persistence_policy_nested_root");
+    const auto nested_root = root / "missing" / "parent" / "shapeshifter";
+    std::filesystem::remove_all(root);
+
+    persistence::Paths paths;
+    const auto result = persistence::resolve_paths(paths, nested_root);
+    REQUIRE(result.ok());
+    CHECK(std::filesystem::is_directory(nested_root));
+    CHECK(paths.settings_file == nested_root / "settings.json");
+    CHECK(paths.high_scores_file == nested_root / "high_scores.json");
+
+    std::filesystem::remove_all(root);
+}
+
 TEST_CASE("Persistence sync seams skip paths outside the web persistence root", "[settings]") {
     const std::filesystem::path current_dir_file = "settings_current_dir_tmp.json";
     CHECK(persistence::prepare_for_persistence_read(current_dir_file).ok());
@@ -389,6 +405,24 @@ TEST_CASE("Persistence paths: directory creation failure is observable", "[setti
     persistence::Paths paths;
     const auto result = persistence::resolve_paths(paths, blocked_root);
     CHECK(result.status == persistence::Status::DirectoryCreateFailed);
+
+    std::filesystem::remove_all(root);
+}
+
+TEST_CASE("Settings persistence: save_settings creates nested parent directories",
+          "[settings][persistence][issue-1025]") {
+    const auto root = std::filesystem::path("test_settings_nested_parent");
+    const auto file = root / "missing" / "parent" / "settings.json";
+    std::filesystem::remove_all(root);
+
+    SettingsState state;
+    state.audio_offset_ms = -40;
+    REQUIRE(settings::save_settings(state, file).ok());
+    CHECK(std::filesystem::exists(file));
+
+    SettingsState loaded;
+    REQUIRE(settings::load_settings(loaded, file).ok());
+    CHECK(loaded.audio_offset_ms == state.audio_offset_ms);
 
     std::filesystem::remove_all(root);
 }


### PR DESCRIPTION
## Summary
- centralize persistence directory creation in persistence_policy
- use recursive std::filesystem directory creation for settings and high-score saves
- cover nested root overrides and nested save paths for settings/high scores

## Root cause
Persistence paths used single-call raylib directory creation at each call site, so nested missing parent paths could fail before settings or high-score files were written.

## Verification
- cmake -B build -S . -Wno-dev
- cmake --build build
- ./build/shapeshifter_tests

Fixes #1025