### PR TITLE
Deduplicate enum_name_or_unknown template helper

### DIFF
--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -13,7 +13,6 @@
 #include "../constants.h"
 
 #include <raylib.h>
-#include <magic_enum/magic_enum.hpp>
 #include <cmath>
 #include <random>
 #include <string_view>
@@ -39,12 +38,6 @@ static const char* shape_key_name(Shape s) {
         case Shape::Triangle: return "key_3(Triangle)";
         default:              return "key_?(?)";
     }
-}
-
-template <typename E>
-std::string_view enum_name_or_unknown(E value) {
-    const std::string_view name = magic_enum::enum_name(value);
-    return name.empty() ? std::string_view{"???"} : name;
 }
 
 static bool test_player_shape_done(const TestPlayerAction& action) {

--- a/app/util/session_logger.cpp
+++ b/app/util/session_logger.cpp
@@ -11,18 +11,7 @@
 #include <string_view>
 #include <utility>
 
-#include <magic_enum/magic_enum.hpp>
 #include <raylib.h>
-
-namespace {
-
-template <typename E>
-std::string_view session_log_enum_name_or_unknown(E value) {
-    const std::string_view name = magic_enum::enum_name(value);
-    return name.empty() ? std::string_view{"???"} : name;
-}
-
-} // namespace
 
 // ── Core log function ────────────────────────────────────────
 
@@ -135,8 +124,8 @@ void session_log_on_obstacle_spawn(entt::registry& reg, entt::entity entity) {
             reg.all_of<RequiredShape>(entity),
             reg.all_of<BlockedLanes>(entity),
             reg.all_of<RequiredLane>(entity));
-    const std::string_view kind_name = session_log_enum_name_or_unknown(kind);
-    const std::string_view shape_name = req ? session_log_enum_name_or_unknown(req->shape) : std::string_view{"-"};
+    const std::string_view kind_name = enum_name_or_unknown(kind);
+    const std::string_view shape_name = req ? enum_name_or_unknown(req->shape) : std::string_view{"-"};
 
     session_log_write(*log, t, "GAME",
         "OBSTACLE_SPAWN beat=%d arrival=%.3f kind=%.*s shape=%.*s lane=%d",
@@ -168,7 +157,7 @@ void session_log_on_scored(entt::registry& reg, entt::entity entity) {
         reg.all_of<RequiredShape>(entity),
         reg.all_of<BlockedLanes>(entity),
         reg.all_of<RequiredLane>(entity));
-    const std::string_view kind_name = session_log_enum_name_or_unknown(kind);
+    const std::string_view kind_name = enum_name_or_unknown(kind);
 
     if (is_miss) {
         session_log_write(*log, t, "GAME",
@@ -177,7 +166,7 @@ void session_log_on_scored(entt::registry& reg, entt::entity entity) {
             beat_num, expected_t, drift,
             static_cast<int>(kind_name.size()), kind_name.data());
     } else if (grade) {
-        const std::string_view tier_name = session_log_enum_name_or_unknown(grade->tier);
+        const std::string_view tier_name = enum_name_or_unknown(grade->tier);
         session_log_write(*log, t, "GAME",
             "COLLISION obstacle=%u beat=%d expected=%.3f drift=%+.3fs kind=%.*s result=CLEAR timing=%.*s(%.2f)",
             static_cast<unsigned>(entt::to_integral(entity)),

--- a/app/util/session_logger.h
+++ b/app/util/session_logger.h
@@ -1,10 +1,21 @@
 #pragma once
 
 #include <entt/entt.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <cstddef>
 #include <cstdio>
 #include <cstdint>
 #include <string>
+#include <string_view>
+
+// Returns the enum name as a string_view, or "???" when magic_enum cannot
+// resolve the value (out-of-range / non-reflective). Intended for log lines
+// where an enum should print symbolically without aborting on bad data.
+template <typename E>
+std::string_view enum_name_or_unknown(E value) {
+    const std::string_view name = magic_enum::enum_name(value);
+    return name.empty() ? std::string_view{"???"} : name;
+}
 
 struct SessionLog {
     // Maximum bytes buffered per frame before a flush. Pre-reserved at


### PR DESCRIPTION
Resolves #1055.

## What changed
- Moved the `enum_name_or_unknown<E>` template from two anonymous-namespace copies into `app/util/session_logger.h`.
- Removed the local copies in `app/systems/test_player_system.cpp` (called `enum_name_or_unknown`) and `app/util/session_logger.cpp` (called `session_log_enum_name_or_unknown`).
- Dropped the now-unused `<magic_enum/magic_enum.hpp>` direct include from `test_player_system.cpp` (the header pulls it in transitively).

Both call sites already include `app/util/session_logger.h`, so no new dependencies were introduced.

## Verification
- `./build.sh` — zero warnings, all targets build.
- `ctest --test-dir build` — 911/911 tests pass (1 skipped: `startup_shutdown_smoke`).
- `grep -n "session_log_enum_name_or_unknown" app/` — zero matches (helper renamed back to `enum_name_or_unknown`).
