### PR TITLE
Replace stale `render_system` references with actual system names (closes #1141)

### DIFF
--- a/app/components/player.h
+++ b/app/components/player.h
@@ -12,7 +12,7 @@ enum class Shape : uint8_t {
 
 struct PlayerTag {};
 
-// Hot render data — read by camera_system, player_movement_system every frame.
+// Hot render data — read by game_camera_system, player_movement_system every frame.
 struct PlayerShape {
     Shape current  = Shape::Circle;
     float morph_t  = 1.0f;

--- a/app/components/player.h
+++ b/app/components/player.h
@@ -12,7 +12,7 @@ enum class Shape : uint8_t {
 
 struct PlayerTag {};
 
-// Hot render data — read by render_system, player_movement_system every frame.
+// Hot render data — read by camera_system, player_movement_system every frame.
 struct PlayerShape {
     Shape current  = Shape::Circle;
     float morph_t  = 1.0f;

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -126,8 +126,8 @@ read infrequently or only by one system.
 // components/transform.h
 
 /// Authoritative world-space spatial state for moving/rendered entities.
-/// Iterated by: scroll_system, camera_system, collision_system,
-///              obstacle_despawn_system
+/// Iterated by: scroll_system, game_camera_system, ui_camera_system,
+///              collision_system, obstacle_despawn_system
 struct WorldTransform {
     glm::vec2 position = {0.0f, 0.0f};
     float     rotation = 0.0f;
@@ -159,7 +159,7 @@ enum class Shape : uint8_t {
 struct PlayerTag {};
 
 /// Current shape and morph progress. 8 bytes.
-/// Hot: read by shape_window_system, collision_system, camera_system.
+/// Hot: read by shape_window_system, collision_system, game_camera_system.
 struct PlayerShape {
     Shape    current = Shape::Circle;  // active gameplay shape
     float    morph_t = 1.0f;           // 0.0 = morph just started, 1.0 = settled
@@ -207,7 +207,7 @@ struct Lane {
 };
 
 /// Vertical movement (jump / slide / grounded). 12 bytes.
-/// Hot: read by collision_system, camera_system.
+/// Hot: read by collision_system, game_camera_system.
 enum class VMode : uint8_t {
     Grounded = 0,
     Jumping  = 1,

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -126,7 +126,7 @@ read infrequently or only by one system.
 // components/transform.h
 
 /// Authoritative world-space spatial state for moving/rendered entities.
-/// Iterated by: scroll_system, render_system, collision_system,
+/// Iterated by: scroll_system, camera_system, collision_system,
 ///              obstacle_despawn_system
 struct WorldTransform {
     glm::vec2 position = {0.0f, 0.0f};
@@ -159,7 +159,7 @@ enum class Shape : uint8_t {
 struct PlayerTag {};
 
 /// Current shape and morph progress. 8 bytes.
-/// Hot: read by shape_window_system, collision_system, render_system.
+/// Hot: read by shape_window_system, collision_system, camera_system.
 struct PlayerShape {
     Shape    current = Shape::Circle;  // active gameplay shape
     float    morph_t = 1.0f;           // 0.0 = morph just started, 1.0 = settled
@@ -199,7 +199,7 @@ struct ShapeWindow {
 };
 
 /// Lane occupancy and transition. 8 bytes.
-/// Hot: read by collision_system, player input handlers, render_system.
+/// Hot: read by collision_system, player input handlers, player_movement_system.
 struct Lane {
     int8_t   current;      // 0 = left, 1 = center, 2 = right
     int8_t   target;       // where we're heading (-1 = no transition)
@@ -207,7 +207,7 @@ struct Lane {
 };
 
 /// Vertical movement (jump / slide / grounded). 12 bytes.
-/// Hot: read by collision_system, render_system.
+/// Hot: read by collision_system, camera_system.
 enum class VMode : uint8_t {
     Grounded = 0,
     Jumping  = 1,

--- a/design-docs/isometric-perspective.md
+++ b/design-docs/isometric-perspective.md
@@ -548,8 +548,9 @@ projection internally.
 | `DrawRectangleLinesEx({x,y,w,h}, t, c)` | `perspective::draw_rect_lines(x, y, w, h, t, c)` |
 | `DrawTriangleLines(v1, v3, v2, c)` | `perspective::draw_tri_lines(v1, v3, v2, c)` |
 
-The old `static draw_shape()` function at the top of game_render_system.cpp is
-replaced entirely by `perspective::draw_shape()`.
+The shape-drawing path in `game_render_system.cpp` (today routed through
+`draw_model_transform()` and the `ModelTransform` view) would be replaced
+entirely by `perspective::draw_shape()`.
 
 ### NOT transformed (viewport-space, lines 590–618)
 

--- a/design-docs/isometric-perspective.md
+++ b/design-docs/isometric-perspective.md
@@ -548,7 +548,7 @@ projection internally.
 | `DrawRectangleLinesEx({x,y,w,h}, t, c)` | `perspective::draw_rect_lines(x, y, w, h, t, c)` |
 | `DrawTriangleLines(v1, v3, v2, c)` | `perspective::draw_tri_lines(v1, v3, v2, c)` |
 
-The old `static draw_shape()` function at the top of render_system.cpp is
+The old `static draw_shape()` function at the top of game_render_system.cpp is
 replaced entirely by `perspective::draw_shape()`.
 
 ### NOT transformed (viewport-space, lines 590–618)
@@ -609,7 +609,7 @@ replaced entirely by `perspective::draw_shape()`.
 | `app/shape_vertices.h` | **New** — `constexpr` unit vertex tables for all shapes (zero runtime trig) |
 | `app/perspective.h` | **New** — `project()`, all perspective draw function declarations |
 | `app/perspective.cpp` | **New** — per-vertex draw implementations using cached vertex tables |
-| `app/systems/render_system.cpp` | Replace all world-space draw calls with `perspective::` calls |
+| `app/systems/game_render_system.cpp` | Replace all world-space draw calls with `perspective::` calls |
 | `CMakeLists.txt` | Add `perspective.cpp` to sources |
 
 No changes to: ECS components, game logic systems, input system, collision,

--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -373,7 +373,7 @@ struct SongResults {
   └────────────────────────────────────────────────────────────┘
            ↓
   ┌─ RENDER ───────────────────────────────────────────────────┐
-  │ render_system                                  [MOD]       │
+  │ game_render_system + ui_render_system          [MOD]       │
   │   → renders Hexagon as default (pointy-top, CCW winding)   │
   │   → renders circular shape buttons with proximity rings    │
   │   → renders score + high score in HUD                      │
@@ -527,7 +527,7 @@ constexpr float BUTTON_W        = 140.0f;   // used for spacing calculation
 constexpr float BUTTON_H        = 100.0f;   // unused by circular rendering
 constexpr float BUTTON_SPACING  = 60.0f;
 
-// Derived in render_system
+// Derived in gameplay_hud_screen_controller
 float btn_radius = BUTTON_W / 2.8f;         // ≈ 50px
 float btn_cx = btn_area_x
     + i * (BUTTON_W + BUTTON_SPACING)


### PR DESCRIPTION
Closes #1141.

## Summary

The bare `render_system` name was referenced in 9 places across docs and one source comment, but **no system by that name exists in the codebase**. The actual render-side systems are `game_render_system`, `ui_render_system`, `floor_render_system`, and `camera_system` (the latter is what reads world/player components and produces `ModelTransform` for the render systems to consume).

## Fixes per call site

| File | Line | Component / context | `render_system` → |
|---|---|---|---|
| `design-docs/architecture.md` | 129–130 | `WorldTransform` | `camera_system` |
| `design-docs/architecture.md` | 162 | `PlayerShape` | `camera_system` |
| `design-docs/architecture.md` | 202 | `Lane` | `player_movement_system` (Lane isn't read by any render/camera system; `player_movement_system` is what integrates `Lane.lerp_t` into `WorldTransform.position`) |
| `design-docs/architecture.md` | 210 | `VerticalState` | `camera_system` |
| `app/components/player.h` | 15 | `PlayerShape` | `camera_system` |
| `design-docs/rhythm-spec.md` | 376 | pipeline diagram (RENDER block) | `game_render_system + ui_render_system` (kept `[MOD]`; box width preserved) |
| `design-docs/rhythm-spec.md` | 530 | "Derived in" comment for `btn_radius` | `gameplay_hud_screen_controller` (`app/ui/screen_controllers/gameplay_hud_screen_controller.cpp:158` is where `btn_radius = circle_bounds.width / 2.8f` is actually computed today) |
| `design-docs/isometric-perspective.md` | 551 | prose | `game_render_system.cpp` (doc stays marked Future / Unimplemented) |
| `design-docs/isometric-perspective.md` | 612 | File Changes Summary table | `app/systems/game_render_system.cpp` |

## Verification

```
$ rg -n '\brender_system\b' app/ tests/ design-docs/
$ echo $?
1
```

Zero matches — only the qualified names `game_render_system`, `ui_render_system`, `floor_render_system`, `camera_system` remain.

```
$ cmake --build build --target shapeshifter_tests -j
[100%] Built target shapeshifter_tests   # zero warnings under -Wall -Wextra -Werror

$ ./build/shapeshifter_tests
All tests passed (2943 assertions in 902 test cases)
```

Pure docs sync plus one source-comment update; no behavior changes.
