### PR TITLE
Point Settings→Title back-action ref to settings controller (#1062)

### DIFF
--- a/design-docs/game-flow.md
+++ b/design-docs/game-flow.md
@@ -131,7 +131,7 @@ Shipped transitions, by controller, as of Round 6 audit:
 
 - `Title → LevelSelect` — body tap (`title_screen_controller.cpp:62-72`).
 - `Title → Settings` — gear-icon tap (same controller).
-- `Settings → Title` — back action (`ui_render_system.cpp:117-122`).
+- `Settings → Title` — back action (`settings_screen_controller.cpp:101-104` and `:141-144`).
 - `LevelSelect → Tutorial` — song selection when FTUE is incomplete.
 - `LevelSelect → Playing` — song selection after FTUE is complete.
 - `Playing ↔ Paused` — pause button / resume.


### PR DESCRIPTION
Closes #1062.

## Problem

`design-docs/game-flow.md` line 134 cited `ui_render_system.cpp:117-122` for the `Settings → Title` back action, but those lines are the `GameOver` / `SongComplete` switch cases in the UI render dispatcher — no transition logic at all.

## Fix

Point the bullet at the real source. The back action is set in two branches of `settings_screen_controller.cpp`:
- `:101-104` — close button pressed before settings state is loaded
- `:141-144` — close button pressed after a settings change has been processed

Both set `gs.next_phase = GamePhase::Title;`.

## Verification

- `grep -n 'next_phase = GamePhase::Title' app/ui/screen_controllers/settings_screen_controller.cpp` → 103, 143.
- Sibling bullet `Title → LevelSelect` (line 132) — `title_screen_controller.cpp:62-72` still correct (covers both gear-tap and start-tap dispatch).
- Other bullets in lines 130–144 don't carry explicit file refs, so no further fixups needed in the same edit.
- Doc-only; no build needed.

## Acceptance criteria

- [x] Line 134 cites a file:line that actually contains the `Settings → Title` transition.
- [x] Other cross-references in the shipping-transitions list confirmed current.
- [x] No code changes.