### PR TITLE
Drop unused constants.h include in session_logger.cpp (closes #1119)

### DIFF
--- a/app/util/session_logger.cpp
+++ b/app/util/session_logger.cpp
@@ -3,7 +3,6 @@
 #include "../components/rhythm.h"
 #include "../components/scoring.h"
 #include "../components/game_state.h"
-#include "../constants.h"
 
 #include <cstdarg>
 #include <cmath>


### PR DESCRIPTION
Closes #1119.

`app/util/session_logger.cpp` included `../constants.h` but never referenced any `constants::*` symbol. Continues the recent unused-includes cleanup series (#1093, #1097, #1100).

## Verification

- `rg -n constants:: app/util/session_logger.cpp` → no matches
- `cmake --build build` → zero warnings, zero errors
- `./build/shapeshifter_tests` → 2951 assertions / 902 test cases pass

Single-line removal; no behavior change.