### PR TITLE
Drop stale ObstacleArchetypeInput mention in obstacle_entity.h header (closes #1169)

### DIFF
--- a/app/entities/obstacle_entity.h
+++ b/app/entities/obstacle_entity.h
@@ -6,7 +6,6 @@
 #include "../components/rhythm.h"  // BeatInfo
 
 // Full construction parameters for an obstacle entity.
-// Subsumes ObstacleArchetypeInput + the scroll speed.
 struct ObstacleSpawnParams {
     ObstacleKind kind;
     float        x        = 0.0f;


### PR DESCRIPTION
## Summary

The header comment over `ObstacleSpawnParams` (`app/entities/obstacle_entity.h:9`) referenced a removed type `ObstacleArchetypeInput`. Drop the stale second sentence; the field-level inline comments already describe the carried data.

## Verification

- `rg -n 'ObstacleArchetypeInput' app/ tests/` → no matches after the change
- `cmake --build build` → succeeds with zero warnings (Clang/macOS)
- `./build/shapeshifter_tests` → 902 test cases / 2943 assertions all pass
- Comment-only change; no behavior impact

Closes #1169.