### PR TITLE
Silence expected scroll_system warnings in invalid-scroll_speed tests (closes #1182)

### DIFF
--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -106,6 +106,19 @@ inline SfxCapture drain_sfx_events(entt::registry& reg) {
     return cap;
 }
 
+// RAII guard that silences raylib TraceLog output for the duration of a scope
+// and restores the default LOG_INFO threshold on destruction. Use to wrap test
+// calls that deliberately exercise production warnings/errors so they don't
+// pollute the test-runner's stderr (which would mask real future warnings).
+// raylib has no GetTraceLogLevel(); restoring to LOG_INFO matches raylib's
+// default and is the level used by the rest of the test binary.
+struct ScopedTraceLogSilencer {
+    ScopedTraceLogSilencer()  { SetTraceLogLevel(LOG_NONE); }
+    ~ScopedTraceLogSilencer() { SetTraceLogLevel(LOG_INFO); }
+    ScopedTraceLogSilencer(const ScopedTraceLogSilencer&)            = delete;
+    ScopedTraceLogSilencer& operator=(const ScopedTraceLogSilencer&) = delete;
+};
+
 // Peek at (and flush) pending PlayHapticEvent events without invoking hardware.
 // Useful for assertions about what events were enqueued before delivery.
 inline HapticCapture drain_haptic_events(entt::registry& reg) {

--- a/tests/test_scroll_rhythm.cpp
+++ b/tests/test_scroll_rhythm.cpp
@@ -91,7 +91,12 @@ TEST_CASE("scroll: invalid scroll_speed preserves finite obstacle position", "[s
     reg.emplace<WorldTransform>(obs, WorldTransform{{0.0f, 123.0f}});
     reg.emplace<BeatInfo>(obs, 0, 4.0f, 0.0f);
 
-    scroll_system(reg, 0.016f);
+    {
+        // Production scroll_system intentionally TraceLog(LOG_WARNING) on invalid
+        // scroll_speed; silence here so the test doesn't pollute stderr.
+        ScopedTraceLogSilencer silence_warning;
+        scroll_system(reg, 0.016f);
+    }
 
     const auto& transform = reg.get<WorldTransform>(obs);
     CHECK(std::isfinite(transform.position.y));
@@ -109,10 +114,15 @@ TEST_CASE("scroll: non-positive scroll_speed skips position updates", "[scroll][
     reg.emplace<WorldTransform>(obs, WorldTransform{{0.0f, 234.0f}});
     reg.emplace<BeatInfo>(obs, 0, 4.0f, 0.0f);
 
-    scroll_system(reg, 0.016f);
-    CHECK_THAT(reg.get<WorldTransform>(obs).position.y, Catch::Matchers::WithinAbs(234.0f, 0.001f));
+    {
+        // Production scroll_system intentionally TraceLog(LOG_WARNING) on invalid
+        // scroll_speed; silence here so the test doesn't pollute stderr.
+        ScopedTraceLogSilencer silence_warning;
+        scroll_system(reg, 0.016f);
+        CHECK_THAT(reg.get<WorldTransform>(obs).position.y, Catch::Matchers::WithinAbs(234.0f, 0.001f));
 
-    song.scroll_speed = -100.0f;
-    scroll_system(reg, 0.016f);
-    CHECK_THAT(reg.get<WorldTransform>(obs).position.y, Catch::Matchers::WithinAbs(234.0f, 0.001f));
+        song.scroll_speed = -100.0f;
+        scroll_system(reg, 0.016f);
+        CHECK_THAT(reg.get<WorldTransform>(obs).position.y, Catch::Matchers::WithinAbs(234.0f, 0.001f));
+    }
 }


### PR DESCRIPTION
## Summary

Closes #1182.

`./build/shapeshifter_tests` was leaking three `WARNING: scroll_system skipped` lines to stderr because two test cases in `tests/test_scroll_rhythm.cpp` deliberately feed invalid `scroll_speed` values (`NaN`, `0.0f`, `-100.0f`) to verify the production early-out in `app/systems/scroll_system.cpp`. The warning is correct production behavior — a malformed beatmap should be loud — but it pollutes test-runner stderr, masking real future warnings.

## What changed

Took the **'silence the test path explicitly'** option from the issue (production code untouched).

- `tests/test_helpers.h` — added a small `ScopedTraceLogSilencer` RAII guard:
  - ctor: `SetTraceLogLevel(LOG_NONE);`
  - dtor: `SetTraceLogLevel(LOG_INFO);` (raylib has no `GetTraceLogLevel`; `LOG_INFO` is its default and matches what the rest of the test binary inherits — only `tests/smoke/startup_shutdown_smoke.cpp` ever overrides it, in a separate binary).
  - `= delete` copy/assign so it stays a true scope guard.
- `tests/test_scroll_rhythm.cpp` — wrapped the four `scroll_system(reg, ...)` calls inside the NaN test and the zero/negative test in a `ScopedTraceLogSilencer` scope. Assertions on `WorldTransform.position.y` are unchanged; the early-out semantics remain fully tested.

## Why not the 'capture & assert' option

Capturing raylib output via `SetTraceLogCallback` requires installing a callback, draining a buffer, restoring the previous (uninspectable) callback, and re-asserting in two separate tests. That's more code than the bug warrants for a P3 cleanup, and the suppression option is explicitly listed as 'Acceptable' in the issue.

## Why not removing the warning from `scroll_system.cpp`

Explicitly listed as 'Not acceptable' in the issue — the warning is useful in production.

## Verification

- `cmake --build build` — clean, zero warnings.
- `./build/shapeshifter_tests 2>&1 | grep 'scroll_system skipped' | wc -l` → `0` (was `3`: NaN, 0.000, -100.000).
- Full suite: `All tests passed (2943 assertions in 902 test cases)` — identical to baseline (silencer adds no assertions, only suppresses output).
- `./build/shapeshifter_tests "[scroll]"` — `All tests passed (11 assertions in 6 test cases)`.
- Spot-check that the test still fails on a real regression: temporarily comment out the `return;` in the `scroll_system` early-out → both `CHECK_THAT(... WithinAbs(123.0f / 234.0f, 0.001f))` checks fail as expected.
- Other unrelated production warnings (beat_scheduler, shape_window, high-score, …) still appear in stderr, confirming the silencer is correctly scope-limited.

## Scope / risk

- Tests-only.
- Two files: `tests/test_helpers.h` (+13 lines, helper added) and `tests/test_scroll_rhythm.cpp` (+17 / -7 in two test cases).
- No production-code changes; no CI / docs changes.
