### PR TITLE
Drop unused get_settings_dir / get_high_scores_dir helpers (closes #1153)

### DIFF
--- a/app/entities/settings.cpp
+++ b/app/entities/settings.cpp
@@ -135,12 +135,6 @@ bool json_integer_to_i64(const nlohmann::json& value, std::int64_t& out) {
 
 }  // namespace
 
-std::filesystem::path get_settings_dir() {
-    persistence::Paths paths;
-    const auto result = persistence::resolve_paths(paths);
-    return result.ok() ? paths.root_dir : std::filesystem::path{};
-}
-
 persistence::Result get_settings_file_path(
     std::filesystem::path& out_path,
     const std::filesystem::path& root_override) {

--- a/app/entities/settings.h
+++ b/app/entities/settings.h
@@ -62,7 +62,6 @@ namespace settings {
 persistence::Result load_settings(SettingsState& state, const std::filesystem::path& path);
 persistence::Result save_settings(const SettingsState& state, const std::filesystem::path& path);
 void mark_dirty_and_save(SettingsPersistence& persistence_state, const SettingsState& state);
-std::filesystem::path get_settings_dir();
 persistence::Result get_settings_file_path(
     std::filesystem::path& out_path,
     const std::filesystem::path& root_override = {});

--- a/app/util/high_score_persistence.cpp
+++ b/app/util/high_score_persistence.cpp
@@ -13,12 +13,6 @@
 
 namespace high_score {
 
-std::filesystem::path get_high_scores_dir() {
-    persistence::Paths paths;
-    const auto result = persistence::resolve_paths(paths);
-    return result.ok() ? paths.root_dir : std::filesystem::path{};
-}
-
 persistence::Result get_high_scores_file_path(
     std::filesystem::path& out_path,
     const std::filesystem::path& root_override) {

--- a/app/util/high_score_persistence.h
+++ b/app/util/high_score_persistence.h
@@ -13,9 +13,6 @@ persistence::Result load_high_scores(HighScoreState& state, const std::filesyste
 // Distinguishes path/open/write failures via structured status.
 persistence::Result save_high_scores(const HighScoreState& state, const std::filesystem::path& path);
 
-// Get platform-specific high scores directory (same as settings dir).
-std::filesystem::path get_high_scores_dir();
-
 // Resolve full high scores file path.
 // Returns structured failure and clears out_path when resolution fails.
 persistence::Result get_high_scores_file_path(


### PR DESCRIPTION
Fixes #1153.

Drops two trivial `get_*_dir()` wrappers around `persistence::resolve_paths`
that have **zero callers** anywhere in `app/`, `tests/`, or `benchmarks/`:

- `settings::get_settings_dir()` — declaration in `app/entities/settings.h`,
  definition in `app/entities/settings.cpp`.
- `high_score::get_high_scores_dir()` — declaration in
  `app/util/high_score_persistence.h`, definition in
  `app/util/high_score_persistence.cpp`.

The companion `get_*_file_path(...)` helpers (which **are** called) remain
untouched.

## Verification

- `./build.sh` succeeds with zero warnings.
- `./build/shapeshifter_tests` passes (2943 assertions / 902 cases).
- `rg -n 'get_settings_dir|get_high_scores_dir' app/ tests/ benchmarks/` → no
  matches.

Same risk profile and pattern as #1100 / #1132 / #1133.