### PR TITLE
Quarantine deprecated lane obstacles

### DIFF
--- a/app/components/obstacle.h
+++ b/app/components/obstacle.h
@@ -11,11 +11,25 @@ struct ResolvedObstacleTag {};
 
 enum class ObstacleKind : uint8_t {
     ShapeGate,
-    LaneBlock,
-    ComboGate,
+    LaneBlock,   // Legacy component fixture only; active beatmaps/factories reject it.
+    ComboGate,   // Legacy component fixture only; active beatmaps/factories reject it.
     SplitPath,
     OnsetMarker,
 };
+
+constexpr bool obstacle_kind_is_legacy_lane_fixture(ObstacleKind kind) {
+    return kind == ObstacleKind::LaneBlock || kind == ObstacleKind::ComboGate;
+}
+
+constexpr bool obstacle_kind_is_active_runtime_spawnable(ObstacleKind kind) {
+    return kind == ObstacleKind::ShapeGate ||
+           kind == ObstacleKind::SplitPath ||
+           kind == ObstacleKind::OnsetMarker;
+}
+
+constexpr bool obstacle_kind_is_active_blocking_beatmap_kind(ObstacleKind kind) {
+    return kind == ObstacleKind::ShapeGate || kind == ObstacleKind::SplitPath;
+}
 
 struct Obstacle {
     int16_t      base_points = 200;

--- a/app/entities/beat_map.cpp
+++ b/app/entities/beat_map.cpp
@@ -33,9 +33,7 @@ bool kind_requires_lane(const ObstacleKind kind) {
 }
 
 bool is_supported_beatmap_kind(const ObstacleKind kind) {
-    return kind == ObstacleKind::ShapeGate ||
-           kind == ObstacleKind::SplitPath ||
-           kind == ObstacleKind::OnsetMarker;
+    return obstacle_kind_is_active_runtime_spawnable(kind);
 }
 
 std::string type_error_message(const char* field, const char* expected, const json& value) {

--- a/app/entities/obstacle_entity.cpp
+++ b/app/entities/obstacle_entity.cpp
@@ -16,6 +16,9 @@ bool obstacle_kind_requires_shape(ObstacleKind kind) {
 }
 
 entt::entity spawn_obstacle_base(entt::registry& reg, const ObstacleSpawnParams& params) {
+    if (!obstacle_kind_is_active_runtime_spawnable(params.kind)) {
+        throw std::logic_error("Deprecated obstacle kind is not spawnable at runtime");
+    }
     if (obstacle_kind_requires_shape(params.kind) && !is_valid_shape(params.shape)) {
         throw std::logic_error("Invalid obstacle shape");
     }
@@ -33,21 +36,9 @@ entt::entity spawn_obstacle_base(entt::registry& reg, const ObstacleSpawnParams&
             reg.emplace<Color>(e, constants::SHAPE_COLORS[shape_index(params.shape)]);
             break;
         }
-        case ObstacleKind::LaneBlock: {
-            reg.emplace<Obstacle>(e, int16_t{constants::PTS_LANE_BLOCK});
-            reg.emplace<BlockedLanes>(e, params.mask);
-            reg.emplace<DrawSize>(e, static_cast<float>(constants::SCREEN_W / 3), 80.0f);
-            reg.emplace<Color>(e, Color{255, 60, 60, 255});
-            break;
-        }
-        case ObstacleKind::ComboGate: {
-            reg.emplace<Obstacle>(e, int16_t{constants::PTS_COMBO_GATE});
-            reg.emplace<RequiredShape>(e, params.shape);
-            reg.emplace<BlockedLanes>(e, params.mask);
-            reg.emplace<DrawSize>(e, constants::SCREEN_W_F, 80.0f);
-            reg.emplace<Color>(e, Color{200, 100, 255, 255});
-            break;
-        }
+        case ObstacleKind::LaneBlock:
+        case ObstacleKind::ComboGate:
+            throw std::logic_error("Deprecated obstacle kind is not spawnable at runtime");
         case ObstacleKind::SplitPath: {
             reg.emplace<Obstacle>(e, int16_t{constants::PTS_SPLIT_PATH});
             reg.emplace<RequiredShape>(e, params.shape);

--- a/app/entities/obstacle_entity.h
+++ b/app/entities/obstacle_entity.h
@@ -11,8 +11,8 @@ struct ObstacleSpawnParams {
     ObstacleKind kind;
     float        x        = 0.0f;
     float        y        = 0.0f;
-    Shape        shape    = Shape::Circle;  // ShapeGate, ComboGate, SplitPath
-    uint8_t      mask     = 0;              // LaneBlock, ComboGate
+    Shape        shape    = Shape::Circle;  // ShapeGate, SplitPath; ComboGate legacy tests
+    uint8_t      mask     = 0;              // Legacy LaneBlock/ComboGate tests
     int8_t       req_lane = 0;              // SplitPath
     float        speed    = 0.0f;
 };

--- a/app/entities/obstacle_render_entity.cpp
+++ b/app/entities/obstacle_render_entity.cpp
@@ -143,6 +143,8 @@ void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical) {
             break;
         }
         case ObstacleKind::LaneBlock: {
+            // Legacy component fixture path. Active beatmaps and obstacle
+            // factories reject LaneBlock; retained for focused ECS tests.
             auto* blocked = reg.try_get<BlockedLanes>(logical);
             if (blocked)
                 for (int i = 0; i < constants::LANE_COUNT; ++i)
@@ -152,6 +154,8 @@ void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical) {
             break;
         }
         case ObstacleKind::ComboGate: {
+            // Legacy component fixture path. Active beatmaps and obstacle
+            // factories reject ComboGate; retained for focused ECS tests.
             auto* blocked = reg.try_get<BlockedLanes>(logical);
             auto* req = reg.try_get<RequiredShape>(logical);
             uint8_t mesh_index = 0;

--- a/app/systems/beat_scheduler_system.cpp
+++ b/app/systems/beat_scheduler_system.cpp
@@ -34,7 +34,7 @@ void beat_scheduler_system(entt::registry& reg, [[maybe_unused]] float dt) {
             song->next_spawn_idx++;
             continue;
         }
-        if (entry.kind != ObstacleKind::ShapeGate && entry.kind != ObstacleKind::SplitPath) {
+        if (!obstacle_kind_is_active_blocking_beatmap_kind(entry.kind)) {
             TraceLog(LOG_WARNING, "Skipping unsupported active beatmap obstacle kind %d",
                      static_cast<int>(entry.kind));
             song->next_spawn_idx++;

--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -139,7 +139,8 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
     // Per-kind structural views — each loop touches only entities that actually
     // carry the required components, eliminating per-entity try_get branches.
 
-    // LaneBlock: BlockedLanes only (no RequiredShape)
+    // Legacy LaneBlock fixture: BlockedLanes only (no RequiredShape).
+    // Active beatmaps and obstacle factories reject this kind.
     {
         auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, BlockedLanes>(
             entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredShape>);
@@ -169,7 +170,8 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
         }
     }
 
-    // ComboGate: RequiredShape + BlockedLanes (no RequiredLane)
+    // Legacy ComboGate fixture: RequiredShape + BlockedLanes (no RequiredLane).
+    // Active beatmaps and obstacle factories reject this kind.
     {
         auto rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, BlockedLanes, BeatInfo>(
             entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredLane>);

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -196,8 +196,8 @@ struct ObstacleTag {};
 /// LowBar/HighBar were removed from the runtime obstacle enum and remain archival only.
 enum class ObstacleKind : uint8_t {
     ShapeGate,   // must match shape
-    LaneBlock,   // avoid blocked lane mask
-    ComboGate,   // required shape + blocked lane mask
+    LaneBlock,   // legacy component fixture only; active beatmaps/factories reject
+    ComboGate,   // legacy component fixture only; active beatmaps/factories reject
     SplitPath,   // shape + specific lane
     OnsetMarker, // visual beat/onset marker; no collision/scoring
 };
@@ -237,14 +237,13 @@ struct NonScorableTag {};
 ```cpp
 // components/obstacle_data.h
 
-/// For ShapeGate / ComboGate / SplitPath: which shape is required. 1 byte.
+/// For ShapeGate / SplitPath, plus legacy ComboGate fixtures: which shape is required. 1 byte.
 struct RequiredShape {
     Shape shape;
 };
 
-/// For LaneBlock / ComboGate: bit mask of blocked lanes (bit 0 = left,
-/// bit 1 = center, bit 2 = right). Active runtime data used by collision,
-/// test-player, render mesh generation, and diagnostics.
+/// For legacy LaneBlock / ComboGate fixtures: bit mask of blocked lanes
+/// (bit 0 = left, bit 1 = center, bit 2 = right).
 struct BlockedLanes {
     uint8_t mask = 0;
 };
@@ -264,8 +263,8 @@ truth for runtime obstacle kind:
 | Runtime kind | Required components | Notes |
 | --- | --- | --- |
 | `ShapeGate` | `RequiredShape` only | Also the fallback for no action components; avoid using the helper for visual-only markers. |
-| `LaneBlock` | `BlockedLanes` only | Active runtime data for lane-block collision and ComboGate rendering/tests. |
-| `ComboGate` | `RequiredShape` + `BlockedLanes` | Shape match plus lane-mask avoidance. |
+| `LaneBlock` | `BlockedLanes` only | Legacy component fixture only; parser, scheduler, and runtime factories reject it for active gameplay. |
+| `ComboGate` | `RequiredShape` + `BlockedLanes` | Legacy component fixture only; parser, scheduler, and runtime factories reject it for active gameplay. |
 | `SplitPath` | `RequiredLane` (+ `RequiredShape` on spawned entities) | `RequiredLane` takes precedence in the helper. |
 | `OnsetMarker` | `NonScorableTag`, no `RequiredShape`/`BlockedLanes`/`RequiredLane` | Authored kind only; normal beat scheduling skips these entries, and spawned markers are visual-only/non-scoring. |
 
@@ -790,7 +789,7 @@ Total: ~73 bytes per entity (1 entity)
 Total: ~42 bytes per entity (5–15 active)
 ```
 
-### 5.3 Lane Block Entity
+### 5.3 Legacy Lane Block Fixture
 
 ```
 ┌─ Lane Block ──────────────────────────────────────────────┐
@@ -806,15 +805,15 @@ Total: ~42 bytes per entity (5–15 active)
 Total: ~41 bytes per entity
 ```
 
-`BlockedLanes::mask` is active runtime data: collision fails if the player is
-in a blocked lane when the obstacle resolves. `ComboGate` reuses the same mask
-with `RequiredShape`; `SplitPath` uses `RequiredLane` instead.
+`BlockedLanes::mask` is retained for legacy component-level tests only.
+The parser, scheduler, and obstacle factories reject LaneBlock and ComboGate
+for active gameplay; `SplitPath` uses `RequiredLane` for shipped lane routing.
 
 ### 5.4 Archived Vertical Bar Entity (Low Bar / High Bar)
 
 LowBar/HighBar entity archetypes are historical only. The current runtime enum, components, and beatmap editor do not expose them as authorable obstacle kinds; use archived design docs if this future design space is reconsidered.
 
-### 5.5 Combo Gate Entity (Shape + Lane)
+### 5.5 Legacy Combo Gate Fixture (Shape + Lane)
 
 ```
 ┌─ Combo Gate ──────────────────────────────────────────────┐
@@ -1382,9 +1381,10 @@ bool check_obstacle_cleared(entt::registry& reg, entt::entity e,
             return shape.current == reg.get<RequiredShape>(e).shape;
 
         case ObstacleKind::LaneBlock:
-            return true;   // passive — push is applied automatically
+            return true;   // legacy fixture only; not spawned by active runtime
 
         case ObstacleKind::ComboGate: {
+            // legacy fixture only; not spawned by active runtime
             bool shape_ok = shape.current == reg.get<RequiredShape>(e).shape;
             uint8_t mask  = reg.get<BlockedLanes>(e).mask;
             bool lane_ok  = !((mask >> lane.current) & 1);

--- a/design-docs/beatmap-editor.md
+++ b/design-docs/beatmap-editor.md
@@ -81,7 +81,7 @@ what the browser provides natively.
 | Context menu | Right-click an obstacle to open an inline context menu |
 | Obstacle palette | Select active obstacle kind before placing (for new placements) |
 | Shape selector | For authored shape_gate/split_path entries: pick circle/square/triangle |
-| Obstacle glyph display | Uses per-kind glyphs/colors for active editor kinds (ShapeGate, SplitPath) plus valid imported ComboGate and OnsetMarker entries. Archived LowBar/HighBar are not authorable. |
+| Obstacle glyph display | Uses per-kind glyphs/colors for active editor kinds (ShapeGate, SplitPath) plus OnsetMarker metadata entries. Archived LowBar/HighBar and legacy ComboGate/LaneBlock are not authorable. |
 | Drag to move | Drag an obstacle to a different beat or lane |
 | Multi-select | Shift-click or box-select, then move/delete as group |
 | Copy/paste | Select a range of beats, copy, paste at a different position |

--- a/design-docs/beatmap-integration.md
+++ b/design-docs/beatmap-integration.md
@@ -182,8 +182,8 @@ The current obstacle components already match the beatmap schema:
 
 ```
   ObstacleKind::ShapeGate      → "shape_gate"       ✓  required shipped obstacle
-  ObstacleKind::LaneBlock      → "lane_block"       ✗  ECS-only/future; parser rejects
-  ObstacleKind::ComboGate      → "combo_gate"       ✗  ECS-only/future; parser rejects
+  ObstacleKind::LaneBlock      → "lane_block"       ✗  legacy component fixture only; parser/scheduler/factories reject
+  ObstacleKind::ComboGate      → "combo_gate"       ✗  legacy component fixture only; parser/scheduler/factories reject
   ObstacleKind::SplitPath      → "split_path"       ✓  runtime-supported, not generated today
   ObstacleKind::OnsetMarker    → "onset_marker"     ✓  non-blocking shipped metadata
 
@@ -507,8 +507,8 @@ Ordered by dependency chain. Steps marked ✅ are already on `main`.
   STEP 3 — Beat Map Loader                         ✅ DONE
   ─────────────────────────────
   • beat_map_loader.h/.cpp: JSON → BeatMap with validation
-  • Parser supports ComboGate and SplitPath as future content; shipped
-    beatmaps currently use ShapeGate plus onset_marker metadata.
+  • Parser supports ShapeGate, SplitPath, and onset_marker only. LaneBlock
+    and ComboGate are legacy component fixtures rejected by active beatmaps.
   • init_song_state() computes derived fields from BPM
 
   STEP 4 — Song Playback + Beat Scheduler          ✅ DONE

--- a/design-docs/feature-specs.md
+++ b/design-docs/feature-specs.md
@@ -399,7 +399,7 @@ from BPM/lead-time math and stays constant within a song.
   BeatMap.difficulties[difficulty].beats
           │
           ├─ onset_marker → metadata only; scheduler skips spawn
-          └─ shape_gate / lane_block / combo_gate / split_path
+          └─ shape_gate / split_path
                     │
                     ▼
   calibrated_arrival_time = authored_beat_time + audio_offset_sec
@@ -438,8 +438,8 @@ struct Obstacle {
 
 enum class ObstacleKind : uint8_t {
     ShapeGate,
-    LaneBlock,
-    ComboGate,
+    LaneBlock,   // legacy component fixture only; active beatmaps/factories reject
+    ComboGate,   // legacy component fixture only; active beatmaps/factories reject
     SplitPath,
     OnsetMarker,
 };

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -211,7 +211,8 @@ inline entt::entity make_shape_gate(entt::registry& reg, Shape shape, float y) {
     return obs;
 }
 
-// Creates a lane block obstacle blocking specified lanes (bitmask)
+// Creates a legacy lane-block component fixture. Active beatmaps and runtime
+// obstacle factories reject LaneBlock; tests use this to cover old ECS data.
 inline entt::entity make_lane_block(entt::registry& reg, uint8_t mask, float y) {
     const auto& song = reg.ctx().get<SongState>();
     auto obs = reg.create();
@@ -228,7 +229,8 @@ inline entt::entity make_lane_block(entt::registry& reg, uint8_t mask, float y) 
 }
 
 
-// Creates a combo gate requiring shape AND lane not blocked
+// Creates a legacy combo-gate component fixture. Active beatmaps and runtime
+// obstacle factories reject ComboGate; tests use this to cover old ECS data.
 inline entt::entity make_combo_gate(entt::registry& reg, Shape shape, uint8_t blocked_mask, float y) {
     const auto& song = reg.ctx().get<SongState>();
     auto obs = reg.create();

--- a/tests/test_obstacle_archetypes.cpp
+++ b/tests/test_obstacle_archetypes.cpp
@@ -228,32 +228,17 @@ TEST_CASE("entity: ShapeGate Triangle - green color", "[archetype]") {
     CHECK(c.r == 100); CHECK(c.g == 255); CHECK(c.b == 100);
 }
 
-TEST_CASE("entity: LaneBlock - blocked lanes and no shape components", "[archetype]") {
+TEST_CASE("entity: deprecated lane obstacles are rejected by runtime factory",
+          "[archetype][legacy][issue1027]") {
     entt::registry reg;
-    auto e = spawn_obstacle(reg, {ObstacleKind::LaneBlock, 60.0f, -120.0f,
-                                   Shape::Circle, uint8_t{0b010}});
 
-    REQUIRE(reg.all_of<ObstacleTag, MotionVelocity, DrawLayer, WorldTransform, Obstacle, BlockedLanes, DrawSize, Color>(e));
-    CHECK(!reg.all_of<RequiredShape>(e));
-    CHECK(!reg.all_of<RequiredLane>(e));
-
-    CHECK(reg.get<Obstacle>(e).base_points == int16_t{constants::PTS_LANE_BLOCK});
-    CHECK(reg.get<BlockedLanes>(e).mask == uint8_t{0b010});
-}
-
-
-
-TEST_CASE("entity: ComboGate - RequiredShape and BlockedLanes", "[archetype]") {
-    entt::registry reg;
-    auto e = spawn_obstacle(reg, {ObstacleKind::ComboGate, 360.0f, -120.0f,
-                                   Shape::Triangle, uint8_t{0b101}});
-
-    REQUIRE(reg.all_of<ObstacleTag, MotionVelocity, DrawLayer, WorldTransform, Obstacle, RequiredShape, BlockedLanes, DrawSize, Color>(e));
-    CHECK(!reg.all_of<RequiredLane>(e));
-
-    CHECK(reg.get<Obstacle>(e).base_points == int16_t{constants::PTS_COMBO_GATE});
-    CHECK(reg.get<RequiredShape>(e).shape == Shape::Triangle);
-    CHECK(reg.get<BlockedLanes>(e).mask == uint8_t{0b101});
+    CHECK_THROWS_WITH(spawn_obstacle(reg, {ObstacleKind::LaneBlock, 60.0f, -120.0f,
+                                           Shape::Circle, uint8_t{0b010}}),
+                      "Deprecated obstacle kind is not spawnable at runtime");
+    CHECK_THROWS_WITH(spawn_obstacle(reg, {ObstacleKind::ComboGate, 360.0f, -120.0f,
+                                           Shape::Triangle, uint8_t{0b101}}),
+                      "Deprecated obstacle kind is not spawnable at runtime");
+    CHECK(reg.view<ObstacleTag>().begin() == reg.view<ObstacleTag>().end());
 }
 
 TEST_CASE("entity: SplitPath - RequiredShape and RequiredLane", "[archetype]") {

--- a/tests/test_obstacle_archetypes.cpp
+++ b/tests/test_obstacle_archetypes.cpp
@@ -232,12 +232,12 @@ TEST_CASE("entity: deprecated lane obstacles are rejected by runtime factory",
           "[archetype][legacy][issue1027]") {
     entt::registry reg;
 
-    CHECK_THROWS_WITH(spawn_obstacle(reg, {ObstacleKind::LaneBlock, 60.0f, -120.0f,
-                                           Shape::Circle, uint8_t{0b010}}),
-                      "Deprecated obstacle kind is not spawnable at runtime");
-    CHECK_THROWS_WITH(spawn_obstacle(reg, {ObstacleKind::ComboGate, 360.0f, -120.0f,
-                                           Shape::Triangle, uint8_t{0b101}}),
-                      "Deprecated obstacle kind is not spawnable at runtime");
+    CHECK_THROWS_AS(spawn_obstacle(reg, {ObstacleKind::LaneBlock, 60.0f, -120.0f,
+                                         Shape::Circle, uint8_t{0b010}}),
+                    std::logic_error);
+    CHECK_THROWS_AS(spawn_obstacle(reg, {ObstacleKind::ComboGate, 360.0f, -120.0f,
+                                         Shape::Triangle, uint8_t{0b101}}),
+                    std::logic_error);
     CHECK(reg.view<ObstacleTag>().begin() == reg.view<ObstacleTag>().end());
 }
 

--- a/tools/check_shape_change_gap.py
+++ b/tools/check_shape_change_gap.py
@@ -2,9 +2,9 @@
 """Deterministic check: every shipped beatmap must satisfy the C++ loader's
 min_shape_change_gap rule (issue #134).
 
-Mirrors `validate_beat_map` Rule 6 in app/systems/beat_map_loader.cpp:
-shape-bearing obstacles (shape_gate, split_path, combo_gate) that change
-shape must be at least MIN_GAP beats apart.
+Mirrors `validate_beat_map` Rule 6 in app/entities/beat_map.cpp:
+active shape-bearing obstacles (shape_gate, split_path) that change shape
+must be at least MIN_GAP beats apart.
 
 Exits 0 on success, 1 on failure. Prints a per-difficulty summary.
 
@@ -22,7 +22,7 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 DEFAULT_DIR = REPO / "content" / "beatmaps"
-SHAPE_KINDS = {"shape_gate", "split_path", "combo_gate"}
+SHAPE_KINDS = {"shape_gate", "split_path"}
 DEFAULT_MIN_GAP = 3
 
 


### PR DESCRIPTION
## Summary
- Reject legacy LaneBlock and ComboGate in active obstacle factory paths while preserving component-level fixture coverage.
- Reuse shared active obstacle vocabulary helpers in beatmap validation/scheduling.
- Update tests, tools, and design docs to mark lane-block/combo-gate as legacy fixtures only.

Fixes #1027

## Verification
- cmake -B build -S . -Wno-dev
- cmake --build build
- ./build/shapeshifter_tests