### PR TITLE
Fix invalid SplitPath lane handling

### DIFF
--- a/app/entities/obstacle_entity.cpp
+++ b/app/entities/obstacle_entity.cpp
@@ -23,6 +23,9 @@ entt::entity spawn_obstacle_base(entt::registry& reg, const ObstacleSpawnParams&
     if (obstacle_kind_requires_shape(params.kind) && !is_valid_shape(params.shape)) {
         throw std::logic_error("Invalid obstacle shape");
     }
+    if (params.kind == ObstacleKind::SplitPath && !lane_utils::is_valid(params.req_lane)) {
+        throw std::logic_error("Invalid obstacle lane");
+    }
 
     auto e = reg.create();
     reg.emplace<WorldTransform>(e, WorldTransform{{params.x, params.y}});

--- a/app/systems/beat_scheduler_system.cpp
+++ b/app/systems/beat_scheduler_system.cpp
@@ -9,6 +9,7 @@
 #include "../components/rendering.h"
 #include "../constants.h"
 #include "../entities/settings.h"
+#include "../util/lane_utils.h"
 
 #include <cmath>
 
@@ -74,12 +75,12 @@ void beat_scheduler_system(entt::registry& reg, [[maybe_unused]] float dt) {
                 - (max_start_y - constants::SPAWN_Y) / song->scroll_speed;
         }
 
-        // Lane-bound obstacles use the authored lane directly.
-        float x_pos = constants::LANE_X[1];
+        // Lane-bound obstacles use a normalized lane so visual position and
+        // lane requirements cannot diverge on invalid beatmap data.
+        const int8_t spawn_lane = lane_utils::valid_or_default(entry.lane);
+        float x_pos = constants::LANE_X[static_cast<int>(spawn_lane)];
         const int lane = static_cast<int>(entry.lane);
-        if (lane >= 0 && lane < constants::LANE_COUNT) {
-            x_pos = constants::LANE_X[lane];
-        } else {
+        if (!lane_utils::is_valid(lane)) {
             TraceLog(LOG_WARNING, "Invalid beatmap lane %d; defaulting to center lane", lane);
         }
 
@@ -90,7 +91,7 @@ void beat_scheduler_system(entt::registry& reg, [[maybe_unused]] float dt) {
             start_y,
             entry.shape,
             entry.blocked_mask,
-            entry.lane,
+            spawn_lane,
             song->scroll_speed
         }, bi);
 

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -380,6 +380,33 @@ TEST_CASE("beat_scheduler: spawns SplitPath in authored lane", "[beat_scheduler]
     CHECK(song.next_spawn_idx == 1);
 }
 
+TEST_CASE("beat_scheduler: defaults invalid SplitPath lane to center lane", "[beat_scheduler][issue1046]") {
+    auto reg = make_rhythm_registry();
+    auto& song = reg.ctx().get<SongState>();
+    auto& map = beat_map(reg);
+
+    map.beats.push_back({0, ObstacleKind::SplitPath, Shape::Square, 9, 0});
+    song.song_time = 10.0f;
+    song.next_spawn_idx = 0;
+
+    CHECK_NOTHROW(beat_scheduler_system(reg, 0.016f));
+
+    auto view = reg.view<ObstacleTag, WorldTransform, RequiredShape, RequiredLane, ObstacleChildren>();
+    REQUIRE(view.size_hint() == 1);
+    for (auto [e, wt, shape, lane, children] : view.each()) {
+        (void)e;
+        CHECK_THAT(wt.position.x, Catch::Matchers::WithinAbs(constants::LANE_X[1], 0.01f));
+        CHECK(shape.shape == Shape::Square);
+        CHECK(lane.lane == int8_t{1});
+        REQUIRE(children.count == 3);
+        for (int i = 0; i < children.count; ++i) {
+            REQUIRE(reg.valid(children.children[i]));
+            CHECK(reg.all_of<MeshChild>(children.children[i]));
+        }
+    }
+    CHECK(song.next_spawn_idx == 1);
+}
+
 TEST_CASE("beat_scheduler: spawns all queued beats from BeatMap entries", "[beat_scheduler]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();

--- a/tests/test_high_score_persistence.cpp
+++ b/tests/test_high_score_persistence.cpp
@@ -6,6 +6,7 @@
 #include <string_view>
 
 #include "components/high_score.h"
+#include "content/level_content_config.h"
 #include "util/high_score_persistence.h"
 
 namespace {
@@ -23,7 +24,7 @@ void remove_path(const std::filesystem::path& path) {
 
 TEST_CASE("High score: keys are stable per song and difficulty", "[high_score]") {
     // make_key_hash() produces a stable FNV-1a hash: same inputs → same hash, different inputs → different hash.
-    // Collision risk across our 9 shipped keys ("1_stomper|easy" … "3_mental|hard") is negligible.
+    // Collision risk across our 9 shipped keys is negligible.
     const auto hash_easy = high_score::make_key_hash("song_001", "easy");
     const auto hash_hard = high_score::make_key_hash("song_001", "hard");
     CHECK(hash_easy == high_score::make_key_hash("song_001", "easy"));
@@ -53,20 +54,19 @@ TEST_CASE("High score: no hash collisions across all 9 shipped song+difficulty k
     // FNV-1a 32-bit collisions across exactly 9 short ASCII keys are negligible —
     // this test confirms the shipped set is collision-free and will catch any future
     // key additions that happen to collide.
-    const char* songs[]       = {"1_stomper", "2_drama", "3_mental"};
-    const char* diffs[]       = {"easy", "medium", "hard"};
+    constexpr int32_t key_count = content_config::LEVEL_COUNT * content_config::DIFFICULTY_COUNT;
 
-    entt::hashed_string::hash_type hashes[9]{};
+    entt::hashed_string::hash_type hashes[key_count]{};
     int32_t idx = 0;
-    for (const char* song : songs) {
-        for (const char* diff : diffs) {
+    for (const char* song : content_config::LEVEL_KEYS) {
+        for (const char* diff : content_config::DIFFICULTY_KEYS) {
             hashes[idx++] = high_score::make_key_hash(song, diff);
         }
     }
+    REQUIRE(idx == key_count);
 
-    // All 9 hashes must be distinct.
-    for (int32_t i = 0; i < 9; ++i) {
-        for (int32_t j = i + 1; j < 9; ++j) {
+    for (int32_t i = 0; i < key_count; ++i) {
+        for (int32_t j = i + 1; j < key_count; ++j) {
             CHECK(hashes[i] != hashes[j]);
         }
     }

--- a/tests/test_obstacle_archetypes.cpp
+++ b/tests/test_obstacle_archetypes.cpp
@@ -212,6 +212,18 @@ TEST_CASE("entity: spawn_obstacle rejects invalid ShapeGate shape before indexin
     CHECK(count_mesh_children(reg) == 0);
 }
 
+TEST_CASE("entity: spawn_obstacle rejects invalid SplitPath lane before creating entities",
+          "[archetype][validation][issue1046]") {
+    entt::registry reg;
+
+    CHECK_THROWS_AS(spawn_obstacle(reg, {ObstacleKind::SplitPath, 360.0f, -120.0f,
+                                         Shape::Square, uint8_t{0}, int8_t{3}}),
+                    std::logic_error);
+    CHECK(reg.view<ObstacleTag>().begin() == reg.view<ObstacleTag>().end());
+    CHECK(reg.view<WorldTransform>().begin() == reg.view<WorldTransform>().end());
+    CHECK(count_mesh_children(reg) == 0);
+}
+
 TEST_CASE("entity: ShapeGate Square - red color", "[archetype]") {
     entt::registry reg;
     auto e = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 60.0f, -120.0f, Shape::Square});


### PR DESCRIPTION
## Summary
- Normalize beatmap lanes before scheduling obstacles so invalid SplitPath data defaults consistently to the center lane
- Reject invalid SplitPath factory lanes before creating logical or mesh entities
- Make high-score collision coverage iterate shipped level/difficulty keys

## Verification
- `cmake -B build -S . -Wno-dev && cmake --build build -- -j$(sysctl -n hw.ncpu) && ./build/shapeshifter_tests`

Fixes #1046
Fixes #1047