### PR TITLE
Drop dead GameState::previous_phase field (closes #1102)

### DIFF
--- a/app/components/game_state.h
+++ b/app/components/game_state.h
@@ -43,7 +43,6 @@ enum class EndScreenChoice : uint8_t { None = 0, Restart = 1, LevelSelect = 2, M
 
 struct GameState {
     GamePhase phase            = GamePhase::Title;
-    GamePhase previous_phase   = GamePhase::Title;
     float     phase_timer      = 0.0f;
     bool      transition_pending = false;
     GamePhase next_phase       = GamePhase::Title;

--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -180,7 +180,7 @@ bool game_loop_init(entt::registry& reg,
     wire_audio_haptic_dispatcher(reg);
     input_system_init(reg);
     reset_ctx_singleton<GameState>(reg, GameState{
-        .phase = GamePhase::Title, .previous_phase = GamePhase::Title,
+        .phase = GamePhase::Title,
         .phase_timer = 0.0f, .transition_pending = false,
         .next_phase = GamePhase::Title
     });

--- a/app/systems/game_phase_transition.cpp
+++ b/app/systems/game_phase_transition.cpp
@@ -47,7 +47,6 @@ void update_web_title(GamePhase phase) {
 }  // namespace
 
 void enter_phase(GameState& gs, GamePhase next_phase) {
-    gs.previous_phase = gs.phase;
     gs.phase = next_phase;
     gs.phase_timer = 0.0f;
 #if defined(__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)

--- a/benchmarks/bench_systems.cpp
+++ b/benchmarks/bench_systems.cpp
@@ -27,7 +27,7 @@ static entt::registry make_bench_registry() {
     wire_input_dispatcher(reg);
     wire_audio_haptic_dispatcher(reg);
     reg.ctx().emplace<GameState>(GameState{
-        GamePhase::Playing, GamePhase::Playing, 0.0f, false, GamePhase::Playing
+        GamePhase::Playing, 0.0f, false, GamePhase::Playing
     });
     reg.ctx().emplace<ScoreState>();
     reg.ctx().emplace<SongState>();

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -504,7 +504,6 @@ enum class EndScreenChoice : uint8_t {
 /// Singleton: governs which systems run and screen transitions.
 struct GameState {
     GamePhase  phase;
-    GamePhase  previous_phase;
     float      phase_timer;          // seconds in current phase
     bool       transition_pending;   // set to request a phase change
     GamePhase  next_phase;           // destination of pending transition
@@ -828,8 +827,8 @@ owns `ScorePopup::remaining`. Obstacle destruction is handled by
 `GameState::transition_pending` and `next_phase` are the canonical transition
 queue. UI controllers and input handlers request a phase by setting those
 fields; `game_state_system` drains the request, clears stale pointer state, and
-then enters the requested phase. `enter_phase` updates `previous_phase`,
-`phase`, and `phase_timer`.
+then enters the requested phase. `enter_phase` updates `phase` and
+`phase_timer`.
 
 `Tutorial` is a defined phase with a controller, but current shipped screens do
 not route into it. Its continue action transitions to `Playing`.
@@ -1051,7 +1050,6 @@ int main(int argc, char* argv[]) {
     wire_input_dispatcher(reg);
     reg.ctx().emplace<GameState>(GameState{
         .phase = GamePhase::Title,
-        .previous_phase = GamePhase::Title,
         .phase_timer = 0.0f,
         .transition_pending = false,
         .next_phase = GamePhase::Title,

--- a/tests/test_energy_system.cpp
+++ b/tests/test_energy_system.cpp
@@ -114,7 +114,7 @@ TEST_CASE("energy: no action when SongState not present", "[energy]") {
     bare_reg.ctx().emplace<InputState>();
     
     bare_reg.ctx().emplace<GameState>(GameState{
-        GamePhase::Playing, GamePhase::Playing, 0.0f, false, GamePhase::Playing
+        GamePhase::Playing, 0.0f, false, GamePhase::Playing
     });
     bare_reg.ctx().emplace<EnergyState>(EnergyState{0.0f, 0.0f, 0.0f});
     runtime_system_scratch_init(bare_reg);
@@ -144,7 +144,7 @@ TEST_CASE("energy: no action when EnergyState not present", "[energy]") {
     bare_reg.ctx().emplace<InputState>();
     
     bare_reg.ctx().emplace<GameState>(GameState{
-        GamePhase::Playing, GamePhase::Playing, 0.0f, false, GamePhase::Playing
+        GamePhase::Playing, 0.0f, false, GamePhase::Playing
     });
     auto& song = bare_reg.ctx().emplace<SongState>();
     song.playing = true;

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -36,7 +36,7 @@ inline entt::registry make_registry() {
     wire_input_dispatcher(reg);
     wire_audio_haptic_dispatcher(reg);
     reg.ctx().emplace<GameState>(GameState{
-        GamePhase::Playing, GamePhase::Playing, 0.0f, false, GamePhase::Playing
+        GamePhase::Playing, 0.0f, false, GamePhase::Playing
     });
     reg.ctx().emplace<ScoreState>();
     create_settings_entity(reg);  // defaults: haptics_enabled=true

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -367,7 +367,7 @@ TEST_CASE("High score bootstrap: persistence path is populated for save call sit
     reg.ctx().get<HighScoreState>() = loaded_at_bootstrap;
     reg.ctx().get<HighScorePersistence>() = HighScorePersistence{file.string()};
     reg.ctx().get<GameState>() = GameState{
-        GamePhase::Playing, GamePhase::Playing, 0.0f, true, GamePhase::SongComplete
+        GamePhase::Playing, 0.0f, true, GamePhase::SongComplete
     };
     auto& score = reg.ctx().get<ScoreState>();
     score.high_score = 1000;

--- a/tests/test_song_playback_system.cpp
+++ b/tests/test_song_playback_system.cpp
@@ -302,7 +302,6 @@ TEST_CASE("song_playback: pause to playing resume guard is one-shot",
     music.paused = true;
 
     gs.phase = GamePhase::Playing;
-    gs.previous_phase = GamePhase::Paused;
     song.playing = true;
 
     song_playback_system(reg, 0.016f);


### PR DESCRIPTION
Closes #1102.

`GameState::previous_phase` was written by `enter_phase()` and four `GameState{...}` constructors, but had **zero production or test readers** — pure dead state, same scaffolding pattern as `transition_alpha` (#1098).

## Diff summary

- `app/components/game_state.h` — drop field from struct
- `app/systems/game_phase_transition.cpp` — drop write in `enter_phase()` (now: `phase = next_phase; phase_timer = 0.0f;`)
- `app/game_loop.cpp` — drop `.previous_phase = …` from designated initializer
- `tests/test_song_playback_system.cpp` — drop dead `gs.previous_phase = GamePhase::Paused;` setup line in the pause→playing resume-guard test (`song_playback_system` does not read the field, so the test is functionally equivalent)
- 5 positional `GameState{…}` initializers trimmed: `benchmarks/bench_systems.cpp`, `tests/test_helpers.h`, `tests/test_energy_system.cpp` (×2), `tests/test_high_score_integration.cpp`
- `design-docs/architecture.md` — remove field from struct, drop \`previous_phase\` from `enter_phase` prose, drop from sample initializer

## Verification

- `cmake --build build` (unity ON, default): zero warnings ✅
- `cmake --build build-no-unity` (unity OFF): zero warnings ✅
- `./build/shapeshifter_tests "*"`: **916/916 passed** (2959 assertions) ✅
- `./build-no-unity/shapeshifter_tests "*"`: **916/916 passed** (2959 assertions) ✅

No behavior change.