### PR TITLE
Fix lane input during active transitions

### DIFF
--- a/app/systems/player_input_system.cpp
+++ b/app/systems/player_input_system.cpp
@@ -30,20 +30,28 @@ void player_input_handle_go(entt::registry& reg, const GoEvent& evt) {
     auto view = reg.view<PlayerTag, PlayerShape, ShapeWindow, Lane, VerticalState>();
     for (auto [entity, pshape, swindow, lane, vstate] : view.each()) {
         lane_utils::normalize(lane);
+        const bool horizontal_input = evt.dir == Direction::Left || evt.dir == Direction::Right;
+        const bool lane_switch_active =
+            lane_utils::is_valid(lane.target) && lane.target != lane.current;
+
         int8_t delta = 0;
-        if (evt.dir == Direction::Left  && lane.current > 0)
-            delta = -1;
-        else if (evt.dir == Direction::Right && lane.current < constants::LANE_COUNT - 1)
-            delta = 1;
+        if (horizontal_input && !lane_switch_active) {
+            if (evt.dir == Direction::Left && lane.current > 0) {
+                delta = -1;
+            } else if (evt.dir == Direction::Right && lane.current < constants::LANE_COUNT - 1) {
+                delta = 1;
+            }
+        }
+
         if (delta != 0) {
             lane.target = lane.current + delta;
             lane.lerp_t = 0.0f;
             push_haptic(reg, HapticEvent::LaneSwitch);
-        } else if (evt.dir == Direction::Up && vstate.mode == VMode::Grounded) {
+        } else if (!horizontal_input && evt.dir == Direction::Up && vstate.mode == VMode::Grounded) {
             vstate.mode = VMode::Jumping;
             vstate.timer = constants::JUMP_DURATION;
             vstate.y_offset = 0.0f;
-        } else if (evt.dir == Direction::Down && vstate.mode == VMode::Grounded) {
+        } else if (!horizontal_input && evt.dir == Direction::Down && vstate.mode == VMode::Grounded) {
             vstate.mode = VMode::Sliding;
             vstate.timer = constants::SLIDE_DURATION;
             vstate.y_offset = 0.0f;

--- a/tests/test_player_systems.cpp
+++ b/tests/test_player_systems.cpp
@@ -70,6 +70,43 @@ TEST_CASE("player_action: swipe right changes lane", "[player]") {
     }
 }
 
+TEST_CASE("player_action: repeated lane input during transition does not restart interpolation",
+          "[player][issue1043]") {
+    auto reg = make_registry();
+    auto p = make_player(reg);
+
+    reg.ctx().get<entt::dispatcher>().enqueue<GoEvent>({Direction::Right});
+    run_semantic_input_tick(reg, 0.016f);
+
+    auto& lane = reg.get<Lane>(p);
+    lane.lerp_t = 0.4f;
+
+    reg.ctx().get<entt::dispatcher>().enqueue<GoEvent>({Direction::Right});
+    run_semantic_input_tick(reg, 0.016f);
+
+    CHECK(lane.current == 1);
+    CHECK(lane.target == 2);
+    CHECK_THAT(lane.lerp_t, Catch::Matchers::WithinAbs(0.4f, 0.0001f));
+}
+
+TEST_CASE("player_action: opposite lane input during transition waits for completion",
+          "[player][issue1043]") {
+    auto reg = make_registry();
+    auto p = make_player(reg);
+
+    auto& lane = reg.get<Lane>(p);
+    lane.current = 1;
+    lane.target = 2;
+    lane.lerp_t = 0.4f;
+
+    reg.ctx().get<entt::dispatcher>().enqueue<GoEvent>({Direction::Left});
+    run_semantic_input_tick(reg, 0.016f);
+
+    CHECK(lane.current == 1);
+    CHECK(lane.target == 2);
+    CHECK_THAT(lane.lerp_t, Catch::Matchers::WithinAbs(0.4f, 0.0001f));
+}
+
 TEST_CASE("player_action: swipe left at lane 0 is clamped", "[player]") {
     auto reg = make_registry();
     auto p = make_player(reg);


### PR DESCRIPTION
## Summary
- Ignore horizontal lane inputs while a lane transition is already active.
- Keep jump/slide handling unchanged for non-horizontal input.
- Add regression tests for duplicate and opposite lane input during an active transition.

## Root cause
`player_input_handle_go` recomputed lane targets from stale `lane.current` and reset `lane.lerp_t` for every horizontal input. Since `lane.current` is only updated after movement interpolation completes, repeated input during a transition could restart interpolation from the old lane center and visually snap movement backward.

## Verification
- `export VCPKG_ROOT="${VCPKG_ROOT:-$HOME/vcpkg}" && ./build.sh && ./build/shapeshifter_tests "[player][issue1043]"`
- `ctest --test-dir build --output-on-failure`

Fixes #1043