### PR TITLE
Split HighScoreSession from HighScoreState (refs #1194)

### DIFF
--- a/app/components/high_score.h
+++ b/app/components/high_score.h
@@ -7,7 +7,7 @@
 
 #include "../systems/persistence_policy_system.h"
 
-// Compact fixed-size high-score table.
+// Compact fixed-size high-score table (durable, persisted to disk).
 // Max entries: LEVEL_COUNT x DIFFICULTY_COUNT = 9.
 // Flat array storage -- no heap nodes, O(N) linear scan (faster than
 // std::map for N <= 9 due to cache locality).
@@ -22,12 +22,17 @@ struct HighScoreState {
 
     std::array<Entry, MAX_ENTRIES> entries{};
     int32_t entry_count{0};
+};
 
+// Active-session pointer into the score table (transient, not persisted).
+// Split out of HighScoreState (#1194/#1203, 1NF: a NULL column whose
+// meaning depends on the surrounding lifecycle belongs in its own table).
+struct HighScoreSession {
     // FNV-1a 32-bit hash of the current session's "song_id|difficulty" key.
     // Set once per session via high_score::make_key_hash(); zero means no active session.
     // Using a hash avoids a heap std::string allocation on the session-start path.
     // Collision risk: negligible across MAX_ENTRIES=9 keys (e.g. "1_stomper|easy").
-    entt::hashed_string::hash_type current_key_hash{0};
+    entt::hashed_string::hash_type key_hash{0};
 };
 
 struct HighScorePersistence {

--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -226,6 +226,7 @@ bool game_loop_init(entt::registry& reg,
         log_persistence_result("high score load", persistence_state.last_load);
         reset_ctx_singleton<HighScoreState>(reg, hs);
         reset_ctx_singleton<HighScorePersistence>(reg, persistence_state);
+        reset_ctx_singleton<HighScoreSession>(reg);
     }
 
     // Cameras + render targets + GPU meshes

--- a/app/systems/game_state_terminal_phase_system.cpp
+++ b/app/systems/game_state_terminal_phase_system.cpp
@@ -30,9 +30,10 @@ bool update_and_persist_high_score(entt::registry& reg) {
     bool recorded_new_high_score = score_exceeds_high_score;
 
     if (auto* hs = reg.ctx().find<HighScoreState>()) {
-        const bool has_active_high_score_key = (hs->current_key_hash != 0);
+        const auto* session = reg.ctx().find<HighScoreSession>();
+        const bool has_active_high_score_key = session && (session->key_hash != 0);
         if (score_exceeds_high_score && has_active_high_score_key) {
-            recorded_new_high_score = high_score::update_if_higher(*hs, score.score);
+            recorded_new_high_score = high_score::update_if_higher(*hs, *session, score.score);
         }
         if (score_exceeds_high_score && recorded_new_high_score) {
             score.high_score = score.score;

--- a/app/systems/high_score_system.cpp
+++ b/app/systems/high_score_system.cpp
@@ -105,9 +105,9 @@ bool ensure_entry(HighScoreState& state, const char* key) {
     return false;
 }
 
-int32_t get_current_high_score(const HighScoreState& state) {
-    if (state.current_key_hash == 0) return 0;
-    return get_score_by_hash(state, state.current_key_hash);
+int32_t get_current_high_score(const HighScoreState& state, const HighScoreSession& session) {
+    if (session.key_hash == 0) return 0;
+    return get_score_by_hash(state, session.key_hash);
 }
 
 namespace {
@@ -130,7 +130,6 @@ bool high_score_state_from_json(const nlohmann::json& obj, HighScoreState& state
     }
 
     HighScoreState next;
-    next.current_key_hash = state.current_key_hash; // preserve session key across load
 
     if (obj.contains("scores")) {
         const auto& scores_obj = obj["scores"];
@@ -234,12 +233,12 @@ persistence::Result save_high_scores(const HighScoreState& state, const std::fil
     return persistence::flush_persistence_writes(path);
 }
 
-bool update_if_higher(HighScoreState& state, int32_t new_score) {
-    if (state.current_key_hash == 0) return false;
+bool update_if_higher(HighScoreState& state, const HighScoreSession& session, int32_t new_score) {
+    if (session.key_hash == 0) return false;
     if (new_score < 0) new_score = 0;
-    int32_t stored = get_score_by_hash(state, state.current_key_hash);
+    int32_t stored = get_score_by_hash(state, session.key_hash);
     if (new_score > stored) {
-        return set_score_by_hash(state, state.current_key_hash, new_score);
+        return set_score_by_hash(state, session.key_hash, new_score);
     }
     return true;
 }

--- a/app/systems/high_score_system.h
+++ b/app/systems/high_score_system.h
@@ -19,10 +19,10 @@ persistence::Result get_high_scores_file_path(
     std::filesystem::path& out_path,
     const std::filesystem::path& root_override = {});
 
-// Update the stored score for state.current_key_hash if new_score is strictly higher.
+// Update the stored score for session.key_hash if new_score is strictly higher.
 // Negative new_score is clamped to 0. Returns false when no active key exists
 // or the active key is missing from the fixed entry table.
-bool update_if_higher(HighScoreState& state, int32_t new_score);
+bool update_if_higher(HighScoreState& state, const HighScoreSession& session, int32_t new_score);
 
 // Build "song_id|difficulty" into caller-supplied buf (no heap allocation).
 // Returns snprintf-style char count (excluding NUL), or -1 if cap is invalid.
@@ -49,6 +49,6 @@ bool set_score_by_hash(HighScoreState& state, entt::hashed_string::hash_type has
 bool ensure_entry(HighScoreState& state, const char* key);
 
 // Returns the stored score for the current session key, or 0 if no session active.
-int32_t get_current_high_score(const HighScoreState& state);
+int32_t get_current_high_score(const HighScoreState& state, const HighScoreSession& session);
 
 } // namespace high_score

--- a/app/systems/play_session.cpp
+++ b/app/systems/play_session.cpp
@@ -162,8 +162,8 @@ void setup_play_session(entt::registry& reg) {
         if (auto* music = reg.ctx().find<MusicContext>()) {
             music->release();
         }
-        if (auto* hs = reg.ctx().find<HighScoreState>()) {
-            hs->current_key_hash = 0;
+        if (auto* session = reg.ctx().find<HighScoreSession>()) {
+            session->key_hash = 0;
         }
         erase_ctx_if_exists<ScoreState>(reg);
         erase_ctx_if_exists<SongState>(reg);
@@ -180,7 +180,7 @@ void setup_play_session(entt::registry& reg) {
 
     assign_or_emplace_ctx(reg, ScoreState{});
 
-    // Wire high score: derive song_id from beatmap filename and set current_key_hash.
+    // Wire high score: derive song_id from beatmap filename and set HighScoreSession::key_hash.
     // The key string is built once in a stack buffer (no heap); ensure_entry pre-registers
     // the entry so update_if_higher can later update by hash without the key string.
     if (auto* hs = reg.ctx().find<HighScoreState>()) {
@@ -193,7 +193,9 @@ void setup_play_session(entt::registry& reg) {
         char key_buf[HighScoreState::KEY_CAP]{};
         high_score::make_key_str(key_buf, HighScoreState::KEY_CAP,
                                  stem.c_str(), beatmap.difficulty.c_str());
-        hs->current_key_hash = entt::hashed_string::value(static_cast<const char*>(key_buf));
+        if (auto* session = reg.ctx().find<HighScoreSession>()) {
+            session->key_hash = entt::hashed_string::value(static_cast<const char*>(key_buf));
+        }
         high_score::ensure_entry(*hs, key_buf);
     }
 
@@ -244,7 +246,8 @@ void setup_play_session(entt::registry& reg) {
     // Load stored high score for this song+difficulty into ScoreState
     if (auto* hs = reg.ctx().find<HighScoreState>()) {
         auto& score = reg.ctx().get<ScoreState>();
-        score.high_score = high_score::get_current_high_score(*hs);
+        const auto* session = reg.ctx().find<HighScoreSession>();
+        score.high_score = session ? high_score::get_current_high_score(*hs, *session) : 0;
     }
 
     spawn_session_player(reg);

--- a/tests/test_component_boundary_wave2.cpp
+++ b/tests/test_component_boundary_wave2.cpp
@@ -61,11 +61,15 @@ static_assert(HighScoreState::KEY_CAP == 32,
 TEST_CASE("HighScoreState: default-constructed is empty", "[boundary_wave2][high_score]") {
     HighScoreState hs{};
     CHECK(hs.entry_count == 0);
-    CHECK(hs.current_key_hash == 0u);
     // All entry scores must be zero (no stale data)
     for (int i = 0; i < HighScoreState::MAX_ENTRIES; ++i) {
         CHECK(hs.entries[i].score == 0);
     }
+}
+
+TEST_CASE("HighScoreSession: default-constructed has zero key hash", "[boundary_wave2][high_score]") {
+    HighScoreSession session{};
+    CHECK(session.key_hash == 0u);
 }
 
 TEST_CASE("HighScoreState: lives in ctx, not attached to entities", "[boundary_wave2][high_score]") {

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -48,6 +48,7 @@ inline entt::registry make_registry() {
     reg.ctx().emplace<SongResults>();
     reg.ctx().emplace<HighScoreState>();
     reg.ctx().emplace<HighScorePersistence>();
+    reg.ctx().emplace<HighScoreSession>();
     reg.ctx().emplace<GameOverState>();
     runtime_system_scratch_init(reg);
     return reg;

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -72,7 +72,7 @@ TEST_CASE("High score integration: setup_play_session loads selected song diffic
 
     setup_play_session(reg);
 
-    CHECK(reg.ctx().get<HighScoreState>().current_key_hash
+    CHECK(reg.ctx().get<HighScoreSession>().key_hash
         == high_score::make_key_hash("1_stomper", "easy"));
     CHECK(reg.ctx().get<ScoreState>().high_score == 1234);
     CHECK_FALSE(reg.view<GameCamera>().empty());
@@ -90,7 +90,7 @@ TEST_CASE("Play session: invalid level-select indices fall back before content l
 
     CHECK(lss.selected_level == content_config::DEFAULT_LEVEL_INDEX);
     CHECK(lss.selected_difficulty == content_config::DEFAULT_DIFFICULTY_INDEX);
-    CHECK(reg.ctx().get<HighScoreState>().current_key_hash
+    CHECK(reg.ctx().get<HighScoreSession>().key_hash
         == high_score::make_key_hash("1_stomper", "medium"));
 }
 
@@ -125,7 +125,8 @@ TEST_CASE("Play session: missing selected beatmap returns to level select withou
     auto& lss = reg.ctx().get<LevelSelectState>();
     auto& high_scores = reg.ctx().get<HighScoreState>();
     high_score::set_score(high_scores, "1_stomper|medium", 4321);
-    high_scores.current_key_hash = high_score::make_key_hash("1_stomper", "medium");
+    auto& session = reg.ctx().get<HighScoreSession>();
+    session.key_hash = high_score::make_key_hash("1_stomper", "medium");
     lss.confirmed = true;
 
     reg.ctx().emplace<PlaySessionContentOverride>(
@@ -138,7 +139,7 @@ TEST_CASE("Play session: missing selected beatmap returns to level select withou
     CHECK(beat_map(reg).beats.empty());
     CHECK(reg.view<PlayerTag>().empty());
     CHECK(reg.ctx().find<ScoreState>() == nullptr);
-    CHECK(high_scores.current_key_hash == 0);
+    CHECK(session.key_hash == 0);
     CHECK(high_scores.entry_count == 1);
 
     reg.ctx().erase<PlaySessionContentOverride>();
@@ -181,7 +182,7 @@ TEST_CASE("Play session: high score key uses loaded fallback difficulty",
     setup_play_session(reg);
 
     CHECK(beat_map(reg).difficulty == "medium");
-    CHECK(reg.ctx().get<HighScoreState>().current_key_hash
+    CHECK(reg.ctx().get<HighScoreSession>().key_hash
         == high_score::make_key_hash("shapeshifter_issue847", "medium"));
     CHECK(reg.ctx().get<ScoreState>().high_score == 4321);
 }
@@ -220,7 +221,7 @@ TEST_CASE("High score integration: new song-complete high score persists",
     reg.ctx().get<HighScorePersistence>().path = file.string();
     auto& high_scores = reg.ctx().get<HighScoreState>();
     high_score::ensure_entry(high_scores, "song_001|easy");
-    high_scores.current_key_hash = high_score::make_key_hash("song_001", "easy");
+    reg.ctx().get<HighScoreSession>().key_hash = high_score::make_key_hash("song_001", "easy");
     high_score::set_score(high_scores, "song_001|easy", 1000);
 
     auto& score = reg.ctx().get<ScoreState>();
@@ -252,7 +253,7 @@ TEST_CASE("High score integration: lower game-over score does not overwrite pers
     reg.ctx().get<HighScorePersistence>().path = file.string();
     auto& high_scores = reg.ctx().get<HighScoreState>();
     high_score::ensure_entry(high_scores, "song_001|easy");
-    high_scores.current_key_hash = high_score::make_key_hash("song_001", "easy");
+    reg.ctx().get<HighScoreSession>().key_hash = high_score::make_key_hash("song_001", "easy");
     high_score::set_score(high_scores, "song_001|easy", 3000);
 
     auto& score = reg.ctx().get<ScoreState>();
@@ -280,7 +281,7 @@ TEST_CASE("High score integration: missing active entry does not report new best
         const std::string key = "song_" + std::to_string(i) + "|easy";
         REQUIRE(high_score::set_score(high_scores, key.c_str(), i * 100));
     }
-    high_scores.current_key_hash = high_score::make_key_hash("overflow", "hard");
+    reg.ctx().get<HighScoreSession>().key_hash = high_score::make_key_hash("overflow", "hard");
 
     auto& score = reg.ctx().get<ScoreState>();
     score.high_score = 1000;
@@ -315,7 +316,7 @@ TEST_CASE("High score integration: failed save keeps dirty state for retry",
     reg.ctx().get<HighScorePersistence>().path = blocked_file.string();
     auto& high_scores = reg.ctx().get<HighScoreState>();
     high_score::ensure_entry(high_scores, "song_001|easy");
-    high_scores.current_key_hash = high_score::make_key_hash("song_001", "easy");
+    reg.ctx().get<HighScoreSession>().key_hash = high_score::make_key_hash("song_001", "easy");
     high_score::set_score(high_scores, "song_001|easy", 1000);
 
     auto& score = reg.ctx().get<ScoreState>();
@@ -375,7 +376,7 @@ TEST_CASE("High score bootstrap: persistence path is populated for save call sit
 
     auto& high_scores = reg.ctx().get<HighScoreState>();
     high_score::ensure_entry(high_scores, "song_001|easy");
-    high_scores.current_key_hash = high_score::make_key_hash("song_001", "easy");
+    reg.ctx().get<HighScoreSession>().key_hash = high_score::make_key_hash("song_001", "easy");
 
     const auto& persistence = reg.ctx().get<HighScorePersistence>();
     REQUIRE_FALSE(persistence.path.empty());

--- a/tests/test_high_score_persistence.cpp
+++ b/tests/test_high_score_persistence.cpp
@@ -74,22 +74,24 @@ TEST_CASE("High score: no hash collisions across all 9 shipped song+difficulty k
 
 TEST_CASE("High score: current score lookup and update never lowers stored score", "[high_score]") {
     HighScoreState state;
-    CHECK(high_score::get_current_high_score(state) == 0);
+    HighScoreSession session;
+    CHECK(high_score::get_current_high_score(state, session) == 0);
 
-    // ensure_entry + current_key_hash mirrors the production setup_play_session path.
+    // ensure_entry + session.key_hash mirrors the production setup_play_session path.
     REQUIRE(high_score::ensure_entry(state, "song_001|easy"));
-    state.current_key_hash = high_score::make_key_hash("song_001", "easy");
-    CHECK(high_score::get_current_high_score(state) == 0);
+    session.key_hash = high_score::make_key_hash("song_001", "easy");
+    CHECK(high_score::get_current_high_score(state, session) == 0);
 
-    CHECK(high_score::update_if_higher(state, 5000));
-    CHECK(high_score::get_current_high_score(state) == 5000);
+    CHECK(high_score::update_if_higher(state, session, 5000));
+    CHECK(high_score::get_current_high_score(state, session) == 5000);
 
-    CHECK(high_score::update_if_higher(state, 1000));
-    CHECK(high_score::get_current_high_score(state) == 5000);
+    CHECK(high_score::update_if_higher(state, session, 1000));
+    CHECK(high_score::get_current_high_score(state, session) == 5000);
 }
 
 TEST_CASE("High score: saturated table reports insert and hash update failures", "[high_score][issue1004]") {
     HighScoreState state;
+    HighScoreSession session;
     for (int32_t i = 0; i < HighScoreState::MAX_ENTRIES; ++i) {
         const std::string key = "song_" + std::to_string(i) + "|easy";
         REQUIRE(high_score::set_score(state, key.c_str(), i * 100));
@@ -99,29 +101,30 @@ TEST_CASE("High score: saturated table reports insert and hash update failures",
     CHECK_FALSE(high_score::set_score(state, "overflow|easy", 9000));
     CHECK_FALSE(high_score::ensure_entry(state, "overflow|medium"));
 
-    state.current_key_hash = high_score::make_key_hash("overflow", "hard");
-    CHECK_FALSE(high_score::update_if_higher(state, 9000));
+    session.key_hash = high_score::make_key_hash("overflow", "hard");
+    CHECK_FALSE(high_score::update_if_higher(state, session, 9000));
     CHECK(high_score::get_score(state, "overflow|hard") == 0);
 
-    state.current_key_hash = high_score::make_key_hash("song_0", "easy");
-    CHECK(high_score::update_if_higher(state, 9000));
+    session.key_hash = high_score::make_key_hash("song_0", "easy");
+    CHECK(high_score::update_if_higher(state, session, 9000));
     CHECK(high_score::get_score(state, "song_0|easy") == 9000);
 }
 
 TEST_CASE("High score: tracks songs and difficulties independently", "[high_score]") {
     HighScoreState state;
+    HighScoreSession session;
 
     REQUIRE(high_score::ensure_entry(state, "song_001|easy"));
-    state.current_key_hash = high_score::make_key_hash("song_001", "easy");
-    CHECK(high_score::update_if_higher(state, 1000));
+    session.key_hash = high_score::make_key_hash("song_001", "easy");
+    CHECK(high_score::update_if_higher(state, session, 1000));
 
     REQUIRE(high_score::ensure_entry(state, "song_001|hard"));
-    state.current_key_hash = high_score::make_key_hash("song_001", "hard");
-    CHECK(high_score::update_if_higher(state, 2000));
+    session.key_hash = high_score::make_key_hash("song_001", "hard");
+    CHECK(high_score::update_if_higher(state, session, 2000));
 
     REQUIRE(high_score::ensure_entry(state, "song_002|easy"));
-    state.current_key_hash = high_score::make_key_hash("song_002", "easy");
-    CHECK(high_score::update_if_higher(state, 3000));
+    session.key_hash = high_score::make_key_hash("song_002", "easy");
+    CHECK(high_score::update_if_higher(state, session, 3000));
 
     CHECK(high_score::get_score(state, "song_001|easy") == 1000);
     CHECK(high_score::get_score(state, "song_001|hard") == 2000);
@@ -270,7 +273,10 @@ TEST_CASE("High score persistence: clamps negative and oversized scores", "[high
     remove_path(dir);
 }
 
-TEST_CASE("High score persistence: load preserves current active key", "[high_score]") {
+TEST_CASE("High score persistence: load does not touch session key", "[high_score]") {
+    // HighScoreSession is a separate ctx singleton (#1194/#1203) — load_high_scores
+    // takes only HighScoreState&, so it is structurally impossible to clobber the
+    // active session key. This regression test guards the API split.
     const auto dir = temp_high_score_path("shapeshifter_high_score_current_key");
     const auto file = dir / "high_scores.json";
     remove_path(dir);
@@ -280,13 +286,14 @@ TEST_CASE("High score persistence: load preserves current active key", "[high_sc
     REQUIRE(high_score::save_high_scores(original, file).ok());
 
     HighScoreState loaded;
+    HighScoreSession session;
     // Simulate a session already active on song_002|hard before the load.
     const auto pre_load_hash = high_score::make_key_hash("song_002", "hard");
-    loaded.current_key_hash = pre_load_hash;
+    session.key_hash = pre_load_hash;
     REQUIRE(high_score::load_high_scores(loaded, file).ok());
 
     // Load must not clobber the in-progress session key.
-    CHECK(loaded.current_key_hash == pre_load_hash);
+    CHECK(session.key_hash == pre_load_hash);
     CHECK(high_score::get_score(loaded, "song_001|easy") == 1000);
 
     remove_path(dir);


### PR DESCRIPTION
## Summary

Per #1194 audit (high_score.h SPLIT verdict) and #1203 1NF doctrine: `current_key_hash` was a NULL-column inside `HighScoreState` — zero meant "no active session" — bundling transient session state into the durable score table.

Extract it into a new `HighScoreSession` ctx singleton holding only `key_hash`. The durable score table (`HighScoreState`), the session pointer (`HighScoreSession`), and the persistence I/O bookkeeping (`HighScorePersistence`) are now three separate components per the "three lifecycles" diagnosis in the audit.

## Before vs after

| Component | Before | After |
|---|---|---|
| Durable table | `HighScoreState { entries, entry_count, current_key_hash }` | `HighScoreState { entries, entry_count }` |
| Session pointer | (NULL column in HighScoreState) | new `HighScoreSession { key_hash }` ctx singleton |
| Persistence | `HighScorePersistence` | unchanged |

## API changes

- `high_score::get_current_high_score(state, session)` now takes `HighScoreSession` alongside `HighScoreState`.
- `high_score::update_if_higher(state, session, new_score)` likewise.
- `high_score_state_from_json` no longer preserves session key — structurally impossible to clobber now that session lives in a separate component.

## Call-site updates

- `app/game_loop.cpp` — emplace `HighScoreSession` next to the other singletons during bootstrap.
- `app/systems/play_session.cpp` — read/write `HighScoreSession::key_hash` instead of `HighScoreState::current_key_hash` for reset and session-start.
- `app/systems/game_state_terminal_phase_system.cpp` — query `HighScoreSession` for the active-key gate.
- `tests/test_helpers.h`, `tests/test_high_score_integration.cpp`, `tests/test_high_score_persistence.cpp`, `tests/test_component_boundary_wave2.cpp` — fixtures and assertions migrated.

## Action-item progress on #1194

- [x] DELETE `rng.h` (#1213)
- [x] MOVE `audio_events.h`, `haptics.h`, `input_events.h` (#1221)
- [x] Extract `Direction` (#1228)
- [x] MOVE `input.h` (#1229), `shape_mesh.h` (#1225), `test_player.h` (#1227), `gameplay_intents.h` (#1226)
- [x] Delete unused `TextAlign` (#1222)
- [x] **SPLIT `high_score.h` (this PR)** ← first SPLIT shipped
- [ ] SPLIT `scoring.h`, `song_state.h`, `game_state.h`, `transform.h`, `rendering.h`

## Verification

- Clean rebuild: zero warnings (`-Wall -Wextra -Werror`).
- `./build/shapeshifter_tests`: **all 2957 assertions pass across 902 test cases** (+1 new test asserting `HighScoreSession` default state).
- `./build/shapeshifter_startup_shutdown_smoke`: green.

Refs #1194 #1203