### PR TITLE
Mark isometric perspective spec as future/unimplemented

### DIFF
--- a/design-docs/isometric-perspective.md
+++ b/design-docs/isometric-perspective.md
@@ -1,5 +1,8 @@
 # Isometric Perspective Effect — Technical Spec (Per-Vertex)
 
+> **Status: Future / Unimplemented.**
+> This spec describes a presentation-only rendering effect that is **not** on `main`. As of this writing the game ships in flat 2D mode: there is no `perspective::` namespace, no `app/perspective.{h,cpp}`, and no `PERSPECTIVE_ANGLE_DEG` / `VP_Y` constant in `app/constants.h`. `design-docs/game.md` correctly hedges this with "the playfield **may** use a pseudo-isometric runway effect"; this document elaborates the design intent for when/if the effect is greenlit. Treat the file change lists and signatures below as a proposal, not a backlog of pending work.
+
 ## Goal
 
 Make the flat 2D game look like the player is viewing a track receding


### PR DESCRIPTION
Resolves #1056.

## What changed
- Added a "Status: Future / Unimplemented" callout directly under the H1 of `design-docs/isometric-perspective.md`.
- The banner names the absent symbols readers will not find on `main` (`perspective::` namespace, `PERSPECTIVE_ANGLE_DEG` / `VP_Y` constants, `app/perspective.{h,cpp}`) and cross-references `game.md`'s tentative "may use" framing.
- Spec body left untouched — design content is still useful as future reference.

## Verification
- `grep -rn "perspective::\|PERSPECTIVE_ANGLE\|VP_Y" app/` returns zero matches, confirming the banner's claims.
- No code files touched, so the build/test surface is unchanged; this is a docs-only change.
