### PR TITLE
Drop 3 unused component-to-component #includes (closes #1132)

### DIFF
--- a/app/components/input.h
+++ b/app/components/input.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "player.h"
 #include <cstdint>
 
 // ── Raw input state (internal to input_system) ──────────────────────────────

--- a/app/components/input_events.h
+++ b/app/components/input_events.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "input.h"       // Direction
-#include "game_state.h"  // GamePhase
 #include "player.h"      // Shape
 #include <cstdint>
 

--- a/app/components/shape_mesh.h
+++ b/app/components/shape_mesh.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "player.h"
 
 // Shape proportions — maps Shape enum to scale factors.
 // radius_scale: model scale multiplier (applied in model-to-world transform)

--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -3,6 +3,7 @@
 #include "../input/keyboard_shape_mapping.h"
 #include "../components/input.h"
 #include "../components/input_events.h"
+#include "../components/player.h"
 #include "../components/rendering.h"
 #include "../components/game_state.h"
 #include "../constants.h"

--- a/tests/test_audio_offset_calibration.cpp
+++ b/tests/test_audio_offset_calibration.cpp
@@ -8,6 +8,7 @@
 
 #include "test_helpers.h"
 #include "entities/beat_map.h"
+#include "components/player.h"
 #include "components/rhythm.h"
 #include "components/shape_mesh.h"
 #include "rendering/camera_resources.h"

--- a/tests/test_entt_dispatcher_contract.cpp
+++ b/tests/test_entt_dispatcher_contract.cpp
@@ -5,6 +5,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <entt/entt.hpp>
+#include "components/game_state.h"
 #include "components/input_events.h"
 #include "components/system_scratch.h"
 #include "test_helpers.h"

--- a/tests/test_haptic_system.cpp
+++ b/tests/test_haptic_system.cpp
@@ -3,6 +3,7 @@
 #include "components/haptics.h"
 #include "components/audio_events.h"
 #include "entities/settings.h"
+#include "components/game_state.h"
 #include "components/player.h"
 #include "components/transform.h"
 #include "components/input_events.h"


### PR DESCRIPTION
Closes #1132.

## Summary

Three component headers in `app/components/` were `#include`-ing other component headers whose symbols are not referenced. Same pattern as the recently-fixed #1119.

## Drops

| Header | Drop | Why it's unused |
| --- | --- | --- |
| `app/components/input.h` | `#include "player.h"` | Defines `InputSource`, `TouchSlot`, `InputState`, `Direction` only; no `Shape`/`PlayerTag`/`PlayerShape`/`ShapeWindow`/`Lane`/`VMode`/`VerticalState` reference. |
| `app/components/input_events.h` | `#include "game_state.h"` | The trailing `// GamePhase` comment was the only mention; `GamePhase`/`GameState`/`EndScreenChoice`/`LevelSelectState`/`to_phase_bit` are never used in the file. |
| `app/components/shape_mesh.h` | `#include "player.h"` | Defines `ShapeProps` and `ShapeMeshConfig` only; the word "Shape" appears only in a docstring. |

## Direct includes added to consumers (include-what-you-use)

| File | Added | Symbol used |
| --- | --- | --- |
| `app/systems/input_system.cpp` | `components/player.h` | `Shape::Circle` |
| `tests/test_entt_dispatcher_contract.cpp` | `components/game_state.h` | `GameState`, `GamePhase` |
| `tests/test_haptic_system.cpp` | `components/game_state.h` | `GameState`, `GamePhase` |
| `tests/test_audio_offset_calibration.cpp` | `components/player.h` | `Shape`, `PlayerShape`, `ShapeWindow` |

## Verification

- `cmake --build build` succeeds with zero warnings (`-Wall -Wextra -Werror`).
- `./build/shapeshifter_tests` passes (2943 assertions / 902 cases).