### PR TITLE
Rename phantom camera_system to game_camera_system in architecture.md (#1061)

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -580,7 +580,7 @@ struct ParticleTag {};
 ```
 
 Score feedback particles are spawned by `scoring_system` when a scored obstacle
-is processed. `particle_system` owns lifetime/gravity and `camera_system` builds
+is processed. `particle_system` owns lifetime/gravity and `game_camera_system` builds
 their effects-pass `ModelTransform` for rendering.
 
 ### 2.12 — COLD: Audio (singleton)


### PR DESCRIPTION
Closes #1061.

## Problem

`design-docs/architecture.md` line 583 (Section 2.11 — Particles) named a system that doesn't exist:

> `particle_system` owns lifetime/gravity and `camera_system` builds their effects-pass `ModelTransform` for rendering.

There is no symbol `camera_system` in the codebase. The actual implementation lives in `app/systems/camera_system.cpp` (the file is named `camera_system`, but it defines two functions, `game_camera_system` and `ui_camera_system`).

## Fix

Rename the in-text reference to `game_camera_system`, the function that actually builds particle `ModelTransform`s.

## Verification

- `grep -nE 'void.*camera_system' app/systems/runtime_systems.h app/systems/camera_system.cpp` → only `game_camera_system` and `ui_camera_system`; no bare `camera_system`.
- `app/systems/camera_system.cpp:319-332` — particle transform block lives inside `game_camera_system`, confirming the rename target.
- `grep -nE '\bcamera_system\b' design-docs/architecture.md` → no matches (the only occurrence is now `game_camera_system`).
- Doc-only; no build needed.

## Acceptance criteria

- [x] Line 583 names `game_camera_system` to match `runtime_systems.h`.
- [x] No bare `camera_system` references remain in the doc.
- [x] No code changes.