### PR TITLE
Drop 7 unused includes across systems/util/ui/session (closes #1097)

### DIFF
--- a/app/session/play_session.cpp
+++ b/app/session/play_session.cpp
@@ -2,7 +2,6 @@
 #include "../components/game_state.h"
 #include "../components/player.h"
 #include "../components/transform.h"
-#include "../components/rendering.h"
 #include "../components/scoring.h"
 #include "../entities/beat_map.h"
 #include "../components/rhythm.h"

--- a/app/systems/player_input_system.cpp
+++ b/app/systems/player_input_system.cpp
@@ -6,7 +6,6 @@
 #include "../components/audio_events.h"
 #include "../components/haptics.h"
 #include "../components/rhythm.h"
-#include "../entities/settings.h"
 #include "../constants.h"
 #include "../util/lane_utils.h"
 #include "../util/shape_lane_mapping.h"

--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -7,8 +7,6 @@
 #include "../components/system_scratch.h"
 #include "../components/transform.h"
 #include "../components/rendering.h"
-#include "../components/haptics.h"
-#include "../entities/settings.h"
 #include "../components/rhythm.h"
 #include "../util/rhythm_math.h"
 #include "../constants.h"

--- a/app/ui/screen_controllers/level_select_screen_controller.cpp
+++ b/app/ui/screen_controllers/level_select_screen_controller.cpp
@@ -4,7 +4,6 @@
 #include "../../components/game_state.h"
 #include "../../content/level_content_config.h"
 #include "../../components/input.h"
-#include "../../components/rendering.h"
 #include "../../constants.h"
 #include "screen_controller_base.h"
 #include <entt/entt.hpp>

--- a/app/ui/screen_controllers/title_screen_controller.cpp
+++ b/app/ui/screen_controllers/title_screen_controller.cpp
@@ -2,7 +2,6 @@
 
 #include "../../components/game_state.h"
 #include "../../components/input.h"
-#include "../../components/rendering.h"
 #include "screen_controller_base.h"
 #include <raygui.h>
 #include "title_screen_dead_zones.h"

--- a/app/util/session_logger.cpp
+++ b/app/util/session_logger.cpp
@@ -1,7 +1,6 @@
 #include "session_logger.h"
 #include "../components/obstacle.h"
 #include "../components/rhythm.h"
-#include "../components/transform.h"
 #include "../components/scoring.h"
 #include "../components/game_state.h"
 #include "../constants.h"


### PR DESCRIPTION
Closes #1097. Direct follow-up to #1091 (#1092) and #1093 (#1094).

Each removed include was verified by (a) grep — zero references to any header-declared symbol in the TU, and (b) removing the include and rebuilding `build-no-unity` (non-unity is the ground truth for include correctness, since unity batches can hide missing ones).

## Removed (7 lines, 6 files)

| File | Removed |
| :-- | :-- |
| `app/systems/scoring_system.cpp` | `../components/haptics.h`, `../entities/settings.h` |
| `app/systems/player_input_system.cpp` | `../entities/settings.h` |
| `app/util/session_logger.cpp` | `../components/transform.h` |
| `app/ui/screen_controllers/title_screen_controller.cpp` | `../../components/rendering.h` |
| `app/ui/screen_controllers/level_select_screen_controller.cpp` | `../../components/rendering.h` |
| `app/session/play_session.cpp` | `../components/rendering.h` |

## Verification

- `cmake --build build` (unity ON, default) — zero warnings.
- `cmake --build build-no-unity` (unity OFF) — zero warnings.
- `./build/shapeshifter_tests "*"` — **916/916** pass (2959 assertions), same as baseline on `main`.

P3 cleanup, no behavior change, no user-visible impact.