### PR TITLE
Assert mutability in test_camera_entity_contracts accessor tests (closes #1189)

### DIFF
--- a/tests/test_camera_entity_contracts.cpp
+++ b/tests/test_camera_entity_contracts.cpp
@@ -122,10 +122,16 @@ TEST_CASE("camera entity: accessor game_camera() returns mutable reference",
     entt::registry reg;
     spawn_game_camera(reg);
 
-    // Must not crash; returned reference must be valid.
+    // Mutate through the returned reference, then re-fetch the underlying
+    // component via the registry's entity id and verify the sentinel is
+    // observable.  This proves the accessor returns a reference to the
+    // canonical entity's component, not a copy or a different entity's.
+    constexpr float sentinel = 12345.0f;
     GameCamera& gc = game_camera(reg);
-    (void)gc;
-    SUCCEED("game_camera() accessor did not crash");
+    gc.cam.fovy = sentinel;
+
+    auto entity = reg.view<GameCamera>().front();
+    CHECK(reg.get<GameCamera>(entity).cam.fovy == sentinel);
 }
 
 TEST_CASE("camera entity: accessors throw before camera entities are spawned",
@@ -141,9 +147,16 @@ TEST_CASE("camera entity: accessor ui_camera() returns mutable reference",
     entt::registry reg;
     spawn_ui_camera(reg);
 
+    // Mutate through the returned reference, then re-fetch the underlying
+    // component via the registry's entity id and verify the sentinel is
+    // observable.  This proves the accessor returns a reference to the
+    // canonical entity's component, not a copy or a different entity's.
+    constexpr float sentinel = 12345.0f;
     UICamera& uc = ui_camera(reg);
-    (void)uc;
-    SUCCEED("ui_camera() accessor did not crash");
+    uc.cam.zoom = sentinel;
+
+    auto entity = reg.view<UICamera>().front();
+    CHECK(reg.get<UICamera>(entity).cam.zoom == sentinel);
 }
 
 TEST_CASE("camera entity: destroying game_cam entity does not affect ui_cam",


### PR DESCRIPTION
Closes #1189.

## What

Two `TEST_CASE`s in `tests/test_camera_entity_contracts.cpp` claimed *\"returns mutable reference\"* in their titles but only stored the reference and called `SUCCEED` — a regression where the accessor returned by value, returned a `const` reference (would not have compiled), or returned a reference to a different entity's component would not have been caught.

## Changes

For both `game_camera()` and `ui_camera()` accessor tests:

- Mutate a public field on the returned reference using a sentinel value (`Camera3D::fovy` for `GameCamera`, `Camera2D::zoom` for `UICamera` — both pre-existing fields).
- Re-fetch the underlying component via the registry's entity id (`reg.get<...>(view.front())`) and `CHECK` that the sentinel is observable.
- Drop the `SUCCEED(...)` lines.

This proves the accessor returns a reference to the canonical entity's component, not a copy or a different entity's component. No production-code changes.

## Verification

- \`cmake --build build\` clean (zero warnings).
- \`./build/shapeshifter_tests \"[entity_contract]\"\` → 21 assertions in 10 test cases pass.
- Full suite: 2948 assertions in 902 test cases pass.