### PR TITLE
Sync decisions.md 2026-05-08 shape geometry decision to post-cleanup reality (closes #1151)

### DIFF
--- a/decisions.md
+++ b/decisions.md
@@ -5,18 +5,17 @@
 ## 2026-05-08: Shape Geometry Audit Post-Cleanup
 
 ### Decision
-Keep shape_vertices.h CIRCLE table; schedule HEXAGON/SQUARE/TRIANGLE arrays for removal in future cleanup.
+Remove `app/util/shape_vertices.h` entirely. Floor rings switch from a constexpr CIRCLE table to per-segment `cos`/`sin` generation; the HEXAGON/SQUARE/TRIANGLE arrays had no production callers and go with it.
 
 ### Rationale
-- CIRCLE table actively used by app/systems/game_render_system.cpp draw_floor_rings()
-- Annulus triangles rendered via raylib 2D APIs inside 3D camera path cannot use direct raylib calls
-- HEXAGON/SQUARE/TRIANGLE arrays only referenced in tests/benchmarks; removable without breaking game logic
+- Floor ring annulus triangles are now generated locally in `app/systems/floor_render_system.cpp::draw_floor_rings()` with `std::cos`/`std::sin` per segment inside an `rlBegin(RL_TRIANGLES)` block, so the constexpr CIRCLE table no longer earns its keep.
+- HEXAGON/SQUARE/TRIANGLE arrays had zero non-test references, so they were removable without breaking game logic.
 
 ### Owner
 Architecture Review (Keaton, Keyser)
 
 ### Status
-✅ Approved. No immediate action.
+✅ Implemented. `app/util/shape_vertices.h` deleted; floor rings now generated with trig in `floor_render_system.cpp::draw_floor_rings()`.
 
 ## 2026-05-08: Phase Transition Mechanism — Single Canonical Path (#482)
 


### PR DESCRIPTION
Closes #1151.

The 2026-05-08 "Shape Geometry Audit Post-Cleanup" entry in `decisions.md` still recorded a forward-looking plan ("Keep shape_vertices.h CIRCLE table; schedule HEXAGON/SQUARE/TRIANGLE arrays for removal in future cleanup") with status **"✅ Approved. No immediate action."** — but the action was actually taken on the same day:

- `app/util/shape_vertices.h` is gone (verified: zero matches under `app/`, `tests/`, `tools/`, `benchmarks/`).
- The CIRCLE table is not used at all anymore; floor ring vertices are generated locally in `floor_render_system.cpp::draw_floor_rings()` with `std::cos`/`std::sin` per segment inside an `rlBegin(RL_TRIANGLES)` block.
- `draw_floor_rings()` lives in `floor_render_system.cpp`, not `game_render_system.cpp` as the rationale claimed.

This PR rewrites the Decision / Rationale / Status of that single block to record what actually happened, matching the "✅ Implemented." phrasing used by the other two entries in the file. The two surviving `app/util/shape_vertices.h` mentions in the new text both explicitly describe the file as deleted (no false claim that it still exists).

## Scope

- 1 file changed: `decisions.md`
- 4 insertions, 5 deletions
- No code changes
- Other decision entries untouched
- `design-docs/isometric-perspective.md` references to `app/shape_vertices.h` left alone — that doc is explicitly marked **"Status: Future / Unimplemented."**

## Verification

```
$ ls app/util/shape_vertices.h
ls: app/util/shape_vertices.h: No such file or directory
$ rg -n 'shape_vertices' app/ tests/ tools/ benchmarks/
(no matches)
$ rg -n 'draw_floor_rings|floor_rings' app/
app/systems/floor_render_system.cpp:89:void draw_floor_rings(const FloorParams& fp) {
app/systems/floor_render_system.cpp:196:    draw_floor_rings(floor_params);
```
