### PR TITLE
Drop two dead component fields (closes #1098)

### DIFF
--- a/app/components/game_state.h
+++ b/app/components/game_state.h
@@ -47,7 +47,6 @@ struct GameState {
     float     phase_timer      = 0.0f;
     bool      transition_pending = false;
     GamePhase next_phase       = GamePhase::Title;
-    float     transition_alpha = 0.0f;
     EndScreenChoice end_choice = EndScreenChoice::None;
 };
 

--- a/app/components/test_player.h
+++ b/app/components/test_player.h
@@ -54,14 +54,13 @@ struct TestPlayerAction {
 struct TestPlayerPlannedTag {};
 
 // ── Test player state (context singleton) ────────────────────
-// Hot state (accessed every frame): active, frame_count, swipe_cooldown_timer,
+// Hot state (accessed every frame): active, swipe_cooldown_timer,
 //   action_count, actions[].
 // Warm state (accessed during perception): skill, rng.
 struct TestPlayerState {
     // ── Hot ──────────────────────────────────────────────────
     TestPlayerSkill skill   = TestPlayerSkill::Pro;
     bool            active  = false;
-    uint32_t        frame_count = 0;
 
     // Delay between consecutive lane swipes (simulates human re-swipe time)
     static constexpr float SWIPE_COOLDOWN = 0.125f;  // 125ms (midpoint of 100-150ms)

--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -182,7 +182,7 @@ bool game_loop_init(entt::registry& reg,
     reset_ctx_singleton<GameState>(reg, GameState{
         .phase = GamePhase::Title, .previous_phase = GamePhase::Title,
         .phase_timer = 0.0f, .transition_pending = false,
-        .next_phase = GamePhase::Title, .transition_alpha = 0.0f
+        .next_phase = GamePhase::Title
     });
     reset_ctx_singleton<ScoreState>(reg);
     reset_ctx_singleton<LevelSelectState>(reg);

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -189,8 +189,6 @@ void test_player_system(entt::registry& reg, float dt) {
     auto* state = reg.ctx().find<TestPlayerState>();
     if (!state || !state->active) return;
 
-    state->frame_count++;
-
     auto& gs    = reg.ctx().get<GameState>();
     auto& disp  = reg.ctx().get<entt::dispatcher>();
     auto* log   = reg.ctx().find<SessionLog>();

--- a/benchmarks/bench_systems.cpp
+++ b/benchmarks/bench_systems.cpp
@@ -27,7 +27,7 @@ static entt::registry make_bench_registry() {
     wire_input_dispatcher(reg);
     wire_audio_haptic_dispatcher(reg);
     reg.ctx().emplace<GameState>(GameState{
-        GamePhase::Playing, GamePhase::Playing, 0.0f, false, GamePhase::Playing, 0.0f
+        GamePhase::Playing, GamePhase::Playing, 0.0f, false, GamePhase::Playing
     });
     reg.ctx().emplace<ScoreState>();
     reg.ctx().emplace<SongState>();

--- a/tests/test_energy_system.cpp
+++ b/tests/test_energy_system.cpp
@@ -114,7 +114,7 @@ TEST_CASE("energy: no action when SongState not present", "[energy]") {
     bare_reg.ctx().emplace<InputState>();
     
     bare_reg.ctx().emplace<GameState>(GameState{
-        GamePhase::Playing, GamePhase::Playing, 0.0f, false, GamePhase::Playing, 0.0f
+        GamePhase::Playing, GamePhase::Playing, 0.0f, false, GamePhase::Playing
     });
     bare_reg.ctx().emplace<EnergyState>(EnergyState{0.0f, 0.0f, 0.0f});
     runtime_system_scratch_init(bare_reg);
@@ -144,7 +144,7 @@ TEST_CASE("energy: no action when EnergyState not present", "[energy]") {
     bare_reg.ctx().emplace<InputState>();
     
     bare_reg.ctx().emplace<GameState>(GameState{
-        GamePhase::Playing, GamePhase::Playing, 0.0f, false, GamePhase::Playing, 0.0f
+        GamePhase::Playing, GamePhase::Playing, 0.0f, false, GamePhase::Playing
     });
     auto& song = bare_reg.ctx().emplace<SongState>();
     song.playing = true;

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -36,7 +36,7 @@ inline entt::registry make_registry() {
     wire_input_dispatcher(reg);
     wire_audio_haptic_dispatcher(reg);
     reg.ctx().emplace<GameState>(GameState{
-        GamePhase::Playing, GamePhase::Playing, 0.0f, false, GamePhase::Playing, 0.0f
+        GamePhase::Playing, GamePhase::Playing, 0.0f, false, GamePhase::Playing
     });
     reg.ctx().emplace<ScoreState>();
     create_settings_entity(reg);  // defaults: haptics_enabled=true

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -367,7 +367,7 @@ TEST_CASE("High score bootstrap: persistence path is populated for save call sit
     reg.ctx().get<HighScoreState>() = loaded_at_bootstrap;
     reg.ctx().get<HighScorePersistence>() = HighScorePersistence{file.string()};
     reg.ctx().get<GameState>() = GameState{
-        GamePhase::Playing, GamePhase::Playing, 0.0f, true, GamePhase::SongComplete, 0.0f
+        GamePhase::Playing, GamePhase::Playing, 0.0f, true, GamePhase::SongComplete
     };
     auto& score = reg.ctx().get<ScoreState>();
     score.high_score = 1000;


### PR DESCRIPTION
Closes #1098.

Both fields were write-only with zero production or test readers — pure scaffolding for features that were never implemented.

## Changes

- `GameState::transition_alpha` — removed from struct + dropped its initializer in `game_loop.cpp`. Likely placeholder for a phase-transition fade-out that never landed.
- `TestPlayerState::frame_count` — removed from struct + dropped its increment in `test_player_system.cpp`. Likely dead instrumentation. The "Hot state" comment in the component header is updated.

Knock-on: four positional `GameState{...}` initializers (test_helpers.h, test_energy_system.cpp ×2, test_high_score_integration.cpp, benchmarks/bench_systems.cpp) had a trailing `0.0f` for the removed field; trimmed in step.

## Verification

- `cmake --build build` (unity ON, default) — zero warnings.
- `cmake --build build-no-unity` (unity OFF) — zero warnings.
- `./build/shapeshifter_tests "*"` — **916/916** pass (2959 assertions), same as baseline on `main`.

P3 cleanup, no behavior change.