### PR TITLE
Drop dead music_context helpers (closes #1145)

### DIFF
--- a/app/audio/music_context.h
+++ b/app/audio/music_context.h
@@ -2,10 +2,6 @@
 
 #include <raylib.h>
 
-inline bool music_stream_has_unloadable_resources(const Music& music) {
-    return music.ctxData != nullptr || music.stream.buffer != nullptr;
-}
-
 inline bool music_stream_is_playable(const Music& music) {
     return IsMusicValid(music) && music.stream.buffer != nullptr;
 }
@@ -28,10 +24,6 @@ struct MusicContext {
 
     void release();
 };
-
-inline bool music_stream_is_valid(Music stream) {
-    return IsMusicValid(stream);
-}
 
 inline bool music_stream_may_own_resources(const Music& stream) {
     return stream.ctxData != nullptr || stream.stream.buffer != nullptr;

--- a/tests/test_music_context.cpp
+++ b/tests/test_music_context.cpp
@@ -31,12 +31,12 @@ TEST_CASE("music context: playable stream requires raylib validity and an audio 
 
 TEST_CASE("music context: rejected partial streams are recognized for unload", "[audio]") {
     Music music{};
-    CHECK_FALSE(music_stream_has_unloadable_resources(music));
+    CHECK_FALSE(music_stream_may_own_resources(music));
 
     music.ctxData = reinterpret_cast<void*>(static_cast<std::uintptr_t>(0x1));
-    CHECK(music_stream_has_unloadable_resources(music));
+    CHECK(music_stream_may_own_resources(music));
 
     music.ctxData = nullptr;
     music.stream.buffer = reinterpret_cast<decltype(music.stream.buffer)>(static_cast<std::uintptr_t>(0x1));
-    CHECK(music_stream_has_unloadable_resources(music));
+    CHECK(music_stream_may_own_resources(music));
 }

--- a/tests/test_song_playback_system.cpp
+++ b/tests/test_song_playback_system.cpp
@@ -6,17 +6,17 @@
 TEST_CASE("music stream helpers validate and identify unloadable rejected handles",
           "[song_playback][music][issue651]") {
     Music empty{};
-    CHECK_FALSE(music_stream_is_valid(empty));
+    CHECK_FALSE(IsMusicValid(empty));
     CHECK_FALSE(music_stream_may_own_resources(empty));
 
     Music partial_context{};
     partial_context.ctxData = reinterpret_cast<void*>(0x1);
-    CHECK_FALSE(music_stream_is_valid(partial_context));
+    CHECK_FALSE(IsMusicValid(partial_context));
     CHECK(music_stream_may_own_resources(partial_context));
 
     Music partial_buffer{};
     partial_buffer.stream.buffer = reinterpret_cast<rAudioBuffer*>(0x1);
-    CHECK_FALSE(music_stream_is_valid(partial_buffer));
+    CHECK_FALSE(IsMusicValid(partial_buffer));
     CHECK(music_stream_may_own_resources(partial_buffer));
 }
 


### PR DESCRIPTION
Closes #1145.

## What

Two helpers in `app/audio/music_context.h` had **zero production call sites** — they existed only to be shadow-tested:

- `music_stream_has_unloadable_resources` — bit-for-bit duplicate of `music_stream_may_own_resources` (which is what production actually uses in `unload_music_stream_resources`).
- `music_stream_is_valid` — trivial pass-through to raylib's `IsMusicValid`, which production calls directly elsewhere in the same header.

This PR deletes both helpers and rewires their tests to call the surviving APIs directly.

## Changes

- `app/audio/music_context.h`: delete both inline helpers.
- `tests/test_music_context.cpp`: 3 call sites → `music_stream_may_own_resources`.
- `tests/test_song_playback_system.cpp`: 3 call sites → `IsMusicValid`.

Diffstat: 3 files changed, 6 insertions(+), 14 deletions(-).

## Verification

- `cmake --build build` — clean, zero warnings (`-Wall -Wextra -Werror`).
- `./build/shapeshifter_tests` — `All tests passed (2943 assertions in 902 test cases)`.
- `grep -rn 'music_stream_has_unloadable_resources\|music_stream_is_valid' app/ tests/` — no matches.

Same drift class as #1136 / #1137.