### PR TITLE
Move input.h from components/ to systems/ (refs #1194)

### DIFF
--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -1,7 +1,7 @@
 #include "game_loop.h"
 #include "version.h"
 #include "constants.h"
-#include "components/input.h"
+#include "systems/input.h"
 #include "components/game_state.h"
 #include "components/scoring.h"
 #include "components/audio.h"

--- a/app/systems/game_state_routing.cpp
+++ b/app/systems/game_state_routing.cpp
@@ -1,6 +1,6 @@
 #include "input_routing.h"
 #include "../components/game_state.h"
-#include "../components/input.h"
+#include "input.h"
 #include "input_events.h"
 #include "audio_events.h"
 #include "haptics.h"

--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -4,7 +4,7 @@
 #include "input_system_private.h"
 #include "play_session.h"
 #include "../components/game_state.h"
-#include "../components/input.h"
+#include "input.h"
 #include "../components/obstacle.h"
 #include "input_events.h"
 #include "../components/player.h"

--- a/app/systems/input.h
+++ b/app/systems/input.h
@@ -9,6 +9,10 @@
 // Pure system-private fields (gestures_configured, was_focused,
 // suppress_mouse_release) live in InputSystemPrivate (see
 // app/systems/input_system_private.h) — issue #1196.
+//
+// Relocated out of app/components/ alongside the input system itself
+// (issue #1194) — this is per-frame ctx-singleton hardware-capture state,
+// not entity-owned component data.
 
 enum class InputSource : uint8_t { None, Mouse, Touch };
 

--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -3,7 +3,7 @@
 #include "input_system_private.h"
 #include "web_input_policy.h"
 #include "../util/keyboard_shape_mapping.h"
-#include "../components/input.h"
+#include "input.h"
 #include "input_events.h"
 #include "../components/player.h"
 #include "../components/rendering.h"

--- a/app/systems/input_system_private.h
+++ b/app/systems/input_system_private.h
@@ -4,7 +4,9 @@
 
 // System-private state for input_system. Stored in registry context, not
 // emplaced on entities — this is per-system scratch, not component data.
-// Relocated out of app/components/input.h (issue #1196).
+// Extracted out of `InputState` (issue #1196). `InputState` itself was
+// later relocated alongside this header from app/components/ to app/systems/
+// (issue #1194).
 //
 //   * gestures_configured       — one-shot SetGesturesEnabled latch.
 //   * was_focused               — previous-frame window focus, for edge detect.

--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
@@ -2,7 +2,7 @@
 
 #include "../../components/game_state.h"
 #include "../../components/energy_bar.h"
-#include "../../components/input.h"
+#include "../../systems/input.h"
 #include "../../systems/input_events.h"
 #include "../../components/obstacle.h"
 #include "../../components/player.h"

--- a/app/ui/screen_controllers/level_select_screen_controller.cpp
+++ b/app/ui/screen_controllers/level_select_screen_controller.cpp
@@ -3,7 +3,7 @@
 
 #include "../../components/game_state.h"
 #include "../../content/level_content_config.h"
-#include "../../components/input.h"
+#include "../../systems/input.h"
 #include "../../constants.h"
 #include "screen_controller_base.h"
 #include <entt/entt.hpp>

--- a/app/ui/screen_controllers/paused_screen_controller.cpp
+++ b/app/ui/screen_controllers/paused_screen_controller.cpp
@@ -1,7 +1,7 @@
 // Paused screen controller - renders raygui layout and dispatches resume/menu actions.
 
 #include "../../components/game_state.h"
-#include "../../components/input.h"
+#include "../../systems/input.h"
 #include "../../constants.h"
 #include "screen_controller_base.h"
 #include <entt/entt.hpp>

--- a/app/ui/screen_controllers/title_screen_controller.cpp
+++ b/app/ui/screen_controllers/title_screen_controller.cpp
@@ -1,7 +1,7 @@
 // Title screen controller - bridges generated rguilayout output to game systems.
 
 #include "../../components/game_state.h"
-#include "../../components/input.h"
+#include "../../systems/input.h"
 #include "screen_controller_base.h"
 #include <raygui.h>
 #include "title_screen_dead_zones.h"

--- a/app/ui/screen_controllers/tutorial_screen_controller.cpp
+++ b/app/ui/screen_controllers/tutorial_screen_controller.cpp
@@ -1,7 +1,7 @@
 // Tutorial screen controller - renders raygui layout and dispatches start action.
 
 #include "../../components/game_state.h"
-#include "../../components/input.h"
+#include "../../systems/input.h"
 #include "../../constants.h"
 #include "../../entities/settings.h"
 #include "../../systems/web_input_policy.h"

--- a/benchmarks/bench_systems.cpp
+++ b/benchmarks/bench_systems.cpp
@@ -5,7 +5,7 @@
 #include "components/transform.h"
 #include "components/player.h"
 #include "components/obstacle.h"
-#include "components/input.h"
+#include "systems/input.h"
 #include "systems/input_events.h"
 #include "components/game_state.h"
 #include "components/scoring.h"

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -401,7 +401,7 @@ struct EnergyState {
 ### 2.7 — COLD: Input (singletons, written once per frame)
 
 ```cpp
-// components/input.h
+// systems/input.h
 
 /// Raw input state — populated by input_system from raylib touch/mouse input.
 /// Singleton. Internal to input_system; downstream systems read the semantic
@@ -1668,7 +1668,6 @@ app/
 │   │                              (RequiredShape, RequiredLane, ShapeGateLane,
 │   │                              BlockedLanes)
 │   ├── scoring.h                ← ScoreState, ScorePopup
-│   ├── input.h                  ← InputState, TouchSlot, InputSource
 │   ├── input_events.h           ← Direction, ButtonPressEvent, GoEvent, MenuActionKind (in systems/)
 │   ├── game_state.h             ← GameState, GamePhase, LevelSelectState
 │   ├── rendering.h              ← DrawSize, DrawLayer, screen/model transforms
@@ -1677,6 +1676,7 @@ app/
 │   └── song_state.h             ← SongState
 │
 ├── systems/                     ← all system free functions
+│   ├── input.h                  ← InputState, TouchSlot, InputSource (singleton hardware-capture state)
 │   ├── all_systems.h            ← convenience #include for all systems
 │   ├── input_system.cpp         ← raylib polling → semantic dispatcher events
 │   ├── game_state_system.cpp    ← phase transitions

--- a/design-docs/rguilayout-portable-c-integration.md
+++ b/design-docs/rguilayout-portable-c-integration.md
@@ -71,7 +71,7 @@ A thin C++ screen controller includes the generated header and calls it:
 ```cpp
 // app/ui/screen_controllers/title_screen_controller.cpp
 #include "components/game_state.h"
-#include "components/input.h"
+#include "systems/input.h"
 #include "screen_controllers/screen_controller_base.h"
 #include <raygui.h>
 #include "ui/generated/title_layout.h"

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -4,7 +4,7 @@
 #include "components/transform.h"
 #include "components/player.h"
 #include "components/obstacle.h"
-#include "components/input.h"
+#include "systems/input.h"
 #include "systems/input_events.h"
 #include "components/game_state.h"
 #include "components/scoring.h"

--- a/tests/test_lifecycle.cpp
+++ b/tests/test_lifecycle.cpp
@@ -8,7 +8,7 @@
 // the InputState context singleton.
 #include <catch2/catch_test_macros.hpp>
 #include <entt/entt.hpp>
-#include "components/input.h"
+#include "systems/input.h"
 
 static bool game_loop_should_quit_from_input(entt::registry& reg) {
     auto* input = reg.ctx().find<InputState>();


### PR DESCRIPTION
Refs #1194 (next action item: "MOVE `input.h` beside the input system").

## Why

`InputState`/`TouchSlot`/`InputSource` are **per-frame hardware-capture state**, owned by `input_system` as a `registry.ctx()` singleton. They are:

- never emplaced on entities
- never queried via `registry.view<...>()`
- only read outside the input subsystem in narrow places (`quit_requested` on title/paused, button-zone hit testing in gameplay HUD)

That is exactly the shape the #1194 audit flagged: system-private singleton, not entity-owned component data. With `Direction` already moved out (PR #1228), the file's remaining contents belong beside their owning system. The `InputSystemPrivate` companion already lives in `app/systems/` (issue #1196 extraction).

## Changes

- **New `app/systems/input.h`** — same declarations as the previous `app/components/input.h`; one breadcrumb comment added pointing at #1194 as the move's rationale.
- **Delete `app/components/input.h`.**
- Update every include site:
  - `app/game_loop.cpp`
  - `app/systems/input_system.cpp`
  - `app/systems/game_state_system.cpp`
  - `app/systems/game_state_routing.cpp`
  - 5 UI screen controllers (`title`, `paused`, `tutorial`, `gameplay_hud`, `level_select`)
  - `tests/test_helpers.h`, `tests/test_lifecycle.cpp`
  - `benchmarks/bench_systems.cpp`
- **`app/systems/input_system_private.h`** — refresh the #1196 breadcrumb: keep the historical "extracted out of `InputState` (#1196)" attribution and note that `InputState` itself later followed (this PR, #1194).
- **`design-docs/architecture.md`** — move the `InputState`/`TouchSlot`/`InputSource` snippet header from `components/input.h` to `systems/input.h`; refresh the directory tree (`input.h` now lives under `systems/`).
- **`design-docs/rguilayout-portable-c-integration.md`** — update the example `title_screen_controller` include path.

No symbol renames, no behaviour changes; pure relocation.

## Validation

| Build | Result |
|---|---|
| Unity Clang `-Wall -Wextra -Werror` | clean, 0 warnings |
| Non-unity Clang `-Wall -Wextra -Werror` | clean, 0 warnings |
| `./build/shapeshifter_tests` | **901 test cases / 2957 assertions pass** |
| `./build-nounity/shapeshifter_tests` | **901 test cases / 2957 assertions pass** |

## #1194 action-item progress (after this PR)

- [x] DELETE `rng.h` (PR #1213)
- [x] MOVE `audio_events.h`, `haptics.h`, `input_events.h` (PR #1221)
- [x] Delete unused `TextAlign` (PR #1222)
- [x] MOVE `shape_mesh.h` (PR #1225)
- [x] MOVE `gameplay_intents.h` (PR #1226)
- [x] MOVE `test_player.h` (PR #1227)
- [x] Extract `Direction` into input-events header (PR #1228)
- [x] **MOVE `input.h` beside the input system (this PR)**
- [ ] SPLIT `high_score.h` / `scoring.h` / `song_state.h` / `game_state.h` / `transform.h` / `rendering.h`