### PR TITLE
Drop stale PARTICLE_LIFE/MAX_PARTICLES from architecture.md (#1059)

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -100,11 +100,17 @@ namespace constants {
 
     // ── Rendering ─────────────────────────────────────
     constexpr float POPUP_DURATION    = 1.2f;     // score popup lifetime
-    constexpr float PARTICLE_LIFE    = 0.6f;
-    constexpr int   MAX_PARTICLES     = 50;
+
+    // ── Particles ─────────────────────────────────────
+    constexpr float PARTICLE_GRAVITY  = 600.0f;   // px/s² applied per frame
 
 } // namespace constants
 ```
+
+> Particle lifetime and burst size are **not** global constants. Each particle
+> stores its own lifetime in `ParticleData::max_time` (see
+> `app/components/particle.h`), and emitters choose per-event lifetimes and
+> counts at the spawn site (e.g. `scoring_system.cpp` for hit feedback bursts).
 
 ---
 


### PR DESCRIPTION
Closes #1059.

## Problem

`design-docs/architecture.md` section 1 (Constants) documented two rendering constants that **never existed** in the codebase:

```cpp
constexpr float PARTICLE_LIFE    = 0.6f;
constexpr int   MAX_PARTICLES     = 50;
```

A developer reading the doc to tune particle behaviour would chase phantom symbols.

## Reality (from code)

- `app/constants.h` defines `POPUP_DURATION` (Rendering) and `PARTICLE_GRAVITY` (Particles) — those are the only globals in this area.
- Particle lifetime is **per-entity**, stored in `ParticleData::max_time` (`app/components/particle.h`) and set at each spawn site (e.g. `scoring_system.cpp:75` for hit-feedback bursts).
- There is no global cap on particle count; emitters choose burst sizes locally.

## Fix

Doc-only:
- Drop the two phantom lines.
- Split the section into `Rendering` (just `POPUP_DURATION`) and a new `Particles` subsection that lists the real `PARTICLE_GRAVITY` constant.
- Add a short callout pointing readers to `ParticleData::max_time` and the spawn sites for per-entity lifetime/burst-size tuning.

## Verification

- `grep -rn 'PARTICLE_LIFE\|MAX_PARTICLES' design-docs/ app/` → no matches.
- `cmake --build build` → clean.
- `./build/shapeshifter_tests` → 2958 assertions in 899 test cases pass.
- No code changes.

## Acceptance criteria

- [x] `design-docs/architecture.md` no longer references `PARTICLE_LIFE` or `MAX_PARTICLES`.
- [x] Section accurately points to where particle lifetime/limit is actually defined.
- [x] No code changes.