### PR TITLE
Split scoring.h: relocate popup components and TerminalResultState (refs #1194)

### DIFF
--- a/app/components/game_state.h
+++ b/app/components/game_state.h
@@ -68,3 +68,12 @@ enum class DeathCause : uint8_t {
 struct GameOverState {
     DeathCause cause = DeathCause::None;
 };
+
+// ── Terminal Result Snapshot (singleton) ─────────────────────
+// Captured by game_state_terminal_phase_system at the moment of song
+// completion / game over.  Read by the Game Over / Song Complete screen
+// controllers (and high-score haptic feedback) to surface "new best" UI.
+struct TerminalResultState {
+    bool    new_best      = false;
+    int32_t previous_best = 0;
+};

--- a/app/components/popup.h
+++ b/app/components/popup.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+#include "rhythm.h"
+#include "text.h"
+
+struct ScorePopup {
+    int32_t    value           = 0;
+    bool       has_timing_tier = false;
+    TimingTier timing_tier     = TimingTier::Ok;
+    float      remaining       = 0.0f;
+    float      max_time        = 0.0f;
+};
+
+// Pre-computed popup display data. Static text/color are initialized at spawn;
+// ui_render_system lazily caches the text width once the active font is known.
+struct PopupDisplay {
+    char     text[16] = {};
+    FontSize font_size = FontSize::Small;
+    uint8_t  r = 255, g = 255, b = 255, a = 255;
+    float    text_half_width = 0.0f;
+    int      measured_font_base_size = -1;
+    unsigned int measured_font_texture_id = 0;
+};

--- a/app/components/scoring.h
+++ b/app/components/scoring.h
@@ -1,9 +1,14 @@
 #pragma once
 
 #include <cstdint>
-#include <entt/entity/entity.hpp>
-#include "../components/text.h"
-#include "../components/rhythm.h"
+
+// TerminalResultState relocated to game_state.h (it pairs with GameOverState /
+// terminal phase). ScorePopup / PopupDisplay relocated to popup.h (popup-entity
+// data, distinct from score-state singletons). Re-included here for source
+// back-compat with consumers that previously got them via scoring.h; new code
+// should include the canonical headers directly.
+#include "game_state.h"
+#include "popup.h"
 
 struct ScoreState {
     int32_t score             = 0;
@@ -11,28 +16,4 @@ struct ScoreState {
     int32_t high_score        = 0;
     int32_t chain_count       = 0;
     float   passive_score_remainder = 0.0f;
-};
-
-struct TerminalResultState {
-    bool    new_best      = false;
-    int32_t previous_best = 0;
-};
-
-struct ScorePopup {
-    int32_t    value           = 0;
-    bool       has_timing_tier = false;
-    TimingTier timing_tier     = TimingTier::Ok;
-    float      remaining       = 0.0f;
-    float      max_time        = 0.0f;
-};
-
-// Pre-computed popup display data. Static text/color are initialized at spawn;
-// ui_render_system lazily caches the text width once the active font is known.
-struct PopupDisplay {
-    char     text[16] = {};
-    FontSize font_size = FontSize::Small;
-    uint8_t  r = 255, g = 255, b = 255, a = 255;
-    float    text_half_width = 0.0f;
-    int      measured_font_base_size = -1;
-    unsigned int measured_font_texture_id = 0;
 };


### PR DESCRIPTION
Continues the `app/components/` audit (#1194) by splitting two non-score concerns out of `scoring.h` to natural homes.

## Changes

| Type                 | New home                      | Concern                                |
|---|---|---|
| `ScorePopup`         | `components/popup.h` (new)    | popup entity gameplay state            |
| `PopupDisplay`       | `components/popup.h` (new)    | popup entity render data               |
| `TerminalResultState`| `components/game_state.h`     | terminal-phase "new best" snapshot     |

`ScorePopup` and `PopupDisplay` are entity-bound popup-archetype components (emplaced by `spawn_score_popup`, queried by `popup_display_system` / `ui_render_system` / `camera_system`). They follow the existing "one entity archetype per file" pattern (cf. `obstacle.h`, `particle.h`, `player.h`) and now sit beside their owners.

`TerminalResultState` is a ctx singleton captured at game-over / song-complete. It pairs with the `GameOverState` / `DeathCause` singletons that PR #1231 moved to `game_state.h`, so it joins them there.

`scoring.h` keeps only `ScoreState` for now and re-includes `popup.h` / `game_state.h` for source back-compat with the 18 direct includers (same approach as `rhythm.h` after #1231).

## Deferred

The `ScoreState` field-level cadence split (accumulators vs animated display vs chain vs passive remainder vs current-song best) is deferred to a follow-up cycle — that one touches ~38 call sites and deserves its own focused PR.

## Action-item progress (#1194)

- [x] DELETE `rng.h` (PR #1213)
- [x] MOVE `audio_events.h`, `haptics.h`, `input_events.h` (PR #1221)
- [x] Extract `Direction` (PR #1228)
- [x] MOVE `input.h` (PR #1229), `shape_mesh.h` (PR #1225), `test_player.h` (PR #1227), `gameplay_intents.h` (PR #1226)
- [x] Delete unused `TextAlign` (PR #1222)
- [x] SPLIT `high_score.h` (PR #1230)
- [x] SPLIT `song_state.h` (PR #1231)
- [x] **SPLIT `scoring.h` part 1: relocate popup + TerminalResultState** (this PR)
- [ ] SPLIT `scoring.h` part 2: `ScoreState` field-level cadence split
- [ ] SPLIT `game_state.h`, `transform.h`, `rendering.h`

## Validation

- 902 Catch2 tests / 2957 assertions pass.
- Zero warnings under both **unity** and **non-unity** Clang `-Wall -Wextra -Werror` builds.
