### PR TITLE
Sync architecture.md § 2.4 to obstacle.h (closes #1139)

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -290,7 +290,7 @@ struct OnsetMarkerTag {};
 ### 2.4 — WARM: Obstacle Specifics (read by collision/scoring, not by scroll)
 
 ```cpp
-// components/obstacle_data.h
+// components/obstacle.h
 
 /// For ShapeGate / SplitPath, plus legacy ComboGate fixtures: which shape is required. 1 byte.
 struct RequiredShape {


### PR DESCRIPTION
Closes #1139.

## Summary
`design-docs/architecture.md:293` opened the § 2.4 'WARM: Obstacle Specifics' code block with `// components/obstacle_data.h`, a header that does not exist. The four structs in the block (`RequiredShape`, `BlockedLanes`, `RequiredLane`, `ShapeGateLane`) actually live in `app/components/obstacle.h` (lines 71, 75, 79, 83 — confirmed by ripgrep). Updated the comment.

## Verification
- `rg -n 'obstacle_data' app/ tests/ design-docs/` → no matches.
- Pure docs sync. No code changes.