### PR TITLE
Sync energy-bar.md to reflect energy_system owning GameOver request (closes #1131)

### DIFF
--- a/design-docs/energy-bar.md
+++ b/design-docs/energy-bar.md
@@ -140,9 +140,12 @@ Current shipped behavior:
 MISS: enqueue_energy_effect(reg, -ENERGY_DRAIN_MISS, true)
 ```
 
-The miss no longer kills the player directly.  `game_state_system` owns the
-energy-depleted `GamePhase::GameOver` transition after queued effects have
-been applied by a prior fixed tick.
+The miss no longer kills the player directly. `energy_system` requests the
+`GamePhase::GameOver` transition in the same fixed tick that drains energy
+to ≤ 0 (provided a `SongState` exists), setting
+`GameOverState::cause = DeathCause::EnergyDepleted`. `game_state_system`
+retains a fallback check that catches pre-existing `energy <= 0` while phase
+is `Playing` (defense-in-depth, not the primary path).
 
 Miss still increments `results->miss_count` and still emplaces
 `ScoredTag` (obstacle is consumed, not re-triggered).


### PR DESCRIPTION
Closes #1131.

## Problem

`design-docs/energy-bar.md` had a contradiction inside the same section:

- **Lines 143-145** (under `### 1. collision_system.cpp — on MISS`) said `game_state_system` owns the energy-depleted `GamePhase::GameOver` transition "after queued effects have been applied by a prior fixed tick" — implying a one-tick delay.
- **Line 178** (under `## System Execution Order`) correctly noted that `energy_system` "applies queued effects, requests GameOver on depletion, smooths display".

The code in `app/systems/energy_system.cpp:48-50` confirms the line-178 description:

```cpp
if (song && energy->energy <= 0.0f) {
    request_energy_depleted_game_over(reg);
}
```

`request_energy_depleted_game_over` (same file, lines 10-20) sets `gs.next_phase = GamePhase::GameOver` and `gs.transition_pending = true` **in the same fixed tick the energy effect lands**, and sets `GameOverState::cause = DeathCause::EnergyDepleted`.

`game_state_system` (`app/systems/game_state_system.cpp:175-186`) still has a redundant safety net that flips to `GamePhase::GameOver` if it catches `energy <= 0` while phase is `Playing`, but it is no longer the *owner* of the request — it is a fallback.

## Fix

Updated lines 143-145 of `design-docs/energy-bar.md` to:

- State that `energy_system` requests the `GamePhase::GameOver` transition in the same fixed tick that drains energy to `<= 0` (provided a `SongState` exists), setting `GameOverState::cause = DeathCause::EnergyDepleted`.
- Note that `game_state_system` retains a fallback check that catches pre-existing `energy <= 0` while phase is `Playing` (defense-in-depth, not the primary path).

The (already-correct) line-178 system-order row is unchanged.

## Verification

Pure documentation change — no code changes required.