### PR TITLE
Sync architecture.md to main.cpp → game_loop.cpp split (#1074)

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -1030,7 +1030,8 @@ variable refresh rates mean we cannot assume a stable frame time.
 Cap accumulator to prevent spiral of death after app-resume pauses.
 
 ```cpp
-// main.cpp — complete main loop pseudocode
+// game_loop.cpp — complete main loop pseudocode (entry point lives in main.cpp,
+// which only parses CLI args and delegates into game_loop_run / game_loop_frame)
 
 #include <raylib.h>
 #include <entt/entt.hpp>
@@ -1533,14 +1534,21 @@ collision window — but that day will not come for an endless runner.
 ### 8.6 Render System Organization
 
 The render layer is implemented as three free functions in
-`app/systems/runtime_systems.h`, called in this order each frame from
-`main.cpp`:
+`app/systems/runtime_systems.h`. Only **two** are called directly from the
+per-frame loop in `app/game_loop.cpp` (`game_loop_frame`); the third is
+invoked internally:
 
-- `floor_render_system(const entt::registry&)` — Layer 0 (floor / background grid)
-- `game_render_system(const entt::registry&, float alpha)` — Layers 1–2
-  (obstacles, player, particles, score popups)
-- `ui_render_system(entt::registry&, float alpha)` — Layer 3 + screen overlays
-  (HUD, title, pause, game over, settings, song-complete)
+- `game_render_system(const entt::registry&, float alpha)` — called from the
+  frame loop. Owns the 3D pass: clears the world target, sets up the camera,
+  and internally calls `floor_render_system(reg)` (Layer 0, floor /
+  background grid) before drawing Layers 1–2 (obstacles, player, particles,
+  score popups).
+- `ui_render_system(entt::registry&, float alpha)` — called from the frame
+  loop. Owns Layer 3 + screen overlays (HUD, title, pause, game over,
+  settings, song-complete).
+- `floor_render_system(const entt::registry&)` — **not** called from the
+  frame loop; invoked from inside `game_render_system` so it shares the same
+  3D camera / world render target.
 
 Note that `ui_render_system` takes a non-const registry because UI controllers
 mutate state (e.g., button presses queue phase transitions), while the two
@@ -1638,7 +1646,8 @@ void render_frame_pseudocode(entt::registry& reg, float alpha) {
 ```
 app/
 ├── CMakeLists.txt
-├── main.cpp                     ← main loop (§6)
+├── main.cpp                     ← thin entry stub: parses CLI args, calls game_loop_run
+├── game_loop.cpp                ← main loop (§6): game_loop_frame, game_loop_run
 ├── constants.h                  ← all tuning knobs (§1)
 │
 ├── components/                  ← all component structs


### PR DESCRIPTION
Closes #1074

## What

Fixes three stale `main.cpp` references in `design-docs/architecture.md`:

1. **§6 pseudocode header (line 1033)** — relabel as `game_loop.cpp` with a note that `main.cpp` is just the CLI entry stub delegating to `game_loop_run`.
2. **§8.6 render organization (lines 1535-1543)** — only **two** of the three render functions (`game_render_system`, `ui_render_system`) are called from the per-frame loop in `game_loop.cpp`; `floor_render_system` is invoked **internally** from `game_render_system` (so it shares the 3D camera / world render target). Rewrote the section to make this call structure explicit.
3. **§8.7 directory tree (line 1641)** — split into two rows so both `main.cpp` (entry stub) and `game_loop.cpp` (main loop) are shown with their real responsibilities.

## Why

P2 doc drift — a developer reading the architecture doc would search `main.cpp` for the main loop and the render dispatch and find neither. The §8.6 description was also wrong about which render functions are invoked from the frame loop vs. which are internal.

## Verification

```
$ grep -n 'main\.cpp\|game_loop\.cpp' design-docs/architecture.md
1033:// game_loop.cpp — complete main loop pseudocode (entry point lives in main.cpp,
1538:per-frame loop in `app/game_loop.cpp` (`game_loop_frame`); the third is
1649:├── main.cpp                     ← thin entry stub: parses CLI args, calls game_loop_run
1650:├── game_loop.cpp                ← main loop (§6): game_loop_frame, game_loop_run
```

Cross-checked against `app/game_loop.cpp` (lines 281, 286 call `game_render_system` / `ui_render_system`) and `app/systems/game_render_system.cpp:70` (`floor_render_system(reg)` called inside).

Pure docs sync — no code changes.