### PR TITLE
Remove obstacle child destroy listener

### DIFF
--- a/app/components/rendering.h
+++ b/app/components/rendering.h
@@ -66,7 +66,7 @@ struct MeshChild {
     MeshType mesh_type = MeshType::Shape;
 };
 
-// Owned mesh children; on_obstacle_destroy cleans up in O(count).
+// Owned mesh children; destroy_obstacle_with_children cleans up in O(count).
 struct ObstacleChildren {
     static constexpr int MAX = 8;
     entt::entity children[MAX]{};

--- a/app/entities/obstacle_render_entity.cpp
+++ b/app/entities/obstacle_render_entity.cpp
@@ -8,12 +8,6 @@
 #include <stdexcept>
 
 namespace {
-struct ObstacleMeshLifetimeState {
-    entt::registry* owner = nullptr;
-    entt::scoped_connection connection;
-};
-
-
 uint8_t checked_shape_mesh_index(Shape shape) {
     const int index = shape_index(shape);
     if (index < 0) throw std::logic_error("Invalid RequiredShape shape");
@@ -49,27 +43,6 @@ struct PendingEntity {
         active = false;
     }
 };
-}
-
-void on_obstacle_destroy(entt::registry& reg, entt::entity parent);
-
-void wire_obstacle_mesh_lifetime(entt::registry& reg) {
-    auto* state = reg.ctx().find<ObstacleMeshLifetimeState>();
-    if (!state) {
-        state = &reg.ctx().emplace<ObstacleMeshLifetimeState>();
-    }
-    if (state->owner == &reg) return;
-
-    reg.storage<ObstacleChildren>();
-    state->connection = entt::scoped_connection{
-        reg.on_destroy<ObstacleChildren>().connect<&on_obstacle_destroy>()};
-    state->owner = &reg;
-}
-
-void unwire_obstacle_mesh_lifetime(entt::registry& reg) {
-    if (auto* state = reg.ctx().find<ObstacleMeshLifetimeState>()) {
-        *state = ObstacleMeshLifetimeState{};
-    }
 }
 
 static void append_child(entt::registry& reg, entt::entity parent, entt::entity child) {
@@ -117,8 +90,6 @@ static entt::entity add_shape_child(entt::registry& reg, entt::entity parent,
 }
 
 void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical) {
-    wire_obstacle_mesh_lifetime(reg);
-
     const auto* wt_ptr = reg.try_get<WorldTransform>(logical);
     auto& col = reg.get<Color>(logical);
     auto& dsz = reg.get<DrawSize>(logical);
@@ -204,13 +175,19 @@ void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical) {
 }
 
 
-// on_destroy listener: destroy MeshChild entities owned by this parent.
-// Uses ObstacleChildren for O(N) lookup instead of scanning the full pool.
-void on_obstacle_destroy(entt::registry& reg, entt::entity parent) {
+void destroy_obstacle_mesh_children(entt::registry& reg, entt::entity parent) {
     auto* oc = reg.try_get<ObstacleChildren>(parent);
     if (!oc) return;
     for (int i = 0; i < oc->count; ++i) {
         if (reg.valid(oc->children[i]))
             reg.destroy(oc->children[i]);
+        oc->children[i] = entt::null;
     }
+    oc->count = 0;
+}
+
+void destroy_obstacle_with_children(entt::registry& reg, entt::entity parent) {
+    if (!reg.valid(parent)) return;
+    destroy_obstacle_mesh_children(reg, parent);
+    reg.destroy(parent);
 }

--- a/app/entities/obstacle_render_entity.h
+++ b/app/entities/obstacle_render_entity.h
@@ -8,11 +8,6 @@
 void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical);
 
 
-// Centralized mesh-child lifetime wiring. Safe to call more than once.
-void wire_obstacle_mesh_lifetime(entt::registry& reg);
-void unwire_obstacle_mesh_lifetime(entt::registry& reg);
-
-
-// EnTT listener: destroys MeshChild entities recorded by ObstacleChildren.
-// Prefer wire_obstacle_mesh_lifetime() over connecting this directly.
-void on_obstacle_destroy(entt::registry& reg, entt::entity parent);
+// Explicit obstacle lifetime helpers. Do not call from EnTT destroy listeners.
+void destroy_obstacle_mesh_children(entt::registry& reg, entt::entity parent);
+void destroy_obstacle_with_children(entt::registry& reg, entt::entity parent);

--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -23,7 +23,6 @@
 #include "util/session_logger.h"
 #include "systems/camera_system.h"
 #include "entities/beat_map.h"
-#include "entities/obstacle_render_entity.h"
 #include "ui/screen_controllers/gameplay_hud_screen_controller.h"
 #include "platform_display.h"
 #include "util/persistence_policy.h"
@@ -234,9 +233,6 @@ bool game_loop_init(entt::registry& reg,
     // Cameras + render targets + GPU meshes
     camera::init(reg);
 
-    // MeshChild auto-cleanup: destroy children when parent ownership is removed.
-    wire_obstacle_mesh_lifetime(reg);
-
     // UI + beatmap + music
     create_beat_map_entity(reg);
     reset_ctx_singleton<SongState>(reg);
@@ -345,7 +341,6 @@ void game_loop_shutdown(entt::registry& reg) {
     // Disconnect all destroy/construct listeners before clearing entities
     unwire_input_dispatcher(reg);
     unwire_audio_haptic_dispatcher(reg);
-    unwire_obstacle_mesh_lifetime(reg);
     reg.on_construct<ObstacleTag>().disconnect<&session_log_on_obstacle_spawn>();
     reg.on_construct<ScoredTag>().disconnect<&session_log_on_scored>();
 

--- a/app/session/play_session.cpp
+++ b/app/session/play_session.cpp
@@ -15,7 +15,6 @@
 #include "../util/rhythm_math.h"
 #include "../entities/camera_entity.h"
 #include "../entities/energy_bar_entity.h"
-#include "../entities/obstacle_render_entity.h"
 #include "../entities/player_entity.h"
 #include "../content/level_content_config.h"
 #include "../systems/all_systems.h"
@@ -107,9 +106,7 @@ void setup_play_session(entt::registry& reg) {
     SettingsPersistence settings_persistence =
         previous_settings_persistence ? *previous_settings_persistence : SettingsPersistence{};
 
-    unwire_obstacle_mesh_lifetime(reg);
     reg.clear();
-    wire_obstacle_mesh_lifetime(reg);
 
     spawn_game_camera(reg);
     spawn_ui_camera(reg);

--- a/app/systems/obstacle_despawn_system.cpp
+++ b/app/systems/obstacle_despawn_system.cpp
@@ -3,6 +3,7 @@
 #include "../components/system_scratch.h"
 #include "../components/transform.h"
 #include "../constants.h"
+#include "../entities/obstacle_render_entity.h"
 
 namespace {
 
@@ -30,5 +31,5 @@ void obstacle_despawn_system(entt::registry& reg, [[maybe_unused]] float dt) {
         }
     }
 
-    for (auto e : to_destroy) reg.destroy(e);
+    for (auto e : to_destroy) destroy_obstacle_with_children(reg, e);
 }

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -432,19 +432,15 @@ TEST_CASE("collision: SongState ctx singleton identity is stable across collisio
     CHECK(song.scroll_speed == 321.0f);
 }
 
-TEST_CASE("ecs: obstacle mesh lifecycle unwire disconnect is idempotent",
+TEST_CASE("ecs: obstacle mesh lifecycle explicit cleanup is idempotent",
           "[ecs][obstacle][lifecycle]") {
     entt::registry reg;
-    wire_obstacle_mesh_lifetime(reg);
-
-    unwire_obstacle_mesh_lifetime(reg);
-    unwire_obstacle_mesh_lifetime(reg);
-    wire_obstacle_mesh_lifetime(reg);
 
     auto parent = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f, Shape::Circle});
     REQUIRE(mesh_child_count(reg) > 0);
 
-    reg.destroy(parent);
+    destroy_obstacle_with_children(reg, parent);
+    destroy_obstacle_with_children(reg, parent);
 
     CHECK(mesh_child_count(reg) == 0);
 }

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -30,7 +30,6 @@
 // Sets up a registry with all singletons in their default state
 inline entt::registry make_registry() {
     entt::registry reg;
-    wire_obstacle_mesh_lifetime(reg);
     reg.ctx().emplace<InputState>();
     reg.ctx().emplace<ScreenTransform>();
     reg.ctx().emplace<entt::dispatcher>();

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -6,6 +6,7 @@
 #include "content/level_content_config.h"
 #include "entities/camera_entity.h"
 #include "entities/obstacle_entity.h"
+#include "entities/obstacle_render_entity.h"
 #include "session/play_session.h"
 #include "test_helpers.h"
 #include "util/high_score_persistence.h"
@@ -112,7 +113,7 @@ TEST_CASE("Play session: restart clears obstacle mesh children without stale lis
     auto next_obstacle = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f, Shape::Square});
     REQUIRE(count_mesh_children(reg) > 0);
 
-    reg.destroy(next_obstacle);
+    destroy_obstacle_with_children(reg, next_obstacle);
 
     CHECK(count_mesh_children(reg) == 0);
 }

--- a/tests/test_obstacle_archetypes.cpp
+++ b/tests/test_obstacle_archetypes.cpp
@@ -92,7 +92,6 @@ TEST_CASE("entity: obstacle roots and mesh children declare world render pass", 
 
 TEST_CASE("entity: obstacle mesh overflow does not create orphan MeshChild", "[archetype][render][cleanup]") {
     entt::registry reg;
-    wire_obstacle_mesh_lifetime(reg);
 
     auto parent = reg.create();
     reg.emplace<WorldTransform>(parent, WorldTransform{{360.0f, -120.0f}});
@@ -117,18 +116,18 @@ TEST_CASE("entity: obstacle mesh overflow does not create orphan MeshChild", "[a
     CHECK(count_mesh_children(reg) == ObstacleChildren::MAX);
     CHECK(reg.get<ObstacleChildren>(parent).count == ObstacleChildren::MAX);
 
-    reg.destroy(parent);
+    destroy_obstacle_with_children(reg, parent);
 
     CHECK(count_mesh_children(reg) == 0);
 }
 
-TEST_CASE("entity: obstacle mesh lifetime is wired by the factory", "[archetype][render][cleanup]") {
+TEST_CASE("entity: obstacle mesh lifetime helper cleans factory children", "[archetype][render][cleanup]") {
     entt::registry reg;
     auto parent = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f, Shape::Circle});
 
     REQUIRE(count_mesh_children(reg) > 0);
 
-    reg.destroy(parent);
+    destroy_obstacle_with_children(reg, parent);
 
     CHECK(count_mesh_children(reg) == 0);
 }
@@ -142,7 +141,7 @@ TEST_CASE("entity: direct mesh factory cleanup does not depend on ObstacleTag or
     spawn_obstacle_meshes(reg, parent);
     REQUIRE(count_mesh_children(reg) > 0);
 
-    reg.destroy(parent);
+    destroy_obstacle_with_children(reg, parent);
 
     CHECK(count_mesh_children(reg) == 0);
 }

--- a/tests/test_perspective.cpp
+++ b/tests/test_perspective.cpp
@@ -6,6 +6,7 @@
 #include "components/rendering.h"
 #include "components/shape_mesh.h"
 #include "components/transform.h"
+#include "entities/obstacle_entity.h"
 #include "rendering/camera_resources.h"
 #include "systems/runtime_systems.h"
 #include <raylib.h>
@@ -127,6 +128,25 @@ TEST_CASE("game_camera_system drops stale MeshChild parents without crashing", "
 
     reg.destroy(parent);
 
+    REQUIRE_NOTHROW(game_camera_system(reg, 0.0f));
+    CHECK_FALSE(reg.valid(child));
+}
+
+TEST_CASE("game_camera_system drops mesh children for destroyed logical obstacle",
+          "[camera3d][mesh_child][obstacle]") {
+    entt::registry reg;
+    reg.ctx().emplace<ShapeMeshConfig>();
+    reg.ctx().emplace<FloorParams>();
+    auto parent = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f, Shape::Circle});
+    REQUIRE(reg.all_of<ObstacleChildren>(parent));
+    const auto children = reg.get<ObstacleChildren>(parent);
+    REQUIRE(children.count > 0);
+    const entt::entity child = children.children[0];
+    REQUIRE(reg.valid(child));
+
+    reg.destroy(parent);
+
+    REQUIRE(reg.valid(child));
     REQUIRE_NOTHROW(game_camera_system(reg, 0.0f));
     CHECK_FALSE(reg.valid(child));
 }

--- a/tests/test_pr43_regression.cpp
+++ b/tests/test_pr43_regression.cpp
@@ -140,8 +140,8 @@ TEST_CASE("MeshChild: ShapeGate renders shape-only (no side slabs)",
 // ═══════════════════════════════════════════════════════════════════════
 // Theme 6 – obstacle mesh lifetime must only destroy children whose parent
 //           is the entity being destroyed, not other obstacles' children.
-// The cleanup listener follows ObstacleChildren ownership directly, so it does
-// not depend on ObstacleTag pool insertion order.
+// Explicit cleanup follows ObstacleChildren ownership directly, so it does not
+// depend on ObstacleTag pool insertion order.
 // ═══════════════════════════════════════════════════════════════════════
 
 // Helper: create an obstacle with an ObstacleChildren list.
@@ -157,7 +157,7 @@ static entt::entity make_obstacle(entt::registry& reg,
     return obs;
 }
 
-// Helper: set up the registry with centralized obstacle mesh lifetime wiring.
+// Helper: set up the registry for obstacle mesh lifetime tests.
 static entt::registry make_obs_registry() {
     return make_registry();
 }
@@ -173,8 +173,7 @@ TEST_CASE("obstacle mesh lifetime: only removes the destroyed parent's children"
     auto obsA = make_obstacle(reg, {childA1, childA2});
     make_obstacle(reg, {childB});
 
-    // Destroy obstacle A via the signal path
-    reg.destroy(obsA);
+    destroy_obstacle_with_children(reg, obsA);
 
     CHECK_FALSE(reg.valid(childA1));
     CHECK_FALSE(reg.valid(childA2));
@@ -195,7 +194,7 @@ TEST_CASE("obstacle mesh lifetime: all children of destroyed parent removed",
     auto bystanderChild = reg.create();
     make_obstacle(reg, {bystanderChild});
 
-    reg.destroy(obsA);
+    destroy_obstacle_with_children(reg, obsA);
 
     for (auto c : children)
         CHECK_FALSE(reg.valid(c));


### PR DESCRIPTION
## Summary\n- remove the ObstacleChildren EnTT destroy listener and its startup/reset wiring\n- route normal obstacle despawn through explicit child cleanup before destroying the parent\n- keep camera stale-child cleanup for direct parent destruction and add regression coverage\n\n## Root cause\nObstacle mesh children were destroyed from an on_destroy<ObstacleChildren> callback, which performed structural registry mutation while EnTT was already processing destruction.\n\n## Verification\n- cmake -B build -S . -Wno-dev\n- cmake --build build --parallel\n- ./build/shapeshifter_tests\n\nFixes #1037