### PR TITLE
Drop unused #include game_state.h in session_logger.cpp (closes #1154)

### DIFF
--- a/app/util/session_logger.cpp
+++ b/app/util/session_logger.cpp
@@ -2,7 +2,6 @@
 #include "../components/obstacle.h"
 #include "../components/rhythm.h"
 #include "../components/scoring.h"
-#include "../components/game_state.h"
 
 #include <cstdarg>
 #include <cmath>


### PR DESCRIPTION
Fixes #1154.

Drops a single unused `#include "../components/game_state.h"` from
`app/util/session_logger.cpp`. The file references no `GameState`,
`GamePhase`, `EndScreenChoice`, `LevelSelectState`, or
`to_phase_bit` symbol, and the corresponding header does not include
`game_state.h` either, so this is a translation-unit-local cleanup
with no consumer impact.

## Verification

- `./build.sh` succeeds with zero warnings.
- `./build/shapeshifter_tests` passes (2943 assertions / 902 cases).
- `rg -n 'game_state' app/util/session_logger.cpp` → no matches.

Same cleanup pattern as #1119 (same file family) and #1133.