### PR TITLE
Drop dead ScoreState::distance_traveled field (closes #1095)

### DIFF
--- a/app/components/scoring.h
+++ b/app/components/scoring.h
@@ -10,7 +10,6 @@ struct ScoreState {
     int32_t displayed_score   = 0;
     int32_t high_score        = 0;
     int32_t chain_count       = 0;
-    float   distance_traveled       = 0.0f;
     float   passive_score_remainder = 0.0f;
 };
 

--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -91,12 +91,10 @@ float chain_multiplier_for_count(int32_t chain_count) {
 void scoring_system(entt::registry& reg, float dt) {
     auto& score   = reg.ctx().get<ScoreState>();
     auto* song    = reg.ctx().find<SongState>();
-    const float scroll_speed = song ? song->scroll_speed : constants::BASE_SCROLL_SPEED;
 
-    // Passive score accrual (distance/time) only while song playback is active.
+    // Passive score accrual (PTS_PER_SECOND) only while song playback is active.
     const bool allow_passive_score = (song == nullptr) || !song->finished;
     if (allow_passive_score) {
-        score.distance_traveled += scroll_speed * dt;
         const float passive_score = score.passive_score_remainder +
             dt * static_cast<float>(constants::PTS_PER_SECOND);
         const int whole_points = static_cast<int>(std::floor(passive_score));

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -355,7 +355,6 @@ struct ScoreState {
     int32_t displayed_score         = 0;     // for smooth scroll-up animation
     int32_t high_score              = 0;     // persisted across sessions
     int32_t chain_count             = 0;     // consecutive obstacles cleared
-    float   distance_traveled       = 0.0f;  // total pixels scrolled (for distance bonus)
     float   passive_score_remainder = 0.0f;  // fractional passive score carried across fixed ticks
 };
 

--- a/design-docs/feature-specs.md
+++ b/design-docs/feature-specs.md
@@ -350,7 +350,6 @@ struct ScoreState {
     int32_t displayed_score = 0;
     int32_t high_score = 0;
     int32_t chain_count = 0;
-    float distance_traveled = 0.0f;
     float passive_score_remainder = 0.0f;
 };
 

--- a/tests/test_scoring_system.cpp
+++ b/tests/test_scoring_system.cpp
@@ -55,7 +55,6 @@ TEST_CASE("scoring: distance bonus accumulates", "[scoring]") {
 
     auto& score = reg.ctx().get<ScoreState>();
     CHECK(score.score >= constants::PTS_PER_SECOND);
-    CHECK(score.distance_traveled > 0.0f);
 }
 
 TEST_CASE("scoring: distance bonus accumulates across fixed ticks", "[scoring][issue764]") {
@@ -314,18 +313,6 @@ TEST_CASE("scoring: displayed_score does not overshoot score", "[scoring]") {
     CHECK(score.displayed_score <= score.score);
 }
 
-TEST_CASE("scoring: distance_traveled accumulates from scroll speed", "[scoring]") {
-    auto reg = make_registry();
-    auto& song = reg.ctx().get<SongState>();
-    song.scroll_speed = 400.0f;
-
-    scoring_system(reg, 1.0f);
-    popup_feedback_system(reg, 1.0f);
-    energy_system(reg, 1.0f);
-
-    CHECK(reg.ctx().get<ScoreState>().distance_traveled == 400.0f);
-}
-
 // On-beat shape gate scores at base points (timing only, no burnout multiplier).
 TEST_CASE("scoring: no-penalty — on-beat gate scores at base points", "[scoring]") {
     auto reg = make_registry();
@@ -471,12 +458,10 @@ TEST_CASE("scoring: passive accrual stops once song playback has finished", "[sc
 
     auto& score = reg.ctx().get<ScoreState>();
     score.score = 500;
-    score.distance_traveled = 123.0f;
 
     scoring_system(reg, 1.0f);
 
     CHECK(score.score == 500);
-    CHECK(score.distance_traveled == 123.0f);
 }
 
 TEST_CASE("scoring: obstacle/timing points still apply after playback has finished", "[scoring][issue445]") {


### PR DESCRIPTION
Closes #1095.

`ScoreState.distance_traveled` accumulated total scrolled pixels every tick but had **zero production readers** — no scoring formula, no HUD, no Game Over screen consumed it. The distance bonus that ships in the score is computed independently in `scoring_system.cpp` via `PTS_PER_SECOND * dt`, with no relationship to `distance_traveled`. The field was kept alive only by three preservation tests.

Per **Option B** in the issue (squad recommendation in https://github.com/yashasg/friendly-parakeet/issues/1095#issuecomment-4451177932): the distance bonus already ships independently; Option A (Game Over distance display + rhythm-mode `scroll_speed` re-sync) is a feature addition, not a cleanup, and deserves its own design issue.

## Diff summary

- **Code:**
  - `app/components/scoring.h` — drop `distance_traveled` from `ScoreState`
  - `app/systems/scoring_system.cpp` — drop the `score.distance_traveled += scroll_speed * dt;` write; drop the now-unused `scroll_speed` local + `BASE_SCROLL_SPEED` fallback (both existed solely to feed the deleted accumulator); update the stale `// Passive score accrual (distance/time)` comment to `// Passive score accrual (PTS_PER_SECOND)`
- **Tests:**
  - `tests/test_scoring_system.cpp` — delete the dedicated `"scoring: distance_traveled accumulates from scroll speed"` test; drop two preservation assertions in unrelated tests (`"scoring: distance bonus accumulates"` no longer asserts the deleted field; `"scoring: passive accrual stops once song playback has finished"` drops the setup write + post-check)
- **Docs:**
  - `design-docs/architecture.md` — drop `distance_traveled` row from the `ScoreState` documented struct
  - `design-docs/feature-specs.md` — drop `distance_traveled` from the `ScoreState` reference struct

## Verification

- `cmake --build build` (unity ON, default): zero warnings ✅
- `cmake --build build-no-unity` (unity OFF): zero warnings ✅
- `./build/shapeshifter_tests "*"`: **915/915 passed** (2956 assertions) ✅
- `./build-no-unity/shapeshifter_tests "*"`: **915/915 passed** (2956 assertions) ✅

Test count drops 916 → 915 because one obsolete test was removed (it asserted that the now-deleted field was set correctly from `scroll_speed`).

No behavior change.
