### PR TITLE
Sync architecture.md ScoreState to include passive_score_remainder (#1071)

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -352,12 +352,13 @@ struct ParticleData {
 
 /// Singleton: overall score state. Written by scoring_system only.
 struct ScoreState {
-    int32_t  score;              // banked score
-    int32_t  displayed_score;    // for smooth scroll-up animation
-    int32_t  high_score;         // persisted across sessions
-    int32_t  chain_count;        // consecutive obstacles cleared
-    float    chain_timer;        // seconds since last clear, retained across rests
-    float    distance_traveled;  // total pixels scrolled (for distance bonus)
+    int32_t score                   = 0;     // banked score
+    int32_t displayed_score         = 0;     // for smooth scroll-up animation
+    int32_t high_score              = 0;     // persisted across sessions
+    int32_t chain_count             = 0;     // consecutive obstacles cleared
+    float   chain_timer             = 0.0f;  // seconds since last clear, retained across rests
+    float   distance_traveled       = 0.0f;  // total pixels scrolled (for distance bonus)
+    float   passive_score_remainder = 0.0f;  // fractional passive score carried across fixed ticks
 };
 
 /// Score popup entity component. 8 bytes.


### PR DESCRIPTION
Closes #1071

## What

Add the `passive_score_remainder` field to the `ScoreState` block in `design-docs/architecture.md` §2.6 so the canonical component reference matches `app/components/scoring.h` (the field was introduced by #962 but never propagated to architecture.md).

Also align field initializers with the canonical header style already used by feature-specs.md SPEC 2 (`= 0` for ints, `= 0.0f` for floats).

## Why

Doc drift — a developer reading architecture.md §2.6 would believe `ScoreState` has six fields and miss the fractional accumulator that drives passive per-second scoring at the production 60 Hz fixed timestep (see `scoring_system.cpp:102-106`).

## Verification

- `grep -n 'passive_score_remainder' design-docs/architecture.md` returns line 361 ✓
- Field order and initializers match `app/components/scoring.h` ✓
- Pure docs sync — no code, no tests, no other docs touched ✓