### PR TITLE
Drop unused obstacle_kind_is_legacy_lane_fixture helper (closes #1136)

### DIFF
--- a/app/components/obstacle.h
+++ b/app/components/obstacle.h
@@ -21,10 +21,6 @@ enum class ObstacleKind : uint8_t {
     OnsetMarker,
 };
 
-constexpr bool obstacle_kind_is_legacy_lane_fixture(ObstacleKind kind) {
-    return kind == ObstacleKind::LaneBlock || kind == ObstacleKind::ComboGate;
-}
-
 constexpr bool obstacle_kind_is_active_runtime_spawnable(ObstacleKind kind) {
     return kind == ObstacleKind::ShapeGate ||
            kind == ObstacleKind::SplitPath ||


### PR DESCRIPTION
Closes #1136.

## Summary
`obstacle_kind_is_legacy_lane_fixture` (`app/components/obstacle.h:24-26`) had zero callers across `app/`, `tests/`, and `design-docs/` — only the definition site existed. Removed.

## Scope
- The two `ObstacleKind` enum values it tested (`LaneBlock`, `ComboGate`) are still referenced as test fixtures and rejection-logic inputs, so the enum cases stay.
- Sibling helpers (`obstacle_kind_is_active_runtime_spawnable`, `...is_active_blocking_beatmap_kind`, `...is_active_beatmap_spawnable`) are still called and untouched.

## Verification
- `cmake --build build` → zero warnings (`-Wall -Wextra -Werror`).
- `./build/shapeshifter_tests` → all 902 test cases / 2943 assertions pass.
- `rg -n 'obstacle_kind_is_legacy_lane_fixture' app/ tests/ design-docs/` → no matches.