### PR TITLE
Sync rhythm-spec.md BeatEntry/BeatMap struct enumerations to header (closes #1120)

### DIFF
--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -195,6 +195,8 @@ struct BeatEntry {
     Shape        shape        = Shape::Circle;
     int8_t       lane         = 1;
     uint8_t      blocked_mask = 0;
+    float        time_sec     = 0.0f;        // optional authored timestamp
+    bool         has_time_sec = false;       // true → time_sec wins over beat_index
 };
 
 struct BeatMap {
@@ -206,6 +208,7 @@ struct BeatMap {
     int                      lead_beats = 4;
     float                    duration   = 180.0f;
     std::string              difficulty;
+    std::vector<float>       beat_times;     // optional analysed onset table
     std::vector<BeatEntry>   beats;
 };
 ```


### PR DESCRIPTION
Closes #1120.

Adds three missing fields to the `BeatEntry` / `BeatMap` struct blocks in `design-docs/rhythm-spec.md` so they match the canonical `app/components/beat_map.h`:

- `BeatEntry::time_sec` (`float`, optional authored timestamp)
- `BeatEntry::has_time_sec` (`bool`, true → time_sec wins over beat_index)
- `BeatMap::beat_times` (`std::vector<float>`, optional analysed onset table)

`design-docs/feature-specs.md:509-526` and `design-docs/beatmap-integration.md:114-137` already show the canonical fields, so this brings rhythm-spec.md back in line with the rest of the doc set.

Doc-only; no code changes; tests pass.