### PR TITLE
MOVE test_player.h: components/ → systems/ (#1194)

### DIFF
--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -11,7 +11,7 @@
 #include "components/rhythm.h"
 #include "components/music.h"
 #include "components/rendering.h"
-#include "components/test_player.h"
+#include "systems/test_player.h"
 #include "components/obstacle.h"
 #include "systems/all_systems.h"
 #include "systems/game_phase_transition.h"

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -1,5 +1,5 @@
 #include "game_loop.h"
-#include "components/test_player.h"
+#include "systems/test_player.h"
 #include "content/level_content_config.h"
 
 #include <cstdio>

--- a/app/systems/test_player.h
+++ b/app/systems/test_player.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "player.h"
+#include "../components/player.h"
 #include "tags/tags.h"
 #include <entt/entity/entity.hpp>
 #include <entt/core/enum.hpp>

--- a/app/systems/test_player_session.h
+++ b/app/systems/test_player_session.h
@@ -2,7 +2,7 @@
 
 #include <entt/entt.hpp>
 #include <cstdint>
-#include "../components/test_player.h"
+#include "test_player.h"
 #include "../content/level_content_config.h"
 
 struct TestPlayerSessionState {

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -1,5 +1,5 @@
 #include "all_systems.h"
-#include "../components/test_player.h"
+#include "test_player.h"
 #include "../components/game_state.h"
 #include "../components/input.h"
 #include "input_events.h"

--- a/design-docs/tester-personas-tech-spec.md
+++ b/design-docs/tester-personas-tech-spec.md
@@ -149,7 +149,7 @@ while (accumulator >= FIXED_DT) {
 ## Skill Config Table (constexpr, not a component)
 
 ```cpp
-// app/components/test_player.h
+// app/systems/test_player.h
 
 enum class TestPlayerSkill : uint8_t { Pro = 0, Good = 1, Bad = 2 };
 
@@ -203,7 +203,7 @@ separate `need_shape` boolean. Same pattern for `target_lane = -1` and
 ## TestPlayerState (context singleton)
 
 ```cpp
-// app/components/test_player.h
+// app/systems/test_player.h
 
 struct TestPlayerState {
     // ── Hot ──────────────────────────────────────────────────
@@ -608,10 +608,9 @@ inside `tick_playing_systems`.
 
 ```
   app/
-    components/
+    systems/
       test_player.h            ← TestPlayerSkill, SkillConfig, TestPlayerAction,
       │                           TestPlayerState (context singleton)
-    systems/
       test_player_system.cpp   ← AI: perceive, decide, wait, execute
       │                           Platform-portable: enqueues events
       │                           directly on the EnTT dispatcher

--- a/tests/smoke/startup_shutdown_smoke.cpp
+++ b/tests/smoke/startup_shutdown_smoke.cpp
@@ -1,4 +1,4 @@
-#include "components/test_player.h"
+#include "systems/test_player.h"
 #include "game_loop.h"
 
 #include <raylib.h>

--- a/tests/test_test_player_system.cpp
+++ b/tests/test_test_player_system.cpp
@@ -1,6 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "test_helpers.h"
-#include "components/test_player.h"
+#include "systems/test_player.h"
 #include "content/level_content_config.h"
 #include "systems/test_player_session.h"
 #include "systems/session_logger_system.h"


### PR DESCRIPTION
Per the audit in #1194: `test_player.h` only contains system-private state for `test_player_system` / `test_player_session` — no entities ever carry these as components.

| Type | Role |
|---|---|
| `TestPlayerSkill` / `SkillConfig` / `SKILL_TABLE` | constexpr config for AI personas |
| `TestPlayerAction` | value type explicitly marked *NOT a component* |
| `TestPlayerState` | ctx singleton (`reg.ctx().emplace<TestPlayerState>()`) |
| `ActionDoneBit` | bitmask flags consumed only by `test_player_system.cpp` |

The only entity-data type from the persona system is `TestPlayerPlannedTag`, which already lives in `app/tags/tags.h`. With this move, the header sits beside its sole owners (`test_player_session.{h,cpp}`, `test_player_system.cpp`).

### Mechanics
- `git mv app/components/test_player.h app/systems/test_player.h`
- Internal `#include "player.h"` → `#include "../components/player.h"` (relative-include fix; `tags/tags.h` already resolves via the `app/` include path)
- 6 call-site include paths updated (`game_loop.cpp`, `main.cpp`, `test_player_session.h`, `test_player_system.cpp`, `tests/test_test_player_system.cpp`, `tests/smoke/startup_shutdown_smoke.cpp`)
- 3 design-doc location references updated (`design-docs/tester-personas-tech-spec.md`)

### Pattern
Same shape as #1225 (`shape_mesh.h`) and #1226 (`gameplay_intents.h`): pure header relocation, no behaviour changes.

### Validation
- 901 Catch2 tests / 2957 assertions pass.
- Zero warnings under both unity (`build`) and non-unity (`build-nounity`) Clang `-Wall -Wextra -Werror` builds.

Closes one bullet of #1194.