### PR TITLE
Add ./run.sh wasm-e2e local pre-PR WASM smoke command (#1080)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,41 @@ export VCPKG_ROOT=/path/to/vcpkg
 ./build.sh           # Release build
 ./run.sh             # Build + run game
 ./run.sh test        # Build + run CTest gates (skips optional Node tests if node/npm is unavailable)
+./run.sh wasm-e2e    # Pre-PR WASM smoke (requires a prior Emscripten build of build-web/, see below)
 cmake --build build --target shapeshifter_benchmarks  # Run benchmarks on demand
 ```
+
+### WebAssembly Pre-PR Smoke Test
+
+`./run.sh wasm-e2e` runs the same Playwright harness CI uses
+(`tests/wasm_runtime_smoke.cjs`) against your local `build-web/` artifact, so
+you can catch browser-only freezes before opening a PR. It boots the build,
+walks Title → LevelSelect → Tutorial → Playing, and verifies the gameplay
+loop stays responsive (phase-marker title transitions, screenshot diffs, and
+swipe-driven lane advances).
+
+Build the WASM artifact once (requires emscripten/emsdk and vcpkg):
+
+```bash
+emcmake cmake -B build-web -S . \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
+    -DVCPKG_OVERLAY_PORTS=$(pwd)/vcpkg-overlay \
+    -DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake \
+    -DVCPKG_TARGET_TRIPLET=wasm32-emscripten \
+    -DSHAPESHIFTER_WASM_SMOKE_MARKERS=ON
+cmake --build build-web -- -j$(nproc)
+```
+
+Then run the smoke test:
+
+```bash
+./run.sh wasm-e2e
+```
+
+Requires Node.js 20+, Python 3, and Google Chrome or Chromium. The script
+auto-detects Chrome on macOS/Linux; override with `CHROMIUM_EXECUTABLE_PATH`
+if needed. Installs `playwright-core` into `node_modules/` on first run.
 
 ### iOS TestFlight Archive (owner-driven signing)
 

--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,14 @@
 set -euo pipefail
 
 cd "$(dirname "$0")"
+
+# Local pre-PR smoke test for the WebAssembly build (issue #1080). Skips the
+# native build path entirely because the WASM artifacts come from build-web/.
+if [[ "${1:-}" == "wasm-e2e" ]]; then
+    shift
+    exec ./tools/wasm_e2e.sh "$@"
+fi
+
 export VCPKG_ROOT="${VCPKG_ROOT:-$HOME/vcpkg}"
 ./build.sh
 

--- a/tools/wasm_e2e.sh
+++ b/tools/wasm_e2e.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Local pre-PR validation for the WebAssembly build (issue #1080).
+#
+# Wraps tests/wasm_runtime_smoke.cjs (the same Playwright harness CI uses) so
+# developers can validate that the WASM build boots, walks Title -> LevelSelect
+# -> Tutorial -> Playing, and stays responsive in a real browser before opening
+# a PR. Mirrors the steps performed by .github/workflows/ci-wasm.yml.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+BUILD_DIR="${WASM_BUILD_DIR:-build-web}"
+SMOKE_SCRIPT="tests/wasm_runtime_smoke.cjs"
+PLAYWRIGHT_VERSION="${PLAYWRIGHT_CORE_VERSION:-1.55.0}"
+REQUIRED_ASSETS=(index.html index.js index.wasm index.data sw.js)
+
+# ── Build artifact checks ────────────────────────────────────
+if [[ ! -d "$BUILD_DIR" ]]; then
+    cat >&2 <<EOF
+error: WASM build directory '$BUILD_DIR' not found.
+
+Build the WASM target first (requires emscripten and vcpkg):
+
+  emcmake cmake -B $BUILD_DIR -S . \\
+      -DCMAKE_BUILD_TYPE=Release \\
+      -DCMAKE_TOOLCHAIN_FILE=\$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \\
+      -DVCPKG_OVERLAY_PORTS=$REPO_ROOT/vcpkg-overlay \\
+      -DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=\$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake \\
+      -DVCPKG_TARGET_TRIPLET=wasm32-emscripten \\
+      -DSHAPESHIFTER_WASM_SMOKE_MARKERS=ON
+  cmake --build $BUILD_DIR -- -j\$(nproc)
+EOF
+    exit 1
+fi
+
+for asset in "${REQUIRED_ASSETS[@]}"; do
+    if [[ ! -s "$BUILD_DIR/$asset" ]]; then
+        echo "error: required WASM artifact '$BUILD_DIR/$asset' missing or empty." >&2
+        echo "       Re-run the emcmake build (see message from prior failure or README §WASM)." >&2
+        exit 1
+    fi
+done
+
+if ! grep -q '^SHAPESHIFTER_WASM_SMOKE_MARKERS:BOOL=ON' "$BUILD_DIR/CMakeCache.txt" 2>/dev/null; then
+    cat >&2 <<EOF
+error: $BUILD_DIR was configured without -DSHAPESHIFTER_WASM_SMOKE_MARKERS=ON.
+
+The smoke test reads document.title markers ([LevelSelect], [Playing],
+[Lane:N]) emitted only when this flag is on, and will hang waiting for
+them otherwise. Re-configure with the flag and rebuild.
+EOF
+    exit 1
+fi
+
+# ── Tooling checks ───────────────────────────────────────────
+if ! command -v node >/dev/null 2>&1; then
+    echo "error: node is required (Node.js 20+). Install node and retry." >&2
+    exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "error: python3 is required to serve $BUILD_DIR. Install python3 and retry." >&2
+    exit 1
+fi
+
+# ── Chromium auto-detect ─────────────────────────────────────
+if [[ -z "${CHROMIUM_EXECUTABLE_PATH:-}" ]]; then
+    candidates=(
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+        "/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta"
+        "/Applications/Chromium.app/Contents/MacOS/Chromium"
+        "$(command -v google-chrome 2>/dev/null || true)"
+        "$(command -v google-chrome-stable 2>/dev/null || true)"
+        "$(command -v chromium 2>/dev/null || true)"
+        "$(command -v chromium-browser 2>/dev/null || true)"
+    )
+    for candidate in "${candidates[@]}"; do
+        if [[ -n "$candidate" ]] && [[ -x "$candidate" ]]; then
+            CHROMIUM_EXECUTABLE_PATH="$candidate"
+            break
+        fi
+    done
+fi
+
+if [[ -z "${CHROMIUM_EXECUTABLE_PATH:-}" ]] || [[ ! -x "${CHROMIUM_EXECUTABLE_PATH}" ]]; then
+    cat >&2 <<EOF
+error: could not locate a Chrome/Chromium executable.
+
+Install Google Chrome or Chromium, or set CHROMIUM_EXECUTABLE_PATH to the
+absolute path of the binary, e.g.:
+
+  CHROMIUM_EXECUTABLE_PATH=/path/to/chrome ./run.sh wasm-e2e
+EOF
+    exit 1
+fi
+export CHROMIUM_EXECUTABLE_PATH
+
+# ── playwright-core install ──────────────────────────────────
+if [[ ! -d node_modules/playwright-core ]]; then
+    if ! command -v npm >/dev/null 2>&1; then
+        echo "error: npm is required to install playwright-core (~$PLAYWRIGHT_VERSION). Install npm and retry." >&2
+        exit 1
+    fi
+    echo "installing playwright-core@$PLAYWRIGHT_VERSION (no-save) into node_modules..."
+    npm install --no-save --no-audit --no-fund "playwright-core@${PLAYWRIGHT_VERSION}" >/dev/null
+fi
+
+# ── Pick a free localhost port ───────────────────────────────
+pick_free_port() {
+    python3 - <<'PY'
+import socket
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+    s.bind(("127.0.0.1", 0))
+    print(s.getsockname()[1])
+PY
+}
+PORT="${WASM_E2E_PORT:-$(pick_free_port)}"
+
+# ── Start serving build-web in the background ────────────────
+SERVER_LOG="$(mktemp -t shapeshifter-wasm-e2e-server.XXXXXX.log)"
+python3 -m http.server "$PORT" --directory "$BUILD_DIR" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+cleanup() {
+    if [[ -n "${SERVER_PID:-}" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+    rm -f "$SERVER_LOG"
+}
+trap cleanup EXIT INT TERM
+
+# Wait for HTTP availability
+URL="http://127.0.0.1:${PORT}/index.html"
+for _ in $(seq 1 40); do
+    if curl -fsS "$URL" -o /dev/null 2>/dev/null; then
+        break
+    fi
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "error: local HTTP server exited before serving $URL." >&2
+        cat "$SERVER_LOG" >&2 || true
+        exit 1
+    fi
+    sleep 0.25
+done
+if ! curl -fsS "$URL" -o /dev/null 2>/dev/null; then
+    echo "error: timed out waiting for $URL to respond." >&2
+    cat "$SERVER_LOG" >&2 || true
+    exit 1
+fi
+
+echo "→ Chromium:    $CHROMIUM_EXECUTABLE_PATH"
+echo "→ Build dir:   $BUILD_DIR"
+echo "→ Serving at:  $URL"
+echo "→ Running:     $SMOKE_SCRIPT"
+echo
+
+# ── Run the smoke harness ────────────────────────────────────
+node "$SMOKE_SCRIPT" --build-dir "$BUILD_DIR" --seed-stale-build-cache "$URL"


### PR DESCRIPTION
Closes #1080.

## Summary

Wires up the existing `tests/wasm_runtime_smoke.cjs` Playwright harness — the one already used by `.github/workflows/ci-wasm.yml` — as a local developer command so we can catch browser-only WASM freezes before opening a PR (instead of finding out from CI on the PR).

```bash
./run.sh wasm-e2e
```

The harness boots the build, walks **Title → LevelSelect → Tutorial → Playing**, and then verifies the gameplay loop stays responsive for ~10s via phase-marker title transitions (`[LevelSelect]`, `[Playing]`, `[Lane:N]`), screenshot diffs, and swipe-driven lane advances. Same coverage as CI.

## Acceptance criteria mapping (from #1080)

| Criterion | How it's met |
|---|---|
| Playwright project configured | Reuses existing `tests/wasm_runtime_smoke.cjs` (CI's harness, `playwright-core`) — no duplicate spec |
| One spec drives boot → all UI screens → enter Playing | Existing spec: `waitForTitlePhase('LevelSelect')` → `'Tutorial'` → `'Playing'` + lane swipes |
| Spec asserts gameplay loop runs ≥10s with no freeze | Post-`Playing` waits + screenshot-diff + lane-marker advances total ~10–15s; any freeze surfaces as `no-visual-response-after-playing-start` or missing-lane-advance |
| Spec runs via local command | New `./run.sh wasm-e2e` dispatching to `tools/wasm_e2e.sh` |
| Failure produces clear logs | Existing fatal[] aggregation in the harness + new wrapper preconditions surface missing build, missing markers, missing Chrome with actionable instructions |

## Open-question answers

1. **Game-loop signal to JS?** Already exists: `SHAPESHIFTER_WASM_SMOKE_MARKERS` build flag emits `document.title` markers from `game_state_system.cpp` / `game_phase_transition.cpp`. No new C++ needed.
2. **Multi-browser support?** Chromium-only for v1 (matches CI and issue's "Chromium minimum"). Chrome path auto-detected on macOS/Linux; `CHROMIUM_EXECUTABLE_PATH` overrides.
3. **Local command?** `./run.sh wasm-e2e` (matches the existing `./run.sh test` / `./run.sh bench` pattern).
4. **WASM serve method?** `python3 -m http.server` on a free port (matches CI).

## What's in this PR

- **`tools/wasm_e2e.sh`** (new) — preconditions + Chrome detection + http server lifecycle + invokes the smoke harness; cleans up on EXIT/INT/TERM via `trap`.
- **`run.sh`** — dispatches the new `wasm-e2e` subcommand *before* the native `./build.sh` so it works without vcpkg/native build configured.
- **`README.md`** — documents the new command, the one-time `emcmake` build invocation that produces `build-web/`, and prerequisites (Node 20+, Python 3, Chrome/Chromium).

## Out of scope (per issue's "v1" scope)

- ❌ GitHub Actions CI gate (CI already runs the same harness; this is the *local* counterpart)
- ❌ Native build coverage (already covered by existing CI workflows)
- ❌ Bundling `emcmake` build into `./run.sh wasm-e2e` itself — emscripten is heavyweight and many devs won't have it; build is a separate prerequisite documented in README

## Verification

Ran end-to-end on macOS (Chrome 14 / Node 25 / Python 3.14):

```
$ ./run.sh wasm-e2e
→ Chromium:    /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
→ Build dir:   build-web
→ Serving at:  http://127.0.0.1:63333/index.html
→ Running:     tests/wasm_runtime_smoke.cjs

WASM runtime smoke passed
```

Also verified failure paths produce actionable messages:
- Missing `build-web/` → prints the `emcmake` command
- Missing `SHAPESHIFTER_WASM_SMOKE_MARKERS=ON` → tells you to re-configure
- Missing Chrome → tells you to set `CHROMIUM_EXECUTABLE_PATH`