### PR TITLE
Remove glm dependency: replace glm::vec2/glm::mat4 with raylib Vector2/Matrix (closes #1199)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,6 @@ configure_file(
 # nlohmann-json: JSON parsing for beat map loading (vcpkg on all platforms).
 
 find_package(EnTT CONFIG REQUIRED)
-find_package(glm CONFIG REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(raylib CONFIG REQUIRED)
@@ -99,7 +98,7 @@ target_compile_options(shapeshifter_warnings INTERFACE
 
 # Mark third-party include directories as SYSTEM so warnings from their
 # headers are suppressed and cannot be promoted to errors by -Werror.
-set(_system_deps EnTT::EnTT glm::glm magic_enum::magic_enum raylib nlohmann_json::nlohmann_json)
+set(_system_deps EnTT::EnTT magic_enum::magic_enum raylib nlohmann_json::nlohmann_json)
 if(BUILD_TESTING)
     list(APPEND _system_deps Catch2::Catch2 Catch2::Catch2WithMain)
 endif()
@@ -189,7 +188,6 @@ target_include_directories(shapeshifter_lib SYSTEM PUBLIC
 )
 target_link_libraries(shapeshifter_lib PUBLIC
     EnTT::EnTT
-    glm::glm
     magic_enum::magic_enum
     nlohmann_json::nlohmann_json
 )

--- a/app/components/rendering.h
+++ b/app/components/rendering.h
@@ -4,9 +4,8 @@
 #include <cstdint>
 #include <cmath>
 #include <entt/entt.hpp>
-#include <glm/mat4x4.hpp>
-#include <glm/vec2.hpp>
 #include <raylib.h>
+#include <raymath.h>
 
 #include "tags/tags.h"
 
@@ -33,8 +32,8 @@ struct ScreenTransform {
     float scale    = 1.0f;
 };
 
-[[nodiscard]] inline glm::vec2 screen_to_virtual(const glm::vec2& screen_pos,
-                                                  const ScreenTransform& st) noexcept {
+[[nodiscard]] inline Vector2 screen_to_virtual(const Vector2& screen_pos,
+                                                const ScreenTransform& st) noexcept {
     assert(std::isfinite(st.scale));
     assert(st.scale > 0.0f);
     const float inv_scale = 1.0f / st.scale;
@@ -49,10 +48,10 @@ struct ScreenTransform {
 enum class MeshType : uint8_t { Shape, Slab, Quad };
 
 struct ModelTransform {
-    glm::mat4 mat{1.0f};
-    Color     tint{255, 255, 255, 255};
-    uint8_t   mesh_index = 0;  // index into ShapeMeshes.shapes[] for Shape type
-    MeshType  mesh_type = MeshType::Shape;
+    Matrix   mat = MatrixIdentity();
+    Color    tint{255, 255, 255, 255};
+    uint8_t  mesh_index = 0;  // index into ShapeMeshes.shapes[] for Shape type
+    MeshType mesh_type = MeshType::Shape;
 };
 
 // Visual mesh child; game_camera_system resolves parent transform + offsets.

--- a/app/components/system_scratch.h
+++ b/app/components/system_scratch.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <entt/entt.hpp>
-#include <glm/vec2.hpp>
+#include <raylib.h>
 #include <cstdint>
 #include <vector>
 
@@ -15,7 +15,7 @@ struct MissRecord {
 
 struct HitRecord {
     entt::entity e = entt::null;
-    glm::vec2 popup_xy = {0.0f, 0.0f};
+    Vector2 popup_xy = {0.0f, 0.0f};
     Obstacle obs;
     bool has_timing = false;
     TimingGrade timing{};

--- a/app/components/transform.h
+++ b/app/components/transform.h
@@ -1,24 +1,24 @@
 #pragma once
 
-#include <glm/vec2.hpp>
+#include <raylib.h>
 
 // Authoritative world-space spatial state for moving/rendered world entities.
 // New entity contracts should use this instead of adding new position structs.
 // Named WorldTransform to avoid colliding with raylib's global Transform type.
 struct WorldTransform {
-    glm::vec2 position = {0.0f, 0.0f};
-    float     rotation = 0.0f;
-    glm::vec2 scale    = {1.0f, 1.0f};
+    Vector2 position = {0.0f, 0.0f};
+    float   rotation = 0.0f;
+    Vector2 scale    = {1.0f, 1.0f};
 };
 
 // Scoped motion for entities that truly integrate position += velocity * dt.
 // Replaces the deleted Velocity struct (issue #349 migration complete).
 struct MotionVelocity {
-    glm::vec2 value = {0.0f, 0.0f};
+    Vector2 value = {0.0f, 0.0f};
 };
 
 // Screen-space UI placement. UI entities should use this instead of
 // WorldTransform so they do not enter world movement/collision/camera views.
 struct UIPosition {
-    glm::vec2 value = {0.0f, 0.0f};
+    Vector2 value = {0.0f, 0.0f};
 };

--- a/app/systems/camera_system.cpp
+++ b/app/systems/camera_system.cpp
@@ -13,7 +13,6 @@
 #include "../entities/settings.h"
 #include "../platform_display.h"
 #include "../util/shape_lane_mapping.h"
-#include <glm/mat4x4.hpp>
 #include <raylib.h>
 #include <raymath.h>
 #include <rlgl.h>
@@ -202,40 +201,31 @@ RenderTargets& RenderTargets::operator=(RenderTargets&& o) noexcept {
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-static glm::mat4 raylib_to_glm_matrix_camera(const Matrix& m) {
-    return glm::mat4{
-        m.m0, m.m1, m.m2, m.m3,
-        m.m4, m.m5, m.m6, m.m7,
-        m.m8, m.m9, m.m10, m.m11,
-        m.m12, m.m13, m.m14, m.m15
-    };
-}
-
 // GenMeshCube is centered at origin. Translate to position the slab's
 // bottom-left corner at (x, 0) and center depth on z so z is the beat/timing plane.
-static glm::mat4 slab_matrix(float x, float z, float w, float h, float d) {
-    return raylib_to_glm_matrix_camera(MatrixMultiply(MatrixScale(w, h, d),
-                                                      MatrixTranslate(x + w / 2, h / 2, z)));
+static Matrix slab_matrix(float x, float z, float w, float h, float d) {
+    return MatrixMultiply(MatrixScale(w, h, d),
+                          MatrixTranslate(x + w / 2, h / 2, z));
 }
 
-static glm::mat4 shape_matrix(float cx, float y_3d, float cz, float sz, float radius_scale) {
+static Matrix shape_matrix(float cx, float y_3d, float cz, float sz, float radius_scale) {
     float s = sz * radius_scale;
-    return raylib_to_glm_matrix_camera(MatrixMultiply(MatrixScale(s, s, s),
-                                                      MatrixTranslate(cx, y_3d, cz)));
+    return MatrixMultiply(MatrixScale(s, s, s),
+                          MatrixTranslate(cx, y_3d, cz));
 }
 
 // Triangular prism rotated so one vertex of the cross-section points up (△)
-static glm::mat4 prism_matrix(float cx, float y_3d, float cz, float sz, float radius_scale) {
+static Matrix prism_matrix(float cx, float y_3d, float cz, float sz, float radius_scale) {
     float s = sz * radius_scale;
     Matrix scale = MatrixScale(s, s, s);
     Matrix rot = MatrixRotateY(90.0f * DEG2RAD);
     Matrix translate = MatrixTranslate(cx, y_3d, cz);
-    return raylib_to_glm_matrix_camera(MatrixMultiply(MatrixMultiply(scale, rot), translate));
+    return MatrixMultiply(MatrixMultiply(scale, rot), translate);
 }
 
 // Pick the correct matrix for a shape mesh (triangle prism needs rotation)
-static glm::mat4 make_shape_matrix(uint8_t mesh_index, float cx, float y_3d, float cz,
-                                   float sz, float radius_scale) {
+static Matrix make_shape_matrix(uint8_t mesh_index, float cx, float y_3d, float cz,
+                                float sz, float radius_scale) {
     if (mesh_index == static_cast<uint8_t>(Shape::Triangle))
         return prism_matrix(cx, y_3d, cz, sz, radius_scale);
     return shape_matrix(cx, y_3d, cz, sz, radius_scale);
@@ -320,9 +310,9 @@ void game_camera_system(entt::registry& reg, [[maybe_unused]] float dt) {
             float ratio = (pdata.max_time > 0.0f) ? (pdata.remaining / pdata.max_time) : 1.0f;
             float sz = pdata.size * ratio;
             float half = sz / 2.0f;
-            glm::mat4 mat = raylib_to_glm_matrix_camera(MatrixMultiply(
+            Matrix mat = MatrixMultiply(
                 MatrixScale(sz, 1, sz),
-                MatrixTranslate(transform.position.x - half, 0, transform.position.y - half)));
+                MatrixTranslate(transform.position.x - half, 0, transform.position.y - half));
             reg.get_or_emplace<ModelTransform>(entity) =
                 ModelTransform{mat, col, 0, MeshType::Quad};
         }

--- a/app/systems/game_render_system.cpp
+++ b/app/systems/game_render_system.cpp
@@ -5,34 +5,23 @@
 #include "../components/game_state.h"
 #include "../util/shape_lane_mapping.h"
 #include "camera_system.h"
-#include <glm/mat4x4.hpp>
 #include <raylib.h>
 #include <rlgl.h>
-
-static Matrix glm_to_raylib_matrix_render(const glm::mat4& m) {
-    Matrix out{};
-    out.m0  = m[0][0]; out.m4  = m[1][0]; out.m8  = m[2][0]; out.m12 = m[3][0];
-    out.m1  = m[0][1]; out.m5  = m[1][1]; out.m9  = m[2][1]; out.m13 = m[3][1];
-    out.m2  = m[0][2]; out.m6  = m[1][2]; out.m10 = m[2][2]; out.m14 = m[3][2];
-    out.m3  = m[0][3]; out.m7  = m[1][3]; out.m11 = m[2][3]; out.m15 = m[3][3];
-    return out;
-}
 
 static void draw_model_transform(const camera::ShapeMeshes& sm, const ModelTransform& mt) {
     // Use a per-draw local copy so the shared material is never mutated.
     Material mat = sm.material;
     mat.maps[MATERIAL_MAP_DIFFUSE].color = mt.tint;
-    const Matrix matrix = glm_to_raylib_matrix_render(mt.mat);
     switch (mt.mesh_type) {
         case MeshType::Slab:
-            DrawMesh(sm.slab, mat, matrix);
+            DrawMesh(sm.slab, mat, mt.mat);
             break;
         case MeshType::Shape:
             if (mt.mesh_index >= kShapeCount) return;
-            DrawMesh(sm.shapes[mt.mesh_index], mat, matrix);
+            DrawMesh(sm.shapes[mt.mesh_index], mat, mt.mat);
             break;
         case MeshType::Quad:
-            DrawMesh(sm.quad, mat, matrix);
+            DrawMesh(sm.quad, mat, mt.mat);
             break;
     }
 }

--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -208,7 +208,7 @@ void input_system(entt::registry& reg, float raw_dt) {
         input.active_source = InputSource::None;
         input.suppress_mouse_release = false;
         const Vector2 mouse_pos = GetMousePosition();
-        const glm::vec2 pos = screen_to_virtual({mouse_pos.x, mouse_pos.y}, st);
+        const Vector2 pos = screen_to_virtual({mouse_pos.x, mouse_pos.y}, st);
         input.start_x = input.curr_x = input.end_x = pos.x;
         input.start_y = input.curr_y = input.end_y = pos.y;
         input.duration = 0.0f;
@@ -238,7 +238,7 @@ void input_system(entt::registry& reg, float raw_dt) {
         for (int touch_index = 0; touch_index < points_to_scan; ++touch_index) {
             const int touch_id = GetTouchPointId(touch_index);
             const Vector2 touch_pos = GetTouchPosition(touch_index);
-            const glm::vec2 tp = screen_to_virtual({touch_pos.x, touch_pos.y}, st);
+            const Vector2 tp = screen_to_virtual({touch_pos.x, touch_pos.y}, st);
             int slot_index = find_touch_slot(input, touch_id);
             if (slot_index < 0) {
                 const bool button_zone = tp.y >= zone_y;

--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -10,6 +10,8 @@
 #include "../components/rhythm.h"
 #include "../util/rhythm_math.h"
 #include "../constants.h"
+#include <raylib.h>
+#include <raymath.h>
 #include <algorithm>
 #include <cmath>
 
@@ -54,11 +56,11 @@ Color score_particle_color(const HitRecord& record) {
     return Color{220, 220, 255, 220};
 }
 
-void spawn_score_particles(entt::registry& reg, const glm::vec2& position, Color color) {
+void spawn_score_particles(entt::registry& reg, const Vector2& position, Color color) {
     constexpr float kLifetime = 0.35f;
     constexpr float kSize = 10.0f;
     constexpr float kSpeed = 90.0f;
-    constexpr glm::vec2 kDirections[] = {
+    constexpr Vector2 kDirections[] = {
         {1.0f, 0.0f},
         {-1.0f, 0.0f},
         {0.0f, 1.0f},
@@ -72,7 +74,7 @@ void spawn_score_particles(entt::registry& reg, const glm::vec2& position, Color
         reg.emplace<ParticleTag>(particle);
         reg.emplace<ParticleData>(particle, kSize, kLifetime, kLifetime);
         reg.emplace<WorldTransform>(particle, WorldTransform{position});
-        reg.emplace<MotionVelocity>(particle, MotionVelocity{dir * kSpeed});
+        reg.emplace<MotionVelocity>(particle, MotionVelocity{Vector2Scale(dir, kSpeed)});
         reg.emplace<Color>(particle, color);
         reg.emplace<TagEffectsPass>(particle);
     }

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -129,16 +129,16 @@ read infrequently or only by one system.
 /// Iterated by: scroll_system, game_camera_system, ui_camera_system,
 ///              collision_system, obstacle_despawn_system
 struct WorldTransform {
-    glm::vec2 position = {0.0f, 0.0f};
-    float     rotation = 0.0f;
-    glm::vec2 scale    = {1.0f, 1.0f};
+    Vector2 position = {0.0f, 0.0f};
+    float   rotation = 0.0f;
+    Vector2 scale    = {1.0f, 1.0f};
 };
 
 /// Movement vector in pixels/second for entities that integrate position.
 /// Iterated with WorldTransform by motion_system every frame.
 /// Rhythm obstacles use BeatInfo and are positioned by scroll_system instead.
 struct MotionVelocity {
-    glm::vec2 value = {0.0f, 0.0f};
+    Vector2 value = {0.0f, 0.0f};
 };
 ```
 

--- a/tests/test_component_raylib_boundaries.cpp
+++ b/tests/test_component_raylib_boundaries.cpp
@@ -21,20 +21,23 @@ std::filesystem::path repo_header(const char* rel) {
 
 }  // namespace
 
-TEST_CASE("component headers use direct runtime + glm types", "[components][boundary][issue-411]") {
+TEST_CASE("component headers use raylib types directly (post #1199)", "[components][boundary][issue-1199]") {
     const std::string transform = read_text(repo_header("app/components/transform.h"));
     const std::string rendering = read_text(repo_header("app/components/rendering.h"));
     const std::string text = read_text(repo_header("app/components/text.h"));
 
-    CHECK(transform.find("#include <raylib.h>") == std::string::npos);
+    CHECK(transform.find("#include <raylib.h>") != std::string::npos);
     CHECK(rendering.find("#include <raylib.h>") != std::string::npos);
     CHECK(text.find("#include <raylib.h>") == std::string::npos);
 
-    CHECK(transform.find("glm::vec2") != std::string::npos);
-    CHECK(rendering.find("glm::mat4") != std::string::npos);
-    CHECK(rendering.find("glm::vec2") != std::string::npos);
+    CHECK(transform.find("Vector2") != std::string::npos);
+    CHECK(rendering.find("Matrix") != std::string::npos);
+    CHECK(rendering.find("Vector2") != std::string::npos);
+    CHECK(rendering.find("Color") != std::string::npos);
+
+    CHECK(transform.find("glm::") == std::string::npos);
+    CHECK(rendering.find("glm::") == std::string::npos);
     CHECK(rendering.find("Vec2f") == std::string::npos);
     CHECK(rendering.find("Mat4f") == std::string::npos);
     CHECK(rendering.find("TintColor") == std::string::npos);
-    CHECK(rendering.find("Color") != std::string::npos);
 }

--- a/tests/test_perspective.cpp
+++ b/tests/test_perspective.cpp
@@ -12,6 +12,7 @@
 #include "systems/runtime_systems.h"
 #include "systems/all_systems.h"
 #include <raylib.h>
+#include <raymath.h>
 #include <cmath>
 
 using Catch::Matchers::WithinAbs;
@@ -125,7 +126,7 @@ TEST_CASE("game_camera_system drops stale MeshChild parents without crashing", "
         child,
         MeshChild{parent, 10.0f, 0.0f, 20.0f, 30.0f, 40.0f, WHITE, 0, MeshType::Slab}
     );
-    reg.emplace<ModelTransform>(child, ModelTransform{glm::mat4{1.0f}, WHITE, 0, MeshType::Slab});
+    reg.emplace<ModelTransform>(child, ModelTransform{MatrixIdentity(), WHITE, 0, MeshType::Slab});
     reg.emplace<TagWorldPass>(child);
 
     reg.destroy(parent);
@@ -164,7 +165,7 @@ TEST_CASE("game_camera_system rejects invalid MeshChild shape index", "[camera3d
         child,
         MeshChild{parent, 10.0f, 0.0f, 20.0f, 30.0f, 40.0f, WHITE, 255, MeshType::Shape}
     );
-    reg.emplace<ModelTransform>(child, ModelTransform{glm::mat4{1.0f}, WHITE, 255, MeshType::Shape});
+    reg.emplace<ModelTransform>(child, ModelTransform{MatrixIdentity(), WHITE, 255, MeshType::Shape});
     reg.emplace<TagWorldPass>(child);
 
     REQUIRE_NOTHROW(game_camera_system(reg, 0.0f));
@@ -181,7 +182,7 @@ TEST_CASE("game_camera_system rejects invalid PlayerShape before mesh lookup", "
     reg.emplace<PlayerShape>(player, PlayerShape{static_cast<Shape>(255), 1.0f});
     reg.emplace<VerticalState>(player);
     reg.emplace<Color>(player, WHITE);
-    reg.emplace<ModelTransform>(player, ModelTransform{glm::mat4{1.0f}, WHITE, 255, MeshType::Shape});
+    reg.emplace<ModelTransform>(player, ModelTransform{MatrixIdentity(), WHITE, 255, MeshType::Shape});
     reg.emplace<TagWorldPass>(player);
 
     REQUIRE_NOTHROW(game_camera_system(reg, 0.0f));
@@ -215,7 +216,7 @@ TEST_CASE("game_camera_system: dense stale-parent cleanup stays within reserved 
             child,
             MeshChild{parent, static_cast<float>(i), 0.0f, 20.0f, 30.0f, 40.0f, WHITE, 0, MeshType::Slab}
         );
-        reg.emplace<ModelTransform>(child, ModelTransform{glm::mat4{1.0f}, WHITE, 0, MeshType::Slab});
+        reg.emplace<ModelTransform>(child, ModelTransform{MatrixIdentity(), WHITE, 0, MeshType::Slab});
         reg.emplace<TagWorldPass>(child);
         reg.destroy(parent);  // make MeshChild stale so cleanup path runs
     }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,7 +5,6 @@
   "description": "Endless runner with shape-shifting and burnout scoring",
   "dependencies": [
     "entt",
-    "glm",
     "magic-enum",
     "raylib",
     "raygui",


### PR DESCRIPTION
Closes #1199.

## Why

raylib already ships layout-compatible types (`Vector2 = {float x, y;}`, `Matrix = column-major 4x4`), so the `glm` wrapper was dead weight. Both `raylib_to_glm_matrix_camera()` and `glm_to_raylib_matrix_render()` were bit-identical reinterpretations of the same column-major storage; once the interior type matches, both helpers collapse cleanly.

## What changed

| File | Change |
|---|---|
| `app/components/transform.h` | `glm::vec2` → `Vector2`; include `<raylib.h>` |
| `app/components/rendering.h` | `glm::vec2` → `Vector2`; `glm::mat4` → `Matrix`; `glm::mat4{1.0f}` → `MatrixIdentity()`; include `<raymath.h>` |
| `app/components/system_scratch.h` | `glm::vec2` → `Vector2`; include `<raylib.h>` |
| `app/systems/camera_system.cpp` | `*_matrix()` helpers return raylib `Matrix` directly; deleted `raylib_to_glm_matrix_camera()` |
| `app/systems/game_render_system.cpp` | `DrawMesh()` uses `mt.mat` directly; deleted `glm_to_raylib_matrix_render()` |
| `app/systems/input_system.cpp` | `screen_to_virtual()` results typed `Vector2` |
| `app/systems/scoring_system.cpp` | `kDirections[]` typed `Vector2`; `dir * kSpeed` → `Vector2Scale(dir, kSpeed)` (raylib `Vector2` has no operator overloads) |
| `tests/test_perspective.cpp` | `ModelTransform{glm::mat4{1.0f}, ...}` → `ModelTransform{MatrixIdentity(), ...}`; include `<raymath.h>` |
| `tests/test_component_raylib_boundaries.cpp` | Assertions flipped — now require `Vector2`/`Matrix` and forbid `glm::`; renamed test case to `[issue-1199]`. `transform.h` must include `<raylib.h>` (Vector2 lives there). |
| `CMakeLists.txt` | Removed `find_package(glm)`, `glm::glm` link, `glm::glm` system-include entry |
| `vcpkg.json` | Removed `"glm"` |
| `design-docs/architecture.md` | Updated `WorldTransform`/`MotionVelocity` snippet to `Vector2` |

## Acceptance (from #1199)

- [x] Zero `glm::` references in `app/` and `tests/` (only negative-assertion string literals remain in `test_component_raylib_boundaries.cpp`)
- [x] `glm` removed from `CMakeLists.txt` and `vcpkg.json`
- [x] `glm_to_raylib_*` and `raylib_to_glm_*` conversion functions deleted
- [x] `test_component_raylib_boundaries.cpp` flipped (require Vector2/Matrix, forbid glm)
- [x] Matrix multiplication order verified against raylib's column-major convention — the deleted conversion helpers were bit-copies, so behaviour is preserved by construction
- [x] Build green; **2958 assertions / 901 Catch2 cases pass; 913/913 ctest tests pass; zero warnings under `-Wall -Wextra -Werror` (Clang on macOS)**

## Verification

```
cmake -B build -S . -Wno-dev
cmake --build build -- -j8     # zero warnings
ctest --test-dir build         # 913/913 pass (1 unrelated GUI smoke skipped)
```

## Notes for reviewers

- The two deleted conversion functions were identity copies under both libraries' column-major storage. No mathematical change.
- `Vector2` has no operator overloads; the only scalar multiply (`spawn_score_particles`) now uses `Vector2Scale()`.
- `transform.h` previously had a test rule forbidding `<raylib.h>` — that is no longer satisfiable without glm, so the rule is flipped to require `<raylib.h>` (per #1199 acceptance criteria).
