### PR TITLE
Drop stale camera_system function-name references (closes #1143)

### DIFF
--- a/app/components/rendering.h
+++ b/app/components/rendering.h
@@ -73,7 +73,7 @@ struct ObstacleChildren {
     int count = 0;
 };
 
-// Screen-space position computed by camera_system for UI rendering.
+// Screen-space position computed by ui_camera_system for UI rendering.
 struct ScreenPosition {
     float x = 0.0f;
     float y = 0.0f;

--- a/tests/test_perspective.cpp
+++ b/tests/test_perspective.cpp
@@ -19,7 +19,7 @@ using Catch::Matchers::WithinAbs;
 // ═════════════════════════════════════════════════════════════════════════════
 // §1  Camera3D setup validation
 // ═════════════════════════════════════════════════════════════════════════════
-// These tests verify the Camera3D configuration constants that camera_system
+// These tests verify the Camera3D configuration constants that game_camera_system
 // uses.  No GPU context required — pure struct/math tests.
 
 TEST_CASE("Camera3D: default setup covers game world", "[camera3d]") {

--- a/tests/test_pr43_regression.cpp
+++ b/tests/test_pr43_regression.cpp
@@ -1,8 +1,8 @@
 // PR #43 regression tests — Baer
 // Covers the six unresolved review threads:
 //   1. ScreenTransform stale on first/resize frame before input_system
-//   2. camera_system slab_matrix Y/Z dimension swap
-//   3. camera_system MeshChild slab Y/Z dimension swap
+//   2. game_camera_system slab_matrix Y/Z dimension swap
+//   3. game_camera_system MeshChild slab Y/Z dimension swap
 //   4. title/controller input routing remains outside legacy ECS hitbox plumbing
 //   6. shape_obstacle child destruction must not touch other parents' children
 
@@ -74,10 +74,10 @@ TEST_CASE("screen_transform ordering: stale identity ST mismaps letterbox-offset
 }
 
 // ═══════════════════════════════════════════════════════════════════════
-// Theme 2 – camera_system slab_matrix dimension order: MeshChild field
+// Theme 2 – game_camera_system slab_matrix dimension order: MeshChild field
 //           contract.  spawn_obstacle_meshes stores depth = DrawSize.h
 //           (scroll-axis) and height = 3D height constant (Y-axis).
-//           camera_system must pass mc.height as h (Y) and mc.depth as
+//           game_camera_system must pass mc.height as h (Y) and mc.depth as
 //           d (Z) to slab_matrix, not the other way around.
 // ═══════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary

Renames the lingering `camera_system` mentions in component/test comments to
the actual functions that own the work. Finishes the cleanup started in #1142.

## Changes

- `app/components/rendering.h`: `ScreenPosition` is written by `ui_camera_system`
- `tests/test_perspective.cpp`: Camera3D config tests cover `game_camera_system`
- `tests/test_pr43_regression.cpp`: `slab_matrix` lives in `game_camera_system`
  (two header-comment references)

## Verification

- After this change, every remaining `\bcamera_system\b` match in `app/`,
  `tests/`, and `design-docs/` is either an `#include "camera_system.h"` line
  or the source-file path in `app/systems/camera_system.cpp` itself — zero
  stale function-name references.
- `cmake --build build` — clean, zero warnings (`-Wall -Wextra -Werror`).
- `./build/shapeshifter_tests` — All tests passed (2943 assertions in 902
  test cases).

Closes #1143.
