### PR TITLE
Sync session_logger path references in tester-personas-tech-spec (closes #1147)

### DIFF
--- a/design-docs/tester-personas-tech-spec.md
+++ b/design-docs/tester-personas-tech-spec.md
@@ -241,7 +241,7 @@ runtime beat telemetry comes from `beat_log_system`.
 ## SessionLog (context singleton)
 
 ```cpp
-// app/session_logger.h
+// app/util/session_logger.h
 
 struct SessionLog {
     FILE*    file  = nullptr;
@@ -648,7 +648,7 @@ inside `tick_playing_systems`.
 ```cmake
   # Add to shapeshifter_lib sources:
   app/systems/test_player_system.cpp
-  app/session_logger.cpp
+  app/util/session_logger.cpp
 ```
 
 ## CLI Activation


### PR DESCRIPTION
Fixes #1147.

The tester-personas-tech-spec.md referenced `app/session_logger.{h,cpp}` in two places, but the file actually lives at `app/util/session_logger.{h,cpp}`. Updated both stale path mentions (one header comment above a code snippet, one CMakeLists example block) so readers / IDE go-to-file land on the real files.

### Acceptance criteria

- [x] Both stale path mentions updated to `app/util/session_logger.{h,cpp}`
- [x] `grep -rn 'app/session_logger' design-docs/` returns no matches
- [x] No code changes; doc-only fix