### PR TITLE
Sync audio-pipeline-spec.md to drop removed GameState::previous_phase (closes #1111)

### DIFF
--- a/docs/audio-pipeline-spec.md
+++ b/docs/audio-pipeline-spec.md
@@ -636,15 +636,19 @@ void song_playback_system(entt::registry& reg, float dt) {
                 // First entry into Playing with music loaded
                 PlayMusicStream(music->stream);
                 music->started = true;
-            } else if (gs.previous_phase == GamePhase::Paused) {
+                music->paused = false;
+            } else if (music->paused) {
                 // Resuming from pause
                 ResumeMusicStream(music->stream);
+                music->paused = false;
             }
-        } else if (gs.phase == GamePhase::Paused && music->started) {
+        } else if (gs.phase == GamePhase::Paused && music->started && !music->paused) {
             PauseMusicStream(music->stream);
+            music->paused = true;
         } else if (gs.phase == GamePhase::GameOver && music->started) {
             StopMusicStream(music->stream);
             music->started = false;
+            music->paused = false;
         }
     }
 


### PR DESCRIPTION
Sync audio-pipeline-spec.md pseudocode to drop removed previous_phase

`GameState::previous_phase` was removed in #1104, but the historical
audio-pipeline implementation spec still showed pseudocode that
detected pause->resume via `gs.previous_phase == GamePhase::Paused`.

Replaced the dangling reference with the canonical mechanism actually
used by `app/systems/song_playback_system.cpp`: a `music->paused` flag
that flips on `Pause` and is cleared on `Resume`.

Doc-only change, no runtime impact.

Closes #1111.
