### PR TITLE
Sync game-flow.md settings paths to app/entities (closes #1161)

### DIFF
--- a/design-docs/game-flow.md
+++ b/design-docs/game-flow.md
@@ -287,7 +287,7 @@ Shipped controls (source: `content/ui/screens/settings.rgl`):
 Not shipped (intentionally absent from this wireframe):
 
 - **Sound / Music volume sliders** — no volume controls exist in `settings.rgl`.
-- **Reset Tutorial [ RESET ]** — `ftue_run_count` / `mark_ftue_complete` plumbing exists in `app/util/settings.h` and `app/util/settings_persistence.h`, but no UI surface ships. If this is still desired, file a separate feature issue rather than implying it ships here.
+- **Reset Tutorial [ RESET ]** — `ftue_run_count` / `mark_ftue_complete` plumbing exists in `app/entities/settings.{h,cpp}` (the `settings::` namespace), but no UI surface ships. If this is still desired, file a separate feature issue rather than implying it ships here.
 
 ---
 


### PR DESCRIPTION
Closes #1161.

`design-docs/game-flow.md:290` still referenced two files that no longer exist on `main`:

- `app/util/settings.h` — moved to `app/entities/settings.h`.
- `app/util/settings_persistence.h` — never existed as a standalone file in current tree; the persistence helpers (`mark_ftue_complete`, `clamp_ftue_run_count`, JSON load/save) were consolidated into `app/entities/settings.{h,cpp}` inside `namespace settings`.

This PR rewrites the single bullet to point at `app/entities/settings.{h,cpp}` (the `settings::` namespace), which is where both `SettingsState` and the `mark_ftue_complete` helper actually live.

## Verification

- `rg -n 'app/util/settings' design-docs/` → no matches.
- `rg -n 'mark_ftue_complete' app/` → `app/entities/settings.h:72`, `app/entities/settings.cpp:288` only.
- 1 file changed, 1 insertion, 1 deletion; doc-only change; no build/test impact.

Same family as #1148 / #1150 / #1158.
