### PR TITLE
Sync architecture.md GameState to drop removed transition_alpha (closes #1112)

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -505,7 +505,6 @@ struct GameState {
     float      phase_timer;          // seconds in current phase
     bool       transition_pending;   // set to request a phase change
     GamePhase  next_phase;           // destination of pending transition
-    float      transition_alpha;     // 0..1 for fade effects
     EndScreenChoice end_choice;      // pending end-screen menu action
 };
 ```
@@ -1051,7 +1050,7 @@ int main(int argc, char* argv[]) {
         .phase_timer = 0.0f,
         .transition_pending = false,
         .next_phase = GamePhase::Title,
-        .transition_alpha = 0.0f
+        .end_choice = EndScreenChoice::None
     });
     reg.ctx().emplace<AudioQueue>();
 


### PR DESCRIPTION
Closes #1112.

`GameState::transition_alpha` was removed in #1099 (commit 3e0ed16) — the field had zero readers — but `design-docs/architecture.md` still referenced it in two places inside fenced ` ```cpp ` blocks that document the canonical struct shape and the main-loop singleton emplace.

## Diff summary

- **§5 `GameState` struct snippet** (~line 502-510): drop the `float transition_alpha; // 0..1 for fade effects` line so the struct now matches `app/components/game_state.h:44-50` field-for-field.
- **§8 main-loop emplace pseudocode** (~line 1049-1055): drop the `.transition_alpha = 0.0f` designated initializer and add `.end_choice = EndScreenChoice::None` so the emplace mirrors the canonical default-initialized struct.

## Verification

`grep -rn 'transition_alpha' design-docs/ docs/ app/` returns zero hits after the change.

Doc-only — no code, build, or test impact. Follows up on #1098 / PR #1099 the same way #1115 follows up on #1102 / PR #1104.
