### PR TITLE
Drop dead ScoreState::chain_timer field (closes #1107)

### DIFF
--- a/app/components/scoring.h
+++ b/app/components/scoring.h
@@ -10,7 +10,6 @@ struct ScoreState {
     int32_t displayed_score   = 0;
     int32_t high_score        = 0;
     int32_t chain_count       = 0;
-    float   chain_timer       = 0.0f;
     float   distance_traveled       = 0.0f;
     float   passive_score_remainder = 0.0f;
 };

--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -104,9 +104,6 @@ void scoring_system(entt::registry& reg, float dt) {
         score.passive_score_remainder = passive_score - static_cast<float>(whole_points);
     }
 
-    // Track rest duration for diagnostics/feedback, but only misses break chain.
-    score.chain_timer += dt;
-
     auto* results = reg.ctx().find<SongResults>();   // #309: hoisted above loop
 
     // Hoist single scratch lookup — miss_buf and hit_buf share the same struct.
@@ -124,7 +121,6 @@ void scoring_system(entt::registry& reg, float dt) {
             enqueue_energy_effect(reg, -constants::ENERGY_DRAIN_MISS, true);
             if (results) results->miss_count++;
             score.chain_count = 0;
-            score.chain_timer = 0.0f;
             if (miss_buf.size() >= miss_buf.capacity()) {
                 ++scratch.miss_capacity_exceeded_count;
             }
@@ -137,7 +133,6 @@ void scoring_system(entt::registry& reg, float dt) {
             enqueue_energy_effect(reg, -constants::ENERGY_DRAIN_MISS, true);
             if (results) results->miss_count++;
             score.chain_count = 0;
-            score.chain_timer = 0.0f;
             if (miss_buf.size() >= miss_buf.capacity()) {
                 ++scratch.miss_capacity_exceeded_count;
             }
@@ -222,7 +217,6 @@ void scoring_system(entt::registry& reg, float dt) {
             const bool contributes_to_chain = r.obs.base_points > 0;
             if (contributes_to_chain) {
                 score.chain_count++;
-                score.chain_timer = 0.0f;
             }
             const float chain_mult = chain_multiplier_for_count(score.chain_count);
             int points = static_cast<int>(

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -355,7 +355,6 @@ struct ScoreState {
     int32_t displayed_score         = 0;     // for smooth scroll-up animation
     int32_t high_score              = 0;     // persisted across sessions
     int32_t chain_count             = 0;     // consecutive obstacles cleared
-    float   chain_timer             = 0.0f;  // seconds since last clear, retained across rests
     float   distance_traveled       = 0.0f;  // total pixels scrolled (for distance bonus)
     float   passive_score_remainder = 0.0f;  // fractional passive score carried across fixed ticks
 };

--- a/design-docs/feature-specs.md
+++ b/design-docs/feature-specs.md
@@ -350,7 +350,6 @@ struct ScoreState {
     int32_t displayed_score = 0;
     int32_t high_score = 0;
     int32_t chain_count = 0;
-    float chain_timer = 0.0f;
     float distance_traveled = 0.0f;
     float passive_score_remainder = 0.0f;
 };

--- a/tests/test_scoring_extended.cpp
+++ b/tests/test_scoring_extended.cpp
@@ -119,14 +119,12 @@ TEST_CASE("scoring: zero-point passive obstacles do not extend chain", "[scoring
     CHECK(score_shape_gate_with_tier(reg, TimingTier::Good) == 200);
     CHECK(score.chain_count == 1);
 
-    score.chain_timer = 1.0f;
     for (int i = 0; i < 3; ++i) {
         (void)make_zero_point_passive_obstacle(reg);
         scoring_system(reg, 0.1f);
     }
 
     CHECK(score.chain_count == 1);
-    CHECK_THAT(score.chain_timer, Catch::Matchers::WithinAbs(1.3f, 0.0001f));
     const int expected_chain2_points = static_cast<int>(
         std::floor(static_cast<float>(constants::PTS_SHAPE_GATE) * (1.0f + constants::CHAIN_MULT_STEP)));
     CHECK(score_shape_gate_with_tier(reg, TimingTier::Good) == expected_chain2_points);
@@ -211,7 +209,6 @@ TEST_CASE("scoring: miss-tagged obstacles do not award score and reset chain", "
     auto reg = make_registry();
     auto& score = reg.ctx().get<ScoreState>();
     score.chain_count = 3;
-    score.chain_timer = 0.5f;
 
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<ScoredTag>(obs);
@@ -223,7 +220,6 @@ TEST_CASE("scoring: miss-tagged obstacles do not award score and reset chain", "
     energy_system(reg, 0.016f);
 
     CHECK(score.chain_count == 0);
-    CHECK(score.chain_timer == 0.0f);
     CHECK(score.score == score_before + static_cast<int>(0.016f * constants::PTS_PER_SECOND));
     CHECK_FALSE(reg.all_of<Obstacle>(obs));
     CHECK_FALSE(reg.all_of<ScoredTag>(obs));


### PR DESCRIPTION
Closes #1107.

`ScoreState.chain_timer` was incremented every tick and reset on hits/misses, but had **zero production readers** — no timeout decision, no HUD display, no Game Over surface. The in-code comment even said the increment was "for diagnostics/feedback", yet no diagnostic or feedback surface anywhere consumed it. The field was kept alive only by two preservation tests asserting its bookkeeping.

`design-docs/architecture.md` annotated the field as "seconds since last clear, retained across rests", implying a planned chain-timeout feature. **No `CHAIN_TIMEOUT` constant exists** in `app/constants.h` and **no system compares `chain_timer` against any threshold**. Per the in-code comment, only misses break chain — never elapsed time.

Per **Option A** in the issue: there is no design pressure for a time-based chain break (only-misses-break-chain is the explicit comment), so drop the field rather than implement a phantom feature.

## Diff summary

- **Code:**
  - `app/components/scoring.h` — drop `chain_timer` from `ScoreState`
  - `app/systems/scoring_system.cpp` — drop the per-tick `chain_timer += dt` increment + the stale `// Track rest duration for diagnostics/feedback` comment; drop the three `= 0.0f` resets (two miss paths, one chain-extending hit path)
- **Tests:**
  - `tests/test_scoring_extended.cpp` — drop `chain_timer` setup + `WithinAbs` assertion in "scoring: zero-point passive obstacles do not extend chain" (core `chain_count` assertions preserved); drop `chain_timer` setup + `== 0.0f` assertion in "scoring: miss-tagged obstacles do not award score and reset chain" (core score / chain_count / component-cleanup assertions preserved)
- **Docs:**
  - `design-docs/architecture.md` — drop `chain_timer` row from documented `ScoreState` struct
  - `design-docs/feature-specs.md` — drop `chain_timer` from reference `ScoreState` struct

`grep -rn 'chain_timer\|CHAIN_TIMEOUT' app/ tests/ design-docs/` returns no matches after this change.

## Verification

- `cmake --build build` (unity ON, default): zero warnings ✅
- `cmake --build build-no-unity` (unity OFF): zero warnings ✅
- `./build/shapeshifter_tests "*"`: **915/915 passed** (2954 assertions) ✅
- `./build-no-unity/shapeshifter_tests "*"`: **915/915 passed** (2954 assertions) ✅

Test case count unchanged from main; assertion count drops 2956 → 2954 because two preservation assertions were removed.

No behavior change.

## Acceptance criteria

- [x] Decided Option A; rationale recorded above (mirrors the in-code comment that only misses break chain).
- [x] Field removed from `ScoreState`; all four writes in `scoring_system.cpp` removed; inline diagnostics comment removed; preservation tests in `test_scoring_extended.cpp` updated; docs synced (`architecture.md`, `feature-specs.md`).
- [x] All builds (unity ON, unity OFF) zero-warning; full test suite passes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>