### PR TITLE
Sync rhythm-spec.md SongResults to match song_state.h (#1067)

### DIFF
--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -257,13 +257,13 @@ one reference.
 
 ```cpp
 struct SongResults {
-    int  perfects = 0;
-    int  goods    = 0;
-    int  oks      = 0;
-    int  misses   = 0;
-    int  chain    = 0;
-    int  max_chain = 0;
-    int  score    = 0;
+    int   perfect_count = 0;
+    int   good_count    = 0;
+    int   ok_count      = 0;
+    int   bad_count     = 0;
+    int   miss_count    = 0;
+    int   max_chain     = 0;
+    int   total_notes   = 0;
 };
 ```
 
@@ -714,7 +714,7 @@ if (!song) return;  // no rhythm context — skip
 
 ## Phase 6 — Results screen (PLANNED)
 ```
-  • SongResults: perfects/goods/oks/misses/chain/score
+  • SongResults: perfect_count/good_count/ok_count/bad_count/miss_count/max_chain/total_notes
   • Grade calculation: S/A/B/C/D/F from accuracy %
   • Results screen: shown on song completion or MISS game-over
 ```


### PR DESCRIPTION
Closes #1067.

## Problem

`design-docs/rhythm-spec.md` §3 ECS Components defined `SongResults` with stale field names that no longer compile against the real struct in `app/components/song_state.h:63-71`:

| Doc field | Real field |
|-----------|------------|
| `perfects` | `perfect_count` |
| `goods` | `good_count` |
| `oks` | `ok_count` |
| `misses` | `miss_count` |
| `chain` | *(removed)* |
| `score` | *(removed; new `total_notes`)* |
| — | `bad_count` *(added)* |

`design-docs/beatmap-integration.md:149-153` already shows the correct names, so `rhythm-spec.md` was the only stale source for this struct.

## Fix

- Replace the §3 struct block (lines 258-268) with the canonical definition from `app/components/song_state.h`.
- Update the matching one-line summary in §Phase 6 (lines ~717) so it lists the same fields.

## Verification

```
$ grep -n "perfects\|goods\|misses\|chain    = 0\|score    = 0" design-docs/rhythm-spec.md
(no matches)
```

No code changed — pure docs sync.
