### PR TITLE
Add missing energy_bar_system to energy-bar.md system-order block (closes #1101)

### DIFF
--- a/design-docs/energy-bar.md
+++ b/design-docs/energy-bar.md
@@ -176,6 +176,7 @@ switch (timing->tier) {
   popup_feedback_system
   popup_display_system
   energy_system            ← applies queued effects, requests GameOver on depletion, smooths display
+  energy_bar_system        ← drives the on-HUD energy-bar visual
   particle_system
 ```
 


### PR DESCRIPTION
Closes #1101.

The system-execution-order block in `design-docs/energy-bar.md` omitted `energy_bar_system`, which actually runs between `energy_system` and `particle_system` in the fixed-tick cycle (`app/systems/fixed_tick_runner.cpp:5-18`).

## Diff (1 line added)

```diff
   energy_system            ← applies queued effects, requests GameOver on depletion, smooths display
+  energy_bar_system        ← drives the on-HUD energy-bar visual
   particle_system
```

Docs-only fix. No source code changes; CI workflows that path-ignore `design-docs/**` will skip (`ci-macos.yml`, `ci-linux.yml`, etc. all set `paths-ignore: design-docs/**`).
