### PR TITLE
Sync beatmap-integration.md §2.1 SongState struct to canonical header (closes #1155)

### DIFF
--- a/design-docs/beatmap-integration.md
+++ b/design-docs/beatmap-integration.md
@@ -137,12 +137,28 @@ struct BeatMap {
 };
 
 struct SongState {
-    float bpm, offset, beat_period, lead_time, scroll_speed;
-    float window_duration, half_window, morph_duration;
+    // ── Session-init fields ──
+    float bpm             = 120.0f;
+    float offset          = 0.0f;
+    int   lead_beats      = 4;
+    float duration_sec    = 180.0f;
+
+    // ── Derived fields ──
+    float beat_period     = 0.5f;
+    float lead_time       = 2.0f;
+    float scroll_speed    = constants::APPROACH_DIST / lead_time;
+    float window_duration = 0.3f;
+    float half_window     = 0.15f;
+    float morph_duration  = 0.1f;
+
+    // ── Per-frame mutable fields ──
     float  song_time     = 0.0f;
     int    current_beat  = -1;
     bool   playing       = false;
     bool   finished      = false;
+    bool   restart_music = false;
+
+    // ── Beat-schedule cursor ──
     size_t next_spawn_idx = 0;
 };
 


### PR DESCRIPTION
Fixes #1155.

Updates the `SongState` struct block in `design-docs/beatmap-integration.md`
§2.1 to match `app/components/song_state.h` (lines 11-39), which is the
canonical declaration. Three fields were missing from the doc:

| Field           | In code | Purpose                                         |
| --------------- | ------- | ----------------------------------------------- |
| `lead_beats`    | line 16 | Session-init field copied from BeatMap          |
| `duration_sec`  | line 17 | Session-init song duration in seconds           |
| `restart_music` | line 34 | Set by `setup_play_session`; consumed by song_playback_system |

`architecture.md §2.6 SongState` was already in sync (closed by #1116) so only
`beatmap-integration.md` needed the patch. The doc's nearby "64B" memory
budget figure still holds: with 8-byte alignment for `size_t`, 12 floats +
3 bools + 1 `size_t` still fits in 64 bytes.

## Verification

- `rg -n 'lead_beats|duration_sec|restart_music' design-docs/beatmap-integration.md` → 7 matches in the §2.1 block.
- No code modified.

Same drift family / cleanup as #1116 / #1117 / #1118 / #1130.