### PR TITLE
Add observable assertions to zero-assertion haptic_system tests (closes #1183)

### DIFF
--- a/tests/test_haptic_system.cpp
+++ b/tests/test_haptic_system.cpp
@@ -28,12 +28,23 @@ TEST_CASE("haptic_system: drains enqueued PlayHapticEvents without crashing", "[
 
 TEST_CASE("haptic_system: no-op when queue is empty", "[haptic]") {
     auto reg = make_registry();
-    haptic_system(reg);  // must not crash or assert
+    const auto entity_count_before = reg.storage<entt::entity>().size();
+
+    haptic_system(reg);
+
+    CHECK(reg.storage<entt::entity>().size() == entity_count_before);
+    auto cap = drain_haptic_events(reg);
+    CHECK(cap.count == 0);
 }
 
 TEST_CASE("haptic_system: safe when dispatcher absent from context", "[haptic]") {
     entt::registry reg;  // bare registry — no dispatcher
-    haptic_system(reg);  // must not crash
+    REQUIRE_FALSE(reg.ctx().contains<entt::dispatcher>());
+
+    haptic_system(reg);
+
+    CHECK_FALSE(reg.ctx().contains<entt::dispatcher>());
+    SUCCEED("haptic_system handled missing dispatcher without throwing");
 }
 
 // ── game_state_system haptic wiring ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #1183.

Two `TEST_CASE` blocks in `tests/test_haptic_system.cpp` previously contained zero Catch2 assertions and relied on "did not crash" as the implicit pass condition. They contributed nothing to the suite's assertion total and a regression that mutated registry state or implicitly inserted a dispatcher would slip through silently.

## What changed

- **`no-op when queue is empty`** — snapshot `reg.storage<entt::entity>().size()` before the call and `CHECK` it is unchanged after; also assert `drain_haptic_events(reg).count == 0` so the empty-queue contract is observable.
- **`safe when dispatcher absent from context`** — `REQUIRE_FALSE(reg.ctx().contains<entt::dispatcher>())` pre-call, `CHECK_FALSE(...)` post-call (catches a regression that silently inserts a dispatcher), plus an explicit `SUCCEED("...")` so Catch2 records a deliberate assertion for the no-throw contract.

`tests/test_haptic_system.cpp` only — `+13 -2`. No production-code changes; no new test infrastructure.

## Verification

- `cmake --build build --target shapeshifter_tests` — clean, zero warnings.
- `./build/shapeshifter_tests` — `All tests passed (2948 assertions in 902 test cases)` (was 2943; +5 from new checks).
- `./build/shapeshifter_tests "[haptic]"` — 14 cases / 20 assertions, all green.
- Spot-check: injecting `reg.create()` into `haptic_system` makes the first test fail; injecting a dispatcher into the bare-registry path makes the second fail.

## Scope / risk

- Tests-only.
- No new helpers — uses existing `drain_haptic_events` and `reg.ctx().contains<>()`.
- Same pattern (`reg.ctx().contains<...>()`) is already used by other tests (e.g., `test_entt_dispatcher_contract.cpp`).
