### PR TITLE
Move gameplay_intents.h from components/ to systems/ (refs #1194)

### DIFF
--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -7,7 +7,7 @@
 #include "../components/rhythm.h"
 #include "../util/rhythm_math.h"
 #include "../components/song_state.h"
-#include "../components/gameplay_intents.h"
+#include "gameplay_intents.h"
 #include "../constants.h"
 #include "../util/lane_utils.h"
 #include <cmath>

--- a/app/systems/energy_system.cpp
+++ b/app/systems/energy_system.cpp
@@ -1,6 +1,6 @@
 #include "all_systems.h"
 #include "../components/game_state.h"
-#include "../components/gameplay_intents.h"
+#include "gameplay_intents.h"
 #include "../components/rhythm.h"
 #include "../constants.h"
 #include <raymath.h>

--- a/app/systems/gameplay_intents.h
+++ b/app/systems/gameplay_intents.h
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <vector>
 
-#include "rhythm.h"
+#include "../components/rhythm.h"
 
 struct PendingEnergyEffects {
     struct Event {

--- a/app/systems/popup_feedback_system.cpp
+++ b/app/systems/popup_feedback_system.cpp
@@ -2,7 +2,7 @@
 
 #include "audio_events.h"
 #include "../components/game_state.h"
-#include "../components/gameplay_intents.h"
+#include "gameplay_intents.h"
 #include "../entities/popup_entity.h"
 #include <optional>
 

--- a/app/systems/runtime_system_scratch.cpp
+++ b/app/systems/runtime_system_scratch.cpp
@@ -5,7 +5,7 @@
 #include "particle_system.h"
 #include "popup_display_system.h"
 #include "scoring_system.h"
-#include "../components/gameplay_intents.h"
+#include "gameplay_intents.h"
 #include "../components/rendering.h"
 
 #include <algorithm>

--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -3,7 +3,7 @@
 #include "../components/game_state.h"
 #include "../components/scoring.h"
 #include "../components/obstacle.h"
-#include "../components/gameplay_intents.h"
+#include "gameplay_intents.h"
 #include "../components/particle.h"
 #include "../components/transform.h"
 #include "../components/rendering.h"

--- a/tests/test_energy_system.cpp
+++ b/tests/test_energy_system.cpp
@@ -1,7 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include "test_helpers.h"
-#include "components/gameplay_intents.h"
+#include "systems/gameplay_intents.h"
 
 // ── energy_system ────────────────────────────────────────────
 

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -18,7 +18,7 @@
 #include "components/rhythm.h"
 #include "util/rhythm_math.h"
 #include "components/high_score.h"
-#include "components/gameplay_intents.h"
+#include "systems/gameplay_intents.h"
 #include "constants.h"
 #include "entities/beat_map.h"
 #include "entities/obstacle_render_entity.h"


### PR DESCRIPTION
## Summary

Relocate `app/components/gameplay_intents.h` → `app/systems/gameplay_intents.h`.

`PendingEnergyEffects` and `ScorePopupRequestQueue` are **ctx singletons** used as inter-system intent queues — produced by `scoring_system` and consumed by `energy_system` / `popup_feedback_system`. They never live on entities, so they fail the component test (see #1194 audit verdict: **MOVE** — "Inter-system queues … reserved in `runtime_system_scratch_init()`. No entity owns them.").

`ScorePopupRequest` is the per-element payload struct in `ScorePopupRequestQueue::requests`, never on entities either.

## Why `app/systems/`?

This follows the same MOVE pattern established this loop cycle by:
- PR #1221 (`audio_events.h` / `haptics.h` / `input_events.h` → `app/systems/`)
- PR #1225 (`shape_mesh.h` → `app/systems/`)

The destination is colocated with the producing system (`scoring_system.cpp`), matching the canonical home pattern.

## Changes

Pure header relocation: **8 files, 8 insertions / 8 deletions**.

- `git mv app/components/gameplay_intents.h app/systems/gameplay_intents.h`
- Updated internal include `#include "rhythm.h"` → `#include "../components/rhythm.h"`
- 5 `app/systems/*.cpp` sites: `#include "../components/gameplay_intents.h"` → `#include "gameplay_intents.h"`
- 2 `tests/*` sites: `#include "components/gameplay_intents.h"` → `#include "systems/gameplay_intents.h"`

Zero behavioural delta.

## Action-item progress on #1194

- [x] DELETE `rng.h` (PR #1213)
- [x] MOVE `audio_events.h`, `haptics.h`, `input_events.h` (PR #1221)
- [x] Delete unused `TextAlign` (PR #1222)
- [x] MOVE `shape_mesh.h` (PR #1225)
- [x] **MOVE `gameplay_intents.h`** (this PR)
- [ ] Extract `Direction` from `input.h` into a tiny shared input-types header alongside `GoEvent`
- [ ] MOVE `input.h`, `test_player.h` beside their owning systems
- [ ] SPLIT `high_score.h` / `scoring.h` / `song_state.h` / `game_state.h` / `transform.h` / `rendering.h`

## Validation

- 901 Catch2 tests / 2957 assertions pass
- Zero warnings under **unity AND non-unity** Clang `-Wall -Wextra -Werror` builds
- No remaining references to `components/gameplay_intents` anywhere on the build path (only in `.squad/decisions.md` historical archives, which intentionally preserve path-at-time-of-entry)

Refs #1194.