### PR TITLE
Drop six unused includes in three systems (#1093)

### DIFF
--- a/app/systems/beat_scheduler_system.cpp
+++ b/app/systems/beat_scheduler_system.cpp
@@ -5,8 +5,6 @@
 #include "../components/rhythm.h"
 #include "../components/song_state.h"
 #include "../components/obstacle.h"
-#include "../components/transform.h"
-#include "../components/rendering.h"
 #include "../constants.h"
 #include "../entities/settings.h"
 #include "../util/lane_utils.h"

--- a/app/systems/camera_system.cpp
+++ b/app/systems/camera_system.cpp
@@ -4,7 +4,6 @@
 #include "../components/rendering.h"
 #include "../components/transform.h"
 #include "../components/player.h"
-#include "../components/obstacle.h"
 #include "../entities/beat_map.h"
 #include "../components/particle.h"
 #include "../components/scoring.h"
@@ -20,7 +19,6 @@
 #include <rlgl.h>
 #include <algorithm>
 #include <cmath>
-#include <tuple>
 #include <stdexcept>
 
 namespace camera {

--- a/app/systems/ui_render_system.cpp
+++ b/app/systems/ui_render_system.cpp
@@ -1,8 +1,6 @@
 #include "all_systems.h"
 #include "camera_system.h"
-#include "../components/transform.h"
 #include "../components/player.h"
-#include "../components/obstacle.h"
 #include "../components/rendering.h"
 #include "../components/scoring.h"
 #include "../components/rhythm.h"


### PR DESCRIPTION
Closes #1093

Removes 6 unused `#include` lines from three system TUs, all individually verified by grep + non-unity build.

## Changes
- `app/systems/beat_scheduler_system.cpp`: drop `<transform.h>` and `<rendering.h>` (no transform/render symbols used).
- `app/systems/ui_render_system.cpp`: drop `<transform.h>` (`ScreenTransform`/`ScreenPosition` come from `rendering.h`, already included) and `<obstacle.h>` (no obstacle types used).
- `app/systems/camera_system.cpp`: drop `<obstacle.h>` (camera builds shape-mesh and particle transforms only) and `<tuple>` (no tuple use anywhere in the TU).

## Verification
- `cmake --build build` (unity ON) — zero warnings ✅
- `cmake --build build-no-unity` (unity OFF) — zero warnings ✅ (confirms removed includes are not load-bearing for sibling TUs in a unity batch)
- `./build/shapeshifter_tests "*"` — 916/916 test cases pass (2959 assertions) ✅

Pure cleanup, no behavior change.