### PR TITLE
Document level CLI argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ See `ios/README.md` for blocker checklist and full command modes.
 ./build/shapeshifter --difficulty hard
 ```
 
+### Level Selection
+
+```bash
+./build/shapeshifter --level 1              # optional; defaults to the configured default level
+./build/shapeshifter --level 1_stomper
+./build/shapeshifter --level "MENTAL CORRUPTION"
+```
+
+`--level <level_id>` accepts a numeric index (`1..N`), a level key, or a level title
+recognized by the runtime parser.
+
 ### Test Player (AI)
 
 ```bash


### PR DESCRIPTION
## Summary
- document optional `--level <level_id>` usage in README
- explain numeric indices, level keys, and runtime-recognized titles
- note that the game defaults to the configured default level when omitted

## Root cause
README command-line examples documented difficulty and test-player options but omitted the implemented `--level` parser.

## Verification
- documentation-only change; reviewed README against `app/main.cpp` parser behavior

Fixes #1023