### PR TITLE
Drop migration scaffolding from energy-bar.md (closes #1159)

### DIFF
--- a/design-docs/energy-bar.md
+++ b/design-docs/energy-bar.md
@@ -28,24 +28,9 @@ to nail this one?"
 
 ---
 
-## Replaces
-
-| Before (current)                | After (energy bar)                 |
-|---------------------------------|------------------------------------|
-| `HPState { int current, max }`  | `EnergyState { float energy }`     |
-| Miss → instant GameOver         | Miss → energy drain                |
-| No reward for timing accuracy   | Ok/Good/Perfect → energy recovery  |
-| `hp_system.cpp` (stub)          | `energy_system.cpp` (full)         |
-| `MAX_HP = 5` (unused int)       | `ENERGY_MAX = 1.0f`               |
-
-The existing `HPState` struct, `hp_system.cpp`, and related constants
-(`MAX_HP`, `HP_DRAIN_ON_MISS`, `HP_RECOVER_ON_PERFECT`) are removed.
-
----
-
 ## Data Design
 
-### EnergyState (registry singleton, replaces HPState)
+### EnergyState (registry singleton)
 
 ```cpp
 struct EnergyState {
@@ -298,25 +283,6 @@ The drain/recovery values are designed so that:
 These values are mirrored in `content/constants.json` so tools and docs can
 consume the same tuning table. Runtime C++ currently uses the matching
 `constants.h` constexpr values for zero-overhead access.
-
----
-
-## Files Changed (Implementation Guide for DoD-Architect)
-
-| File | Change |
-|------|--------|
-| `app/components/song_state.h` | Replace `HPState` with `EnergyState` |
-| `app/constants.h` | Replace `MAX_HP`/`HP_*` with `ENERGY_*` constants |
-| `app/systems/hp_system.cpp` | Rename to `energy_system.cpp`, rewrite logic |
-| `app/systems/all_systems.h` | Replace `hp_system` decl with `energy_system` |
-| `app/systems/collision_system.cpp` | Miss → drain energy instead of instant GameOver |
-| `app/systems/scoring_system.cpp` | Add energy recovery/drain on TimingGrade |
-| `app/session/play_session.cpp` | Init `EnergyState` instead of `HPState` |
-| `app/ui/screen_controllers/gameplay_hud_screen_controller.cpp` | Draw energy bar (color ramp, flash, pulse) |
-| `app/main.cpp` | Emplace `EnergyState`, call `energy_system`, update tick order |
-| `CMakeLists.txt` | Rename source file if needed |
-| `content/constants.json` | Add energy tuning values |
-| `tests/*` | Update any test referencing `HPState` |
 
 ---
 


### PR DESCRIPTION
Closes #1159.

`design-docs/energy-bar.md` is the v1.0 design spec for the Energy Bar System, but two sections still read as a pre-migration plan even though the HP→Energy migration shipped long ago.

## What changed

Dropped two migration-scaffolding sections plus one stale section header:

- **"Replaces" (lines 31-43)** — Before/After comparison table plus a sentence claiming `HPState`, `hp_system.cpp`, `MAX_HP`, `HP_DRAIN_ON_MISS`, `HP_RECOVER_ON_PERFECT` "are removed". None of those symbols exist on `main`.
- **"Files Changed (Implementation Guide for DoD-Architect)" (lines 304-321)** — per-file migration plan referencing `app/systems/hp_system.cpp` to be renamed, `HPState` to be replaced, etc. Pre-migration plan; everything in the table is already done.
- **Section header at line 48** — `### EnergyState (registry singleton, replaces HPState)` → `### EnergyState (registry singleton)`. The "replaces HPState" parenthetical was migration-era framing.

The Concept, Data Design, Tuning, math scenarios, and Non-Goals sections are untouched.

## Verification

```
$ rg -n 'hp_system|HPState|MAX_HP|HP_DRAIN|HP_RECOVER' app/
(no matches)

$ rg -n 'hp_system|HPState|MAX_HP|HP_DRAIN|HP_RECOVER' design-docs/energy-bar.md
(no matches)
```

- 1 file changed, 1 insertion, 35 deletions.
- Doc-only change; no build/test impact.

Same doc-drift family as #1148 / #1150 / #1151 / #1155 / #1158.
