### PR TITLE
Sync raygui-rguilayout-ui-spec.md to as-built generated/ + screen_controllers/ paths (closes #1177)

### DIFF
--- a/design-docs/raygui-rguilayout-ui-spec.md
+++ b/design-docs/raygui-rguilayout-ui-spec.md
@@ -2,40 +2,39 @@
 
 ## Status
 
-Draft for `ui_layout_refactor`.
+Implemented. All migration phases described below have shipped; this spec now documents the as-built rguilayout / raygui screen-controller architecture.
 
-This spec replaces the current JSON-driven UI layout path with raygui controls and rguilayout-authored/generated layout files. It is based on the existing `content/ui/screens/*.json`, `content/ui/routes.json`, `design-docs/game-flow.md`, and the current implementation under `app/ui/` and `app/systems/ui_render_system.cpp` (raygui screen-controller dispatch + render-pass glue).
+This spec replaced the legacy JSON-driven UI layout path with raygui controls and rguilayout-authored/generated layout files. The current implementation lives under `app/ui/generated/`, `app/ui/screen_controllers/`, and `app/systems/ui_render_system.cpp` (raygui screen-controller dispatch + render-pass glue).
 
 Current runtime note: proximity rings are active HUD timing feedback in
 `gameplay_hud_screen_controller.cpp` and are specified by
-`design-docs/rhythm-spec.md`. This migration must preserve equivalent runtime
-behavior unless a separate gameplay/design decision removes the feature. The
-`approach_ring` fields called out below are stale JSON layout data, not the
-active C++ proximity-ring behavior.
+`design-docs/rhythm-spec.md`. The migration preserved this behavior; the
+historical `approach_ring` JSON layout fields (which lived in the now-removed
+`content/ui/screens/gameplay.json`) were intentionally not ported and are not
+the active C++ proximity-ring behavior.
 
-Current directive: the rguilayout application is vendored under `tools/rguilayout/`; `.rgl` files replace the current `content/ui` JSON layout sources; exported `.c/.h` files live directly under `app/ui`; CMake/CI/build-pipeline integration is deferred.
+Current directive: the rguilayout application is vendored under `tools/rguilayout/`; `.rgl` files have replaced the legacy `content/ui` JSON layout sources; exported `.h` files live under `app/ui/generated/` (the export pattern in use today is header-only — no `.c` exports are committed); the headers are compiled in via the screen-controller `.cpp` files under `app/ui/screen_controllers/`.
 
-The Excalidraw tool currently returns an empty scene, so Excalidraw is not a usable source of truth for this draft. If Excalidraw is restored later, it should be used as visual reference only; rguilayout `.rgl` files remain the authoring source for eventual compiled UI layout.
+The Excalidraw tool currently returns an empty scene, so Excalidraw is not a usable source of truth for this spec. If Excalidraw is restored later, it should be used as visual reference only; rguilayout `.rgl` files remain the authoring source for compiled UI layout.
 
 ## Goals
 
-1. Replace hand-authored runtime JSON UI layout files with rguilayout `.rgl` authoring files and generated `.c/.h` exports. Wiring those generated files into the game build is a later integration task.
+1. Replace hand-authored runtime JSON UI layout files with rguilayout `.rgl` authoring files and generated header exports compiled in via screen controllers.
 2. Use raygui for menu, overlay, settings, pause, and HUD UI controls where appropriate.
 3. Keep layout geometry contained in rguilayout exported files. Do not mirror exported rectangles, anchors, widget IDs, or hit targets into ECS components, ECS entities, or `reg.ctx()` layout caches.
 4. Preserve existing `GamePhase`-driven screen-controller dispatch and dispatcher-driven game commands.
-5. Remove duplicated UI geometry across JSON, `ui_layout_cache.h`, and `ui_button_spawner.h`.
+5. Keep UI geometry contained in generated rguilayout exports. The legacy duplicators (`ui_layout_cache.h`, `ui_button_spawner.h`, and the `UIElementTag` / `UIText` / `UIButton` / `UIShape` widget components) have already been removed; do not re-introduce equivalent project-owned layout structures.
 
 ## Non-goals
 
 - Do not change gameplay scoring, energy, input semantics, level selection rules, or song result computation.
-- Do not port stale `approach_ring` layout data from `content/ui/screens/gameplay.json`. Preserve the active C++ proximity-ring HUD behavior unless a separate gameplay/design decision removes it.
+- Do not re-introduce the stale `approach_ring` layout data that lived in the removed `content/ui/screens/gameplay.json`. Preserve the active C++ proximity-ring HUD behavior unless a separate gameplay/design decision removes it.
 - Do not create custom ECS layout components/entities to represent rguilayout data.
-- Do not require rguilayout to be installed in CI or at runtime.
-- Do not add CMake targets, CI compile steps, cache changes, or generated-code build wiring in the near-term authoring phases.
+- Do not require rguilayout to be installed in CI or at runtime (CI does not run the authoring tool).
 
 ## Core decision: exported files own layout data
 
-The rguilayout export is the intended runtime boundary for UI layout data once build integration lands. Until then, generated files may be committed as migration artifacts but are not wired into CMake, CI, or the running game.
+The rguilayout export is the runtime boundary for UI layout data. Generated headers are committed under `app/ui/generated/` and consumed by screen controllers under `app/ui/screen_controllers/`.
 
 The rguilayout tool itself lives in:
 
@@ -48,12 +47,13 @@ For each migrated screen, commit:
 | File | Role | Runtime behavior |
 |---|---|---|
 | `content/ui/screens/<screen>.rgl` | Editable rguilayout source replacing `content/ui/screens/<screen>.json` | Not compiled |
-| `app/ui/<screen>.c` | Generated C export | Committed but not built until the later build-integration task |
-| `app/ui/<screen>.h` | Generated API/header | Committed beside the generated C file; included by future adapters after build integration |
+| `app/ui/generated/<screen>_layout.h` (e.g. `title_layout.h`) | Generated C/C++ header with `GuiLayout_*` symbols, anchors, and a `<Screen>LayoutState` struct | Header-only; included by the matching screen controller `.cpp` and compiled in transitively |
+
+The current export pattern is header-only — there are no committed generated `.c` files. The screen controller TU that includes the layout header acts as the implementation owner.
 
 Recommendation: keep screen layouts under `content/ui/screens/*.rgl` because the existing split already stores screen JSON in `content/ui/screens/` and keeps `content/ui/routes.json` at the root. Use root-level `content/ui/*.rgl` only if a future non-screen/global layout source is introduced. Route data is not layout geometry; do not replace `routes.json` with an `.rgl` unless routing is moved to another non-layout source.
 
-The generated `.c/.h` files contain the runtime layout geometry and generated `GuiLayout_*`-style APIs. Hand-written code may call generated APIs and may pass dynamic state/text into them after the deferred integration task, but it must not copy generated rectangles into project-owned structs or ECS storage.
+The generated headers contain the runtime layout geometry and generated `GuiLayout_*`-style APIs. Hand-written code may call generated APIs and pass dynamic state/text into them, but it must not copy generated rectangles into project-owned structs or ECS storage.
 
 Disallowed:
 
@@ -66,7 +66,7 @@ Disallowed:
 Allowed:
 
 - Existing game/menu state in ECS or ctx: active phase/screen, score, high score, energy, selected song, selected difficulty, settings values, dispatcher/services.
-- Thin non-ECS adapters that include generated headers, call generated layout APIs, bind runtime text/state, apply platform guards, and translate raygui return values into existing events.
+- Thin non-ECS screen controllers that include generated headers, call generated layout APIs, bind runtime text/state, apply platform guards, and translate raygui return values into existing events.
 - Custom raygui-style controls implemented as drawing/input functions, provided their placement comes from generated rguilayout exports and not duplicated ECS layout state.
 
 ## Runtime architecture
@@ -80,13 +80,13 @@ content/ui/screens/<screen>.rgl
         |
         | export generated code
         v
-app/ui/<screen>.c/.h
+app/ui/generated/<screen>_layout.h
         |
-        | deferred: future CMake/CI integration wires generated files
+        | included by the matching screen controller TU
         v
-app/ui/rguilayout_adapters/<screen>_adapter.cpp
+app/ui/screen_controllers/<screen>_screen_controller.cpp
         |
-        | included/called by UI render path
+        | called by UI render path
         v
 ui_render_system()
         |
@@ -95,22 +95,22 @@ ui_render_system()
 existing dispatcher + game state systems
 ```
 
-Screen controllers and `ui_render_system` remain responsible for screen dispatch and widget interaction. They should not load JSON, spawn widget entities, or populate layout caches for rguilayout screens.
+Screen controllers and `ui_render_system` are responsible for screen dispatch and widget interaction. They do not load JSON, spawn widget entities, or populate layout caches for rguilayout screens.
 
-`ui_render_system` switches on the active screen and calls the relevant adapter. The adapter calls generated layout functions directly. If the generated header exposes named controls, slots, or rectangles, adapters may use those generated symbols directly; the key rule is that the values stay in generated files and are not persisted into ECS or copied into hand-written layout tables.
+`ui_render_system` switches on the active screen and calls the relevant screen controller. The controller calls generated layout functions directly. If the generated header exposes named controls, slots, or rectangles, the controller may use those generated symbols directly; the key rule is that the values stay in generated files and are not persisted into ECS or copied into hand-written layout tables.
 
 ## Screen migration scope
 
 | Screen | Migration target | Notes |
 |---|---|---|
-| Title | Generated layout + raygui adapter | Preserve start/confirm behavior. Exit stays platform-gated off web. |
-| Tutorial | Generated layout + adapter | Runtime demo shapes may be drawn by custom functions into generated slots. |
-| Level Select | Generated layout + adapter | Song list may remain data-driven, but card placement must come from generated layout or generated list slots, not `LevelSelectLayout`. |
-| Gameplay HUD | Generated layout + adapter/custom controls | HUD is in scope. Use generated placement for score, high score, pause, energy, lane divider, and shape buttons. |
-| Paused | Generated layout + adapter | Preserve dim overlay behavior; overlay geometry/color must not come from JSON caches. |
-| Game Over | Generated layout + adapter | Dynamic score/high score/death reason is bound at render time. |
-| Song Complete | Generated layout + adapter | Dynamic score/high score/stat table is bound at render time. |
-| Settings | Generated layout + adapter | Wire only when `GamePhase::Settings` / route support exists; runtime toggle text is state-derived. |
+| Title | Generated layout + raygui screen controller | Preserve start/confirm behavior. Exit stays platform-gated off web. |
+| Tutorial | Generated layout + screen controller | Runtime demo shapes may be drawn by custom functions into generated slots. |
+| Level Select | Generated layout + screen controller | Song list may remain data-driven, but card placement must come from generated layout or generated list slots, not `LevelSelectLayout`. |
+| Gameplay HUD | Generated layout + screen controller / custom controls | HUD is in scope. Use generated placement for score, high score, pause, energy, lane divider, and shape buttons. |
+| Paused | Generated layout + screen controller | Preserve dim overlay behavior; overlay geometry/color must not come from JSON caches. |
+| Game Over | Generated layout + screen controller | Dynamic score/high score/death reason is bound at render time. |
+| Song Complete | Generated layout + screen controller | Dynamic score/high score/stat table is bound at render time. |
+| Settings | Generated layout + screen controller | Wire only when `GamePhase::Settings` / route support exists; runtime toggle text is state-derived. |
 
 ## HUD treatment
 
@@ -122,7 +122,7 @@ HUD controls should be implemented as raygui or raygui-style immediate-mode func
 
 | HUD element | Implementation |
 |---|---|
-| Score / high score | `GuiLabel` or existing text draw called from the HUD adapter using generated slots. |
+| Score / high score | `GuiLabel` or existing text draw called from the HUD screen controller using generated slots. |
 | Pause button | Stock `GuiButton` is acceptable. |
 | Energy bar | `GuiProgressBar` or project `GuiEnergyBar(...)` custom control. LOW blink/text/border behavior stays dynamic, but bounds come from generated layout. |
 | Shape buttons | Project `GuiShapeButton(...)` custom controls are acceptable for circular hit testing, colorblind glyphs, and shape-specific drawing. Placement comes from generated layout. |
@@ -131,25 +131,25 @@ HUD controls should be implemented as raygui or raygui-style immediate-mode func
 
 Custom controls are not ECS entities. They are immediate-mode UI functions called during rendering. They may read game state and return clicks/commands, but they do not own persistent layout data.
 
-## Adapter boundary
+## Screen controller boundary
 
-Adapters live under:
+Screen controllers live under:
 
 ```text
-app/ui/rguilayout_adapters/
-  title_adapter.cpp/.h
-  tutorial_adapter.cpp/.h
-  level_select_adapter.cpp/.h
-  gameplay_hud_adapter.cpp/.h
-  paused_adapter.cpp/.h
-  game_over_adapter.cpp/.h
-  song_complete_adapter.cpp/.h
-  settings_adapter.cpp/.h
+app/ui/screen_controllers/
+  title_screen_controller.cpp/.h
+  tutorial_screen_controller.cpp/.h
+  level_select_screen_controller.cpp/.h
+  gameplay_hud_screen_controller.cpp/.h
+  paused_screen_controller.cpp/.h
+  game_over_screen_controller.cpp/.h
+  song_complete_screen_controller.cpp/.h
+  settings_screen_controller.cpp/.h
 ```
 
-A single `app/ui/rguilayout_adapters.cpp` bootstrap file is acceptable only for the first screen; split once a second screen lands.
+A shared `app/ui/screen_controllers/screen_controller_base.h` provides the common dispatch surface used by `ui_render_system`. One screen controller TU also acts as the `RAYGUI_IMPLEMENTATION` owner (currently `title_screen_controller.cpp`).
 
-Adapters may contain:
+Screen controllers may contain:
 
 - `extern "C"` / C++ include boundaries for generated headers.
 - Calls to generated `GuiLayout_*` functions or generated control symbols.
@@ -159,7 +159,7 @@ Adapters may contain:
 - Dispatcher/event glue translating UI clicks into existing commands.
 - Short-lived stack-local state required by raygui/generated APIs.
 
-Adapters must not contain:
+Screen controllers must not contain:
 
 - Copied `Rectangle` constants from generated files.
 - Normalized coordinate constants duplicated from `.rgl`.
@@ -180,18 +180,18 @@ Dynamic UI values stay runtime-driven:
 - Song-complete timing/stat table.
 - Settings toggle labels and audio offset.
 
-The adapter reads existing game state/resolvers and passes current values into generated layout calls or uses generated slots to draw dynamic controls. This preserves dynamic behavior without copying layout data into ECS.
+The screen controller reads existing game state/resolvers and passes current values into generated layout calls or uses generated slots to draw dynamic controls. This preserves dynamic behavior without copying layout data into ECS.
 
 If rguilayout's generated API cannot directly accept a dynamic string for a control, prefer one of these approaches:
 
-1. Author the control as a named empty/placeholder slot in `.rgl`, expose it in generated output, and draw the dynamic raygui/custom control from the adapter using that generated slot.
+1. Author the control as a named empty/placeholder slot in `.rgl`, expose it in generated output, and draw the dynamic raygui/custom control from the screen controller using that generated slot.
 2. Adjust the `.rgl`/export pattern so the generated file exposes a generated hook/state struct for dynamic labels.
 
 Do not solve this by creating project-owned layout constants or ECS layout mirrors.
 
 ## Input and event flow
 
-raygui controls perform immediate-mode hit testing. The adapter converts successful clicks/activations into the same semantic events the game already understands.
+raygui controls perform immediate-mode hit testing. The screen controller converts successful clicks/activations into the same semantic events the game already understands.
 
 Examples:
 
@@ -201,87 +201,79 @@ Examples:
 - HUD pause -> existing pause action.
 - Shape button click/touch -> existing player shape-change path.
 
-For migrated raygui controls, do not spawn parallel ECS hit-test entities. Generated adapters should emit semantic UI/gameplay actions directly as they take ownership of those controls.
+For migrated raygui controls, do not spawn parallel ECS hit-test entities. Screen controllers emit semantic UI/gameplay actions directly as they take ownership of those controls.
 
 ## Build integration
 
-Deferred. Do not add a CMake target for rguilayout output in the near-term authoring phases, and do not require CI to compile generated `.c/.h` files yet.
+Generated headers are wired into the build as part of `shapeshifter_lib`:
 
-For now:
-
-- `tools/rguilayout/` is the vendored application/tooling location.
+- `tools/rguilayout/` is the vendored authoring/tooling location and is not built or run by CMake/CI.
 - `.rgl` layout sources live in `content/ui/screens/` unless a future global/root layout source is justified.
-- Generated `.c/.h` exports live directly in `app/ui/`.
-- Generated files are committed artifacts only; they are not part of `shapeshifter`, `shapeshifter_tests`, native CI, or WASM CI until a later build-integration task.
+- Generated `.h` exports live under `app/ui/generated/` and are picked up via `target_include_directories(... app/ui)`; consumers `#include "../generated/<screen>_layout.h"`.
+- Screen controller `.cpp` files under `app/ui/screen_controllers/` are globbed into `shapeshifter_lib` (`UI_SCREEN_CONTROLLER_SOURCES`) and consume the generated headers.
+- One screen controller TU owns `RAYGUI_IMPLEMENTATION` and is excluded from unity batching to keep the raygui implementation isolated; today this is `app/ui/screen_controllers/title_screen_controller.cpp`.
 
-Future build integration should decide the exact raygui implementation target shape, generated-C target shape, unity exclusions, include directories, warning policy, and native/WASM CI coverage. When that task happens, generated code should be isolated from unity batching and kept warning-clean without weakening warnings for hand-written code.
+The native build (`shapeshifter`, `shapeshifter_tests`) and WASM build compile the generated headers transitively through the screen controllers and stay warning-clean under `-Wall -Wextra -Werror` / `/W4 /WX`.
 
 ## CI and cache
 
-- CI does not run rguilayout.
-- CI does not compile committed generated `.c/.h` files until the deferred build-integration task.
-- No CMake cache-key changes are required for the near-term authoring/documentation phases.
-- In the future PR that wires raygui/generated layout targets into CMake, update native and WASM cache keys for any new build inputs.
+- CI does not run the rguilayout authoring application.
+- Native CI and WASM CI compile screen controllers (and therefore the generated headers they include) as part of `shapeshifter_lib`.
+- CMake cache keys cover the screen controller globs and the generated headers via the standard `CONFIGURE_DEPENDS` glob; no extra cache key changes are required when a new generated header is added alongside a new controller.
 - No WASM preload changes are needed unless a later design introduces external UI assets. This spec does not require an external `.rgs` style file.
 
 ## Migration phases
 
-### Phase 1: Authoring source layout
+### Phase 1: Authoring source layout — done
 
 1. Use the vendored rguilayout application under `tools/rguilayout/`.
-2. Store screen `.rgl` files as `content/ui/screens/<screen>.rgl`, replacing the matching `content/ui/screens/<screen>.json` layout source when that screen migrates.
+2. Store screen `.rgl` files as `content/ui/screens/<screen>.rgl`, replacing the matching `content/ui/screens/<screen>.json` layout source as each screen migrates.
 3. Keep `content/ui/routes.json` until routing is moved to code or another non-layout source.
-4. Export generated `.c/.h` files directly to `app/ui/<screen>.c` and `app/ui/<screen>.h`.
-5. Do not wire generated files into CMake, CI, or runtime yet.
+4. Export generated headers to `app/ui/generated/<screen>_layout.h`.
+5. Wire generated headers and screen controllers into `shapeshifter_lib`.
 
-### Phase 2: First screen authoring proof
+### Phase 2: First screen authoring proof — done
 
-1. Author and export the Title screen: `content/ui/screens/title.rgl` + `app/ui/title.c/.h`.
-2. Preserve tap/Enter start behavior and web exit-button gating in the intended adapter contract.
-3. Leave the generated files unwired until the deferred build-integration task.
+1. Authored and exported the Title screen: `content/ui/screens/title.rgl` + `app/ui/generated/title_layout.h`.
+2. Tap/Enter start behavior and web exit-button gating are preserved by `app/ui/screen_controllers/title_screen_controller.cpp`.
+3. Generated header and controller compile into `shapeshifter_lib`.
 
-### Phase 3: Deferred build integration
+### Phase 3: Build integration — done
 
-Add raygui/generated-code build support, adapter compilation, native CI coverage, and WASM CI coverage in a dedicated platform task. This is intentionally not required for the near-term rguilayout authoring handoff.
+raygui/generated-code build support, screen controller compilation, native CI coverage, and WASM CI coverage are in place. `RAYGUI_IMPLEMENTATION` ownership lives on `title_screen_controller.cpp` and that TU is excluded from unity batching.
 
-### Phase 4: Menus and overlays
+### Phase 4: Menus and overlays — done
 
-Migrate Tutorial, Paused, Game Over, Song Complete, Level Select, and Settings one at a time. Each screen deletes its JSON/layout-cache/widget-entity dependency when its generated adapter is live.
+Tutorial, Paused, Game Over, Song Complete, Level Select, and Settings each have a generated header under `app/ui/generated/` and a matching screen controller. Their JSON/layout-cache/widget-entity dependencies have been removed.
 
-### Phase 5: Gameplay HUD
+### Phase 5: Gameplay HUD — done
 
-Migrate HUD placement to rguilayout generated exports and adapters. Implement shape buttons and energy bar as raygui-style custom immediate-mode controls if stock raygui controls are insufficient. Do not migrate stale approach-ring data.
+HUD placement is driven by `app/ui/generated/gameplay_hud_layout.h` and `app/ui/screen_controllers/gameplay_hud_screen_controller.cpp`. Shape buttons and the energy bar are implemented as raygui-style custom immediate-mode controls. Stale approach-ring layout data was not migrated; the active proximity-ring timing cue is preserved.
 
-### Phase 6: Delete old UI layout path
+### Phase 6: Delete old UI layout path — done (with one exception)
 
-Once all screens are generated:
-
-1. Delete `content/ui/screens/*.json` and `content/ui/routes.json` if routes have been moved to code or another non-layout source.
-2. Delete `ui_loader.*` layout loading code.
-3. Delete `ui_layout_cache.h` and all ctx layout cache writes/reads.
-4. Keep `ui_button_spawner.h` removed; migrated screens should not depend on widget entities/hitboxes.
-5. Delete `UIElementTag`/`UIText`/`UIButton`/`UIShape` components if they no longer serve non-layout gameplay behavior.
-6. Keep legacy hit-test helpers removed; migrated controls should rely on raygui/controller callbacks and semantic events rather than UI hitbox entities.
+1. `content/ui/screens/*.json` files have been removed; `content/ui/routes.json` is intentionally kept until routing moves to code or another non-layout source.
+2. `ui_loader.*` layout loading code is gone.
+3. `ui_layout_cache.h` and all ctx layout cache writes/reads are gone.
+4. `ui_button_spawner.h` is gone; migrated screens do not depend on widget entities/hitboxes.
+5. `UIElementTag` / `UIText` / `UIButton` / `UIShape` components are gone.
+6. Legacy hit-test helpers are gone; migrated controls rely on raygui/controller callbacks and semantic events rather than UI hitbox entities.
 
 ## Validation
 
-- Documentation/source-layout correction does not create `.rgl` files or generated `.c/.h` files.
-- Search confirms near-term phases do not require a CMake target or CI job for generated rguilayout output.
-- Future native build and tests remain warning-free once generated files are wired.
-- Future native unity build still catches ODR hazards in hand-written code.
-- Future WASM build remains warning-free and does not unity-merge raygui implementation or generated C.
-- No runtime path opens `content/ui/screens/*.json` after full migration.
-- Search confirms no `HudLayout`, `LevelSelectLayout`, `OverlayLayout`, or replacement layout-cache structs remain after Phase 6.
-- Search confirms no stale JSON `approach_ring` data is referenced by migrated UI code; active proximity-ring rendering remains covered by the gameplay HUD adapter.
+- `cmake --build build` and `./build/shapeshifter_tests` pass with zero warnings (`-Wall -Wextra -Werror`, `/W4 /WX`).
+- Native unity build still catches ODR hazards in hand-written code; the `RAYGUI_IMPLEMENTATION` TU is excluded from unity batching.
+- WASM build remains warning-free and does not unity-merge raygui implementation or generated C.
+- No runtime path opens `content/ui/screens/*.json` (those files are gone).
+- No project-owned `HudLayout`, `LevelSelectLayout`, or `OverlayLayout` cache struct exists; the only matches under `app/` are the generated `*LayoutState` structs that are allowed to live inside `app/ui/generated/`.
+- No stale JSON `approach_ring` data is referenced by UI code; active proximity-ring rendering is owned by the gameplay HUD screen controller.
 - Screen behavior parity is verified for title, level select, pause/resume, game over, song complete, settings, and gameplay HUD controls.
 
 ## Open issues / risks
 
 1. Excalidraw is unavailable in this session. If a visual source exists, export or restore it before final visual polish.
-2. rguilayout's exact generated API shape must be validated with the first exported screen. The no-ECS-layout-mirror rule holds regardless of API shape.
-3. Dynamic text/control slots may require a consistent rguilayout naming convention so generated headers expose stable symbols.
-4. Settings is present as JSON today but not in `routes.json`; route/state work is required before the settings screen can be fully reachable.
-5. Current `content/ui/screens/gameplay.json` contains stale `approach_ring` fields. The migration should intentionally drop those layout fields while preserving the active proximity-ring timing cue documented in `rhythm-spec.md`.
+2. Dynamic text/control slots may require a consistent rguilayout naming convention so generated headers expose stable symbols.
+3. Settings is present in `routes.json` only via `GamePhase::Settings` / route support; verify route/state coverage as routes evolve.
 
 ## Contributing agent inputs
 


### PR DESCRIPTION
## Summary

Closes #1177.

The `design-docs/raygui-rguilayout-ui-spec.md` was still labelled "Draft for `ui_layout_refactor`" and described pre-migration paths (`app/ui/<screen>.c/.h`, `app/ui/rguilayout_adapters/<screen>_adapter.cpp`, "Build integration: Deferred", future-tense Phase 6 deletions). The migration has shipped, so the spec was several rounds of drift behind reality.

This PR is **docs-only**: it edits a single design-doc file to match what's actually in the tree.

## What changed

- **Status / overview**: `Draft` → `Implemented`; intro now says it documents the as-built architecture.
- **Generated headers**: `app/ui/<screen>.c/.h` directly under `app/ui/` → `app/ui/generated/<screen>_layout.h` (header-only; no `.c` exports). Per-screen file table updated.
- **Adapters → screen controllers**: every `adapter` reference, the boundary section, the runtime architecture diagram, and the Allowed/Dynamic-text/Input sections now use `app/ui/screen_controllers/<screen>_screen_controller.cpp/.h`. A note about the shared `screen_controller_base.h` and `RAYGUI_IMPLEMENTATION` ownership on `title_screen_controller.cpp` was added.
- **Build integration**: the "Deferred" section was replaced with a description of the as-built CMake wiring (`UI_SCREEN_CONTROLLER_SOURCES` glob, generated headers picked up via `target_include_directories`, unity exclusion of the raygui implementation TU, native + WASM CI coverage). The matching CI / cache section was likewise updated.
- **Migration phases**: each of Phases 1-6 is now marked **done**, with Phase 6's `routes.json` exception preserved. Old phase steps that prescribed wiring/CMake/CI deferral are removed.
- **Validation / Open issues / Goals / Non-goals**: tightened to remove references to removed files (`gameplay.json`, `ui_layout_cache.h`, `ui_button_spawner.h`, `UIElementTag`/`UIText`/`UIButton`/`UIShape`) and the obsolete "do not add CMake targets" near-term constraint. The grep-based validation bullet was reworded to acknowledge the generated `*LayoutState` structs that are allowed to live under `app/ui/generated/`.

## Verification

- `cmake --build build` — clean, zero warnings.
- `./build/shapeshifter_tests` — `All tests passed (2943 assertions in 902 test cases)`.
- Final scan: `grep -n "rguilayout_adapters\|app/ui/<screen>\|app/ui/title\.c\|adapter\b\|\.c/\.h\|Deferred\|deferred" design-docs/raygui-rguilayout-ui-spec.md` returns only one historical attribution to "Hockney … deferred CMake/CI/build integration guidance" in the Contributing-agents list, which is intentionally kept as the original input record.

## Scope / risk

- One file changed: `design-docs/raygui-rguilayout-ui-spec.md` (+89 / -97 lines).
- No source, build, or asset changes.
- No new files.
