### PR TITLE
Delete dead RNGState component (refs #1194)

### DIFF
--- a/app/components/rng.h
+++ b/app/components/rng.h
@@ -1,7 +1,0 @@
-#pragma once
-
-#include <random>
-
-struct RNGState {
-    std::mt19937 engine{1u};
-};

--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -13,7 +13,6 @@
 #include "components/rendering.h"
 #include "components/test_player.h"
 #include "components/obstacle.h"
-#include "components/rng.h"
 #include "systems/all_systems.h"
 #include "systems/game_phase_transition.h"
 #include "systems/runtime_systems.h"
@@ -189,7 +188,6 @@ bool game_loop_init(entt::registry& reg,
     reset_ctx_singleton<EnergyState>(reg);
     reset_ctx_singleton<GameOverState>(reg);
     reset_ctx_singleton<SongResults>(reg);
-    reset_ctx_singleton<RNGState>(reg);
     reset_ctx_singleton<TestPlayerState>(reg);
     reset_ctx_singleton<TestPlayerSessionState>(reg);
     reset_ctx_singleton<SessionLog>(reg);

--- a/app/session/play_session.cpp
+++ b/app/session/play_session.cpp
@@ -9,7 +9,6 @@
 #include "../audio/music_context.h"
 #include "../components/high_score.h"
 #include "../systems/high_score_system.h"
-#include "../components/rng.h"
 #include "../entities/settings.h"
 #include "../util/rhythm_math.h"
 #include "../entities/camera_entity.h"
@@ -114,9 +113,6 @@ void setup_play_session(entt::registry& reg) {
     if (restore_settings) {
         create_settings_entity(reg, settings, settings_persistence);
     }
-
-    // Reset singletons
-    assign_or_emplace_ctx(reg, RNGState{});
 
     // Load beatmap from level selection. BeatMap is an entity singleton whose
     // cold asset data remains immutable for the duration of the play session.

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -135,8 +135,6 @@ TEST_CASE("ecs: make_registry creates all singletons", "[ecs]") {
     static_cast<void>(reg.ctx().get<HighScoreState>());
     static_cast<void>(reg.ctx().get<HighScorePersistence>());
     static_cast<void>(reg.ctx().get<GameOverState>());
-    // Misc
-    static_cast<void>(reg.ctx().get<RNGState>());
     SUCCEED("all required ctx singletons exist in registry context");
 }
 

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -18,7 +18,6 @@
 #include "components/rhythm.h"
 #include "util/rhythm_math.h"
 #include "components/high_score.h"
-#include "components/rng.h"
 #include "components/gameplay_intents.h"
 #include "constants.h"
 #include "entities/beat_map.h"
@@ -48,7 +47,6 @@ inline entt::registry make_registry() {
     reg.ctx().emplace<HighScoreState>();
     reg.ctx().emplace<HighScorePersistence>();
     reg.ctx().emplace<GameOverState>();
-    reg.ctx().emplace<RNGState>();
     runtime_system_scratch_init(reg);
     return reg;
 }


### PR DESCRIPTION
## Summary

Delete the `RNGState` ctx singleton, which is emplaced/reset in setup paths but never read in production. Live RNG is `TestPlayerState::rng` (its own `std::mt19937`).

This is the first action item from the #1194 component audit (`rng.h` tagged DELETE).

## Changes

- Delete `app/components/rng.h` (the only contents were a one-field `RNGState { std::mt19937 engine{1u}; }`).
- Remove the include + `reset_ctx_singleton<RNGState>(reg)` call in `app/game_loop.cpp`.
- Remove the include + `assign_or_emplace_ctx(reg, RNGState{})` call in `app/session/play_session.cpp`. The `// Reset singletons` comment, which was annotating only that one line, is also removed.
- Remove the include + `reg.ctx().emplace<RNGState>()` line in `tests/test_helpers.h::make_registry()`.
- Remove the `reg.ctx().get<RNGState>()` presence check in `tests/test_components.cpp` (and the now-orphaned `// Misc` comment).

`+0/-17` net.

## Verification

- `cmake --build build` — clean (`-Wall -Wextra -Werror`, zero warnings).
- `ctest --test-dir build` — `913/913` passing (1 smoke test `startup_shutdown_smoke` skipped pre-existing).

## Out of scope (for future PRs against #1194)

- Other component audit verdicts (MOVE: `audio_events`, `haptics`, `input_events`, `system_scratch`, etc.; SPLIT: `game_state`, `high_score`, `rendering`, `scoring`, `song_state`, `transform`).
- The historical references to `RNGState` in `.squad/decisions.md` and `.squad/agents/*/history*.md` are dated audit/decision logs and are intentionally not modified.