### PR TITLE
Consolidate 15 ECS marker tags into app/tags/tags.h (closes #1201)

### DIFF
--- a/app/components/energy_bar.h
+++ b/app/components/energy_bar.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include "tags/tags.h"
+
 // Entity-backed HUD state for the survival energy meter.
 // EnergyState remains the gameplay resource; these components hold only the
 // per-frame visual contract consumed by the gameplay HUD renderer.
-
-struct EnergyBarTag {};
 
 struct EnergyBarLayout {
     float x = 16.0f;

--- a/app/components/obstacle.h
+++ b/app/components/obstacle.h
@@ -3,15 +3,7 @@
 #include <cstdint>
 
 #include "player.h"
-
-struct ObstacleTag {};
-
-// Runtime cue authored from beatmap onset metadata. It is visible but
-// intentionally non-scorable and non-blocking.
-struct OnsetMarkerTag {};
-
-// Presence means scoring has consumed the obstacle's final hit/miss result.
-struct ResolvedObstacleTag {};
+#include "tags/tags.h"
 
 enum class ObstacleKind : uint8_t {
     ShapeGate,
@@ -57,16 +49,6 @@ constexpr ObstacleKind obstacle_kind_from_components(bool has_required_shape,
     }
     return ObstacleKind::ShapeGate;
 }
-
-// Existential tag: presence means the obstacle has been cleared and awaits scoring.
-struct ScoredTag {};
-
-// Existential tag: obstacle does not participate in the scoring ladder
-// (no score popup, no chain contribution).
-struct NonScorableTag {};
-
-// Existential tag: scored obstacle was failed/missed and should not award points.
-struct MissTag {};
 
 struct RequiredShape {
     Shape shape = Shape::Circle;

--- a/app/components/particle.h
+++ b/app/components/particle.h
@@ -1,6 +1,6 @@
 #pragma once
 
-struct ParticleTag {};
+#include "tags/tags.h"
 
 struct ParticleData {
     float size      = 4.0f;

--- a/app/components/player.h
+++ b/app/components/player.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include "tags/tags.h"
 #include "window_phase.h"
 
 enum class Shape : uint8_t {
@@ -9,8 +10,6 @@ enum class Shape : uint8_t {
     Triangle,
     Hexagon,
 };
-
-struct PlayerTag {};
 
 // Hot render data — read by game_camera_system, player_movement_system every frame.
 struct PlayerShape {

--- a/app/components/rendering.h
+++ b/app/components/rendering.h
@@ -8,6 +8,8 @@
 #include <glm/vec2.hpp>
 #include <raylib.h>
 
+#include "tags/tags.h"
+
 struct DrawSize {
     float w = 64.0f;
     float h = 64.0f;
@@ -80,7 +82,5 @@ struct ScreenPosition {
 };
 
 
-// Render-pass membership tags; one per entity.
-struct TagWorldPass   {};  // drawn in BeginMode3D (3D world geometry)
-struct TagEffectsPass {};  // particles, post-process overlays
-struct TagHUDPass     {};  // screen-space UI elements
+// Render-pass membership tags (TagWorldPass / TagEffectsPass / TagHUDPass)
+// live in app/tags/tags.h; included above for back-compat.

--- a/app/components/test_player.h
+++ b/app/components/test_player.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "player.h"
+#include "tags/tags.h"
 #include <entt/entity/entity.hpp>
 #include <entt/core/enum.hpp>
 #include <cstdint>
@@ -50,8 +51,6 @@ struct TestPlayerAction {
     ActionDoneBit done_flags = ActionDoneBit{};
 
 };
-
-struct TestPlayerPlannedTag {};
 
 // ── Test player state (context singleton) ────────────────────
 // Hot state (accessed every frame): active, swipe_cooldown_timer,

--- a/app/entities/beat_map.h
+++ b/app/entities/beat_map.h
@@ -2,11 +2,10 @@
 
 #include "components/beat_map.h"
 #include "components/song_state.h"
+#include "tags/tags.h"
 #include <entt/entt.hpp>
 #include <string>
 #include <vector>
-
-struct BeatMapTag {};
 
 // Creates the singleton beat-map entity and returns its handle.
 // Throws std::logic_error if the registry already has a BeatMapTag entity.

--- a/app/entities/settings.h
+++ b/app/entities/settings.h
@@ -7,8 +7,7 @@
 #include <string>
 
 #include "../util/persistence_policy.h"
-
-struct SettingsTag {};
+#include "tags/tags.h"
 
 struct SettingsState {
     static constexpr int16_t MIN_AUDIO_OFFSET_MS = -250;

--- a/app/tags/tags.h
+++ b/app/tags/tags.h
@@ -1,0 +1,52 @@
+#pragma once
+
+// Canonical home for ECS marker tags.
+//
+// Per the ECS folder allowlist (`.squad/decisions.md`), `app/tags/` contains
+// exactly one header — this file. Every empty marker struct used as an EnTT
+// tag belongs here. Do not add new per-tag headers; extend this file instead.
+//
+// Tags are pure existence markers: presence on an entity is the entire signal.
+// They carry no data and have no methods. Systems query for them via
+// `registry.view<Tag>()` (or `entt::exclude<Tag>` for absence).
+
+// ── Player ───────────────────────────────────────────────────
+struct PlayerTag {};
+
+// ── Obstacles ────────────────────────────────────────────────
+struct ObstacleTag {};
+
+// Runtime cue authored from beatmap onset metadata. It is visible but
+// intentionally non-scorable and non-blocking.
+struct OnsetMarkerTag {};
+
+// Presence means scoring has consumed the obstacle's final hit/miss result.
+struct ResolvedObstacleTag {};
+
+// Presence means the obstacle has been cleared and awaits scoring.
+struct ScoredTag {};
+
+// Obstacle does not participate in the scoring ladder
+// (no score popup, no chain contribution).
+struct NonScorableTag {};
+
+// Scored obstacle was failed/missed and should not award points.
+struct MissTag {};
+
+// ── Particles ────────────────────────────────────────────────
+struct ParticleTag {};
+
+// ── HUD / Energy bar ─────────────────────────────────────────
+struct EnergyBarTag {};
+
+// ── Test player (deterministic AI) ───────────────────────────
+struct TestPlayerPlannedTag {};
+
+// ── Render-pass membership; one per entity ───────────────────
+struct TagWorldPass   {};  // drawn in BeginMode3D (3D world geometry)
+struct TagEffectsPass {};  // particles, post-process overlays
+struct TagHUDPass     {};  // screen-space UI elements
+
+// ── Singletons ───────────────────────────────────────────────
+struct BeatMapTag {};
+struct SettingsTag {};


### PR DESCRIPTION
Closes #1201.

## Summary

Per the ECS folder allowlist (`.squad/decisions.md`), `app/tags/` holds a single header — `tags.h` — that declares every marker tag in the codebase. Previously 15 tags were scattered across 6 files in `components/` and `entities/`.

## Approach: pure relocation

Tag types and their usages are unchanged. Each former host file now `#include "tags/tags.h"` so all existing consumers continue to compile unmodified — no behaviour changes, no semantic drift.

This minimises risk and keeps the diff scoped to the structural goal of this issue: get tag declarations into one canonical home so the upcoming canon-drift linter (per the issue's *Why now* section) can be a 3-line filesystem + grep test.

## Tags moved

| Tag | Was in | Now in |
|---|---|---|
| `PlayerTag` | `app/components/player.h` | `app/tags/tags.h` |
| `ObstacleTag`, `OnsetMarkerTag`, `ResolvedObstacleTag`, `ScoredTag`, `NonScorableTag`, `MissTag` | `app/components/obstacle.h` | `app/tags/tags.h` |
| `ParticleTag` | `app/components/particle.h` | `app/tags/tags.h` |
| `EnergyBarTag` | `app/components/energy_bar.h` | `app/tags/tags.h` |
| `TestPlayerPlannedTag` | `app/components/test_player.h` | `app/tags/tags.h` |
| `TagWorldPass`, `TagEffectsPass`, `TagHUDPass` | `app/components/rendering.h` | `app/tags/tags.h` |
| `BeatMapTag` | `app/entities/beat_map.h` | `app/tags/tags.h` |
| `SettingsTag` | `app/entities/settings.h` | `app/tags/tags.h` |

## Acceptance criteria

- [x] `app/tags/tags.h` exists with all 15 tag struct declarations.
- [x] Zero `struct \w*Tag\w*\s*\{\s*\}` declarations remain anywhere outside `app/tags/`.
- [x] All include sites continue to resolve — host files re-export tags via `#include "tags/tags.h"`, so the existing consumer graph is preserved without churn.
- [x] CMake unaffected: `app/` is already on the public include path; headers do not need to be listed explicitly.
- [x] Build is warning-free under Clang `-Wall -Wextra -Werror` (native macOS).
- [x] All 901 test cases / 2956 assertions pass (`./build/shapeshifter_tests`).
- [x] No semantic changes — pure relocation; tag types and usages stay identical.

## Out of scope (per issue)

- Renaming tags (`TagWorldPass` → `WorldPassTag` etc.) — pure relocation only.
- Splitting `tags.h` into sub-headers — directive is explicit: one header.
- Rewriting consumer includes to drop the host-component header where only the tag was used. That is a follow-up sweep for the god-class split issues (#1194/#1195/#1196) and would change archetypes; outside this scope.

## Verification

Local: clean build with zero warnings; `./build/shapeshifter_tests` reports `All tests passed (2956 assertions in 901 test cases)`.
