### PR TITLE
Drop stale enforce_first_collision_floor reference in rhythm-spec.md (closes #1167)

### DIFF
--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -100,9 +100,7 @@ player's first reaction window opens (issue #175).
 
 **Authoring rule:** The active onset-based path enforces the floor before
 obstacle materialization by dropping snapped onset candidates whose audio time
-falls inside the per-difficulty floor. Legacy cleanup-enabled generation still
-uses `enforce_first_collision_floor` to postpone or drop an already-authored
-leading obstacle while preserving the rhythm grid for subsequent obstacles.
+falls inside the per-difficulty floor.
 
 `tests/test_shipped_beatmap_first_collision.cpp` is not a shipped-content floor
 gate for the onset-based path. It is a structural integrity guard that ensures


### PR DESCRIPTION
Closes #1167.

The legacy cleanup-enabled generation path is gone from the codebase:

```
rg -n 'enforce_first_collision_floor' app/ tests/   # → 0 matches
```

Drop the sentence that named the non-existent symbol so the spec describes
what `main` does today (onset-drop policy) without trailing legacy prose.

## Acceptance criteria

- [x] Sentence beginning "Legacy cleanup-enabled generation still uses…" dropped.
- [x] `rg -n 'enforce_first_collision_floor' design-docs/` → 0 matches.
- [x] Doc-only change; no code/test impact.