### PR TITLE
Cover 5 unread capacity_exceeded_count counters with dense-burst tests (#1089)

### DIFF
--- a/tests/test_particle_system.cpp
+++ b/tests/test_particle_system.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include "components/system_scratch.h"
 #include "test_helpers.h"
 #include "constants.h"
 
@@ -138,4 +139,26 @@ TEST_CASE("particle: reduce_motion=false preserves gravity behavior (#534)",
     particle_system(reg, 0.1f);
     CHECK_THAT(reg.get<MotionVelocity>(e).value.y,
                Catch::Matchers::WithinAbs(constants::PARTICLE_GRAVITY * 0.1f, 0.01f));
+}
+
+// #1089 — ParticleSystemScratch::capacity_exceeded_count must stay at zero
+// when a dense expiry pass fits inside the reserved expired buffer.
+TEST_CASE("particle: dense expiry burst stays within reserved capacity",
+          "[particle][issue1089]") {
+    auto reg = make_registry();
+    constexpr int dense_count = 6;
+    runtime_system_scratch_reserve(reg, dense_count);
+
+    auto& scratch = reg.ctx().get<ParticleSystemScratch>();
+    const auto expired_capacity = scratch.expired.capacity();
+
+    for (int i = 0; i < dense_count; ++i) {
+        // Tiny remaining lifetime so the next tick expires every particle.
+        make_particle(reg, 5.0f, 0.001f, 1.0f);
+    }
+
+    particle_system(reg, 0.016f);
+
+    CHECK(scratch.expired.capacity() == expired_capacity);
+    CHECK(scratch.capacity_exceeded_count == 0u);
 }

--- a/tests/test_perspective.cpp
+++ b/tests/test_perspective.cpp
@@ -5,10 +5,12 @@
 #include "components/player.h"
 #include "components/rendering.h"
 #include "components/shape_mesh.h"
+#include "components/system_scratch.h"
 #include "components/transform.h"
 #include "entities/obstacle_entity.h"
 #include "rendering/camera_resources.h"
 #include "systems/runtime_systems.h"
+#include "systems/all_systems.h"
 #include <raylib.h>
 #include <cmath>
 
@@ -184,4 +186,42 @@ TEST_CASE("game_camera_system rejects invalid PlayerShape before mesh lookup", "
 
     REQUIRE_NOTHROW(game_camera_system(reg, 0.0f));
     CHECK_FALSE(reg.all_of<ModelTransform>(player));
+}
+
+// #1089 — MeshChildCleanupScratch::capacity_exceeded_count must stay at zero
+// when a dense stale-parent cleanup pass fits inside the reserved
+// stale_children buffer. runtime_system_scratch_reserve sizes the buffer at
+// `beat_capacity * ObstacleChildren::MAX`, mirroring the worst-case slab
+// fan-out per beat.
+TEST_CASE("game_camera_system: dense stale-parent cleanup stays within reserved capacity",
+          "[camera3d][mesh_child][issue1089]") {
+    entt::registry reg;
+    reg.ctx().emplace<ShapeMeshConfig>();
+    reg.ctx().emplace<FloorParams>();
+    runtime_system_scratch_init(reg);
+    constexpr int beat_capacity = 4;
+    runtime_system_scratch_reserve(reg, beat_capacity);
+
+    auto& scratch = reg.ctx().get<MeshChildCleanupScratch>();
+    const auto stale_capacity = scratch.stale_children.capacity();
+    REQUIRE(stale_capacity >= static_cast<std::size_t>(beat_capacity * ObstacleChildren::MAX));
+
+    constexpr int dense_count = beat_capacity * ObstacleChildren::MAX;
+    for (int i = 0; i < dense_count; ++i) {
+        auto parent = reg.create();
+        reg.emplace<WorldTransform>(parent, WorldTransform{{static_cast<float>(i), 0.0f}});
+        auto child = reg.create();
+        reg.emplace<MeshChild>(
+            child,
+            MeshChild{parent, static_cast<float>(i), 0.0f, 20.0f, 30.0f, 40.0f, WHITE, 0, MeshType::Slab}
+        );
+        reg.emplace<ModelTransform>(child, ModelTransform{glm::mat4{1.0f}, WHITE, 0, MeshType::Slab});
+        reg.emplace<TagWorldPass>(child);
+        reg.destroy(parent);  // make MeshChild stale so cleanup path runs
+    }
+
+    game_camera_system(reg, 0.0f);
+
+    CHECK(scratch.stale_children.capacity() == stale_capacity);
+    CHECK(scratch.capacity_exceeded_count == 0u);
 }

--- a/tests/test_popup_display_system.cpp
+++ b/tests/test_popup_display_system.cpp
@@ -459,3 +459,26 @@ TEST_CASE("popup_display_system: reduce_motion=false leaves drift untouched (#53
     const auto& vel = reg.get<MotionVelocity>(e);
     CHECK(vel.value.y == -80.0f);  // popup_display_system never touches it
 }
+
+// #1089 — PopupDisplayScratch::capacity_exceeded_count must stay at zero when
+// a dense expiry pass fits inside the reserved expired buffer.
+TEST_CASE("popup_display_system: dense expiry burst stays within reserved capacity",
+          "[popup_display][issue1089]") {
+    entt::registry reg;
+    runtime_system_scratch_init(reg);
+    constexpr int dense_count = 6;
+    runtime_system_scratch_reserve(reg, dense_count);
+
+    auto& scratch = reg.ctx().get<PopupDisplayScratch>();
+    const auto expired_capacity = scratch.expired.capacity();
+
+    for (int i = 0; i < dense_count; ++i) {
+        // Tiny remaining lifetime so the next tick expires every popup.
+        make_popup_entity(reg, std::nullopt, 100, 0.001f, 1.0f);
+    }
+
+    popup_display_system(reg, 0.016f);
+
+    CHECK(scratch.expired.capacity() == expired_capacity);
+    CHECK(scratch.capacity_exceeded_count == 0u);
+}

--- a/tests/test_scoring_system.cpp
+++ b/tests/test_scoring_system.cpp
@@ -526,3 +526,28 @@ TEST_CASE("runtime scratch: dense scoring burst stays within reserved capacity",
     CHECK(energy.events.size() == static_cast<std::size_t>(dense_count));
     CHECK(popup_queue.requests.size() == static_cast<std::size_t>(dense_count));
 }
+
+// #1089: miss_capacity_exceeded_count is incremented from scoring_system's
+// miss pass when miss_buf would grow past its reserve. Mirror the hit-burst
+// coverage above so the counter is observed and not just write-only.
+TEST_CASE("runtime scratch: dense miss burst stays within reserved capacity",
+          "[scoring][issue1089]") {
+    auto reg = make_registry();
+    constexpr int dense_count = 6;
+    runtime_system_scratch_reserve(reg, dense_count);
+
+    auto& scratch = reg.ctx().get<ScoringSystemScratch>();
+    const auto miss_capacity = scratch.miss_buf.capacity();
+
+    for (int i = 0; i < dense_count; ++i) {
+        auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y + static_cast<float>(i));
+        reg.emplace<ScoredTag>(obs);
+        reg.emplace<MissTag>(obs);
+        reg.emplace<TimingGrade>(obs, TimingTier::Bad, 0.5f);
+    }
+
+    scoring_system(reg, 0.0f);
+
+    CHECK(scratch.miss_buf.capacity() == miss_capacity);
+    CHECK(scratch.miss_capacity_exceeded_count == 0u);
+}

--- a/tests/test_world_systems.cpp
+++ b/tests/test_world_systems.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include "components/system_scratch.h"
 #include "test_helpers.h"
 
 // ── motion_system ────────────────────────────────────────────
@@ -476,6 +477,30 @@ TEST_CASE("cleanup: destroys multiple obstacles past DESTROY_Y in one pass", "[c
 
     for (int i = 0; i < N; ++i)
         CHECK_FALSE(reg.valid(obs[i]));
+}
+
+// #1089 — ObstacleDespawnScratch::capacity_exceeded_count must stay at zero
+// when a dense pass fits inside the reserved to_destroy buffer.
+TEST_CASE("cleanup: dense despawn burst stays within reserved capacity",
+          "[cleanup][issue1089]") {
+    auto reg = make_registry();
+    constexpr int dense_count = 6;
+    runtime_system_scratch_reserve(reg, dense_count);
+
+    auto& scratch = reg.ctx().get<ObstacleDespawnScratch>();
+    const auto destroy_capacity = scratch.to_destroy.capacity();
+
+    for (int i = 0; i < dense_count; ++i) {
+        auto obs = reg.create();
+        reg.emplace<ObstacleTag>(obs);
+        reg.emplace<WorldTransform>(obs,
+            WorldTransform{{0.0f, constants::DESTROY_Y + static_cast<float>(i + 1) * 10.0f}});
+    }
+
+    obstacle_despawn_system(reg, 0.016f);
+
+    CHECK(scratch.to_destroy.capacity() == destroy_capacity);
+    CHECK(scratch.capacity_exceeded_count == 0u);
 }
 
 // #242 / #280 — cleanup must not emplace MissTag or ScoredTag; that is miss_detection_system's job.


### PR DESCRIPTION
## Summary
Per-frame `std::vector` scratch buffers in `app/components/system_scratch.h` and `app/components/gameplay_intents.h` carry a defensive `capacity_exceeded_count` field that is incremented when a hot-loop `push_back` would otherwise force a reallocation past the reserved capacity. The pattern only acts as a regression guard if a test reads the counter after a dense pass fits inside the reserve.

The dense-burst test in `tests/test_scoring_system.cpp:500` (`[scoring][issue557]`) already covered three counters; this PR adds a sibling test for each of the remaining five so the pattern is uniformly enforced.

Closes #1089 via Option A (additive — preferred per the issue).

## New tests

| Counter | Test file | Test name |
|---|---|---|
| `ScoringSystemScratch::miss_capacity_exceeded_count` | `tests/test_scoring_system.cpp` | `runtime scratch: dense miss burst stays within reserved capacity` |
| `ObstacleDespawnScratch::capacity_exceeded_count` | `tests/test_world_systems.cpp` | `cleanup: dense despawn burst stays within reserved capacity` |
| `PopupDisplayScratch::capacity_exceeded_count` | `tests/test_popup_display_system.cpp` | `popup_display_system: dense expiry burst stays within reserved capacity` |
| `ParticleSystemScratch::capacity_exceeded_count` | `tests/test_particle_system.cpp` | `particle: dense expiry burst stays within reserved capacity` |
| `MeshChildCleanupScratch::capacity_exceeded_count` | `tests/test_perspective.cpp` | `game_camera_system: dense stale-parent cleanup stays within reserved capacity` |

Each new test:
1. Calls `runtime_system_scratch_reserve(reg, dense_count)` to size the buffer.
2. Captures the buffer's initial `.capacity()`.
3. Drives a pass with exactly `dense_count` items so the buffer is filled but not exceeded.
4. Asserts `buf.capacity()` is unchanged AND `capacity_exceeded_count == 0`.

The MeshChild test uses `beat_capacity * ObstacleChildren::MAX` entities, mirroring the worst-case slab fan-out per beat that `runtime_system_scratch_reserve` already accounts for (`runtime_system_scratch.cpp:52`).

## Verification
- `./build/shapeshifter_tests "[issue1089]"` — **5 new test cases pass** (11 assertions).
- `./build/shapeshifter_tests` — **904 / 904 cases pass** (was 899; +5).
- `cmake --build build` — both `shapeshifter` and `shapeshifter_tests` build clean (`-Wall -Wextra -Werror`, zero warnings).
- No production code changed; counters are still incremented from exactly the same sites.