### PR TITLE
Drop dead ShapeWindow::peak_time field, sync docs to press_time (closes #1096)

### DIFF
--- a/app/components/player.h
+++ b/app/components/player.h
@@ -27,7 +27,6 @@ struct ShapeWindow {
     float       window_timer  = 0.0f;
     float       window_start  = 0.0f;
     float       press_time    = -1.0f;
-    float       peak_time     = 0.0f;
     float       window_scale  = 1.0f;
 };
 

--- a/app/systems/player_input_system.cpp
+++ b/app/systems/player_input_system.cpp
@@ -81,7 +81,6 @@ void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt)
         sw.window_timer = 0.0f;
         sw.window_start = song->song_time;
         sw.press_time = song->song_time;
-        sw.peak_time = song->song_time + song->half_window;
         ps.morph_t = 0.0f;
         sw.window_scale = 1.0f;
         sw.graded = false;

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -176,8 +176,9 @@ struct PlayerShape {
 ///   - When `phase == MorphIn` completes, shape_window_activation_system
 ///                        promotes `target_shape` into `PlayerShape.current`
 ///                        and resets the morph animation.
-///   - `press_time`/`peak_time` feed timing-grade computation when an
-///                        obstacle resolves.
+///   - `press_time`       feeds timing-grade computation when an obstacle
+///                        resolves (collision_system compares it against
+///                        BeatInfo.arrival_time).
 ///
 /// `WindowPhase` lives in `components/window_phase.h` so it can be shared by
 /// player.h and rhythm.h without a header cycle.
@@ -195,7 +196,6 @@ struct ShapeWindow {
     float       window_timer;   // seconds into the current phase
     float       window_start;   // song_time when the current window opened
     float       press_time;     // song_time of the latest valid press (-1 = none)
-    float       peak_time;      // song_time at the dead-center of the window
     float       window_scale;   // per-note window width multiplier
 };
 

--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -261,7 +261,6 @@ struct ShapeWindow {
     float       window_timer = 0.0f;          // seconds in current phase/window
     float       window_start = 0.0f;          // absolute song_time of window start
     float       press_time   = -1.0f;         // absolute song_time of input
-    float       peak_time    = 0.0f;          // absolute song_time of window peak
     float       window_scale = 1.0f;          // shortening factor from early hit
 };
 ```
@@ -344,7 +343,7 @@ struct SongResults {
   │ collision_system                               [MOD]       │
   │   → checks shape match at obstacle arrival                 │
   │   → computes TimingGrade from BeatInfo.arrival_time        │
-  │     (falls back to ShapeWindow.peak_time if no BeatInfo)   │
+  │     against ShapeWindow.press_time                         │
   │   → on HIT: applies window_scale shortening if !graded     │
   │   → on MISS: drain EnergyState; GameOver only at energy=0  │
   │   → emplaces ScoredTag on both HIT and MISS paths          │

--- a/tests/test_player_action_rhythm.cpp
+++ b/tests/test_player_action_rhythm.cpp
@@ -1,5 +1,4 @@
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include "test_helpers.h"
 
 // ── semantic input pipeline: rhythm mode ───────────────────────────────
@@ -57,22 +56,6 @@ TEST_CASE("player_action: post-song rhythm context still starts window for trail
     CHECK(sw.press_time == song.song_time);
 }
 
-TEST_CASE("player_action: rhythm mode calculates peak_time correctly", "[player_rhythm]") {
-    auto reg = make_rhythm_registry();
-    auto player = make_rhythm_player(reg);
-    auto& song = reg.ctx().get<SongState>();
-    song.song_time = 10.0f;
-
-    auto btn = make_shape_button(reg, Shape::Triangle);
-    press_button(reg, btn);
-
-    run_semantic_input_tick(reg, 0.016f);
-
-    auto& sw = reg.get<ShapeWindow>(player);
-    float expected_peak = 10.0f + song.half_window;
-    CHECK_THAT(sw.peak_time, Catch::Matchers::WithinAbs(expected_peak, 0.001f));
-}
-
 TEST_CASE("player_action: rhythm mode treats same shape during Active as no-op", "[player_rhythm]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
@@ -83,13 +66,11 @@ TEST_CASE("player_action: rhythm mode treats same shape during Active as no-op",
     sw.window_timer = 0.1f;
     sw.window_start = 1.0f;
     sw.press_time = 1.0f;
-    sw.peak_time = 1.15f;
     sw.graded = true;
 
     const float initial_window_start = sw.window_start;
     const float initial_window_timer = sw.window_timer;
     const float initial_press_time = sw.press_time;
-    const float initial_peak_time = sw.peak_time;
 
     auto btn = make_shape_button(reg, Shape::Square);
     press_button(reg, btn);
@@ -100,7 +81,6 @@ TEST_CASE("player_action: rhythm mode treats same shape during Active as no-op",
     CHECK(sw.window_start == initial_window_start);
     CHECK(sw.window_timer == initial_window_timer);
     CHECK(sw.press_time == initial_press_time);
-    CHECK(sw.peak_time == initial_peak_time);
     CHECK(sw.graded);
 }
 

--- a/tests/test_player_input_rhythm_extended.cpp
+++ b/tests/test_player_input_rhythm_extended.cpp
@@ -1,5 +1,4 @@
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include "test_helpers.h"
 
 // ── semantic input pipeline: rhythm mode window management ───────
@@ -56,13 +55,11 @@ TEST_CASE("player_input_rhythm: same shape in Active is no-op", "[player][rhythm
     sw.window_start = song.song_time - 0.5f;
     sw.window_timer = 0.5f;
     sw.press_time = song.song_time - 0.5f;
-    sw.peak_time = song.song_time - 0.25f;
     sw.graded = true;  // was previously graded
 
     const float initial_window_start = sw.window_start;
     const float initial_window_timer = sw.window_timer;
     const float initial_press_time = sw.press_time;
-    const float initial_peak_time = sw.peak_time;
 
     auto btn = make_shape_button(reg, Shape::Circle);
     press_button(reg, btn);
@@ -73,7 +70,6 @@ TEST_CASE("player_input_rhythm: same shape in Active is no-op", "[player][rhythm
     CHECK(sw.window_start == initial_window_start);
     CHECK(sw.window_timer == initial_window_timer);
     CHECK(sw.press_time == initial_press_time);
-    CHECK(sw.peak_time == initial_peak_time);
     CHECK(sw.graded);
 }
 


### PR DESCRIPTION
Closes #1096.

`ShapeWindow.peak_time` was written by `player_input_system` on every shape press but had **zero production readers** — `collision_system` uses `press_time` exclusively for the timing-grade delta. Two design docs (`architecture.md`, `rhythm-spec.md`) incorrectly claimed `peak_time` was a fallback timing-grade input.

Per **Option B** in the issue (squad recommendation in https://github.com/yashasg/friendly-parakeet/issues/1096#issuecomment-4451177960): the code is correct, the docs are wrong; remove the dead field and sync docs to reality.

## Diff summary

- **Code:**
  - `app/components/player.h` — drop `peak_time` from `ShapeWindow`
  - `app/systems/player_input_system.cpp` — drop the `sw.peak_time = song->song_time + song->half_window;` write
- **Tests:**
  - `tests/test_player_action_rhythm.cpp` — delete the entire "calculates peak_time correctly" test (the only behavioral test); drop the now-meaningless preservation lines in the no-op-on-active test; drop unused matchers include
  - `tests/test_player_input_rhythm_extended.cpp` — drop preservation assertions for `peak_time`; drop unused matchers include
- **Docs:**
  - `design-docs/architecture.md` — drop `peak_time` from struct; rewrite the `press_time` doc-comment to reference only `press_time` and to call out collision_system's use of `BeatInfo.arrival_time`
  - `design-docs/rhythm-spec.md` — drop `peak_time` from struct; replace "(falls back to ShapeWindow.peak_time if no BeatInfo)" with "against ShapeWindow.press_time"

## Verification

- `cmake --build build` (unity ON, default): zero warnings ✅
- `cmake --build build-no-unity` (unity OFF): zero warnings ✅
- `./build/shapeshifter_tests "*"`: **915/915 passed** (2956 assertions) ✅
- `./build-no-unity/shapeshifter_tests "*"`: **915/915 passed** (2956 assertions) ✅

Test count drops from 916 → 915 because one obsolete test was removed (it asserted that the now-deleted field was set correctly).

No behavior change.
