### PR TITLE
Drop stale beat_map_loader references in design-docs (closes #1148)

### DIFF
--- a/design-docs/beatmap-editor.md
+++ b/design-docs/beatmap-editor.md
@@ -186,7 +186,7 @@ depending on whether the click target is an existing obstacle or empty space.
 | Import beatmap JSON | Load an existing `*_beatmap.json` via file picker or drag-drop |
 | Import analysis JSON | Overlay beat timestamps and structure sections from `*_analysis.json` |
 | Export beatmap JSON | Download as `{song_id}_beatmap.json` matching the game's schema |
-| Auto-validate | Run validation rules from `beat_map_loader.cpp` before export |
+| Auto-validate | Run validation rules from `app/entities/beat_map.cpp` before export |
 | Validation panel | Show errors/warnings inline (e.g., "different-shape gates < 3 beats apart") |
 
 ### 3.8 Validation Rules (from `validate_beat_map`)
@@ -463,7 +463,7 @@ export function downloadFile(filename, content)        → void  // triggers bro
 
 // ValidationError = { beatIndex: int, message: string, severity: "error"|"warning" }
 //
-// Validation rules (from beat_map_loader.cpp validate_beat_map):
+// Validation rules (from app/entities/beat_map.cpp validate_beat_map):
 //   1. Beat indices monotonically increasing
 //   2. No beat index beyond song duration
 //   3. BPM in [60, 300]
@@ -506,7 +506,7 @@ export const DEFAULT_ZOOM = 40; // pixels per beat
 
 ### 4.5 Export Format
 
-Exactly matches what `beat_map_loader.cpp` expects:
+Exactly matches what `app/entities/beat_map.cpp` expects:
 
 ```json
 {
@@ -605,7 +605,7 @@ Depends on: constants.js
 Depends on: constants.js
 
 - `importBeatmap(json)` — parse JSON, normalize to internal state shape
-- `exportBeatmap(state)` — serialize state to JSON matching `beat_map_loader.cpp` format
+- `exportBeatmap(state)` — serialize state to JSON matching `app/entities/beat_map.cpp` format
 - `importAnalysis(json)` — parse analysis file, extract structure/onsets/beats
 - `validate(state)` — all 8 validation rules, returns error array
 - `downloadFile(name, content)` — Blob + URL.createObjectURL + click trick

--- a/design-docs/beatmap-integration.md
+++ b/design-docs/beatmap-integration.md
@@ -16,7 +16,7 @@
   │  ✅ raylib for rendering, input, windowing                      │
   │  ✅ nlohmann-json in vcpkg.json                                 │
   │  ✅ BeatMap, SongState, SongResults in rhythm.h                 │
-  │  ✅ beat_map_loader.h/.cpp — JSON → BeatMap with validation     │
+  │  ✅ app/entities/beat_map.{h,cpp} — JSON → BeatMap with validation │
   │  ✅ song_playback_system — uses GetMusicTimePlayed() when audio │
   │     is loaded, with += dt fallback for silent/test mode         │
   │  ✅ beat_scheduler_system — spawns obstacles from BeatMap       │
@@ -249,11 +249,12 @@ creates the standard runtime obstacle archetypes via `spawn_rhythm_obstacle()`.
   ✅ = implemented and live in app/
 ```
 
-## 3.2 beat_map_loader — ✅ ALREADY IMPLEMENTED
+## 3.2 app/entities/beat_map (loader) — ✅ ALREADY IMPLEMENTED
 
 ```
-  app/beat_map_loader.h / .cpp — on main branch.
+  app/entities/beat_map.h / .cpp — on main branch.
   Loads JSON → BeatMap, validates, inits SongState.
+  Exposes load_beat_map() and load_and_validate_beat_map().
   Uses nlohmann-json. Called once at startup.
 ```
 
@@ -413,7 +414,7 @@ endif()
 
 ```
   ✅ app/components/rhythm.h             — BeatMap, SongState, SongResults, etc.
-  ✅ app/beat_map_loader.h / .cpp        — JSON → BeatMap with validation
+  ✅ app/entities/beat_map.h / .cpp       — JSON → BeatMap with validation
   ✅ app/systems/song_playback_system.cpp — song_time advancement
   ✅ app/systems/beat_scheduler_system.cpp — obstacle spawning from BeatMap
   ✅ app/systems/shape_window_system.cpp  — timing window morphing
@@ -524,7 +525,7 @@ Ordered by dependency chain. Steps marked ✅ are already on `main`.
 
   STEP 3 — Beat Map Loader                         ✅ DONE
   ─────────────────────────────
-  • beat_map_loader.h/.cpp: JSON → BeatMap with validation
+  • app/entities/beat_map.h/.cpp: JSON → BeatMap with validation
   • Parser supports ShapeGate, SplitPath, and onset_marker only. LaneBlock
     and ComboGate are legacy component fixtures rejected by active beatmaps.
   • init_song_state() computes derived fields from BPM

--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -719,7 +719,7 @@ if (!song) return;  // no rhythm context — skip
 
 ## Phase 1 — Beat map loading (DONE)
 ```
-  • BeatMap component + beat_map_loader.cpp
+  • BeatMap component + app/entities/beat_map.cpp
   • JSON parser → BeatMap.beats vector
   • Integrated into game_state_system on enter_playing
   • song->playing = true only when beats is non-empty


### PR DESCRIPTION
Fixes #1148.

The design-docs referenced a `beat_map_loader.h/.cpp` file that does not exist on `main`. The actual loader lives in `app/entities/beat_map.{h,cpp}`, exposed via `load_beat_map()` and `load_and_validate_beat_map()`.

Updated all 10 stale references to point at the real path:

- `design-docs/beatmap-integration.md` (5 mentions + section header at L19, L252, L255, L416, L527)
- `design-docs/beatmap-editor.md` (4 mentions at L189, L466, L509, L608)
- `design-docs/rhythm-spec.md` (1 mention at L722)

The last 5 mentions weren't enumerated in the issue body but the explicit AC ("`grep -rn 'beat_map_loader' design-docs/` returns no matches") required addressing them too.

### Acceptance criteria

- [x] `grep -rn 'beat_map_loader' design-docs/` returns no matches
- [x] All references point at `app/entities/beat_map.{h,cpp}` (or the underlying `load_beat_map` / `validate_beat_map` functions)
- [x] Doc-only change; no source/test changes; no build/test impact