### PR TITLE
Sync rhythm-spec.md §3 SongState struct to match canonical header (#1078)

### DIFF
--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -206,12 +206,33 @@ struct BeatMap {
 
 ```cpp
 struct SongState {
-    float  song_time      = 0.0f;   // seconds elapsed
-    int    current_beat   = 0;      // index of next unspawned obstacle
-    float  scroll_speed   = 600.0f; // px/s, derived from BPM + difficulty
-    float  morph_duration = 0.1f;   // seconds, derived from BPM for MorphIn/MorphOut
-    float  half_window    = 0.150f; // half the OK window in seconds
-    bool   playing        = false;  // true only when beats array is non-empty
+    // ── Session-init fields (set by init_song_state / setup_play_session) ──
+    // Copied from BeatMap; fixed for the lifetime of a session.
+    float bpm             = 120.0f;
+    float offset          = 0.0f;
+    int   lead_beats      = 4;
+    float duration_sec    = 180.0f;
+
+    // ── Derived fields (computed once by util/rhythm_math.h) ────────────────
+    // Recalculated from bpm/lead_beats at session init; read-only during play.
+    float beat_period     = 0.5f;   // seconds per beat
+    float lead_time       = 2.0f;   // total approach window in seconds
+    float scroll_speed    = constants::APPROACH_DIST / lead_time; // pixels per second
+    float window_duration = 0.3f;   // hit-window width in seconds
+    float half_window     = 0.15f;  // window_duration / 2
+    float morph_duration  = 0.1f;   // shape-morph animation length in seconds
+
+    // ── Per-frame mutable fields ─────────────────────────────────────────────
+    float  song_time     = 0.0f;   // mutated every frame by song_playback_system
+    int    current_beat  = -1;     // mutated every frame by song_playback_system
+    bool   playing       = false;  // set true by setup_play_session; cleared by
+                                   //   song_playback_system or terminal GameOver entry
+    bool   finished      = false;  // set true by song_playback_system or terminal GameOver entry
+    bool   restart_music = false;  // set true by setup_play_session; consumed/cleared
+                                   //   on the next tick by song_playback_system
+
+    // ── Beat-schedule cursor (per-frame, reset at session init) ─────────────
+    size_t next_spawn_idx = 0;     // advanced each frame by beat_scheduler_system
 };
 ```
 


### PR DESCRIPTION
Closes #1078

## What

Replace the outdated 6-field `SongState` snippet in `design-docs/rhythm-spec.md` §3 with the full 14-field struct from `app/components/song_state.h`, organized by lifecycle (Session-init / Derived / Per-frame mutable / Beat-schedule cursor) to mirror the canonical header.

Also fixes two wrong initializers that were already in the doc:
- `current_beat = 0` → `-1`
- `scroll_speed = 600.0f` → `constants::APPROACH_DIST / lead_time`

## Why

P1 doc drift — a developer reading rhythm-spec.md would have a fundamentally wrong mental model of which fields are session-init inputs (`bpm`, `offset`, `lead_beats`, `duration_sec`), which are derived (`beat_period`, `lead_time`, `window_duration`, etc.), which mutate per-frame (`song_time`, `current_beat`, `playing`, `finished`, `restart_music`), and the beat-schedule cursor (`next_spawn_idx`).

## Verification

Every canonical field name now appears in the §3 SongState section:

```
bpm offset lead_beats duration_sec beat_period lead_time
scroll_speed window_duration half_window morph_duration
song_time current_beat playing finished restart_music next_spawn_idx
```

Pure docs sync — no code, no tests, no other docs touched.

(Note: original PR title/body incorrectly referenced #1077; corrected to #1078 — the actual issue this PR addresses. #1077 remains open.)