### PR TITLE
Drop dead ShapeWindow::window_scale field (closes #1125)

### DIFF
--- a/app/components/player.h
+++ b/app/components/player.h
@@ -27,7 +27,6 @@ struct ShapeWindow {
     float       window_timer  = 0.0f;
     float       window_start  = 0.0f;
     float       press_time    = -1.0f;
-    float       window_scale  = 1.0f;
 };
 
 struct Lane {

--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -104,7 +104,6 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
                 // shape_window_system on the next frame.
                 p_window.window_start -= remaining * (1.0f - scale);
             }
-            p_window.window_scale = scale;
             p_window.graded = true;
         }
     };

--- a/app/systems/player_input_system.cpp
+++ b/app/systems/player_input_system.cpp
@@ -82,7 +82,6 @@ void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt)
         sw.window_start = song->song_time;
         sw.press_time = song->song_time;
         ps.morph_t = 0.0f;
-        sw.window_scale = 1.0f;
         sw.graded = false;
         if (auto* disp = reg.ctx().find<entt::dispatcher>()) {
             disp->enqueue<PlaySfxEvent>({SFX::ShapeShift});

--- a/app/systems/shape_window_system.cpp
+++ b/app/systems/shape_window_system.cpp
@@ -119,7 +119,6 @@ void shape_window_system(entt::registry& reg, [[maybe_unused]] float dt) {
                     swindow.phase = WindowPhase::Idle;
                     swindow.window_timer = 0.0f;
                     swindow.press_time = -1.0f;
-                    swindow.window_scale = 1.0f;
                     swindow.graded = false;
                     apply_shape_color(reg, entity, Shape::Hexagon);
                     break;
@@ -132,7 +131,6 @@ void shape_window_system(entt::registry& reg, [[maybe_unused]] float dt) {
                     swindow.phase = WindowPhase::Idle;
                     swindow.window_timer = 0.0f;
                     swindow.press_time = -1.0f;
-                    swindow.window_scale = 1.0f;
                     swindow.graded = false;
                     apply_shape_color(reg, entity, Shape::Hexagon);
                 }

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -196,7 +196,6 @@ struct ShapeWindow {
     float       window_timer;   // seconds into the current phase
     float       window_start;   // song_time when the current window opened
     float       press_time;     // song_time of the latest valid press (-1 = none)
-    float       window_scale;   // per-note window width multiplier
 };
 
 /// Lane occupancy and transition. 8 bytes.

--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -264,7 +264,6 @@ struct ShapeWindow {
     float       window_timer = 0.0f;          // seconds in current phase/window
     float       window_start = 0.0f;          // absolute song_time of window start
     float       press_time   = -1.0f;         // absolute song_time of input
-    float       window_scale = 1.0f;          // shortening factor from early hit
 };
 ```
 
@@ -326,7 +325,7 @@ struct SongResults {
   │ player_input_system handlers                  [MOD]       │
   │   → handle ButtonPressEvent shape input                    │
   │   → transition ShapeWindow into MorphIn phase              │
-  │   → reset graded + window_scale on new window start        │
+  │   → reset graded on new window start                       │
   │                                                            │
   │ shape_window_activation_system                ★ NEW        │
   │   → ticks the MorphIn phase before collision so the player │
@@ -737,8 +736,8 @@ if (!song) return;  // no rhythm context — skip
 ## Phase 3 — Shape window (DONE)
 ```
   • shape_window_system: Idle→MorphIn→Active→MorphOut→Idle
-  • player_input_system handlers: trigger window, reset graded/window_scale
-  • ShapeWindow: owns window_scale + graded fields
+  • player_input_system handlers: trigger window, reset graded
+  • ShapeWindow: owns graded field; collision_system applies window_scale_for_tier on hit
   • collision_system: window scaling on GOOD/PERFECT
 ```
 

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -477,6 +477,5 @@ TEST_CASE("collision: Perfect timing shrinks window via window_start adjustment"
     float remaining = song.window_duration - 0.0f;
     float expected_shift = remaining * 0.50f;
     CHECK_THAT(sw.window_start, Catch::Matchers::WithinAbs(original_window_start - expected_shift, 0.0001f));
-    CHECK(sw.window_scale == 0.50f);
     CHECK(sw.graded);
 }

--- a/tests/test_player_action_rhythm.cpp
+++ b/tests/test_player_action_rhythm.cpp
@@ -23,7 +23,6 @@ TEST_CASE("player_action: rhythm mode starts MorphIn on button press from Idle",
     CHECK(ps.morph_t == 0.0f);
     CHECK(sw.window_start == 5.0f);
     CHECK(sw.graded == false);
-    CHECK(sw.window_scale == 1.0f);
 
     song.song_time += song.morph_duration + 0.01f;
     shape_window_system(reg, song.morph_duration + 0.01f);

--- a/tests/test_rhythm_system.cpp
+++ b/tests/test_rhythm_system.cpp
@@ -741,7 +741,6 @@ TEST_CASE("window_scaling: PERFECT grade shortens remaining window", "[rhythm][w
 
     CHECK(sw.graded);
     // Post-#223: Perfect scale = 0.50 (shrinks remaining window by 50%)
-    CHECK(sw.window_scale == 0.50f);
     // window_start moved backward so remaining Active window expires at 50%
     float remaining = song.window_duration - timer_before;
     float expected_shift = remaining * 0.50f;
@@ -773,7 +772,6 @@ TEST_CASE("window_scaling: GOOD grade shortens window slightly", "[rhythm][windo
 
     CHECK(sw.graded);
     // Post-#223: Good scale = 0.75 (shrinks remaining window by 25%)
-    CHECK(sw.window_scale == 0.75f);
     float remaining = song.window_duration - timer_before;
     float expected_shift = remaining * 0.25f;
     CHECK_THAT(sw.window_start, WithinAbs(start_before - expected_shift, 0.001f));
@@ -803,7 +801,6 @@ TEST_CASE("window_scaling: OK grade keeps window unchanged", "[rhythm][window_sc
 
     CHECK(sw.graded);
     // Post-#223: Ok scale = 1.0 → no window adjustment
-    CHECK(sw.window_scale == 1.00f);
     CHECK_THAT(sw.window_start, WithinAbs(start_before, 0.001f));
     // window_timer must NOT be changed by collision_system
     CHECK_THAT(sw.window_timer, WithinAbs(song.window_duration * 0.3f, 0.001f));
@@ -832,7 +829,6 @@ TEST_CASE("window_scaling: BAD grade keeps window unchanged", "[rhythm][window_s
 
     CHECK(sw.graded);
     // Post-#223: Bad scale = 1.0 → no window adjustment
-    CHECK(sw.window_scale == 1.00f);
     CHECK_THAT(sw.window_start, WithinAbs(start_before, 0.001f));
     // window_timer must NOT be changed by collision_system
     CHECK_THAT(sw.window_timer, WithinAbs(song.window_duration * 0.2f, 0.001f));
@@ -872,7 +868,6 @@ TEST_CASE("window_scaling: graded resets on new window", "[rhythm][window_scalin
 
     // Simulate a graded window
     sw.graded = true;
-    sw.window_scale = 0.5f;
 
     // Start a new window via semantic input drain
     auto btn = make_shape_button(reg, Shape::Triangle);
@@ -881,7 +876,6 @@ TEST_CASE("window_scaling: graded resets on new window", "[rhythm][window_scalin
     run_semantic_input_tick(reg, 0.016f);
 
     CHECK_FALSE(sw.graded);
-    CHECK(sw.window_scale == 1.0f);
 }
 
 // Integration: obstacle arrives on-beat

--- a/tests/test_shape_window_extended.cpp
+++ b/tests/test_shape_window_extended.cpp
@@ -57,7 +57,6 @@ TEST_CASE("shape_window: Active phase expires into MorphOut", "[shape_window][rh
     ps.current = Shape::Circle;
     sw.phase = WindowPhase::Active;
     sw.window_start = song.song_time;
-    sw.window_scale = 1.0f;
 
     // Advance past window_duration
     song.song_time += song.window_duration + 0.01f;
@@ -88,7 +87,6 @@ TEST_CASE("shape_window: MorphOut returns to Idle with Hexagon", "[shape_window]
     CHECK(ps.current == Shape::Hexagon);
     CHECK(sw.target_shape == Shape::Hexagon);
     CHECK(sw.press_time == -1.0f);
-    CHECK(sw.window_scale == 1.0f);
     CHECK_FALSE(sw.graded);
 }
 
@@ -118,10 +116,10 @@ TEST_CASE("shape_window: Active duration is driven by song window duration", "[s
     ps.current = Shape::Circle;
     sw.phase = WindowPhase::Active;
     sw.window_start = song.song_time;
-    sw.window_scale = 1.50f;
 
-    // window_scale is recorded for grading state; collision_system applies
-    // valid shortening by shifting window_start, not by extending duration here.
+    // collision_system shortens the active window by shifting window_start;
+    // shape_window_system itself derives Active duration purely from
+    // song_time vs window_start + window_duration.
     song.song_time += song.window_duration + 0.01f;
     shape_window_system(reg, 0.016f);
 


### PR DESCRIPTION
Closes #1125

## What

Removes the dead `ShapeWindow::window_scale` field. It was assigned in `collision_system`, `shape_window_system` (x2), and `player_input_system` but never read by production code. Continues the dead-field cleanup series (#1095, #1096, #1107).

## Why the issue plan was partially incorrect

The issue proposed deleting `window_scale_for_tier` and the `scale` local in `collision_system.cpp:96`. That's wrong: `scale` IS used to drive the real window-collapse behavior:

```cpp
float scale = window_scale_for_tier(tier);
const float active_elapsed = song.song_time - p_window.window_start;
float remaining = song.window_duration - active_elapsed;
if (remaining > 0.0f && scale < 1.0f) {
    p_window.window_start -= remaining * (1.0f - scale);  // observable behavior
}
p_window.window_scale = scale;  // dead — only this assignment removed
```

Removing the helper would silently break PERFECT/GOOD window shortening. So this PR keeps `window_scale_for_tier`, `timing_multiplier`, and the local `scale` variable.

The issue also said tests had "zero readers" but multiple tests do CHECK the field — those CHECKs are white-box assertions of dead state and are removed; the surrounding behavioral assertions (window_start shift, graded flag) are retained.

## Changes

**Code (app/):**
- Remove `window_scale` field from `struct ShapeWindow`
- Remove 4 dead writes (collision_system, shape_window_system x2, player_input_system)

**Tests:** Remove white-box CHECKs / setup lines for `sw.window_scale` in 4 files. Behavioral coverage retained:
- `window_scale_for_tier` value tests (helpers, beat_map_validation, rhythm_system)
- `window_start` shift assertions
- `graded` flag assertions
- Issue #223 regression tests in test_shape_window_extended.cpp

**Docs:** Remove field from struct definitions in architecture.md and rhythm-spec.md. Update reset/owns lines in rhythm-spec.md. Conceptual references to the "window scale" factor are kept since they describe `window_scale_for_tier`-driven behavior, not a stored field.

## Verification

- `cmake --build build` — zero warnings
- `./build/shapeshifter_tests` — 2943 assertions in 902 test cases pass
- `./build/shapeshifter_startup_shutdown_smoke` — exit 0
- `grep -R '\.window_scale' app/ tests/` — no remaining field references