### PR TITLE
Drop dead WorldTransform.rotation/scale fields (refs #1194)

### DIFF
--- a/app/components/transform.h
+++ b/app/components/transform.h
@@ -5,10 +5,12 @@
 // Authoritative world-space spatial state for moving/rendered world entities.
 // New entity contracts should use this instead of adding new position structs.
 // Named WorldTransform to avoid colliding with raylib's global Transform type.
+//
+// Rotation and scale fields previously lived here but no runtime system read
+// them (only defaults were asserted in tests). Removed per issue #1194; if a
+// future entity needs rotation or scale, give it its own component table.
 struct WorldTransform {
     Vector2 position = {0.0f, 0.0f};
-    float   rotation = 0.0f;
-    Vector2 scale    = {1.0f, 1.0f};
 };
 
 // Scoped motion for entities that truly integrate position += velocity * dt.

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -8,13 +8,10 @@
 
 // Verify component defaults and basic ECS operations
 
-TEST_CASE("components: WorldTransform defaults to identity world transform", "[components][transform]") {
+TEST_CASE("components: WorldTransform defaults to origin position", "[components][transform]") {
     WorldTransform transform{};
     CHECK(transform.position.x == 0.0f);
     CHECK(transform.position.y == 0.0f);
-    CHECK(transform.rotation == 0.0f);
-    CHECK(transform.scale.x == 1.0f);
-    CHECK(transform.scale.y == 1.0f);
 }
 
 TEST_CASE("components: MotionVelocity defaults to zero vector", "[components][transform]") {


### PR DESCRIPTION
First cut of the `transform.h` SPLIT action item from #1194 ("delete dead rotation/scale runtime paths").

## What

`WorldTransform.rotation` and `WorldTransform.scale` had **no runtime readers** anywhere in `app/`. They were only referenced in `tests/test_components.cpp` asserting their defaults — coverage that proves nothing when the fields are never consumed.

After this PR `WorldTransform` is just:

```cpp
struct WorldTransform {
    Vector2 position = {0.0f, 0.0f};
};
```

## Verification

```
rg -n '\.(rotation|scale)\b'        app/   # only Camera2D.rotation and ScreenTransform.scale — neither is WorldTransform
rg -n '->(rotation|scale)\b'         app/   # no hits
rg -n 'WorldTransform.*\.(rotation|scale)' .  # no hits
```

The only `.rotation` in `app/` is on raylib's `Camera2D` (camera_entity.cpp:28). All `.scale` hits are on `ScreenTransform` (the letterbox state), not `WorldTransform`.

## Build / tests

- `cmake --build build` — zero warnings with `-Wall -Wextra -Werror`
- `./build/shapeshifter_tests` — All 2954 assertions in 902 test cases pass

## Out of scope

- Renaming `WorldTransform` → `Position` (single-field now, but that's a wrapper-noise cleanup tracked in #1198)
- Picking the collision strategy for `MotionVelocity` / `UIPosition` vs raw `Vector2` (also #1198)
- The rest of `transform.h` / `rendering.h` / `game_state.h` SPLITs from #1194

Refs #1194.