### PR TITLE
Fix onset marker cue spawning

### DIFF
--- a/app/components/obstacle.h
+++ b/app/components/obstacle.h
@@ -6,6 +6,10 @@
 
 struct ObstacleTag {};
 
+// Runtime cue authored from beatmap onset metadata. It is visible but
+// intentionally non-scorable and non-blocking.
+struct OnsetMarkerTag {};
+
 // Presence means scoring has consumed the obstacle's final hit/miss result.
 struct ResolvedObstacleTag {};
 
@@ -29,6 +33,11 @@ constexpr bool obstacle_kind_is_active_runtime_spawnable(ObstacleKind kind) {
 
 constexpr bool obstacle_kind_is_active_blocking_beatmap_kind(ObstacleKind kind) {
     return kind == ObstacleKind::ShapeGate || kind == ObstacleKind::SplitPath;
+}
+
+constexpr bool obstacle_kind_is_active_beatmap_spawnable(ObstacleKind kind) {
+    return obstacle_kind_is_active_blocking_beatmap_kind(kind) ||
+           kind == ObstacleKind::OnsetMarker;
 }
 
 struct Obstacle {

--- a/app/entities/obstacle_entity.cpp
+++ b/app/entities/obstacle_entity.cpp
@@ -52,6 +52,7 @@ entt::entity spawn_obstacle_base(entt::registry& reg, const ObstacleSpawnParams&
         }
         case ObstacleKind::OnsetMarker: {
             reg.emplace<Obstacle>(e, int16_t{0});
+            reg.emplace<OnsetMarkerTag>(e);
             reg.emplace<NonScorableTag>(e);
             reg.emplace<DrawSize>(e, constants::SCREEN_W_F, 80.0f);
             reg.emplace<Color>(e, Color{255, 255, 255, 80});

--- a/app/entities/obstacle_render_entity.cpp
+++ b/app/entities/obstacle_render_entity.cpp
@@ -93,10 +93,12 @@ void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical) {
     const auto* wt_ptr = reg.try_get<WorldTransform>(logical);
     auto& col = reg.get<Color>(logical);
     auto& dsz = reg.get<DrawSize>(logical);
-    const ObstacleKind kind = obstacle_kind_from_components(
-        reg.all_of<RequiredShape>(logical),
-        reg.all_of<BlockedLanes>(logical),
-        reg.all_of<RequiredLane>(logical));
+    const ObstacleKind kind = reg.all_of<OnsetMarkerTag>(logical)
+        ? ObstacleKind::OnsetMarker
+        : obstacle_kind_from_components(
+            reg.all_of<RequiredShape>(logical),
+            reg.all_of<BlockedLanes>(logical),
+            reg.all_of<RequiredLane>(logical));
 
     switch (kind) {
         case ObstacleKind::ShapeGate: {
@@ -169,6 +171,10 @@ void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical) {
                                 0.0f, 30, {255, 255, 255, 180});
             break;
         }
+        case ObstacleKind::OnsetMarker:
+            add_slab_child(reg, logical, 0.0f, dsz.w, dsz.h,
+                           constants::OBSTACLE_3D_HEIGHT, col);
+            break;
         default:
             break;
     }

--- a/app/systems/beat_scheduler_system.cpp
+++ b/app/systems/beat_scheduler_system.cpp
@@ -30,11 +30,7 @@ void beat_scheduler_system(entt::registry& reg, [[maybe_unused]] float dt) {
 
     while (song->next_spawn_idx < map->beats.size()) {
         const auto& entry = map->beats[song->next_spawn_idx];
-        if (entry.kind == ObstacleKind::OnsetMarker) {
-            song->next_spawn_idx++;
-            continue;
-        }
-        if (!obstacle_kind_is_active_blocking_beatmap_kind(entry.kind)) {
+        if (!obstacle_kind_is_active_beatmap_spawnable(entry.kind)) {
             TraceLog(LOG_WARNING, "Skipping unsupported active beatmap obstacle kind %d",
                      static_cast<int>(entry.kind));
             song->next_spawn_idx++;

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -286,7 +286,7 @@ void test_player_system(entt::registry& reg, float dt) {
     }
 
     auto obs_view = reg.view<ObstacleTag, WorldTransform, Obstacle>(
-        entt::exclude<ScoredTag, TestPlayerPlannedTag>);
+        entt::exclude<ScoredTag, TestPlayerPlannedTag, NonScorableTag>);
     for (auto [entity, obs_wt, obs] : obs_view.each()) {
         (void)obs;
         float dist = p_transform.position.y - obs_wt.position.y;
@@ -444,7 +444,8 @@ void test_player_system(entt::registry& reg, float dt) {
                                  && pending_shape_obstacle != action.obstacle);
         bool zone_blocked = false;
         {
-            auto zone_view = reg.view<ObstacleTag, Obstacle, WorldTransform>(entt::exclude<ScoredTag>);
+            auto zone_view = reg.view<ObstacleTag, Obstacle, WorldTransform>(
+                entt::exclude<ScoredTag, NonScorableTag>);
             for (auto [ze, obstacle, zwt] : zone_view.each()) {
                 (void)obstacle;
                 if (ze == action.obstacle) continue; // don't self-block
@@ -465,7 +466,8 @@ void test_player_system(entt::registry& reg, float dt) {
             if (action.target_lane < next_lane) next_lane--;
             else if (action.target_lane > next_lane) next_lane++;
 
-            auto closer_view = reg.view<ObstacleTag, Obstacle, WorldTransform>(entt::exclude<ScoredTag>);
+            auto closer_view = reg.view<ObstacleTag, Obstacle, WorldTransform>(
+                entt::exclude<ScoredTag, NonScorableTag>);
             for (auto [oe, obstacle, owt] : closer_view.each()) {
                 (void)obstacle;
                 if (oe == action.obstacle) continue;
@@ -530,7 +532,8 @@ void test_player_system(entt::registry& reg, float dt) {
                                       && pending_shape_obstacle != action.obstacle);
         bool vert_zone_blocked = false;
         {
-            auto zone_view = reg.view<ObstacleTag, Obstacle, WorldTransform>(entt::exclude<ScoredTag>);
+            auto zone_view = reg.view<ObstacleTag, Obstacle, WorldTransform>(
+                entt::exclude<ScoredTag, NonScorableTag>);
             for (auto [ze, obstacle, zwt] : zone_view.each()) {
                 (void)obstacle;
                 if (ze == action.obstacle) continue;

--- a/app/util/session_logger.cpp
+++ b/app/util/session_logger.cpp
@@ -129,10 +129,12 @@ void session_log_on_obstacle_spawn(entt::registry& reg, entt::entity entity) {
     if (rlane) lane = rlane->lane;
 
     float arrival = beat ? beat->arrival_time : 0.0f;
-    const ObstacleKind kind = obstacle_kind_from_components(
-        reg.all_of<RequiredShape>(entity),
-        reg.all_of<BlockedLanes>(entity),
-        reg.all_of<RequiredLane>(entity));
+    const ObstacleKind kind = reg.all_of<OnsetMarkerTag>(entity)
+        ? ObstacleKind::OnsetMarker
+        : obstacle_kind_from_components(
+            reg.all_of<RequiredShape>(entity),
+            reg.all_of<BlockedLanes>(entity),
+            reg.all_of<RequiredLane>(entity));
     const std::string_view kind_name = session_log_enum_name_or_unknown(kind);
     const std::string_view shape_name = req ? session_log_enum_name_or_unknown(req->shape) : std::string_view{"-"};
 

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -279,7 +279,7 @@ TEST_CASE("beat_scheduler: spawns multiple beats when time is past all", "[beat_
 
     int count = 0;
     for (auto e : reg.view<ObstacleTag>()) { ++count; (void)e; }
-    CHECK(count == 3);
+    CHECK(count == 4);
     CHECK(song.next_spawn_idx == 4);
 }
 
@@ -298,6 +298,63 @@ TEST_CASE("beat_scheduler: skips unsupported active beatmap obstacle kinds", "[b
 
     auto view = reg.view<ObstacleTag>();
     CHECK(view.begin() == view.end());
+    CHECK(song.next_spawn_idx == 1);
+}
+
+TEST_CASE("beat_scheduler: spawns OnsetMarker as visible non-scorable cue",
+          "[beat_scheduler][onset_marker][issue1042]") {
+    auto reg = make_rhythm_registry();
+    auto& song = reg.ctx().get<SongState>();
+    auto& map = beat_map(reg);
+    auto& score = reg.ctx().get<ScoreState>();
+    auto& energy = reg.ctx().get<EnergyState>();
+    auto& results = reg.ctx().get<SongResults>();
+
+    map.beats.push_back({0, ObstacleKind::OnsetMarker, Shape::Circle, 1, 0});
+    song.song_time = 10.0f;
+    song.next_spawn_idx = 0;
+
+    beat_scheduler_system(reg, 0.016f);
+
+    auto view = reg.view<ObstacleTag, OnsetMarkerTag, NonScorableTag, Obstacle,
+                         BeatInfo, WorldTransform, ObstacleChildren>();
+    REQUIRE(view.size_hint() == 1);
+
+    entt::entity cue = entt::null;
+    for (auto [e, obstacle, beat, wt, children] : view.each()) {
+        (void)beat;
+        cue = e;
+        CHECK(obstacle.base_points == int16_t{0});
+        CHECK_FALSE(reg.all_of<RequiredShape>(e));
+        CHECK_FALSE(reg.all_of<BlockedLanes>(e));
+        CHECK_FALSE(reg.all_of<RequiredLane>(e));
+        REQUIRE(children.count == 1);
+        const auto child = children.children[0];
+        REQUIRE(reg.valid(child));
+        REQUIRE(reg.all_of<MeshChild>(child));
+        const auto& mesh = reg.get<MeshChild>(child);
+        CHECK(mesh.mesh_type == MeshType::Slab);
+        CHECK_THAT(mesh.width, Catch::Matchers::WithinAbs(constants::SCREEN_W_F, 0.01f));
+
+        wt.position.y = constants::DESTROY_Y + 10.0f;
+    }
+    REQUIRE(reg.valid(cue));
+
+    const int score_before = score.score;
+    const int chain_before = score.chain_count;
+    const float energy_before = energy.energy;
+    const int misses_before = results.miss_count;
+
+    miss_detection_system(reg, 0.0f);
+    scoring_system(reg, 0.0f);
+    energy_system(reg, 0.0f);
+
+    CHECK_FALSE(reg.all_of<MissTag>(cue));
+    CHECK_FALSE(reg.all_of<ScoredTag>(cue));
+    CHECK(score.score == score_before);
+    CHECK(score.chain_count == chain_before);
+    CHECK(energy.energy == energy_before);
+    CHECK(results.miss_count == misses_before);
     CHECK(song.next_spawn_idx == 1);
 }
 
@@ -344,7 +401,7 @@ TEST_CASE("beat_scheduler: spawns all queued beats from BeatMap entries", "[beat
         ++obstacle_count;
         if (reg.all_of<RequiredShape>(e)) ++shape_gate_count;
     }
-    CHECK(obstacle_count == 2);
+    CHECK(obstacle_count == 3);
     CHECK(shape_gate_count == 2);
     CHECK(song.next_spawn_idx == 3);
 }


### PR DESCRIPTION
## Summary\n- Spawn authored onset_marker beatmap entries instead of silently skipping them\n- Render onset markers as translucent non-blocking cue slabs with OnsetMarkerTag + NonScorableTag\n- Keep test player planning and scoring/miss systems from treating onset cues as gameplay obstacles\n\n## Root cause\nThe beat scheduler explicitly skipped ObstacleKind::OnsetMarker, and the render factory inferred render kind only from shape/lane/blocking components, so an onset cue with no gameplay requirements produced no visible mesh.\n\n## Verification\n- cmake -B build -S . -Wno-dev\n- cmake --build build --parallel\n- ./build/shapeshifter_tests "[beat_scheduler],[archetype],[scoring]"\n- ./build/shapeshifter_tests\n\nCloses #1042