### PR TITLE
Sync rhythm-spec.md § 4 pipeline to drop non-existent beat_tick event (closes #1135)

### DIFF
--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -315,7 +315,6 @@ struct SongResults {
   ┌─ RHYTHM ENGINE ────────────────────────────────────────────┐
   │ song_playback_system                          ★ NEW        │
   │   → advances SongState.song_time by dt                     │
-  │   → fires beat_tick event (for hex pulse VFX)              │
   │                                                            │
   │ beat_scheduler_system                         ★ NEW        │
   │   → reads BeatMap.beats[next_spawn_idx]                    │


### PR DESCRIPTION
Closes #1135.

## Summary
`design-docs/rhythm-spec.md` § Section 4 'Execution order (one frame)' (line 318) claimed the shipped `song_playback_system` fires a `beat_tick` event. No such event exists — `rg beat_tick app/ tests/` returns zero matches. Dropped the misleading bullet.

## Scope
- Pure docs sync. No code changes.
- The remaining `beat_tick` mention in § Phase 5 PLANNED stays untouched per the issue's stated scope (it sits under a never-shipped subsection).

## Verification
- `rg -n 'beat_tick' design-docs/rhythm-spec.md` → returns the single Phase-5 PLANNED line only.
- `rg -n 'beat_tick' app/ tests/` → still zero matches (unchanged).