### PR TITLE
Drop unused includes and simplify runtime_system_scratch_init (#1091)

### DIFF
--- a/app/systems/camera_system.cpp
+++ b/app/systems/camera_system.cpp
@@ -21,7 +21,6 @@
 #include <algorithm>
 #include <cmath>
 #include <tuple>
-#include <vector>
 #include <stdexcept>
 
 namespace camera {

--- a/app/systems/runtime_system_scratch.cpp
+++ b/app/systems/runtime_system_scratch.cpp
@@ -17,23 +17,14 @@ std::size_t gameplay_capacity(std::size_t beat_capacity) {
 }  // namespace
 
 void runtime_system_scratch_init(entt::registry& reg) {
-    reg.ctx().erase<ScoringSystemScratch>();
-    reg.ctx().erase<PendingEnergyEffects>();
-    reg.ctx().erase<ScorePopupRequestQueue>();
-    reg.ctx().erase<ObstacleDespawnScratch>();
-    reg.ctx().erase<PopupDisplayScratch>();
-    reg.ctx().erase<ParticleSystemScratch>();
-    reg.ctx().erase<MeshChildCleanupScratch>();
-    reg.ctx().erase<WasmSmokeLaneMarkerState>();
-
-    reg.ctx().emplace<ScoringSystemScratch>();
-    reg.ctx().emplace<PendingEnergyEffects>();
-    reg.ctx().emplace<ScorePopupRequestQueue>();
-    reg.ctx().emplace<ObstacleDespawnScratch>();
-    reg.ctx().emplace<PopupDisplayScratch>();
-    reg.ctx().emplace<ParticleSystemScratch>();
-    reg.ctx().emplace<MeshChildCleanupScratch>();
-    reg.ctx().emplace<WasmSmokeLaneMarkerState>();
+    reg.ctx().insert_or_assign(ScoringSystemScratch{});
+    reg.ctx().insert_or_assign(PendingEnergyEffects{});
+    reg.ctx().insert_or_assign(ScorePopupRequestQueue{});
+    reg.ctx().insert_or_assign(ObstacleDespawnScratch{});
+    reg.ctx().insert_or_assign(PopupDisplayScratch{});
+    reg.ctx().insert_or_assign(ParticleSystemScratch{});
+    reg.ctx().insert_or_assign(MeshChildCleanupScratch{});
+    reg.ctx().insert_or_assign(WasmSmokeLaneMarkerState{});
 
     runtime_system_scratch_reserve(reg, 0);
 }

--- a/app/systems/ui_render_system.cpp
+++ b/app/systems/ui_render_system.cpp
@@ -21,7 +21,6 @@
 #include "../ui/screen_controllers/gameplay_hud_screen_controller.h"
 #include <raylib.h>
 #include <raymath.h>
-#include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <string>


### PR DESCRIPTION
Closes #1091.

## Summary

Three small hygiene cleanups in `app/systems/` identified by the parallel pass and individually verified.

| Change | File | Lines |
|---|---|---|
| Drop unused `<vector>` include | `app/systems/camera_system.cpp` | -1 |
| Drop unused `<algorithm>` include (only `std::lround` is used, which is in `<cmath>`) | `app/systems/ui_render_system.cpp` | -1 |
| Replace paired `ctx().erase<T>()` + `ctx().emplace<T>()` with `ctx().insert_or_assign(T{})` per type | `app/systems/runtime_system_scratch.cpp` | -16 / +8 |

### Why `insert_or_assign` (not `emplace_or_replace`)

EnTT 3.16's `registry_context` does not expose `emplace_or_replace`. The relevant API is:

- `emplace<T>(args...)` — insert-only; **does not replace** if a value of type `T` already exists.
- `insert_or_assign(T&&)` — inserts if absent, assigns if present. This matches the original "ensure a fresh default-constructed instance" semantics in one call.

Same end state as the previous erase + emplace pair, half the lines, single semantic operation.

## Verification

- `cmake --build build --target shapeshifter_lib --clean-first` → zero warnings, zero errors (Clang `-Wall -Wextra -Werror`).
- `./build/shapeshifter_tests` → 916/916 pass (1 skipped `startup_shutdown_smoke`, same as baseline on `main`).

## Risk

None. No behavior change; all callers of `runtime_system_scratch_init` continue to see the same post-condition (each scratch ctx singleton is freshly default-constructed).
