### PR TITLE
Move Direction enum from components/input.h to systems/input_events.h (refs #1194)

### DIFF
--- a/app/components/input.h
+++ b/app/components/input.h
@@ -42,7 +42,5 @@ struct InputState {
     TouchSlot touch_slots[MaxTrackedTouches] = {};
 };
 
-// ── Directions ──────────────────────────────────────────────────────────────
-// Shared by semantic input producers and consumers.
-
-enum class Direction : uint8_t { Left, Right, Up, Down };
+// Note: `Direction` lives in app/systems/input_events.h alongside `GoEvent`,
+// the only event that carries it (issue #1194).

--- a/app/systems/input_events.h
+++ b/app/systems/input_events.h
@@ -1,8 +1,14 @@
 #pragma once
 
-#include "../components/input.h"   // Direction
 #include "../components/player.h"  // Shape
 #include <cstdint>
+
+// ── Directions ──────────────────────────────────────────────────────────────
+// Directional intent shared by gesture producers (input_system,
+// test_player_system) and listeners (player_input_system, level_select
+// controller). Lives next to `GoEvent` — its only carrier (issue #1194).
+
+enum class Direction : uint8_t { Left, Right, Up, Down };
 
 enum class MenuActionKind : uint8_t {
     Confirm       = 0,

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -1,7 +1,6 @@
 #include "all_systems.h"
 #include "test_player.h"
 #include "../components/game_state.h"
-#include "../components/input.h"
 #include "input_events.h"
 #include "../components/player.h"
 #include "../components/transform.h"

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -442,13 +442,19 @@ struct InputState {
     float button_end_x = 0.0f, button_end_y = 0.0f;
     TouchSlot touch_slots[MaxTrackedTouches] = {};
 };
-
-/// Directional intent shared by gesture producers and listeners.
-enum class Direction : uint8_t { Left, Right, Up, Down };
 ```
 
 ```cpp
 // systems/input_events.h
+
+/// Directional intent shared by gesture producers (input_system,
+/// test_player_system) and listeners (player_input_system, level_select
+/// controller). Lives next to `GoEvent` — its only carrier (issue #1194).
+enum class Direction : uint8_t { Left, Right, Up, Down };
+```
+
+```cpp
+// systems/input_events.h (continued)
 
 /// Semantic input events — produced by input_system, HUD controllers, and
 /// test_player_system; consumed by listeners wired through entt::dispatcher.
@@ -1662,8 +1668,8 @@ app/
 │   │                              (RequiredShape, RequiredLane, ShapeGateLane,
 │   │                              BlockedLanes)
 │   ├── scoring.h                ← ScoreState, ScorePopup
-│   ├── input.h                  ← InputState, TouchSlot, Direction
-│   ├── input_events.h           ← ButtonPressEvent, GoEvent, MenuActionKind
+│   ├── input.h                  ← InputState, TouchSlot, InputSource
+│   ├── input_events.h           ← Direction, ButtonPressEvent, GoEvent, MenuActionKind (in systems/)
 │   ├── game_state.h             ← GameState, GamePhase, LevelSelectState
 │   ├── rendering.h              ← DrawSize, DrawLayer, screen/model transforms
 │   ├── particle.h               ← ParticleData, ParticleTag


### PR DESCRIPTION
Refs #1194 (next action item: "Extract `Direction` from `input.h` into a tiny shared input-types header alongside `GoEvent`").

## Why

`Direction` is semantic-event vocabulary, not hardware-capture state. Its **only** carrier is `GoEvent`, which already lives in `app/systems/input_events.h`. The previous home in `app/components/input.h` forced `systems/input_events.h` to reach back into `components/` just to spell its event payload type — exactly the kind of cross-layer dependency the #1194 audit calls out.

Every consumer of `Direction` (`input_system`, `test_player_system`, `player_input_system`, `level_select_controller`) already includes `input_events.h` for `GoEvent`, so no new transitive includes are needed.

## Changes

- **`app/components/input.h`** — Remove the `Direction` enum; leave a one-line breadcrumb comment pointing at its new home.
- **`app/systems/input_events.h`** — Add `Direction` next to `GoEvent`; drop the now-unused `#include "../components/input.h"`.
- **`app/systems/test_player_system.cpp`** — Drop `#include "../components/input.h"` (only used `Direction`; already includes `input_events.h`).
- **`design-docs/architecture.md`** — Move the `Direction` snippet from the `components/input.h` block into the `systems/input_events.h` block, and correct the directory tree (`input_events.h` lives in `systems/`, not `components/`; carries `Direction` now).

Files that include `components/input.h` for `InputState`/`TouchSlot` (`game_loop.cpp`, `input_system.cpp`, `game_state_routing.cpp`, screen controllers, lifecycle/helpers tests) are unchanged — those symbols stay in place pending the larger "MOVE `input.h` beside the input system" item.

## Validation

| Build | Result |
|---|---|
| Unity Clang `-Wall -Wextra -Werror` | clean, 0 warnings |
| Non-unity Clang `-Wall -Wextra -Werror` | clean, 0 warnings |
| `./build/shapeshifter_tests` | **901 test cases / 2957 assertions pass** |
| `./build-nounity/shapeshifter_tests` | **901 test cases / 2957 assertions pass** |

## #1194 action-item progress (after this PR)

- [x] DELETE `rng.h` (PR #1213)
- [x] MOVE `audio_events.h`, `haptics.h`, `input_events.h` (PR #1221)
- [x] Delete unused `TextAlign` (PR #1222)
- [x] MOVE `shape_mesh.h` (PR #1225)
- [x] MOVE `gameplay_intents.h` (PR #1226)
- [x] MOVE `test_player.h` (PR #1227)
- [x] **Extract `Direction` into input-events header (this PR)**
- [ ] MOVE `input.h` beside the input system
- [ ] SPLIT `high_score.h` / `scoring.h` / `song_state.h` / `game_state.h` / `transform.h` / `rendering.h`