### PR TITLE
Update Level Select layout reference to RGL

### DIFF
--- a/design-docs/game-flow.md
+++ b/design-docs/game-flow.md
@@ -181,7 +181,7 @@ and screen width (W) for portrait mode (9:16 aspect ratio target).
 After tapping "start" on the title screen, the player is taken to the
 **LevelSelect** screen (`GamePhase::LevelSelect`). This screen presents
 a list of available songs and difficulty options. The layout is defined in
-`content/ui/screens/level_select.json`. Confirming a selection transitions
+`content/ui/screens/level_select.rgl`. Confirming a selection transitions
 to `GamePhase::Playing`.
 
 ---


### PR DESCRIPTION
## Summary\n- replace the stale Level Select JSON layout reference in game-flow.md with the current .rgl source\n- confirm content/ui/screens layout sources remain .rgl-only\n\n## Root cause\nThe game flow doc still referenced the removed `content/ui/screens/level_select.json` layout source after the UI layout migration moved authored screen layouts to rguilayout `.rgl` files.\n\n## Verification\n- searched `design-docs/game-flow.md` for stale gameplay/level-select JSON layout references\n- listed `content/ui/screens/` and confirmed layout sources were unchanged\n\nCloses #1035