### PR TITLE
Split rendering.h junk drawer: ObstacleChildren, ScreenTransform, mesh-render descriptors (refs #1194)

### DIFF
--- a/app/components/camera_resources.h
+++ b/app/components/camera_resources.h
@@ -6,6 +6,17 @@
 
 #include "../constants.h"
 
+// Letterbox scale/offset: window to virtual space. camera_system ctx singleton,
+// recomputed once per frame by compute_screen_transform() before input_system
+// runs. Coordinate-conversion helper screen_to_virtual() lives in
+// app/systems/camera_system.h. Relocated out of app/components/rendering.h
+// (issue #1194 SPLIT).
+struct ScreenTransform {
+    float offset_x = 0.0f;
+    float offset_y = 0.0f;
+    float scale    = 1.0f;
+};
+
 // Per-frame render parameters computed from SongState beat pulse.
 struct FloorParams {
     float   size  = 0.0f;

--- a/app/components/obstacle.h
+++ b/app/components/obstacle.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <entt/entt.hpp>
 
 #include "player.h"
 #include "tags/tags.h"
@@ -64,4 +65,14 @@ struct BlockedLanes {
 
 struct RequiredLane {
     int8_t lane = 0;
+};
+
+// Owned mesh children for a logical obstacle entity. destroy_obstacle_with_children
+// in app/entities/obstacle_render_entity.cpp cleans up in O(count). Relocated out
+// of app/components/rendering.h (issue #1194 SPLIT) — child-ownership is an
+// obstacle-archetype concern, not a generic render concept.
+struct ObstacleChildren {
+    static constexpr int MAX = 8;
+    entt::entity children[MAX]{};
+    int count = 0;
 };

--- a/app/components/render_mesh.h
+++ b/app/components/render_mesh.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstdint>
+#include <entt/entt.hpp>
+#include <raylib.h>
+#include <raymath.h>
+
+// Per-entity GPU mesh-render descriptors. Authoritative producer:
+// camera_system (game_camera_system pass). Authoritative consumer:
+// game_render_system. Universal across drawable archetypes (player,
+// obstacles, popups, particles, mesh children) — not obstacle-specific.
+//
+// Relocated out of app/components/rendering.h (issue #1194 SPLIT).
+
+enum class MeshType : uint8_t { Shape, Slab, Quad };
+
+struct ModelTransform {
+    Matrix   mat = MatrixIdentity();
+    Color    tint{255, 255, 255, 255};
+    uint8_t  mesh_index = 0;  // index into ShapeMeshes.shapes[] for Shape type
+    MeshType mesh_type = MeshType::Shape;
+};
+
+// Visual mesh child; game_camera_system resolves parent transform + offsets.
+struct MeshChild {
+    entt::entity parent = entt::null;
+    float x = 0.0f;             // absolute X position in game coords
+    float z_offset = 0.0f;      // offset from parent WorldTransform.position.y (scroll axis)
+    float width = 0.0f;         // slab width (game coords)
+    float depth = 0.0f;         // slab depth (game coords)
+    float height = 0.0f;        // slab height (game coords)
+    Color tint{255, 255, 255, 255};
+    uint8_t mesh_index = 0;  // index into ShapeMeshes.shapes[] for Shape type
+    MeshType mesh_type = MeshType::Shape;
+};

--- a/app/components/rendering.h
+++ b/app/components/rendering.h
@@ -1,11 +1,22 @@
 #pragma once
 
 #include <cstdint>
-#include <entt/entt.hpp>
-#include <raylib.h>
-#include <raymath.h>
 
 #include "tags/tags.h"
+
+// Back-compat shim. The junk-drawer "rendering.h" was split (issue #1194):
+//   ScreenTransform                -> components/camera_resources.h
+//   MeshType / ModelTransform /
+//     MeshChild                    -> components/render_mesh.h
+//   ObstacleChildren               -> components/obstacle.h
+// Re-included here so existing `#include "components/rendering.h"` sites keep
+// compiling; new code should include the canonical header directly.
+//
+// The wrapper-noise types DrawSize / DrawLayer / Layer / ScreenPosition remain
+// here pending the wrapper deletion sweep (issue #1198).
+#include "camera_resources.h"
+#include "obstacle.h"
+#include "render_mesh.h"
 
 struct DrawSize {
     float w = 64.0f;
@@ -23,52 +34,11 @@ struct DrawLayer {
     Layer layer = Layer::Game;
 };
 
-// Letterbox scale/offset: window to virtual space.
-// Coordinate-conversion helper lives in app/systems/camera_system.h
-// (screen_to_virtual) — components headers stay data-only.
-struct ScreenTransform {
-    float offset_x = 0.0f;
-    float offset_y = 0.0f;
-    float scale    = 1.0f;
-};
-
-// Computed by game_camera_system from WorldTransform/DrawSize/Shape.
-// MeshType tells the render system which GPU mesh to draw.
-enum class MeshType : uint8_t { Shape, Slab, Quad };
-
-struct ModelTransform {
-    Matrix   mat = MatrixIdentity();
-    Color    tint{255, 255, 255, 255};
-    uint8_t  mesh_index = 0;  // index into ShapeMeshes.shapes[] for Shape type
-    MeshType mesh_type = MeshType::Shape;
-};
-
-// Visual mesh child; game_camera_system resolves parent transform + offsets.
-struct MeshChild {
-    entt::entity parent = entt::null;
-    float x = 0.0f;             // absolute X position in game coords
-    float z_offset = 0.0f;      // offset from parent WorldTransform.position.y (scroll axis)
-    float width = 0.0f;         // slab width (game coords)
-    float depth = 0.0f;         // slab depth (game coords)
-    float height = 0.0f;        // slab height (game coords)
-    Color tint{255, 255, 255, 255};
-    uint8_t mesh_index = 0;  // index into ShapeMeshes.shapes[] for Shape type
-    MeshType mesh_type = MeshType::Shape;
-};
-
-// Owned mesh children; destroy_obstacle_with_children cleans up in O(count).
-struct ObstacleChildren {
-    static constexpr int MAX = 8;
-    entt::entity children[MAX]{};
-    int count = 0;
-};
-
 // Screen-space position computed by ui_camera_system for UI rendering.
 struct ScreenPosition {
     float x = 0.0f;
     float y = 0.0f;
 };
-
 
 // Render-pass membership tags (TagWorldPass / TagEffectsPass / TagHUDPass)
 // live in app/tags/tags.h; included above for back-compat.

--- a/app/systems/game_render_system.cpp
+++ b/app/systems/game_render_system.cpp
@@ -1,7 +1,7 @@
 #include "all_systems.h"
 #include "runtime_systems.h"
 #include "floor_render_system.h"
-#include "../components/rendering.h"
+#include "../components/render_mesh.h"
 #include "../components/game_state.h"
 #include "../util/shape_lane_mapping.h"
 #include "camera_system.h"

--- a/tests/test_component_raylib_boundaries.cpp
+++ b/tests/test_component_raylib_boundaries.cpp
@@ -24,22 +24,27 @@ std::filesystem::path repo_header(const char* rel) {
 TEST_CASE("component headers use raylib types directly (post #1199)", "[components][boundary][issue-1199]") {
     const std::string transform = read_text(repo_header("app/components/transform.h"));
     const std::string rendering = read_text(repo_header("app/components/rendering.h"));
+    const std::string render_mesh = read_text(repo_header("app/components/render_mesh.h"));
     const std::string text = read_text(repo_header("app/components/text.h"));
 
     CHECK(transform.find("#include <raylib.h>") != std::string::npos);
-    CHECK(rendering.find("#include <raylib.h>") != std::string::npos);
+    // Post #1194 SPLIT: rendering.h is a back-compat shim. Matrix/Color now
+    // live in render_mesh.h alongside ModelTransform/MeshChild, which is the
+    // canonical raylib-types contract this test guards.
+    CHECK(render_mesh.find("#include <raylib.h>") != std::string::npos);
     CHECK(text.find("#include <raylib.h>") == std::string::npos);
 
     CHECK(transform.find("Vector2") != std::string::npos);
-    CHECK(rendering.find("Matrix") != std::string::npos);
-    // Vector2 is no longer required in rendering.h: the only consumer
-    // (screen_to_virtual) was moved to app/systems/camera_system.h to keep
-    // the components header data-only (issue #1196).
-    CHECK(rendering.find("Color") != std::string::npos);
+    CHECK(render_mesh.find("Matrix") != std::string::npos);
+    CHECK(render_mesh.find("Color") != std::string::npos);
 
     CHECK(transform.find("glm::") == std::string::npos);
     CHECK(rendering.find("glm::") == std::string::npos);
+    CHECK(render_mesh.find("glm::") == std::string::npos);
     CHECK(rendering.find("Vec2f") == std::string::npos);
     CHECK(rendering.find("Mat4f") == std::string::npos);
     CHECK(rendering.find("TintColor") == std::string::npos);
+    CHECK(render_mesh.find("Vec2f") == std::string::npos);
+    CHECK(render_mesh.find("Mat4f") == std::string::npos);
+    CHECK(render_mesh.find("TintColor") == std::string::npos);
 }


### PR DESCRIPTION
Next cut of the `rendering.h` SPLIT action item from #1194 (audit verdict: *junk drawer: pass tags + size/layer wrappers + camera letterbox + screen_to_virtual() helper + render descriptors + child-ownership*).

## What moved

| Type | New home | Concern |
|---|---|---|
| `ScreenTransform` | `components/camera_resources.h` | camera-system letterbox ctx singleton |
| `MeshType` / `ModelTransform` / `MeshChild` | `components/render_mesh.h` (new) | per-entity GPU mesh-render descriptors |
| `ObstacleChildren` | `components/obstacle.h` | obstacle-archetype child-entity ownership |

`camera_resources.h` already houses the other camera-pipeline ctx singletons (`RenderTargets`, `ShapeMeshes`, `FloorParams`), so `ScreenTransform` sits with its authoritative producer/owner. `render_mesh.h` is a new header for the universal entity-bound mesh-render descriptors that `camera_system` produces and `game_render_system` consumes — these are emplaced on player, popup, particle, obstacle, **and** mesh-child entities, so they don't belong in `obstacle.h`. `ObstacleChildren` is obstacle-archetype-specific (literally named that way) and now sits with the obstacle component table.

## Shim / back-compat

`rendering.h` becomes a thin shim that re-includes the new canonical headers, matching the pattern from #1231 / #1233 / #1235. The wrapper-noise types `DrawSize` / `DrawLayer` / `Layer` / `ScreenPosition` remain in `rendering.h` pending the wrapper deletion sweep (#1198).

`game_render_system.cpp`'s only types from `rendering.h` were `ModelTransform` / `MeshType` — both moved to `render_mesh.h`, so the include switches to the canonical header. Other consumers stay on the shim (they still need `DrawSize` / `Layer` / `ScreenPosition`), matching the *patch only direct consumers* pattern from #1231 / #1233.

## Test contract update

`tests/test_component_raylib_boundaries.cpp` guarded the post-#1199 contract that `components/rendering.h` uses raylib types directly (`Matrix`, `Color`, `#include <raylib.h>`) and never uses `glm` / `Vec2f` / `Mat4f` / `TintColor` wrappers. Post-split that *type-presence* contract migrates to `render_mesh.h` (the canonical home of `Matrix` and `Color`). The *negative-wrappers* contract is retained on **both** the shim and the new header.

## Build / tests

- `cmake --build build` — zero warnings with `-Wall -Wextra -Werror`
- `cmake --build build-no-unity` — zero warnings (non-unity)
- `./build/shapeshifter_tests` — **All 2959 assertions in 902 test cases pass** (+5 from the boundary test's new `render_mesh.h` checks)

## Out of scope

- `game_state.h` SPLIT (blocked on enum eradication ordering in #1202 / #1204)
- `DrawSize` / `DrawLayer` / `Layer` / `ScreenPosition` wrapper deletion (tracked by #1198)
- Switching every shim consumer to canonical headers (deferred; matches the *patch direct consumers only* pattern from #1231 / #1233)

Refs #1194.