### PR TITLE
Sync DeathCause comment to energy-only reality (closes #1160)

### DIFF
--- a/app/components/song_state.h
+++ b/app/components/song_state.h
@@ -47,9 +47,9 @@ struct EnergyState {
 
 // ── Game Over Cause (singleton) ─────────────────────
 // Tracks the most recent reason the player's run ended.  Set by the
-// system that triggered the end-of-run condition (collision or energy)
-// and read by the Game Over screen to surface a one-line, platform-
-// neutral, colorblind-safe reason.
+// system that triggered the end-of-run condition (currently only
+// energy depletion) and read by the Game Over screen to surface a
+// one-line, platform-neutral, colorblind-safe reason.
 enum class DeathCause : uint8_t {
     None = 0,
     EnergyDepleted = 1,


### PR DESCRIPTION
Closes #1160.

The `DeathCause` enum in `app/components/song_state.h` only has `None` and `EnergyDepleted` (collision-as-instant-death was replaced by the energy bar system long ago). The comment above the enum still claimed the cause is set "by the system that triggered the end-of-run condition (collision or energy)", which overclaims the modeled causes.

This PR rewrites only the parenthetical to "(currently only energy depletion)" — keeping the colorblind-safe / one-line / platform-neutral rationale intact, and leaving language room for future causes without naming a non-existent one.

## Verification

- `rg -n 'DeathCause::Collision|DeathCause::Coll' app/ tests/` → no matches.
- `rg -n 'DeathCause::' app/ tests/` → only `None` and `EnergyDepleted` referenced.
- `cmake --build build` → succeeds with zero warnings.
- `./build/shapeshifter_tests` → 2943 assertions / 902 cases pass.
- 1 file changed, 3 insertions, 3 deletions; comment-only edit.

Same family as #1116 / #1155.
