### PR TITLE
Delete unused TextAlign enum from components/text.h (refs #1194)

### DIFF
--- a/app/components/text.h
+++ b/app/components/text.h
@@ -1,11 +1,7 @@
 #pragma once
 
-#include <cstdint>
-
 // UI/domain-facing text enums used by ECS components.
 // Runtime font resources are owned by TextContext in app/rendering/text_resources.h.
-
-enum class TextAlign : uint8_t { Left, Center, Right };
 
 // Named constants for the pre-loaded font sizes.
 enum class FontSize : int { Small = 0, Medium = 1, Large = 2 };


### PR DESCRIPTION
## Summary

Opportunistic cleanup from #1194's checklist ("Delete unused `TextAlign` from `text.h`"). The `TextAlign` enum was defined in `app/components/text.h` but has zero call sites anywhere in `app/`, `tests/`, or `benchmarks/`. The only surviving mentions live in:

- `docs/sokol-migration.md` — a doc explicitly labeled *"Historical Note: abandoned SDL2 to Sokol migration plan ... not an active implementation plan"*
- `.squad/decisions-archive.md` and `.squad/agents/kujan/history-archive.md` — archived squad agent histories

None of those are in the build path, so the enum is dead weight.

## Changes

- Remove `enum class TextAlign : uint8_t { Left, Center, Right };` from `app/components/text.h`
- Drop the now-unused `<cstdint>` include (no remaining `uint8_t` consumers in this header)

`FontSize` stays — it is still used by `ScoreState`, `PopupDisplay`, and `ui_render_system`.

## Validation

- Unity Clang `-Wall -Wextra -Werror` build: zero warnings
- Non-unity Clang `-Wall -Wextra -Werror` build: zero warnings
- `shapeshifter_tests`: **901 test cases / 2957 assertions pass** on both configurations

## Refs

- #1194 — Audit: `app/components/` — delete dead, move non-component state out, split god-structs