### PR TITLE
Document real three-function render split in architecture.md §8.6 (#1063)

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -1531,10 +1531,27 @@ collision window — but that day will not come for an endless runner.
 
 ### 8.6 Render System Organization
 
-The render system draws in layer order to avoid sorting:
+The render layer is implemented as three free functions in
+`app/systems/runtime_systems.h`, called in this order each frame from
+`main.cpp`:
+
+- `floor_render_system(const entt::registry&)` — Layer 0 (floor / background grid)
+- `game_render_system(const entt::registry&, float alpha)` — Layers 1–2
+  (obstacles, player, particles, score popups)
+- `ui_render_system(entt::registry&, float alpha)` — Layer 3 + screen overlays
+  (HUD, title, pause, game over, settings, song-complete)
+
+Note that `ui_render_system` takes a non-const registry because UI controllers
+mutate state (e.g., button presses queue phase transitions), while the two
+game-world passes are read-only.
+
+The pseudocode below is a single-function illustration of the combined
+per-frame draw order; the real code splits these layers across the three
+functions above.
 
 ```cpp
-void render_system(entt::registry& reg, float alpha) {
+// Combined render-layer pseudocode (real implementation is split — see above).
+void render_frame_pseudocode(entt::registry& reg, float alpha) {
     ClearBackground({18, 18, 24, 255});
 
     auto phase = reg.ctx().get<GameState>().phase;


### PR DESCRIPTION
Closes #1063.

## Problem

`design-docs/architecture.md` §8.6 ("Render System Organization") presented a single pseudocode entry point that doesn't exist in the codebase:

```cpp
void render_system(entt::registry& reg, float alpha) {
    ClearBackground({18, 18, 24, 255});
    // ...
}
```

Real implementation (`app/systems/runtime_systems.h:40-42`) splits the render layer across **three** free functions:

- `floor_render_system(const entt::registry&)` — no alpha param, read-only
- `game_render_system(const entt::registry&, float alpha)` — read-only
- `ui_render_system(entt::registry&, float alpha)` — non-const (UI controllers mutate phase state)

A reader greppin' `render_system(` from §8.6 would find no implementation; the section also contradicted §6 (main loop), which already shows both `game_render_system` and `ui_render_system` being called.

## Fix

Rewrite the §8.6 intro to enumerate the real three functions with correct signatures and a one-line note about the const-vs-non-const distinction. Rename the pseudocode wrapper from `render_system` to `render_frame_pseudocode` and prefix it with a comment marking it as illustration. Pseudocode body is kept intact — it still correctly describes the combined per-frame draw order.

## Verification

- `grep -nE 'void.*render_system' app/systems/runtime_systems.h` → `floor_render_system`, `game_render_system`, `ui_render_system` (no bare `render_system`).
- `grep -nE '\brender_system\(' design-docs/architecture.md` → no matches (the only standalone reference is gone; `game_render_system(`/`ui_render_system(` matches preserved on lines 1109, 1110, 1310, 1539, 1541).
- Other `render_system` references in the doc (lines 129, 162, 204, 212) are conceptual doc-comments inside component declarations in §2 — explicitly out of this issue's scope (§8 cross-check only).
- Doc-only; no build needed.

## Acceptance criteria

- [x] §8.6 no longer claims a `render_system(entt::registry&, float)` function exists.
- [x] Real split into `floor_/game_/ui_render_system` reflected with correct signatures and the const/non-const distinction called out.
- [x] `grep -nE '\brender_system\(' design-docs/architecture.md` matches nothing not also covered by the unified-pseudocode framing or `game_/ui_/floor_` prefixes.
- [x] No code changes.