### PR TITLE
Sync architecture.md component summary table with 6 missing entries (closes #1126)

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -642,6 +642,9 @@ DrawSize             8     COLD       render
 DrawLayer            1     COLD       render
 PopupDisplay        36     COLD       popup_display (fade), ui_render
 ParticleTag          0     COLD       render (filter)
+EnergyBarTag         0     COLD       energy_bar_system (filter), gameplay_hud (filter)
+EnergyBarLayout     24     COLD       energy_bar_system (read), gameplay_hud (read)
+EnergyBarVisual     24     COLD       energy_bar_system (write), gameplay_hud (read)
 ─────────────────────────────────────────────────────────────
 SINGLETONS (ctx)
 ─────────────────────────────────────────────────────────────
@@ -652,8 +655,11 @@ GameState           12     per-frame  game_state_system
 BeatMap             var    session    setup_play_session (write), beat_scheduler (read)
 SongState           48     per-frame  song_playback/beat_scheduler
 EnergyState         12     per-frame  energy_system (write), ui_render (read)
+PendingEnergyEffects var   per-frame  scoring_system (push), energy_system (drain)
 ScoreState          28     per-frame  scoring_system (write), render (read)
+ScorePopupRequestQueue var per-frame  scoring_system (push), popup_feedback_system (drain)
 PlaySfxEvent        var    per-frame  dispatcher events drained by audio_system
+TestPlayerState     var    session    test_player_system (read/write), test_player_session (init), game_loop (reset)
 ─────────────────────────────────────────────────────────────
 ```
 


### PR DESCRIPTION
Closes #1126

## What

Adds six real, in-use components/singletons to the architecture.md "Component Summary Table" (the canonical at-a-glance ECS registry). Continues the sibling drift-fix series #1112, #1113, #1114, #1103.

## Entries added

**COLD tier (entity-backed HUD visual contract):**
| Component | Bytes | Defined in | Iterated by |
|---|---:|---|---|
| EnergyBarTag | 0 | `app/components/energy_bar.h:7` | energy_bar_system (filter), gameplay_hud (filter) |
| EnergyBarLayout | 24 | `app/components/energy_bar.h:9-16` | energy_bar_system (read), gameplay_hud (read) |
| EnergyBarVisual | 24 | `app/components/energy_bar.h:18-25` | energy_bar_system (write), gameplay_hud (read) |

**Singletons (ctx storage):**
| Component | Bytes | Defined in | Iterated by |
|---|---:|---|---|
| PendingEnergyEffects | var | `app/components/gameplay_intents.h:8-16` | scoring_system (push), energy_system (drain) |
| ScorePopupRequestQueue | var | `app/components/gameplay_intents.h:26-29` | scoring_system (push), popup_feedback_system (drain) |
| TestPlayerState | var | `app/components/test_player.h:60` | test_player_system, test_player_session (init), game_loop (reset) |

ACCESS tier and ITERATED-BY columns verified by greps of `app/` for each symbol.

## Verification

- Doc-only change. No code touched.
- All readers/writers cross-checked against actual app/ source.