### PR TITLE
Sync beatmap-integration.md § 3.1 FRAME PIPELINE with actual system order (closes #1127)

### DIFF
--- a/design-docs/beatmap-integration.md
+++ b/design-docs/beatmap-integration.md
@@ -205,30 +205,48 @@ creates the standard runtime obstacle archetypes via `spawn_rhythm_obstacle()`.
 
 ```
   ┌──────────────────────────────────────────────────────────────────┐
-  │  FRAME PIPELINE (on main branch — raylib)                       │
+  │  FRAME PIPELINE (on main branch — raylib + EnTT)                │
   │                                                                  │
-  │  input_system            (polls raylib input → InputState)      │
+  │  PER-FRAME (variable dt — game_loop.cpp):                        │
+  │  ✅ compute_screen_transform   (refresh letterbox + scale)      │
+  │  ✅ input_system               (raylib → InputState + events)   │
+  │  ✅ gameplay_hud_process_button_input (HUD buttons → events)    │
+  │  ✅ test_player_system         (autoplay perception/planning)   │
   │       │                                                          │
-  │  gesture_system          (InputState → GestureResult)           │
-  │  game_state_system       (phase transitions)                    │
-  │  ✅ song_playback_system (advances SongState.song_time)         │
-  │  ✅ beat_scheduler_system (SongState + BeatMap → spawn entities)│
-  │  player_input handlers   (ButtonPressEvent/GoEvent → Player)    │
-  │  shape_window_system     (timing window morphing)               │
-  │  player_movement_system  (animate WorldTransform from Lane/VState)│
-  │  scroll_system           (WorldTransform += MotionVelocity × dt)│
-  │  collision_system        (player vs obstacles → ScoredTag)      │
-  │  scoring_system          (ScoredTag → ScoreState, popups)       │
-  │  energy_system           (miss tracking → drain → game over)    │
-  │  particle_system         (ParticleData timer → gravity/cull)    │
-  │  obstacle_despawn_system (destroy off-camera obstacles)         │
-  │  popup_display_system    (ScorePopup timer → fade/cull)         │
+  │       ▼  while (accumulator >= FIXED_DT) tick_fixed_systems(dt) │
   │       │                                                          │
-  │  render_system           (draw everything)                      │
-  │  ✅ audio_system          (dispatcher-driven SFX playback)      │
+  │  ✅ game_camera_system         (camera follow)                  │
+  │  ✅ ui_camera_system           (HUD camera)                     │
+  │  ✅ game_render_system         (world target)                   │
+  │  ✅ ui_render_system           (UI target)                      │
+  │  ✅ audio_system               (dispatcher → SFX playback)      │
+  │  ✅ haptic_system              (HapticEvent dispatch)           │
+  │                                                                  │
+  │  FIXED TICK (tick_fixed_systems — fixed_tick_runner.cpp):        │
+  │  ✅ game_state_system          (phase + semantic input drain)   │
+  │  ✅ song_playback_system       (advances SongState.song_time)   │
+  │  ✅ tick_playing_systems       (gated on GamePhase::Playing)    │
+  │  ✅ obstacle_despawn_system    (destroy off-camera obstacles)   │
+  │  ✅ popup_feedback_system      (drain ScorePopupRequestQueue)   │
+  │  ✅ popup_display_system       (ScorePopup timer → fade/cull)   │
+  │  ✅ energy_system              (drain PendingEnergyEffects)     │
+  │  ✅ energy_bar_system          (HUD bar visual update)          │
+  │  ✅ particle_system            (ParticleData timer → cull)      │
+  │                                                                  │
+  │  PLAYING TICK (tick_playing_systems — playing_systems_runner):   │
+  │  ✅ beat_log_system            (per-beat diagnostic log)        │
+  │  ✅ beat_scheduler_system      (BeatMap → spawn entities)       │
+  │  ✅ shape_window_activation_system (early MorphIn tick)         │
+  │  ✅ player_movement_system     (animate WorldTransform)         │
+  │  ✅ scroll_system              (WorldTransform += MotionVel·dt) │
+  │  ✅ motion_system              (additional motion components)   │
+  │  ✅ collision_system           (player vs obstacles → ScoredTag)│
+  │  ✅ shape_window_system        (runs AFTER collision — see #871)│
+  │  ✅ miss_detection_system      (window expired → MissTag)       │
+  │  ✅ scoring_system             (ScoredTag → ScoreState + popups)│
   └──────────────────────────────────────────────────────────────────┘
 
-  ✅ = already implemented
+  ✅ = implemented and live in app/
 ```
 
 ## 3.2 beat_map_loader — ✅ ALREADY IMPLEMENTED


### PR DESCRIPTION
Closes #1127

## What

The Data Flow Diagram in `design-docs/beatmap-integration.md` § 3.1 had drifted significantly from the live pipeline on `main`. It (a) referenced `gesture_system` which does not exist, (b) ordered `obstacle_despawn → popup_display → energy → particle` differently from the actual fixed-tick runner, (c) was missing six real systems, and (d) showed `shape_window_system` BEFORE collision when (per #871 / #1124) it runs after.

## Source of truth

Synced to actual order in:
- `app/game_loop.cpp` — per-frame outer loop
- `app/systems/fixed_tick_runner.cpp` — fixed tick (phase-agnostic)
- `app/systems/playing_systems_runner.cpp` — playing-only sub-tick

## Diagram structure

Restructured the single block into three labeled groups:

- **PER-FRAME** (variable dt): compute_screen_transform → input_system → gameplay_hud_process_button_input → test_player_system → [fixed-tick loop] → game_camera_system → ui_camera_system → game_render_system → ui_render_system → audio_system → haptic_system
- **FIXED TICK** (`tick_fixed_systems`): game_state_system → song_playback_system → tick_playing_systems → obstacle_despawn_system → popup_feedback_system → popup_display_system → energy_system → energy_bar_system → particle_system
- **PLAYING TICK** (`tick_playing_systems`, gated on `GamePhase::Playing`): beat_log_system → beat_scheduler_system → shape_window_activation_system → player_movement_system → scroll_system → motion_system → collision_system → shape_window_system → miss_detection_system → scoring_system

## Acceptance criteria checklist

- [x] No reference to `gesture_system` remains in beatmap-integration.md.
- [x] Diagram order matches `fixed_tick_runner.cpp` and `playing_systems_runner.cpp`.
- [x] Lists `popup_feedback_system`, `energy_bar_system`, `beat_log_system`, `shape_window_activation_system`, `motion_system`, `miss_detection_system`.
- [x] `shape_window_system` shown AFTER `collision_system`.
- [x] No code changes.

Out of scope: `gesture_system` references in `tester-personas-tech-spec.md` and `rhythm-spec.md` — issue scope was beatmap-integration.md only.