### PR TITLE
Sync architecture.md SongState struct to add duration_sec & restart_music (closes #1113)

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -376,6 +376,7 @@ struct SongState {
     float bpm             = 120.0f;
     float offset          = 0.0f;
     int   lead_beats      = 4;
+    float duration_sec    = 180.0f;
     float beat_period     = 0.5f;
     float lead_time       = 2.0f;
     float scroll_speed    = constants::APPROACH_DIST / lead_time;
@@ -386,6 +387,7 @@ struct SongState {
     int   current_beat    = -1;
     bool  playing         = false;
     bool  finished        = false;
+    bool  restart_music   = false;
     size_t next_spawn_idx = 0;
 };
 


### PR DESCRIPTION
Sync architecture.md SongState struct to include `duration_sec` and `restart_music`

`design-docs/architecture.md` §2.6 showed the `SongState` struct missing
two canonical fields that exist in `app/components/song_state.h`:

- `float duration_sec = 180.0f;` — session-init field (copied from BeatMap)
- `bool  restart_music = false;` — per-frame flag (set by `setup_play_session`, consumed by `song_playback_system`)

Added both fields in the same positions as the canonical header so the
two struct definitions match field-for-field.

Doc-only change, no runtime impact.

Closes #1113.
