### PR TITLE
Replace stale RequiredVAct diagram label with Obstacle.kind (closes #1168)

### DIFF
--- a/design-docs/tester-personas-tech-spec.md
+++ b/design-docs/tester-personas-tech-spec.md
@@ -67,7 +67,7 @@
   │ (per obs)    │     │ RequiredShape│     │ arrival_time   │
   │              │     │ BlockedLanes │     │                │
   └──────┬───────┘     │ RequiredLane │     └───────┬────────┘
-         │             │ RequiredVAct │             │
+         │             │ Obstacle.kind│             │
          │             └──────┬───────┘             │
          ▼                    ▼                     ▼
   ┌──────────────────────────────────────────────────────────┐


### PR DESCRIPTION
## Summary

The data-flow diagram in `design-docs/tester-personas-tech-spec.md` listed `RequiredVAct` inside the obstacle-data box, but no such component exists on `main`. The vertical-action requirement is encoded in `Obstacle.kind` (`ObstacleKind::Jumpable` / `ObstacleKind::Slidable`).

Renamed the label to `Obstacle.kind` — width matches the existing 13-char `RequiredShape` slot, so ASCII alignment is preserved.

## Verification

- `rg -n 'RequiredVAct' design-docs/` → no matches after the change
- Diff is exactly one line; surrounding diagram still scans cleanly
- Doc-only change; no build/test impact

Closes #1168.