### PR TITLE
Preserve ShapeGate authored lane in ECS

### DIFF
--- a/app/components/obstacle.h
+++ b/app/components/obstacle.h
@@ -67,6 +67,10 @@ struct RequiredShape {
     Shape shape = Shape::Circle;
 };
 
+struct ShapeGateLane {
+    int8_t lane = 0;
+};
+
 struct BlockedLanes {
     uint8_t mask = 0;
 };

--- a/app/entities/obstacle_entity.cpp
+++ b/app/entities/obstacle_entity.cpp
@@ -4,6 +4,7 @@
 #include "../components/rendering.h"
 #include "obstacle_render_entity.h"
 #include "../constants.h"
+#include "../util/lane_utils.h"
 #include "../util/shape_lane_mapping.h"
 #include <stdexcept>
 
@@ -32,6 +33,8 @@ entt::entity spawn_obstacle_base(entt::registry& reg, const ObstacleSpawnParams&
         case ObstacleKind::ShapeGate: {
             reg.emplace<Obstacle>(e, int16_t{constants::PTS_SHAPE_GATE});
             reg.emplace<RequiredShape>(e, params.shape);
+            reg.emplace<ShapeGateLane>(
+                e, static_cast<int8_t>(lane_utils::nearest_lane_for_x(params.x)));
             reg.emplace<DrawSize>(e, constants::SCREEN_W_F, 80.0f);
             reg.emplace<Color>(e, constants::SHAPE_COLORS[shape_index(params.shape)]);
             break;

--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -10,16 +10,9 @@
 #include "../components/gameplay_intents.h"
 #include "../constants.h"
 #include "../util/lane_utils.h"
-#include <raylib.h>
 #include <cmath>
 
 namespace {
-
-Rectangle centered_hitbox_rect(float x) {
-    constexpr float kHitboxEdgePadding = 1.0e-4f;
-    const float size = constants::PLAYER_SIZE + kHitboxEdgePadding;
-    return {x - size * 0.5f, 0.0f, size, 1.0f};
-}
 
 bool player_matches_required_shape(const PlayerShape& p_shape,
                                     const ShapeWindow& p_window,
@@ -49,9 +42,8 @@ bool player_matches_required_shape(const PlayerShape& p_shape,
     return p_window.phase != WindowPhase::Idle && p_window.target_shape == required;
 }
 
-bool shape_gate_lane_match(float obstacle_x, float player_x) {
-    return CheckCollisionRecs(centered_hitbox_rect(player_x),
-                              centered_hitbox_rect(obstacle_x));
+bool shape_gate_lane_match(int8_t obstacle_lane, int player_lane) {
+    return static_cast<int>(obstacle_lane) == player_lane;
 }
 
 }  // namespace
@@ -72,8 +64,7 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
     // loops since player transform and vertical state don't change mid-frame.
     // Precomputing here avoids redundant addition + Vector2 construction per obstacle.
     const float player_timing_y = p_transform.position.y + p_vstate.y_offset;
-    const float player_x        = p_transform.position.x;
-    const int player_lane       = lane_utils::nearest_lane_for_x(player_x);
+    const int player_lane       = lane_utils::nearest_lane_for_x(p_transform.position.x);
 
     // resolve: tag entity as scored (cleared) or missed.
     // kind is passed by the caller — no try_get needed since each per-kind
@@ -153,19 +144,35 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
 
     // ShapeGate: RequiredShape only (no BlockedLanes, no RequiredLane)
     {
-        auto rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, BeatInfo>(
+        auto rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, ShapeGateLane, BeatInfo>(
             entt::exclude<ScoredTag, ResolvedObstacleTag, BlockedLanes, RequiredLane>);
-        for (auto [e, obstacle, wt, req, info] : rhythm_view.each()) {
+        for (auto [e, obstacle, wt, req, lane, info] : rhythm_view.each()) {
             (void)obstacle;
-            const bool lane_ok = shape_gate_lane_match(wt.position.x, player_x);
+            const bool lane_ok = shape_gate_lane_match(lane.lane, player_lane);
             resolve_shape_obstacle(e, wt, req.shape, lane_ok, &info);
         }
 
-        auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape>(
+        auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, ShapeGateLane>(
             entt::exclude<ScoredTag, ResolvedObstacleTag, BlockedLanes, RequiredLane, BeatInfo>);
-        for (auto [e, obstacle, wt, req] : view.each()) {
+        for (auto [e, obstacle, wt, req, lane] : view.each()) {
             (void)obstacle;
-            const bool lane_ok = shape_gate_lane_match(wt.position.x, player_x);
+            const bool lane_ok = shape_gate_lane_match(lane.lane, player_lane);
+            resolve_shape_obstacle(e, wt, req.shape, lane_ok, nullptr);
+        }
+
+        auto fallback_rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, BeatInfo>(
+            entt::exclude<ScoredTag, ResolvedObstacleTag, BlockedLanes, RequiredLane, ShapeGateLane>);
+        for (auto [e, obstacle, wt, req, info] : fallback_rhythm_view.each()) {
+            (void)obstacle;
+            const bool lane_ok = lane_utils::nearest_lane_for_x(wt.position.x) == player_lane;
+            resolve_shape_obstacle(e, wt, req.shape, lane_ok, &info);
+        }
+
+        auto fallback_view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape>(
+            entt::exclude<ScoredTag, ResolvedObstacleTag, BlockedLanes, RequiredLane, BeatInfo, ShapeGateLane>);
+        for (auto [e, obstacle, wt, req] : fallback_view.each()) {
+            (void)obstacle;
+            const bool lane_ok = lane_utils::nearest_lane_for_x(wt.position.x) == player_lane;
             resolve_shape_obstacle(e, wt, req.shape, lane_ok, nullptr);
         }
     }

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -82,12 +82,13 @@ TEST_CASE("beat_scheduler: spawns ShapeGate when time passes spawn_time", "[beat
     CHECK(count == 1);
 
     // Verify it's a ShapeGate with correct components
-    auto view = reg.view<ObstacleTag, Obstacle, RequiredShape>();
-    for (auto [e, obs, rs] : view.each()) {
+    auto view = reg.view<ObstacleTag, Obstacle, RequiredShape, ShapeGateLane>();
+    for (auto [e, obs, rs, lane] : view.each()) {
         (void)obs;
         CHECK_FALSE(reg.all_of<BlockedLanes>(e));
         CHECK_FALSE(reg.all_of<RequiredLane>(e));
         CHECK(rs.shape == Shape::Circle);
+        CHECK(lane.lane == int8_t{1});
     }
 }
 
@@ -102,11 +103,12 @@ TEST_CASE("beat_scheduler: defaults invalid ShapeGate lane to center lane", "[be
 
     beat_scheduler_system(reg, 0.016f);
 
-    auto view = reg.view<ObstacleTag, WorldTransform>();
+    auto view = reg.view<ObstacleTag, WorldTransform, ShapeGateLane>();
     REQUIRE(view.size_hint() == 1);
-    for (auto [e, wt] : view.each()) {
+    for (auto [e, wt, lane] : view.each()) {
         (void)e;
         CHECK_THAT(wt.position.x, Catch::Matchers::WithinAbs(constants::LANE_X[1], 0.01f));
+        CHECK(lane.lane == int8_t{1});
     }
 }
 

--- a/tests/test_collision_extended.cpp
+++ b/tests/test_collision_extended.cpp
@@ -151,6 +151,7 @@ TEST_CASE("collision: on-beat shape press requires player hitbox to reach target
 
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.get<WorldTransform>(obs).position.x = constants::LANE_X[0];
+    reg.get<ShapeGateLane>(obs).lane = int8_t{0};
     reg.emplace<BeatInfo>(obs, 0, song.song_time, song.song_time - song.lead_time);
 
     auto& lane = reg.get<Lane>(player);

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -33,11 +33,12 @@ TEST_CASE("collision: shape gate drains energy with wrong shape", "[collision]")
     CHECK(energy.flash_timer > 0.0f);
 }
 
-TEST_CASE("collision: shape gate hitbox edge handling", "[collision][edge]") {
+TEST_CASE("collision: shape gate collision uses authored lane, not visual hitbox edge",
+          "[collision][edge][issue1036]") {
     constexpr struct {
         float offset;
         bool missed;
-    } cases[] = {{constants::PLAYER_SIZE, false}, {constants::PLAYER_SIZE + 0.01f, true}};
+    } cases[] = {{constants::PLAYER_SIZE, false}, {constants::PLAYER_SIZE + 0.01f, false}};
 
     for (const auto& tc : cases) {
         auto reg = make_registry();
@@ -60,6 +61,7 @@ TEST_CASE("collision: shape gate does not clear from target lane before strafe a
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
 
     reg.get<WorldTransform>(obs).position.x = constants::LANE_X[0];
+    reg.get<ShapeGateLane>(obs).lane = int8_t{0};
     lane.target = 0;
     lane.lerp_t = 0.0f;
 
@@ -69,7 +71,7 @@ TEST_CASE("collision: shape gate does not clear from target lane before strafe a
     CHECK(reg.all_of<MissTag>(obs));
 }
 
-TEST_CASE("collision: shape gate ignores shape-derived lane without explicit target",
+TEST_CASE("collision: shape gate ignores visual lane drift from authored lane",
           "[collision][issue874]") {
     auto reg = make_registry();
     make_player(reg);
@@ -80,7 +82,7 @@ TEST_CASE("collision: shape gate ignores shape-derived lane without explicit tar
     collision_system(reg, 0.016f);
 
     CHECK(reg.all_of<ScoredTag>(obs));
-    CHECK(reg.all_of<MissTag>(obs));
+    CHECK_FALSE(reg.all_of<MissTag>(obs));
 }
 
 TEST_CASE("collision: shape gate clears when interpolated player hitbox reaches lane",
@@ -91,6 +93,7 @@ TEST_CASE("collision: shape gate clears when interpolated player hitbox reaches 
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
 
     reg.get<WorldTransform>(obs).position.x = constants::LANE_X[0];
+    reg.get<ShapeGateLane>(obs).lane = int8_t{0};
     reg.get<WorldTransform>(player).position.x = constants::LANE_X[0];
     lane.target = 0;
     lane.lerp_t = 1.0f;

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -203,6 +203,7 @@ inline entt::entity make_shape_gate(entt::registry& reg, Shape shape, float y) {
     reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, song.scroll_speed}});
     reg.emplace<Obstacle>(obs, int16_t{constants::PTS_SHAPE_GATE});
     reg.emplace<RequiredShape>(obs, shape);
+    reg.emplace<ShapeGateLane>(obs, int8_t{1});
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);
     reg.emplace<DrawLayer>(obs, Layer::Game);
     reg.emplace<TagWorldPass>(obs);

--- a/tests/test_obstacle_archetypes.cpp
+++ b/tests/test_obstacle_archetypes.cpp
@@ -51,12 +51,13 @@ TEST_CASE("entity: ShapeGate Circle - correct components and color", "[archetype
     entt::registry reg;
     auto e = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f, Shape::Circle});
 
-    REQUIRE(reg.all_of<ObstacleTag, MotionVelocity, DrawLayer, WorldTransform, Obstacle, RequiredShape, DrawSize, Color>(e));
+    REQUIRE(reg.all_of<ObstacleTag, MotionVelocity, DrawLayer, WorldTransform, Obstacle, RequiredShape, ShapeGateLane, DrawSize, Color>(e));
     CHECK(!reg.all_of<BlockedLanes>(e));
     CHECK(!reg.all_of<RequiredLane>(e));
 
     CHECK(reg.get<Obstacle>(e).base_points == int16_t{constants::PTS_SHAPE_GATE});
     CHECK(reg.get<RequiredShape>(e).shape == Shape::Circle);
+    CHECK(reg.get<ShapeGateLane>(e).lane == int8_t{1});
     CHECK(reg.get<WorldTransform>(e).position.x == 360.0f);
     CHECK(reg.get<WorldTransform>(e).position.y == -120.0f);
 

--- a/tests/test_player_input_rhythm_extended.cpp
+++ b/tests/test_player_input_rhythm_extended.cpp
@@ -221,6 +221,7 @@ TEST_CASE("player_input_rhythm: circle press in lane 0 does not force mismatch b
 
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.get<WorldTransform>(obs).position.x = constants::LANE_X[0];
+    reg.get<ShapeGateLane>(obs).lane = int8_t{0};
 
     auto btn = make_shape_button(reg, Shape::Circle);
     press_button(reg, btn);


### PR DESCRIPTION
## Summary\n- add ShapeGateLane runtime ECS data for ShapeGate obstacles\n- use ShapeGate lane comparisons in collision instead of raylib rectangle overlap\n- cover authored-lane match/mismatch, visual drift, invalid lane fallback, and transition behavior in tests\n\n## Root cause\nShapeGate lane semantics were inferred from WorldTransform.x and hitbox overlap, so gameplay correctness could change with visual placement or hitbox tuning.\n\n## Verification\n- cmake -B build -S . -Wno-dev\n- cmake --build build --parallel\n- ./build/shapeshifter_tests\n\nFixes #1036