### PR TITLE
Remove dead PlayerShape::previous field and all 6 write sites (#1076)

### DIFF
--- a/app/components/player.h
+++ b/app/components/player.h
@@ -15,7 +15,6 @@ struct PlayerTag {};
 // Hot render data — read by render_system, player_movement_system every frame.
 struct PlayerShape {
     Shape current  = Shape::Circle;
-    Shape previous = Shape::Circle;
     float morph_t  = 1.0f;
 };
 

--- a/app/entities/player_entity.cpp
+++ b/app/entities/player_entity.cpp
@@ -17,7 +17,6 @@ entt::entity create_player_entity(entt::registry& reg) {
     {
         PlayerShape ps;
         ps.current  = Shape::Hexagon;
-        ps.previous = Shape::Hexagon;
         reg.emplace<PlayerShape>(player, ps);
     }
     {

--- a/app/systems/player_input_system.cpp
+++ b/app/systems/player_input_system.cpp
@@ -77,9 +77,7 @@ void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt)
     }
 
     auto begin_shape_window = [&](PlayerShape& ps, ShapeWindow& sw) {
-        Shape previous_shape = ps.current;
         sw.target_shape = pressed_shape;
-        ps.previous = previous_shape;
         sw.phase = WindowPhase::MorphIn;
         sw.window_timer = 0.0f;
         sw.window_start = song->song_time;
@@ -107,7 +105,6 @@ void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt)
             }
         } else {
             if (pressed_shape != pshape.current) {
-                pshape.previous = pshape.current;
                 pshape.current  = pressed_shape;
                 pshape.morph_t  = 1.0f;
                 const auto& sc = constants::SHAPE_COLORS[pressed_shape_index];

--- a/app/systems/shape_window_system.cpp
+++ b/app/systems/shape_window_system.cpp
@@ -102,7 +102,6 @@ void shape_window_system(entt::registry& reg, [[maybe_unused]] float dt) {
                     swindow.phase = WindowPhase::MorphOut;
                     swindow.window_start = swindow.window_start + effective_duration;
                     swindow.window_timer = 0.0f;
-                    pshape.previous = pshape.current;
                     pshape.morph_t = 0.0f;
                 }
                 break;
@@ -116,7 +115,6 @@ void shape_window_system(entt::registry& reg, [[maybe_unused]] float dt) {
                              song->morph_duration);
                     pshape.morph_t = 1.0f;
                     pshape.current = Shape::Hexagon;
-                    pshape.previous = Shape::Hexagon;
                     swindow.target_shape = Shape::Hexagon;
                     swindow.phase = WindowPhase::Idle;
                     swindow.window_timer = 0.0f;
@@ -130,7 +128,6 @@ void shape_window_system(entt::registry& reg, [[maybe_unused]] float dt) {
                 if (pshape.morph_t >= 1.0f) {
                     pshape.morph_t = 1.0f;
                     pshape.current = Shape::Hexagon;
-                    pshape.previous = Shape::Hexagon;
                     swindow.target_shape = Shape::Hexagon;
                     swindow.phase = WindowPhase::Idle;
                     swindow.window_timer = 0.0f;

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -66,7 +66,6 @@ TEST_CASE("components: UIPosition is distinct screen-space placement", "[compone
 TEST_CASE("components: PlayerShape defaults to Circle", "[components]") {
     PlayerShape ps{};
     CHECK(ps.current == Shape::Circle);
-    CHECK(ps.previous == Shape::Circle);
     CHECK(ps.morph_t == 1.0f);
 }
 

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -187,7 +187,6 @@ inline entt::entity make_rhythm_player(entt::registry& reg) {
     auto player = make_player(reg);
     auto& ps = reg.get<PlayerShape>(player);
     ps.current = Shape::Hexagon;
-    ps.previous = Shape::Hexagon;
     auto& sw = reg.get<ShapeWindow>(player);
     sw.target_shape = Shape::Hexagon;
     sw.phase = WindowPhase::Idle;

--- a/tests/test_helpers_and_functions.cpp
+++ b/tests/test_helpers_and_functions.cpp
@@ -196,7 +196,6 @@ TEST_CASE("make_rhythm_player: starts as Hexagon", "[helpers]") {
     auto player = make_rhythm_player(reg);
     auto& ps = reg.get<PlayerShape>(player);
     CHECK(ps.current == Shape::Hexagon);
-    CHECK(ps.previous == Shape::Hexagon);
     auto& sw = reg.get<ShapeWindow>(player);
     CHECK(sw.target_shape == Shape::Hexagon);
     CHECK(sw.phase == WindowPhase::Idle);

--- a/tests/test_perspective.cpp
+++ b/tests/test_perspective.cpp
@@ -176,7 +176,7 @@ TEST_CASE("game_camera_system rejects invalid PlayerShape before mesh lookup", "
     auto player = reg.create();
     reg.emplace<PlayerTag>(player);
     reg.emplace<WorldTransform>(player, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
-    reg.emplace<PlayerShape>(player, PlayerShape{static_cast<Shape>(255), Shape::Hexagon, 1.0f});
+    reg.emplace<PlayerShape>(player, PlayerShape{static_cast<Shape>(255), 1.0f});
     reg.emplace<VerticalState>(player);
     reg.emplace<Color>(player, WHITE);
     reg.emplace<ModelTransform>(player, ModelTransform{glm::mat4{1.0f}, WHITE, 255, MeshType::Shape});

--- a/tests/test_player_action_rhythm.cpp
+++ b/tests/test_player_action_rhythm.cpp
@@ -167,7 +167,6 @@ TEST_CASE("player_action: rhythm mode ACCEPTS button press during MorphOut (#209
     song.song_time = 15.0f;
     sw.phase = WindowPhase::MorphOut;
     ps.current = Shape::Circle;
-    ps.previous = Shape::Circle;
     sw.window_timer = 0.05f;
     sw.window_start = 14.9f;
 
@@ -199,7 +198,6 @@ TEST_CASE("player_action: legacy mode instant shape change", "[player_legacy]") 
 
     auto& ps = reg.get<PlayerShape>(player);
     CHECK(ps.current == Shape::Triangle);
-    CHECK(ps.previous == Shape::Circle);
     CHECK(ps.morph_t == 1.0f);
     CHECK(drain_sfx_events(reg).count > 0);
 }

--- a/tests/test_player_archetype.cpp
+++ b/tests/test_player_archetype.cpp
@@ -39,7 +39,6 @@ TEST_CASE("player_entity: initial shape is Hexagon", "[archetype][player]") {
 
     auto& ps = reg.get<PlayerShape>(p);
     CHECK(ps.current  == Shape::Hexagon);
-    CHECK(ps.previous == Shape::Hexagon);
 }
 
 TEST_CASE("player_entity: ShapeWindow starts Idle targeting Hexagon", "[archetype][player]") {

--- a/tests/test_player_input_rhythm_extended.cpp
+++ b/tests/test_player_input_rhythm_extended.cpp
@@ -162,7 +162,6 @@ TEST_CASE("player_input: non-rhythm shape press changes immediately", "[player]"
     auto view = reg.view<PlayerTag, PlayerShape>();
     for (auto [e, ps] : view.each()) {
         CHECK(ps.current == Shape::Square);
-        CHECK(ps.previous == Shape::Circle);
         CHECK(ps.morph_t == 1.0f);
     }
 

--- a/tests/test_player_systems.cpp
+++ b/tests/test_player_systems.cpp
@@ -16,7 +16,6 @@ TEST_CASE("player_action: shape change on button press", "[player]") {
     auto view = reg.view<PlayerTag, PlayerShape>();
     for (auto [e, ps] : view.each()) {
         CHECK(ps.current  == Shape::Triangle);
-        CHECK(ps.previous == Shape::Circle);
         CHECK(ps.morph_t  == 1.0f);
     }
     // Should have pushed ShapeShift SFX

--- a/tests/test_redfoot_testflight_ui.cpp
+++ b/tests/test_redfoot_testflight_ui.cpp
@@ -86,7 +86,7 @@ void spawn_aligned_player(entt::registry& reg, float y) {
     auto p = reg.create();
     reg.emplace<PlayerTag>(p);
     reg.emplace<WorldTransform>(p, WorldTransform{{constants::LANE_X[1], y}});
-    PlayerShape ps; ps.current = Shape::Hexagon; ps.previous = Shape::Hexagon;
+    PlayerShape ps; ps.current = Shape::Hexagon;
     reg.emplace<PlayerShape>(p, ps);
     ShapeWindow sw{};
     sw.phase = WindowPhase::Idle;

--- a/tests/test_shape_window_extended.cpp
+++ b/tests/test_shape_window_extended.cpp
@@ -75,7 +75,6 @@ TEST_CASE("shape_window: MorphOut returns to Idle with Hexagon", "[shape_window]
     auto& song = reg.ctx().get<SongState>();
 
     ps.current = Shape::Circle;
-    ps.previous = Shape::Circle;
     sw.phase = WindowPhase::MorphOut;
     sw.window_start = song.song_time;
     sw.press_time = song.song_time - 0.25f;
@@ -87,7 +86,6 @@ TEST_CASE("shape_window: MorphOut returns to Idle with Hexagon", "[shape_window]
 
     CHECK(sw.phase == WindowPhase::Idle);
     CHECK(ps.current == Shape::Hexagon);
-    CHECK(ps.previous == Shape::Hexagon);
     CHECK(sw.target_shape == Shape::Hexagon);
     CHECK(sw.press_time == -1.0f);
     CHECK(sw.window_scale == 1.0f);

--- a/tests/test_shape_window_system.cpp
+++ b/tests/test_shape_window_system.cpp
@@ -48,7 +48,6 @@ TEST_CASE("shape_window: MorphIn completes and transitions to Active", "[shape_w
 
     sw.phase = WindowPhase::MorphIn;
     sw.target_shape = Shape::Triangle;
-    ps.previous = Shape::Hexagon;
     sw.window_timer = 0.0f;
     sw.window_start = reg.ctx().get<SongState>().song_time;
     ps.morph_t = 0.0f;
@@ -142,7 +141,6 @@ TEST_CASE("shape_window: Active transitions to MorphOut when window expires", "[
 
     CHECK(sw.phase == WindowPhase::MorphOut);
     CHECK(sw.window_timer == 0.0f);
-    CHECK(ps.previous == Shape::Square);
     CHECK(ps.morph_t == 0.0f);
 }
 
@@ -154,7 +152,6 @@ TEST_CASE("shape_window: MorphOut increments timer and morph_t", "[shape_window]
     auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     sw.phase = WindowPhase::MorphOut;
-    ps.previous = Shape::Circle;
     sw.window_timer = 0.0f;
     sw.window_start = reg.ctx().get<SongState>().song_time;
     ps.morph_t = 0.0f;
@@ -174,7 +171,6 @@ TEST_CASE("shape_window: MorphOut completes and returns to Idle/Hexagon", "[shap
     auto& song = reg.ctx().get<SongState>();
 
     sw.phase = WindowPhase::MorphOut;
-    ps.previous = Shape::Triangle;
     ps.current = Shape::Triangle;
     sw.target_shape = Shape::Triangle;
     sw.window_timer = 0.0f;
@@ -188,7 +184,6 @@ TEST_CASE("shape_window: MorphOut completes and returns to Idle/Hexagon", "[shap
     CHECK(sw.phase == WindowPhase::Idle);
     CHECK(ps.morph_t == 1.0f);
     CHECK(ps.current == Shape::Hexagon);
-    CHECK(ps.previous == Shape::Hexagon);
     CHECK(sw.target_shape == Shape::Hexagon);
     CHECK(sw.window_timer == 0.0f);
 }
@@ -205,7 +200,6 @@ TEST_CASE("shape_window: full cycle MorphIn -> Active -> MorphOut -> Idle", "[sh
     // Start in MorphIn
     sw.phase = WindowPhase::MorphIn;
     sw.target_shape = Shape::Circle;
-    ps.previous = Shape::Hexagon;
     sw.window_timer = 0.0f;
     sw.window_start = reg.ctx().get<SongState>().song_time;
     ps.morph_t = 0.0f;
@@ -318,7 +312,6 @@ TEST_CASE("shape_window: invalid morph_duration completes MorphOut without non-f
     sw.phase = WindowPhase::MorphOut;
     sw.target_shape = Shape::Triangle;
     ps.current = Shape::Triangle;
-    ps.previous = Shape::Triangle;
     sw.window_start = song.song_time;
     ps.morph_t = 0.0f;
     song.morph_duration = -0.1f;
@@ -329,5 +322,4 @@ TEST_CASE("shape_window: invalid morph_duration completes MorphOut without non-f
     CHECK(ps.morph_t == 1.0f);
     CHECK(sw.phase == WindowPhase::Idle);
     CHECK(ps.current == Shape::Hexagon);
-    CHECK(ps.previous == Shape::Hexagon);
 }


### PR DESCRIPTION
Closes #1076

## What

`PlayerShape::previous` was written from 6 sites across 4 files but never read anywhere in `app/`. The shape morph visuals are driven entirely by `current` + `morph_t`. The field is leftover from an earlier interpolation design and was carrying maintenance cost — every time `current` was updated, contributors were obliged to update `previous` too.

## Changes

**App-side (4 files, all writes deleted):**
- `app/components/player.h` — remove `Shape previous = Shape::Circle;` from `PlayerShape`.
- `app/entities/player_entity.cpp` — drop `ps.previous = Shape::Hexagon;`.
- `app/systems/player_input_system.cpp` — drop `ps.previous = previous_shape;` and the now-unused `Shape previous_shape = ps.current;` local in the `begin_shape_window` lambda; drop the rhythm-fallback `pshape.previous = pshape.current;` write.
- `app/systems/shape_window_system.cpp` — drop the three `pshape.previous = …` writes (Active→MorphOut transition, invalid-morph_duration MorphOut completion, normal MorphOut completion).

**Test cleanup (11 files):** removed `ps.previous` writes and `CHECK(ps.previous == …)` assertions across the test suite. None of these asserted real behavior — they were verifying the dead writes themselves. Also updated the one `PlayerShape{Shape, Shape, float}` aggregate-init in `test_perspective.cpp` to the new `{Shape, float}` shape.

## Verification

```
$ grep -rn '\.previous\b' app/ tests/ | grep -E 'PlayerShape|pshape\.previous|ps\.previous'
(no matches — only unrelated previous_shape locals, previous_phase, previous_best, previous_high_score remain)

$ cmake --build build
… 0 warnings, 0 errors (clang -Wall -Wextra -Werror)

$ ./build/shapeshifter_tests
All tests passed (2948 assertions in 899 test cases)
```

No new readers introduced. If a future feature needs interpolation between shapes, re-add the field with a real consumer in the same change.