### PR TITLE
Drop dead UNREADABLE_KINDS chain in level_designer.py (closes #1181)

### DIFF
--- a/tools/level_designer.py
+++ b/tools/level_designer.py
@@ -162,7 +162,6 @@ DIFFICULTY_KINDS = {
     "medium": {"shape_gate"},
     "hard":   {"shape_gate"},
 }
-UNREADABLE_KINDS = {"low_bar", "high_bar"}
 MAX_EMPTY_GAP = {"easy": 40, "medium": 33, "hard": 32}
 MAX_BEAT_DIFF = {diff: gap + 1 for diff, gap in MAX_EMPTY_GAP.items()}
 MIN_SHAPE_CHANGE_GAP = 3
@@ -1117,10 +1116,6 @@ def lane_of(obs, fallback=1):
 
 def is_shape_gate(obs):
     return obs.get("kind") == "shape_gate"
-
-
-def is_unreadable_kind(obs):
-    return obs.get("kind") in UNREADABLE_KINDS
 
 
 def clamp_lane(lane):
@@ -2832,15 +2827,6 @@ def is_readable_gap_one_family(left, right):
     )
 
 
-def has_readable_gap_one_neighbors(previous, left, right, following):
-    """No bar obstacle may sit within 2 beats around a gap=1 pair."""
-    if previous and left["beat"] - previous["beat"] <= 2 and is_unreadable_kind(previous):
-        return False
-    if following and following["beat"] - right["beat"] <= 2 and is_unreadable_kind(following):
-        return False
-    return True
-
-
 def clean_gap_one_early(obstacles, difficulty):
     """RULE: gap=1 pairs must obey per-difficulty readability policy."""
     if len(obstacles) < 2:
@@ -2869,9 +2855,6 @@ def clean_gap_one_early(obstacles, difficulty):
                 gap_one_run = 0
                 continue
 
-            previous = result[-2] if len(result) > 1 else None
-            following = obstacles[i + 1] if i + 1 < len(obstacles) else None
-
             violation = False
             if difficulty == "easy":
                 violation = True
@@ -2888,8 +2871,6 @@ def clean_gap_one_early(obstacles, difficulty):
                 )
 
             if not is_readable_gap_one_family(left, right):
-                violation = True
-            if not has_readable_gap_one_neighbors(previous, left, right, following):
                 violation = True
 
             if violation:


### PR DESCRIPTION
## Summary

Closes #1181.

`tools/level_designer.py` carried a dead chain of constants and helpers whose only purpose was to filter out `low_bar` / `high_bar` obstacle kinds. Both kinds were removed from the runtime `ObstacleKind` enum and from the generator's emission paths long ago, so the chain has been unreachable for some time:

- `DIFFICULTY_KINDS` (line 160) only contains `{shape_gate}` for every difficulty.
- Every `obs["kind"] = ...` assignment in the file (lines 1140, 2506, 2554, 3140, 3756) sets `"shape_gate"`. No code path ever assigns `"low_bar"` or `"high_bar"`.
- `grep -rn "low_bar\|high_bar" content/` returns no matches — no shipped beatmap contains those kinds either.

So `is_unreadable_kind(obs)` always returned `False`, which meant `has_readable_gap_one_neighbors(...)` always returned `True`, which meant the `if not has_readable_gap_one_neighbors(...): violation = True` branch in `clean_gap_one_early` never fired, which meant the per-iteration `previous` / `following` lookups feeding it were unused.

## What changed

Single file, all deletions:

- Removed the `UNREADABLE_KINDS` constant (was line 165).
- Removed the `is_unreadable_kind()` helper (was lines 1122-1123).
- Removed the `has_readable_gap_one_neighbors()` helper (was lines 2835-2841).
- Removed the orphaned caller block in `clean_gap_one_early` (was lines 2892-2893).
- Removed the now-unused `previous` / `following` lookups in the same loop (was lines 2858-2859).

Total: `1 file changed, 19 deletions(-)`. No additions.

## Why output is provably unchanged

The removed `if not has_readable_gap_one_neighbors(...): violation = True` evaluates to `if not True: violation = True`, i.e., `if False: violation = True`, i.e., a no-op. So generator output is byte-stable for any input — no need to re-bake `content/beatmaps/`.

## Verification

- `python3 -m py_compile tools/level_designer.py` — OK.
- `grep -n "UNREADABLE_KINDS\|is_unreadable_kind\|has_readable_gap_one_neighbors" tools/` — 0 hits across the whole `tools/` tree (and 0 hits across `app/`, `tests/`, `content/` to begin with).
- `ctest -R "^python_tool_tests$"` — passes.
- `ctest -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|validate_required_cross_lane_jump_time|check_shape_change_gap)$"` — all 9 pass.
- `cmake --build build` — clean, zero warnings.
- `./build/shapeshifter_tests` — `All tests passed (2943 assertions in 902 test cases)` (unchanged from baseline).

## Scope / risk

- One file: `tools/level_designer.py`.
- Only deletions; no additions.
- No runtime / app / content / build / docs changes.
- No CI workflow changes.
