### PR TITLE
Replace duplicate ScorePopup/ParticleData rows with PopupDisplay (#1075)

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -643,8 +643,7 @@ OnsetMarkerTag       0     WARM       obstacle_render_entity, session_logger
 Color                4     COLD       render
 DrawSize             8     COLD       render
 DrawLayer            1     COLD       render
-ScorePopup           5     COLD       render, scoring
-ParticleData         8     COLD       render
+PopupDisplay        36     COLD       popup_display (fade), ui_render
 ParticleTag          0     COLD       render (filter)
 ─────────────────────────────────────────────────────────────
 SINGLETONS (ctx)


### PR DESCRIPTION
Closes #1075.

## Drift fixed

The Component Summary Table in `design-docs/architecture.md` §2 listed `ScorePopup` and `ParticleData` **twice each**, with the COLD entries carrying byte counts that didn't match the canonical structs in `app/components/`. The detailed §2.5/§2.6 component definitions were already correct; only the summary table was wrong.

## Resolution (Option B from issue)

Replaced the two duplicate rows with a single `PopupDisplay` row — the popup-side render component the COLD entries appear to have been mis-typed for, which was previously absent from the table.

```diff
 Color                4     COLD       render
 DrawSize             8     COLD       render
 DrawLayer            1     COLD       render
-ScorePopup           5     COLD       render, scoring
-ParticleData         8     COLD       render
+PopupDisplay        36     COLD       popup_display (fade), ui_render
 ParticleTag          0     COLD       render (filter)
```

## Byte counts verified against source

- `ScorePopup` (HOT row, 16 bytes) — matches `app/components/scoring.h` ScorePopup (int32 + bool + TimingTier + 2× float = 16).
- `ParticleData` (HOT row, 12 bytes) — matches `app/components/particle.h` (3× float = 12).
- `PopupDisplay` (new COLD row, 36 bytes) — matches `app/components/scoring.h` PopupDisplay (char[16] + FontSize{int} + 4× uint8_t + float + int + uint = 36; verified with sizeof check on clang++ -std=c++20).

## Iteration list for PopupDisplay

- `popup_display_system` — per-frame alpha fade (`reg.view<ScorePopup, PopupDisplay, Color>`).
- `ui_render_system` — HUD pass draw (`reg.view<PopupDisplay, ScreenPosition, TagHUDPass>`).

## Acceptance criteria

- [x] `grep -E '^\s*(ScorePopup|ParticleData)\b' design-docs/architecture.md` returns exactly one row per struct.
- [x] Each row's byte count matches the canonical struct.
- [x] Option B chosen — `PopupDisplay` added with accurate byte count and consumer list.
- [x] No code changes — pure docs sync.