### PR TITLE
ci(windows-msvc): mark ctrf reporter step continue-on-error (closes #1108)

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -242,8 +242,14 @@ jobs:
           name: ctrf-report-windows-msvc
           path: build-msvc/ctrf-report.json
 
+      # Best-effort: this reporter step has been silently failing on PRs after
+      # the artifact upload finalizes (no error, no exit code), marking the job
+      # red even though build + tests are green. Tracked in #1108. The Linux
+      # and Windows-Clang reporter steps still post comments, so PR test-result
+      # visibility is preserved. Remove continue-on-error once #1108 is rooted.
       - name: Report test results
         if: always() && steps.run-tests.outcome != 'skipped'
+        continue-on-error: true
         uses: ctrf-io/github-test-reporter@v1
         with:
           report-path: 'build-msvc/ctrf-report.json'


### PR DESCRIPTION
Closes #1108.

The post-test `ctrf-io/github-test-reporter@v1` step in the **Build (Windows, MSVC)** job has been silently failing on PRs after the artifact upload finalizes — no `##[error]`, no exit code, no PR comment — marking the whole job red even though build + tests are green. The same step on the **Build (Windows, Clang)** job in the same workflow, and the **MSVC** job on `main` push events, both work. So the failure is specific to MSVC reporter on the `pull_request` event (most recently observed twice consecutively on PR #1106's run id 25868397770).

This was a regression introduced by #910 when MSVC CTRF reporting was added.

## Change

Apply **Option A** from #1108: add `continue-on-error: true` to the MSVC `Report test results` step in `.github/workflows/ci-windows.yml` and add a tracking comment that links back to #1108 so the override gets removed once a root cause is found (Option C in the issue).

## What this preserves

- Linux + Windows-Clang reporter comments still post correctly, so PR test-result visibility is preserved.
- The MSVC `Upload CTRF report` step (`actions/upload-artifact@v5`) still runs unconditionally and uploads the well-formed `build-msvc/ctrf-report.json` artifact, so the raw test-results data is available even when the reporter PR-comment step flakes.
- All actual build/test failures still fail the job (the `Build & test` step is unaffected).

## Diff

Single-file, 6-line addition to `.github/workflows/ci-windows.yml`.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-windows.yml'))"` — valid YAML ✅
- Once this lands, PR #1106 (and any subsequent PRs blocked by the same flake) become mergeable on rebase.

## Acceptance criteria

- [x] PR #1106 (and any subsequent PRs) no longer fail Build (Windows, MSVC) when build + tests are green and the reporter flakes.
- [x] Documented in the workflow comment that the reporter is best-effort and tracked under #1108.
- [ ] Root cause documented in #1108; `continue-on-error` removed once a permanent fix lands. *(Tracked separately under #1108 — not in scope for this unblock PR.)*

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>