### PR TITLE
Move screen_to_virtual() out of components/rendering.h (refs #1196)

### DIFF
--- a/app/components/rendering.h
+++ b/app/components/rendering.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <cassert>
 #include <cstdint>
-#include <cmath>
 #include <entt/entt.hpp>
 #include <raylib.h>
 #include <raymath.h>
@@ -26,22 +24,13 @@ struct DrawLayer {
 };
 
 // Letterbox scale/offset: window to virtual space.
+// Coordinate-conversion helper lives in app/systems/camera_system.h
+// (screen_to_virtual) — components headers stay data-only.
 struct ScreenTransform {
     float offset_x = 0.0f;
     float offset_y = 0.0f;
     float scale    = 1.0f;
 };
-
-[[nodiscard]] inline Vector2 screen_to_virtual(const Vector2& screen_pos,
-                                                const ScreenTransform& st) noexcept {
-    assert(std::isfinite(st.scale));
-    assert(st.scale > 0.0f);
-    const float inv_scale = 1.0f / st.scale;
-    return {
-        (screen_pos.x - st.offset_x) * inv_scale,
-        (screen_pos.y - st.offset_y) * inv_scale
-    };
-}
 
 // Computed by game_camera_system from WorldTransform/DrawSize/Shape.
 // MeshType tells the render system which GPU mesh to draw.

--- a/app/systems/camera_system.h
+++ b/app/systems/camera_system.h
@@ -1,8 +1,11 @@
 #pragma once
+#include "../components/rendering.h"
 #include "../entities/camera_entity.h"
 #include "../rendering/camera_resources.h"
-#include <raylib.h>
+#include <cassert>
+#include <cmath>
 #include <entt/entt.hpp>
+#include <raylib.h>
 
 namespace camera {
 
@@ -17,3 +20,17 @@ void shutdown(entt::registry& reg);
 // Update ScreenTransform (letterbox scale/offset) from the current window size.
 // Called before input_system so coordinate transforms are never one-frame stale.
 void compute_screen_transform(entt::registry& reg);
+
+// Convert a window-space pixel position into the virtual coordinate space using
+// the current letterbox scale/offset. Lives in the camera system because the
+// transform is owned and updated there; components/rendering.h stays data-only.
+[[nodiscard]] inline Vector2 screen_to_virtual(const Vector2& screen_pos,
+                                                const ScreenTransform& st) noexcept {
+    assert(std::isfinite(st.scale));
+    assert(st.scale > 0.0f);
+    const float inv_scale = 1.0f / st.scale;
+    return {
+        (screen_pos.x - st.offset_x) * inv_scale,
+        (screen_pos.y - st.offset_y) * inv_scale
+    };
+}

--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -1,4 +1,5 @@
 #include "all_systems.h"
+#include "camera_system.h"
 #include "web_input_policy.h"
 #include "../input/keyboard_shape_mapping.h"
 #include "../components/input.h"

--- a/tests/test_component_raylib_boundaries.cpp
+++ b/tests/test_component_raylib_boundaries.cpp
@@ -32,7 +32,9 @@ TEST_CASE("component headers use raylib types directly (post #1199)", "[componen
 
     CHECK(transform.find("Vector2") != std::string::npos);
     CHECK(rendering.find("Matrix") != std::string::npos);
-    CHECK(rendering.find("Vector2") != std::string::npos);
+    // Vector2 is no longer required in rendering.h: the only consumer
+    // (screen_to_virtual) was moved to app/systems/camera_system.h to keep
+    // the components header data-only (issue #1196).
     CHECK(rendering.find("Color") != std::string::npos);
 
     CHECK(transform.find("glm::") == std::string::npos);

--- a/tests/test_ndc_viewport.cpp
+++ b/tests/test_ndc_viewport.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include "test_helpers.h"
+#include "systems/camera_system.h"
 #include <algorithm>
 #include <cmath>
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Per #1196, `app/components/` headers must stay data-only. `rendering.h`
inlined `screen_to_virtual()` — a coordinate-conversion function — which
violated that boundary. This PR moves the function next to
`compute_screen_transform()` in `app/systems/camera_system.h`, where
`ScreenTransform` is computed and owned. No behavior change.

## What

- Move `[[nodiscard]] inline Vector2 screen_to_virtual(...)` from
  `app/components/rendering.h` to `app/systems/camera_system.h`.
- Drop now-unused `<cassert>` and `<cmath>` includes from
  `components/rendering.h`. Add them to `camera_system.h`.
- `app/systems/input_system.cpp` now `#include`s `camera_system.h`
  directly (it was relying on the function being parked in a transitively
  included components header).
- `tests/test_ndc_viewport.cpp` adds the same include.
- `tests/test_component_raylib_boundaries.cpp` drops the now-stale
  assertion that `rendering.h` contains `Vector2` — the only Vector2
  consumer moved out. Negative `glm::`/`Vec2f` checks are kept.

## Why

Same line as #1196: "Functions on component headers are the camel's nose;
behavior belongs in systems." This is one of the action items called out
by the issue. Component headers should be queryable POD; screen-to-virtual
is a system helper that depends on `ScreenTransform` being kept current
by `compute_screen_transform()` (already in `camera_system.h`).

## Verification

- `cmake --build build` — clean, zero warnings (`-Wall -Wextra -Werror`).
- `./build/shapeshifter_tests` — **901/901** test cases, **2957/2957**
  assertions pass.
- `./build/shapeshifter_startup_shutdown_smoke` — exits cleanly.
- Diff is +25/-15 across 5 files; no symbols renamed; no signature change.

## Issue progress

Addresses one of four action items in #1196 (the
`screen_to_virtual()` move). The other three (move `system_scratch.h`,
relocate `InputState` private fields, replace `GameState` blob) remain
open.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>