### PR TITLE
Drop redundant #include persistence_policy.h in settings.cpp (closes #1170)

### DIFF
--- a/app/entities/settings.cpp
+++ b/app/entities/settings.cpp
@@ -1,5 +1,4 @@
 #include "settings.h"
-#include "../util/persistence_policy.h"
 #include <fstream>
 #include <algorithm>
 #include <cstdint>


### PR DESCRIPTION
## Summary

`app/entities/settings.cpp:2` directly included `../util/persistence_policy.h`, but `settings.h` (included on line 1) already pulls in the same header. The direct include in `settings.cpp` is dead code.

## Verification

- `grep persistence_policy app/entities/settings.cpp` → no matches after removal
- `cmake --build build` → succeeds with zero warnings (Clang/macOS)
- `./build/shapeshifter_tests` → 902 test cases / 2943 assertions all pass
- `settings.cpp` only uses `persistence::` names already exposed transitively via `settings.h`

Closes #1170.