### PR TITLE
Use captured swipe start for deferred gesture zone check

### DIFF
--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -378,14 +378,12 @@ void input_system(entt::registry& reg, float raw_dt) {
         Direction gesture_dir = Direction::Up;
         const bool has_gesture_swipe = raylib_gesture_swipe_direction(gesture_dir);
 
-        bool gesture_started_in_swipe_zone = false;
-        if (input.click) {
-            gesture_started_in_swipe_zone = input.end_y < constants::SCREEN_H_F * constants::SWIPE_ZONE_SPLIT;
-        } else {
-            const Vector2 touch_pos = GetTouchPosition(0);
-            const glm::vec2 tp = screen_to_virtual({touch_pos.x, touch_pos.y}, st);
-            gesture_started_in_swipe_zone = tp.y < constants::SCREEN_H_F * constants::SWIPE_ZONE_SPLIT;
-        }
+        // Gesture fired after the touch already ended: use the captured swipe
+        // start (set at touch-down) instead of GetTouchPosition(0), which would
+        // return stale data or fall back to the mouse cursor on raylib 5.x.
+        const float zone_threshold = constants::SCREEN_H_F * constants::SWIPE_ZONE_SPLIT;
+        const float gesture_origin_y = input.click ? input.end_y : input.start_y;
+        const bool gesture_started_in_swipe_zone = gesture_origin_y < zone_threshold;
 
         if (has_gesture_swipe && gesture_started_in_swipe_zone) {
             input.click = false;


### PR DESCRIPTION
Fixes #1051

## Problem

When raylib's gesture system fires a `GESTURE_SWIPE_*` one frame after the finger lifts (i.e. the deferred-gesture branch at `input_system.cpp:375-394`), the code was calling `GetTouchPosition(0)` to determine where the swipe started. At that point `GetTouchPointCount() == 0`, so raylib returns stale data — on raylib 5.x, `GetTouchPosition(0)` falls back to the mouse cursor when no touch is active. The zone classification therefore reflected the cursor position, not the actual swipe origin.

## Fix

`InputState::start_y` is already captured when a touch enters a slot (`input_system.cpp:258-259, 266-267`) and persists across the frame boundary into this branch. Read it directly instead of querying raylib.

```diff
-        bool gesture_started_in_swipe_zone = false;
-        if (input.click) {
-            gesture_started_in_swipe_zone = input.end_y < constants::SCREEN_H_F * constants::SWIPE_ZONE_SPLIT;
-        } else {
-            const Vector2 touch_pos = GetTouchPosition(0);
-            const glm::vec2 tp = screen_to_virtual({touch_pos.x, touch_pos.y}, st);
-            gesture_started_in_swipe_zone = tp.y < constants::SCREEN_H_F * constants::SWIPE_ZONE_SPLIT;
-        }
+        const float zone_threshold = constants::SCREEN_H_F * constants::SWIPE_ZONE_SPLIT;
+        const float gesture_origin_y = input.click ? input.end_y : input.start_y;
+        const bool gesture_started_in_swipe_zone = gesture_origin_y < zone_threshold;
```

## Verification

- `cmake --build build` (unity, `-Wall -Wextra -Werror`) — clean, zero warnings.
- `cmake --build build-nonunity` (per-TU) — clean, zero warnings.
- `./build/shapeshifter_tests` — all 899 tests / 2958 assertions pass.

## Acceptance criteria (from issue)

- [x] `GetTouchPosition(0)` is no longer called on a path where `GetTouchPointCount() == 0`.
- [x] Deferred swipe gesture classification uses the captured `input.start_y`.
- [x] Build remains zero-warning.
- [x] All 899 tests still pass.