### PR TITLE
Sync tester-personas-tech-spec.md TestPlayerState struct (closes #1114)

### DIFF
--- a/design-docs/tester-personas-tech-spec.md
+++ b/design-docs/tester-personas-tech-spec.md
@@ -206,31 +206,31 @@ separate `need_shape` boolean. Same pattern for `target_lane = -1` and
 // app/components/test_player.h
 
 struct TestPlayerState {
-    TestPlayerSkill skill    = TestPlayerSkill::Pro;
-    bool            active   = false;
-    uint32_t        frame_count = 0;
+    // ── Hot ──────────────────────────────────────────────────
+    TestPlayerSkill skill   = TestPlayerSkill::Pro;
+    bool            active  = false;
+
+    // Delay between consecutive lane swipes (simulates human re-swipe time)
+    static constexpr float SWIPE_COOLDOWN = 0.125f;  // 125ms
+    float swipe_cooldown_timer = 0.0f;
 
     // Action queue — fixed capacity, no heap allocation in hot path.
-    // Max obstacles on screen at 120 BPM / 4 lead beats ≈ 8-12.
-    static constexpr int MAX_ACTIONS = 16;
-    TestPlayerAction actions[MAX_ACTIONS];
+    static constexpr int MAX_ACTIONS = 32;
+    TestPlayerAction actions[MAX_ACTIONS] = {};
     int              action_count = 0;
 
-    // Planned obstacle tracking — linear scan is faster than hash
-    // for N < 50 due to cache locality.
-    static constexpr int MAX_PLANNED = 64;
-    entt::entity     planned[MAX_PLANNED];
-    int              planned_count = 0;
-
-    // RNG (2.5KB — acceptable for singleton)
+    // ── Warm ─────────────────────────────────────────────────
     std::mt19937     rng;
 };
 ```
 
 **DoD note**: `std::vector` replaced with fixed-size arrays. We know
-the upper bound (~12 on-screen obstacles). Fixed arrays avoid heap
-allocation and give deterministic memory layout. Linear scan over 16
-entries fits in a single cache line of indices.
+the upper bound (~12 on-screen obstacles); `MAX_ACTIONS = 32` gives
+generous headroom. Fixed arrays avoid heap allocation and give
+deterministic memory layout. Planned-obstacle tracking no longer uses
+an inline `planned[]` array on the singleton — perception now tags
+each planned obstacle entity with the empty `TestPlayerPlannedTag`
+component, letting EnTT views drive the dedup check.
 
 ## Removed ring-zone component
 
@@ -590,8 +590,8 @@ inside `tick_playing_systems`.
   │ 🟡3 │  Original design used std::vector for action queue     │
   │     │  and planned list. Heap allocation in a per-frame      │
   │     │  system, even if small.                                │
-  │     │  FIX: Fixed-size arrays (MAX_ACTIONS=16, MAX_PLANNED   │
-  │     │  =64). Upper bounds known from BPM analysis.           │
+  │     │  FIX: Fixed-size action queue (MAX_ACTIONS=32) and a   │
+  │     │  per-entity TestPlayerPlannedTag for planning dedup.   │
   ├─────┼────────────────────────────────────────────────────────┤
   │ 🟡4 │  Original design used 7 separate bool fields for      │
   │     │  need_shape, need_lane, need_jump, need_slide,         │


### PR DESCRIPTION
Closes #1114.

`design-docs/tester-personas-tech-spec.md` §"TestPlayerState (context singleton)" had drifted away from the canonical `app/components/test_player.h:60-75`:

| Doc said | Code reality |
| --- | --- |
| `uint32_t frame_count = 0;` | Removed in commit 3e0ed16 (PR #1099) |
| `MAX_ACTIONS = 16` | `MAX_ACTIONS = 32` |
| `entt::entity planned[MAX_PLANNED]; int planned_count;` | Replaced by per-entity `TestPlayerPlannedTag` component |
| (missing) | `SWIPE_COOLDOWN = 0.125f` constant + `float swipe_cooldown_timer` field |

## Diff summary

- Rewrite the §"TestPlayerState (context singleton)" struct snippet to match the canonical header field-for-field, including the Hot/Warm grouping, the swipe-cooldown constant + timer, `MAX_ACTIONS = 32`, and default-aggregate-init brace. Drop the inline planning array and reword the trailing DoD note to describe the `TestPlayerPlannedTag` mechanism instead.
- Update the §3 self-review fix-log row that still mentioned `MAX_ACTIONS=16, MAX_PLANNED=64` so the historical findings table also reflects the current shape.

## Verification

`grep -rn 'frame_count\|planned_count\|MAX_PLANNED' design-docs/tester-personas-tech-spec.md` returns zero hits after the change. The remaining `planned[]` reference is the deliberate negative mention inside the new DoD note explaining the change.

Doc-only — no code, build, or test impact.
