### PR TITLE
Move InputState private fields into InputSystemPrivate ctx singleton (refs #1196)

### DIFF
--- a/app/components/input.h
+++ b/app/components/input.h
@@ -5,6 +5,10 @@
 // ── Raw input state (internal to input_system) ──────────────────────────────
 // Tracks touch/mouse hardware state. Downstream systems should read
 // semantic events, not this struct — except for quit_requested.
+//
+// Pure system-private fields (gestures_configured, was_focused,
+// suppress_mouse_release) live in InputSystemPrivate (see
+// app/systems/input_system_private.h) — issue #1196.
 
 enum class InputSource : uint8_t { None, Mouse, Touch };
 
@@ -33,9 +37,6 @@ struct InputState {
     bool  click          = false;
     bool  touching       = false;
     bool  quit_requested = false;
-    bool was_focused = true;
-    bool gestures_configured = false;
-    bool suppress_mouse_release = false;
     bool button_touch_up = false;
     float button_end_x = 0.0f, button_end_y = 0.0f;
     TouchSlot touch_slots[MaxTrackedTouches] = {};

--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -1,6 +1,7 @@
 #include "all_systems.h"
 #include "game_phase_transition.h"
 #include "game_state_system.h"
+#include "input_system_private.h"
 #include "play_session.h"
 #include "../components/game_state.h"
 #include "../components/input.h"
@@ -94,19 +95,9 @@ void game_state_system(entt::registry& reg, float dt) {
 
         // Clear any in-flight pointer capture when changing screens so
         // down/up state from the previous phase cannot leak into the next UI.
-        if (auto* input = reg.ctx().find<InputState>()) {
-            input->touch_down = false;
-            input->touch_up = false;
-            input->click = false;
-            input->button_touch_up = false;
-            input->touching = false;
-            input->active_source = InputSource::None;
-            input->suppress_mouse_release = false;
-            input->duration = 0.0f;
-            for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
-                input->touch_slots[i] = TouchSlot{};
-            }
-        }
+        // Owned by input_system because suppress_mouse_release lives in
+        // InputSystemPrivate (issue #1196).
+        input_system_clear_pointer_state(reg);
 
         switch (gs.next_phase) {
             case GamePhase::Playing:

--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -1,5 +1,6 @@
 #include "all_systems.h"
 #include "camera_system.h"
+#include "input_system_private.h"
 #include "web_input_policy.h"
 #include "../util/keyboard_shape_mapping.h"
 #include "../components/input.h"
@@ -149,6 +150,8 @@ void input_system_init(entt::registry& reg) {
 #else
     (void)policy;
 #endif
+    reg.ctx().erase<InputSystemPrivate>();
+    reg.ctx().emplace<InputSystemPrivate>();
 }
 
 bool web_input_touch_capable(const entt::registry& reg) {
@@ -158,13 +161,32 @@ bool web_input_touch_capable(const entt::registry& reg) {
     return false;
 }
 
+void input_system_clear_pointer_state(entt::registry& reg) {
+    if (auto* input = reg.ctx().find<InputState>()) {
+        input->touch_down = false;
+        input->touch_up = false;
+        input->click = false;
+        input->button_touch_up = false;
+        input->touching = false;
+        input->active_source = InputSource::None;
+        input->duration = 0.0f;
+        for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
+            input->touch_slots[i] = TouchSlot{};
+        }
+    }
+    if (auto* priv = reg.ctx().find<InputSystemPrivate>()) {
+        priv->suppress_mouse_release = false;
+    }
+}
+
 void input_system(entt::registry& reg, float raw_dt) {
     auto& input = reg.ctx().get<InputState>();
+    auto& priv  = reg.ctx().get<InputSystemPrivate>();
     auto& st    = reg.ctx().get<ScreenTransform>();
     auto& disp  = reg.ctx().get<entt::dispatcher>();
-    if (!input.gestures_configured) {
+    if (!priv.gestures_configured) {
         SetGesturesEnabled(kGameplayGestureFlags);
-        input.gestures_configured = true;
+        priv.gestures_configured = true;
     }
     input.touch_down = false;
     input.touch_up   = false;
@@ -185,29 +207,29 @@ void input_system(entt::registry& reg, float raw_dt) {
     const int touch_point_count = GetTouchPointCount();
     const bool mouse_released = allow_mouse_input && IsMouseButtonReleased(MOUSE_BUTTON_LEFT);
     if (allow_mouse_input &&
-        input.suppress_mouse_release &&
+        priv.suppress_mouse_release &&
         touch_point_count == 0 &&
         !mouse_released) {
-        input.suppress_mouse_release = false;
+        priv.suppress_mouse_release = false;
     }
 
     // ── Mouse (desktop) — click-only semantics ─
     if (allow_mouse_input &&
         input.active_source != InputSource::Touch &&
-        !input.suppress_mouse_release &&
+        !priv.suppress_mouse_release &&
         touch_point_count == 0 &&
         IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
         input.active_source = InputSource::Mouse;
-        input.suppress_mouse_release = false;
+        priv.suppress_mouse_release = false;
     }
     if (allow_mouse_input &&
         input.active_source != InputSource::Touch &&
         mouse_released) {
-        const bool suppress_this_release = input.suppress_mouse_release;
+        const bool suppress_this_release = priv.suppress_mouse_release;
         input.click      = !suppress_this_release;
         input.touching   = false;
         input.active_source = InputSource::None;
-        input.suppress_mouse_release = false;
+        priv.suppress_mouse_release = false;
         const Vector2 mouse_pos = GetMousePosition();
         const Vector2 pos = screen_to_virtual({mouse_pos.x, mouse_pos.y}, st);
         input.start_x = input.curr_x = input.end_x = pos.x;
@@ -304,7 +326,7 @@ void input_system(entt::registry& reg, float raw_dt) {
         bool had_swipe_zone_release = false;
         input.touch_up  = true;
         input.touching  = false;
-        input.suppress_mouse_release = true;
+        priv.suppress_mouse_release = true;
         input.active_source = InputSource::None;
         for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
             auto& slot = input.touch_slots[i];
@@ -365,13 +387,13 @@ void input_system(entt::registry& reg, float raw_dt) {
     // Pause only on the frame focus is *lost*, not every frame while unfocused.
     {
         bool focused = IsWindowFocused();
-        if (input.was_focused && !focused &&
+        if (priv.was_focused && !focused &&
             reg.ctx().get<GameState>().phase == GamePhase::Playing) {
             auto& gs = reg.ctx().get<GameState>();
             gs.transition_pending = true;
             gs.next_phase = GamePhase::Paused;
         }
-        input.was_focused = focused;
+        priv.was_focused = focused;
     }
 
     if (input.active_source != InputSource::Mouse &&

--- a/app/systems/input_system_private.h
+++ b/app/systems/input_system_private.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <entt/entt.hpp>
+
+// System-private state for input_system. Stored in registry context, not
+// emplaced on entities — this is per-system scratch, not component data.
+// Relocated out of app/components/input.h (issue #1196).
+//
+//   * gestures_configured       — one-shot SetGesturesEnabled latch.
+//   * was_focused               — previous-frame window focus, for edge detect.
+//   * suppress_mouse_release    — pointer-capture latch that swallows the next
+//                                 mouse release after a touch end so a touch
+//                                 swipe does not also fire a stray click event.
+//
+// Reset via input_system_init() and input_system_clear_pointer_state().
+struct InputSystemPrivate {
+    bool gestures_configured = false;
+    bool was_focused = true;
+    bool suppress_mouse_release = false;
+};
+
+// Clears in-flight pointer-capture state so the next phase/screen starts from
+// a clean slate. Called from game_state_system on phase transitions; the input
+// system owns the reset because it owns the fields being cleared.
+void input_system_clear_pointer_state(entt::registry& reg);

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -256,12 +256,13 @@ TEST_CASE("game_state: transition clears in-flight pointer capture", "[gamestate
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
     auto& input = reg.ctx().get<InputState>();
+    auto& priv = reg.ctx().get<InputSystemPrivate>();
 
     input.touch_down = true;
     input.touch_up = false;
     input.touching = true;
     input.active_source = InputSource::Mouse;
-    input.suppress_mouse_release = true;
+    priv.suppress_mouse_release = true;
     input.duration = 0.25f;
 
     gs.transition_pending = true;
@@ -273,7 +274,7 @@ TEST_CASE("game_state: transition clears in-flight pointer capture", "[gamestate
     CHECK_FALSE(input.touch_up);
     CHECK_FALSE(input.touching);
     CHECK(input.active_source == InputSource::None);
-    CHECK_FALSE(input.suppress_mouse_release);
+    CHECK_FALSE(priv.suppress_mouse_release);
     CHECK(input.duration == 0.0f);
 }
 

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -25,11 +25,13 @@
 #include "systems/all_systems.h"
 #include "systems/runtime_systems.h"
 #include "systems/input_routing.h"
+#include "systems/input_system_private.h"
 
 // Sets up a registry with all singletons in their default state
 inline entt::registry make_registry() {
     entt::registry reg;
     reg.ctx().emplace<InputState>();
+    reg.ctx().emplace<InputSystemPrivate>();
     reg.ctx().emplace<ScreenTransform>();
     reg.ctx().emplace<entt::dispatcher>();
     wire_input_dispatcher(reg);


### PR DESCRIPTION
Closes the third action item in #1196.

## What

Relocates the three system-private fields out of `app/components/input.h`:

- `gestures_configured` — one-shot `SetGesturesEnabled` latch
- `was_focused` — previous-frame window focus for edge-detect
- `suppress_mouse_release` — pointer-capture latch that swallows the next mouse release after a touch end

They now live in `InputSystemPrivate`, a registry context singleton declared in the new `app/systems/input_system_private.h`, beside the input system that owns them. Per #1196 these are "system-private state laundered through the component layer" — only `input_system` reads/writes them in production flow.

## Where the inline cross-cutting reset went

The phase-transition reset block in `game_state_system.cpp` that previously poked `InputState` fields directly now calls the new `input_system_clear_pointer_state(registry&)` helper exported from `input_system.cpp`. The input system owns the reset of its own state instead of the game-state system reaching into it.

`input_system_init()` emplaces a fresh `InputSystemPrivate` on the registry, mirroring how `reset_ctx_singleton<InputState>` initializes the public component. Tests gain an `emplace<InputSystemPrivate>()` in `make_registry` and the one external assertion site (`test_game_state_extended.cpp`) now reads the private struct directly.

## Files

| Change | File |
|---|---|
| New | `app/systems/input_system_private.h` |
| -3 fields | `app/components/input.h` |
| +clear helper, route reads/writes via `priv` | `app/systems/input_system.cpp` |
| Call `input_system_clear_pointer_state` instead of inline poke | `app/systems/game_state_system.cpp` |
| Emplace new ctx singleton in `make_registry` | `tests/test_helpers.h` |
| Re-target one assertion at the private struct | `tests/test_game_state_extended.cpp` |

## Updated #1196 checklist

- [x] Move `screen_to_virtual()` out of `rendering.h` (PR #1214)
- [x] Move `system_scratch.h` contents to per-system locations (PR #1215)
- [x] Move `InputState` private fields into `app/systems/` (this PR)
- [ ] Replace `GameState` blob with discrete components / events (deferred; covered by the existential-UI refactor — bigger surface area)

## Validation

- Unity build: `cmake --build build -j` — clean, zero warnings (Clang `-Wall -Wextra -Werror`).
- Non-unity build: `cmake -B build_nonunity -DSHAPESHIFTER_UNITY_BUILD=OFF` — clean.
- Tests: `./build/shapeshifter_tests` — 2957 assertions in 901 test cases pass.
- ctest: `ctest --output-on-failure` — 913/913 pass (1 default-skipped startup-shutdown smoke).