### PR TITLE
Split ScoreState by cadence: ScoreState / ScoreDisplay / CurrentSongHighScore (refs #1194)

### DIFF
--- a/app/components/scoring.h
+++ b/app/components/scoring.h
@@ -10,10 +10,29 @@
 #include "game_state.h"
 #include "popup.h"
 
+// Live scoring accumulators owned by scoring_system. All three fields are
+// written every frame the system runs:
+//   - score / chain_count are advanced on each scored obstacle
+//   - passive_score_remainder is the fractional carry from time-based scoring
+// Read-only consumers (HUD, end screens, telemetry) take a const reference.
 struct ScoreState {
-    int32_t score             = 0;
-    int32_t displayed_score   = 0;
-    int32_t high_score        = 0;
-    int32_t chain_count       = 0;
+    int32_t score                   = 0;
+    int32_t chain_count             = 0;
     float   passive_score_remainder = 0.0f;
+};
+
+// HUD-side animated readout that lags toward ScoreState::score for a "ticking
+// up" feel. Owned by scoring_system's tween block; read by the gameplay HUD
+// controller. Lifecycle: ctx-bound singleton, reset alongside ScoreState.
+struct ScoreDisplay {
+    int32_t displayed = 0;
+};
+
+// Best score for the currently loaded song+difficulty. Snapshotted from the
+// durable HighScoreState table at session load (in play_session) and bumped
+// at terminal phase if the current run exceeded it. Distinct from
+// HighScoreState (which spans every song+difficulty combo and persists to
+// disk) — this singleton is the single per-run best the HUD/end-screens read.
+struct CurrentSongHighScore {
+    int32_t value = 0;
 };

--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -184,6 +184,8 @@ bool game_loop_init(entt::registry& reg,
         .next_phase = GamePhase::Title
     });
     reset_ctx_singleton<ScoreState>(reg);
+    reset_ctx_singleton<ScoreDisplay>(reg);
+    reset_ctx_singleton<CurrentSongHighScore>(reg);
     reset_ctx_singleton<LevelSelectState>(reg);
     reset_ctx_singleton<EnergyState>(reg);
     reset_ctx_singleton<GameOverState>(reg);

--- a/app/systems/game_state_terminal_phase_system.cpp
+++ b/app/systems/game_state_terminal_phase_system.cpp
@@ -25,8 +25,9 @@ void persist_dirty_high_scores(const HighScoreState& high_scores, HighScorePersi
 
 bool update_and_persist_high_score(entt::registry& reg) {
     auto& score = reg.ctx().get<ScoreState>();
-    const int32_t previous_high_score = score.high_score;
-    const bool score_exceeds_high_score = (score.score > score.high_score);
+    auto& current = reg.ctx().get<CurrentSongHighScore>();
+    const int32_t previous_high_score = current.value;
+    const bool score_exceeds_high_score = (score.score > current.value);
     bool recorded_new_high_score = score_exceeds_high_score;
 
     if (auto* hs = reg.ctx().find<HighScoreState>()) {
@@ -36,7 +37,7 @@ bool update_and_persist_high_score(entt::registry& reg) {
             recorded_new_high_score = high_score::update_if_higher(*hs, *session, score.score);
         }
         if (score_exceeds_high_score && recorded_new_high_score) {
-            score.high_score = score.score;
+            current.value = score.score;
         }
         if (auto* hp = reg.ctx().find<HighScorePersistence>()) {
             if (score_exceeds_high_score && recorded_new_high_score && has_active_high_score_key) {
@@ -45,7 +46,7 @@ bool update_and_persist_high_score(entt::registry& reg) {
             persist_dirty_high_scores(*hs, *hp);
         }
     } else if (score_exceeds_high_score) {
-        score.high_score = score.score;
+        current.value = score.score;
     }
 
     if (auto* result = reg.ctx().find<TerminalResultState>()) {

--- a/app/systems/play_session.cpp
+++ b/app/systems/play_session.cpp
@@ -167,6 +167,8 @@ void setup_play_session(entt::registry& reg) {
             session->key_hash = 0;
         }
         erase_ctx_if_exists<ScoreState>(reg);
+        erase_ctx_if_exists<ScoreDisplay>(reg);
+        erase_ctx_if_exists<CurrentSongHighScore>(reg);
         erase_ctx_if_exists<SongState>(reg);
         erase_ctx_if_exists<EnergyState>(reg);
         erase_ctx_if_exists<SongResults>(reg);
@@ -180,6 +182,8 @@ void setup_play_session(entt::registry& reg) {
     runtime_system_scratch_reserve(reg, beatmap.beats.size());
 
     assign_or_emplace_ctx(reg, ScoreState{});
+    assign_or_emplace_ctx(reg, ScoreDisplay{});
+    assign_or_emplace_ctx(reg, CurrentSongHighScore{});
 
     // Wire high score: derive song_id from beatmap filename and set HighScoreSession::key_hash.
     // The key string is built once in a stack buffer (no heap); ensure_entry pre-registers
@@ -244,11 +248,11 @@ void setup_play_session(entt::registry& reg) {
     }
     assign_or_emplace_ctx(reg, GameOverState{});
 
-    // Load stored high score for this song+difficulty into ScoreState
+    // Load stored high score for this song+difficulty into CurrentSongHighScore
     if (auto* hs = reg.ctx().find<HighScoreState>()) {
-        auto& score = reg.ctx().get<ScoreState>();
+        auto& current = reg.ctx().get<CurrentSongHighScore>();
         const auto* session = reg.ctx().find<HighScoreSession>();
-        score.high_score = session ? high_score::get_current_high_score(*hs, *session) : 0;
+        current.value = session ? high_score::get_current_high_score(*hs, *session) : 0;
     }
 
     spawn_session_player(reg);

--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -280,10 +280,11 @@ void scoring_system(entt::registry& reg, float dt) {
     }
 
     // Smooth score display
+    auto& display = reg.ctx().get<ScoreDisplay>();
     float display_speed = 5000.0f * dt;
-    if (score.displayed_score < score.score) {
-        score.displayed_score += static_cast<int>(display_speed);
-        if (score.displayed_score > score.score)
-            score.displayed_score = score.score;
+    if (display.displayed < score.score) {
+        display.displayed += static_cast<int>(display_speed);
+        if (display.displayed > score.score)
+            display.displayed = score.score;
     }
 }

--- a/app/ui/screen_controllers/game_over_screen_controller.cpp
+++ b/app/ui/screen_controllers/game_over_screen_controller.cpp
@@ -43,12 +43,13 @@ void draw_game_over_value(Vector2 anchor, float x, float y, float w, float h,
 
 void draw_game_over_scoreboard(entt::registry& reg, const GameOverLayoutState& state) {
     const auto& score = reg.ctx().get<ScoreState>();
+    const auto& current = reg.ctx().get<CurrentSongHighScore>();
 
     char value[32] = {};
     std::snprintf(value, sizeof(value), "%d", score.score);
     draw_game_over_value(state.Anchor01, 210, 540, 300, 46, value, 36);
 
-    std::snprintf(value, sizeof(value), "%d", score.high_score);
+    std::snprintf(value, sizeof(value), "%d", current.value);
     draw_game_over_value(state.Anchor01, 210, 634, 300, 32, value, 24);
 
     if (const auto* result = reg.ctx().find<TerminalResultState>(); result && result->new_best) {

--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
@@ -412,20 +412,23 @@ void render_gameplay_hud_screen_ui(entt::registry& reg) {
     auto& controller = screen_controller<GameplayHudController>(reg);
     auto& state = controller.state();
     auto* score = reg.ctx().find<ScoreState>();
+    auto* display = reg.ctx().find<ScoreDisplay>();
+    auto* current = reg.ctx().find<CurrentSongHighScore>();
 
     int saved_text_size = GuiGetStyle(DEFAULT, TEXT_SIZE);
 
     // Render score at top-left
-    if (score) {
+    if (score && display) {
         GuiSetStyle(DEFAULT, TEXT_SIZE, 28);
         char score_text[32];
-        std::snprintf(score_text, sizeof(score_text), "%d", score->displayed_score);
+        std::snprintf(score_text, sizeof(score_text), "%d", display->displayed);
         GuiLabel(Rectangle{ 80, 20, 200, 40 }, score_text);
-        
+
         // High score below
         GuiSetStyle(DEFAULT, TEXT_SIZE, 18);
         char high_score_text[32];
-        std::snprintf(high_score_text, sizeof(high_score_text), "BEST: %d", score->high_score);
+        const int32_t high = current ? current->value : 0;
+        std::snprintf(high_score_text, sizeof(high_score_text), "BEST: %d", high);
         GuiSetAlpha(0.7f);
         GuiLabel(Rectangle{ 80, 50, 200, 30 }, high_score_text);
         GuiSetAlpha(1.0f);

--- a/app/ui/screen_controllers/song_complete_screen_controller.cpp
+++ b/app/ui/screen_controllers/song_complete_screen_controller.cpp
@@ -27,12 +27,13 @@ void draw_song_complete_value(Vector2 anchor, float x, float y, float w, float h
 
 void draw_song_complete_scoreboard(entt::registry& reg, const SongCompleteLayoutState& state) {
     const auto& score = reg.ctx().get<ScoreState>();
+    const auto& current = reg.ctx().get<CurrentSongHighScore>();
 
     char value[32] = {};
     std::snprintf(value, sizeof(value), "%d", score.score);
     draw_song_complete_value(state.Anchor01, 160, 463, 400, 50, value, 36);
 
-    std::snprintf(value, sizeof(value), "%d", score.high_score);
+    std::snprintf(value, sizeof(value), "%d", current.value);
     draw_song_complete_value(state.Anchor01, 160, 573, 400, 50, value, 36);
 
     if (const auto* result = reg.ctx().find<TerminalResultState>(); result && result->new_best) {

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -101,8 +101,18 @@ TEST_CASE("components: PlayHapticEvent wraps HapticEvent", "[components]") {
 TEST_CASE("components: ScoreState defaults to zero", "[components]") {
     ScoreState s{};
     CHECK(s.score == 0);
-    CHECK(s.high_score == 0);
     CHECK(s.chain_count == 0);
+    CHECK(s.passive_score_remainder == 0.0f);
+}
+
+TEST_CASE("components: ScoreDisplay defaults to zero", "[components]") {
+    ScoreDisplay d{};
+    CHECK(d.displayed == 0);
+}
+
+TEST_CASE("components: CurrentSongHighScore defaults to zero", "[components]") {
+    CurrentSongHighScore c{};
+    CHECK(c.value == 0);
 }
 
 TEST_CASE("components: GameState defaults to title", "[components]") {
@@ -120,6 +130,8 @@ TEST_CASE("ecs: make_registry creates all singletons", "[ecs]") {
     // Gameplay state
     static_cast<void>(reg.ctx().get<GameState>());
     static_cast<void>(reg.ctx().get<ScoreState>());
+    static_cast<void>(reg.ctx().get<ScoreDisplay>());
+    static_cast<void>(reg.ctx().get<CurrentSongHighScore>());
     // Audio / haptics / settings (queues replaced by dispatcher events)
     static_cast<void>(settings_state(reg));
     // Level / song / rhythm

--- a/tests/test_game_over_screen_controller.cpp
+++ b/tests/test_game_over_screen_controller.cpp
@@ -68,8 +68,9 @@ TEST_CASE("game_over: score / high score / cause are visible via registry single
 
     // Simulate a finished run.
     auto& score = reg.ctx().get<ScoreState>();
-    score.score      = 12345;
-    score.high_score = 99999;
+    auto& current = reg.ctx().get<CurrentSongHighScore>();
+    score.score = 12345;
+    current.value = 99999;
 
     auto& gos = reg.ctx().insert_or_assign(GameOverState{});
     gos.cause = DeathCause::EnergyDepleted;
@@ -82,7 +83,7 @@ TEST_CASE("game_over: score / high score / cause are visible via registry single
     // game_over_screen_controller reads to populate the layout slots.
     const auto& s = reg.ctx().get<ScoreState>();
     CHECK(s.score      == 12345);
-    CHECK(s.high_score == 99999);
+    CHECK(reg.ctx().get<CurrentSongHighScore>().value == 99999);
 
     const auto& g = reg.ctx().get<GameOverState>();
     CHECK(g.cause == DeathCause::EnergyDepleted);
@@ -95,8 +96,9 @@ TEST_CASE("game_over: render binds score/high-score/reason into scoreboard draw 
     ScopedGameOverHooks hooks;
 
     auto& score = reg.ctx().get<ScoreState>();
+    auto& current = reg.ctx().get<CurrentSongHighScore>();
     score.score = 31415;
-    score.high_score = 92653;
+    current.value = 92653;
 
     auto& gos = reg.ctx().get<GameOverState>();
     gos.cause = DeathCause::EnergyDepleted;
@@ -117,8 +119,9 @@ TEST_CASE("game_over: render binds new-best badge and previous score", "[game_ov
     ScopedGameOverHooks hooks;
 
     auto& score = reg.ctx().get<ScoreState>();
+    auto& current = reg.ctx().get<CurrentSongHighScore>();
     score.score = 5000;
-    score.high_score = 5000;
+    current.value = 5000;
     reg.ctx().insert_or_assign(TerminalResultState{true, 3000});
 
     auto& gos = reg.ctx().get<GameOverState>();
@@ -139,8 +142,9 @@ TEST_CASE("game_over: render omits empty reason binding for DeathCause::None", "
     ScopedGameOverHooks hooks;
 
     auto& score = reg.ctx().get<ScoreState>();
+    auto& current = reg.ctx().get<CurrentSongHighScore>();
     score.score = 7;
-    score.high_score = 11;
+    current.value = 11;
 
     auto& gos = reg.ctx().get<GameOverState>();
     gos.cause = DeathCause::None;

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -100,8 +100,9 @@ TEST_CASE("game_state: song complete waits for scored obstacle to be destroyed",
 TEST_CASE("game_state: enter_song_complete updates high score", "[gamestate]") {
     auto reg = make_registry();
     auto& score = reg.ctx().get<ScoreState>();
+    auto& current = reg.ctx().get<CurrentSongHighScore>();
     score.score = 8000;
-    score.high_score = 5000;
+    current.value = 5000;
 
     auto& gs = reg.ctx().get<GameState>();
     gs.transition_pending = true;
@@ -109,7 +110,7 @@ TEST_CASE("game_state: enter_song_complete updates high score", "[gamestate]") {
 
     game_state_system(reg, 0.016f);
 
-    CHECK(score.high_score == 8000);
+    CHECK(current.value == 8000);
     CHECK(gs.phase == GamePhase::SongComplete);
     const auto& terminal = reg.ctx().get<TerminalResultState>();
     CHECK(terminal.new_best);
@@ -119,8 +120,9 @@ TEST_CASE("game_state: enter_song_complete updates high score", "[gamestate]") {
 TEST_CASE("game_state: enter_song_complete preserves higher high_score", "[gamestate]") {
     auto reg = make_registry();
     auto& score = reg.ctx().get<ScoreState>();
+    auto& current = reg.ctx().get<CurrentSongHighScore>();
     score.score = 1000;
-    score.high_score = 9000;
+    current.value = 9000;
 
     auto& gs = reg.ctx().get<GameState>();
     gs.transition_pending = true;
@@ -128,7 +130,7 @@ TEST_CASE("game_state: enter_song_complete preserves higher high_score", "[games
 
     game_state_system(reg, 0.016f);
 
-    CHECK(score.high_score == 9000);
+    CHECK(current.value == 9000);
 }
 
 TEST_CASE("game_state: song_complete button choice restart", "[gamestate]") {
@@ -528,8 +530,9 @@ TEST_CASE("song_complete: score.score is retained (not zeroed) after enter_song_
           "[gamestate][song_complete]") {
     auto reg = make_registry();
     auto& score = reg.ctx().get<ScoreState>();
-    score.score      = 12345;
-    score.high_score = 10000;
+    auto& current = reg.ctx().get<CurrentSongHighScore>();
+    score.score = 12345;
+    current.value = 10000;
 
     auto& gs = reg.ctx().get<GameState>();
     gs.transition_pending = true;

--- a/tests/test_haptic_system.cpp
+++ b/tests/test_haptic_system.cpp
@@ -67,8 +67,9 @@ TEST_CASE("game state haptic: DeathCrash enqueued on game over", "[haptic]") {
 TEST_CASE("game state haptic: NewHighScore enqueued when score exceeds high score on game over", "[haptic]") {
     auto reg = make_registry();
     auto& score = reg.ctx().get<ScoreState>();
+    auto& current = reg.ctx().get<CurrentSongHighScore>();
     score.score = 1000;
-    score.high_score = 500;
+    current.value = 500;
     reg.ctx().get<GameState>().transition_pending = true;
     reg.ctx().get<GameState>().next_phase = GamePhase::GameOver;
 
@@ -84,8 +85,9 @@ TEST_CASE("game state haptic: NewHighScore enqueued when score exceeds high scor
 TEST_CASE("game state haptic: NewHighScore NOT enqueued when no new high score on game over", "[haptic]") {
     auto reg = make_registry();
     auto& score = reg.ctx().get<ScoreState>();
+    auto& current = reg.ctx().get<CurrentSongHighScore>();
     score.score = 400;
-    score.high_score = 500;
+    current.value = 500;
     reg.ctx().get<GameState>().transition_pending = true;
     reg.ctx().get<GameState>().next_phase = GamePhase::GameOver;
 

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -40,6 +40,8 @@ inline entt::registry make_registry() {
         GamePhase::Playing, 0.0f, false, GamePhase::Playing
     });
     reg.ctx().emplace<ScoreState>();
+    reg.ctx().emplace<ScoreDisplay>();
+    reg.ctx().emplace<CurrentSongHighScore>();
     create_settings_entity(reg);  // defaults: haptics_enabled=true
     reg.ctx().emplace<LevelSelectState>();
     create_beat_map_entity(reg);

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -74,7 +74,7 @@ TEST_CASE("High score integration: setup_play_session loads selected song diffic
 
     CHECK(reg.ctx().get<HighScoreSession>().key_hash
         == high_score::make_key_hash("1_stomper", "easy"));
-    CHECK(reg.ctx().get<ScoreState>().high_score == 1234);
+    CHECK(reg.ctx().get<CurrentSongHighScore>().value == 1234);
     CHECK_FALSE(reg.view<GameCamera>().empty());
     CHECK_FALSE(reg.view<UICamera>().empty());
 }
@@ -184,7 +184,7 @@ TEST_CASE("Play session: high score key uses loaded fallback difficulty",
     CHECK(beat_map(reg).difficulty == "medium");
     CHECK(reg.ctx().get<HighScoreSession>().key_hash
         == high_score::make_key_hash("shapeshifter_issue847", "medium"));
-    CHECK(reg.ctx().get<ScoreState>().high_score == 4321);
+    CHECK(reg.ctx().get<CurrentSongHighScore>().value == 4321);
 }
 
 TEST_CASE("Play session: SongResults total_notes excludes onset marker metadata",
@@ -225,7 +225,8 @@ TEST_CASE("High score integration: new song-complete high score persists",
     high_score::set_score(high_scores, "song_001|easy", 1000);
 
     auto& score = reg.ctx().get<ScoreState>();
-    score.high_score = 1000;
+    auto& current = reg.ctx().get<CurrentSongHighScore>();
+    current.value = 1000;
     score.score = 2500;
 
     auto& gs = reg.ctx().get<GameState>();
@@ -234,7 +235,7 @@ TEST_CASE("High score integration: new song-complete high score persists",
 
     game_state_system(reg, 0.016f);
 
-    CHECK(score.high_score == 2500);
+    CHECK(current.value == 2500);
     CHECK(high_score::get_score(high_scores, "song_001|easy") == 2500);
 
     HighScoreState loaded;
@@ -257,7 +258,8 @@ TEST_CASE("High score integration: lower game-over score does not overwrite pers
     high_score::set_score(high_scores, "song_001|easy", 3000);
 
     auto& score = reg.ctx().get<ScoreState>();
-    score.high_score = 3000;
+    auto& current = reg.ctx().get<CurrentSongHighScore>();
+    current.value = 3000;
     score.score = 1000;
 
     auto& gs = reg.ctx().get<GameState>();
@@ -266,7 +268,7 @@ TEST_CASE("High score integration: lower game-over score does not overwrite pers
 
     game_state_system(reg, 0.016f);
 
-    CHECK(score.high_score == 3000);
+    CHECK(current.value == 3000);
     CHECK(high_score::get_score(high_scores, "song_001|easy") == 3000);
     CHECK_FALSE(std::filesystem::exists(file));
 
@@ -284,7 +286,8 @@ TEST_CASE("High score integration: missing active entry does not report new best
     reg.ctx().get<HighScoreSession>().key_hash = high_score::make_key_hash("overflow", "hard");
 
     auto& score = reg.ctx().get<ScoreState>();
-    score.high_score = 1000;
+    auto& current = reg.ctx().get<CurrentSongHighScore>();
+    current.value = 1000;
     score.score = 2500;
 
     auto& gs = reg.ctx().get<GameState>();
@@ -293,7 +296,7 @@ TEST_CASE("High score integration: missing active entry does not report new best
 
     game_state_system(reg, 0.016f);
 
-    CHECK(score.high_score == 1000);
+    CHECK(current.value == 1000);
     CHECK_FALSE(reg.ctx().get<TerminalResultState>().new_best);
     CHECK_FALSE(reg.ctx().get<HighScorePersistence>().dirty);
     CHECK(high_score::get_score(high_scores, "overflow|hard") == 0);
@@ -320,7 +323,8 @@ TEST_CASE("High score integration: failed save keeps dirty state for retry",
     high_score::set_score(high_scores, "song_001|easy", 1000);
 
     auto& score = reg.ctx().get<ScoreState>();
-    score.high_score = 1000;
+    auto& current = reg.ctx().get<CurrentSongHighScore>();
+    current.value = 1000;
     score.score = 2500;
 
     auto& gs = reg.ctx().get<GameState>();
@@ -371,7 +375,8 @@ TEST_CASE("High score bootstrap: persistence path is populated for save call sit
         GamePhase::Playing, 0.0f, true, GamePhase::SongComplete
     };
     auto& score = reg.ctx().get<ScoreState>();
-    score.high_score = 1000;
+    auto& current = reg.ctx().get<CurrentSongHighScore>();
+    current.value = 1000;
     score.score = 2500;
 
     auto& high_scores = reg.ctx().get<HighScoreState>();

--- a/tests/test_redfoot_testflight_ui.cpp
+++ b/tests/test_redfoot_testflight_ui.cpp
@@ -111,6 +111,8 @@ TEST_CASE("redfoot/#168: collision miss is non-terminal cause context",
     reg.ctx().emplace<GameState>().phase = GamePhase::Playing;
     reg.ctx().emplace<EnergyState>();
     reg.ctx().emplace<ScoreState>();
+    reg.ctx().emplace<ScoreDisplay>();
+    reg.ctx().emplace<CurrentSongHighScore>();
     reg.ctx().emplace<SongResults>();
     reg.ctx().emplace<SongState>();
     reg.ctx().emplace<GameOverState>();

--- a/tests/test_scoring_system.cpp
+++ b/tests/test_scoring_system.cpp
@@ -192,18 +192,19 @@ TEST_CASE("scoring: SFX pushed on score", "[scoring]") {
     CHECK(drain_sfx_events(reg).count > 0);
 }
 
-TEST_CASE("scoring: displayed_score rolls up toward score", "[scoring]") {
+TEST_CASE("scoring: ScoreDisplay rolls up toward score", "[scoring]") {
     auto reg = make_registry();
     auto& score = reg.ctx().get<ScoreState>();
+    auto& display = reg.ctx().get<ScoreDisplay>();
     score.score = 1000;
-    score.displayed_score = 0;
+    display.displayed = 0;
 
     scoring_system(reg, 0.1f);
     popup_feedback_system(reg, 0.1f);
     energy_system(reg, 0.1f);
 
-    CHECK(score.displayed_score > 0);
-    CHECK(score.displayed_score <= score.score);
+    CHECK(display.displayed > 0);
+    CHECK(display.displayed <= score.score);
 }
 
 TEST_CASE("scoring: not in Playing phase skips processing", "[scoring]") {
@@ -297,20 +298,21 @@ TEST_CASE("scoring: obstacle entity cleaned up after scoring", "[scoring]") {
     CHECK(reg.valid(obs));
 }
 
-TEST_CASE("scoring: displayed_score does not overshoot score", "[scoring]") {
+TEST_CASE("scoring: ScoreDisplay does not overshoot score", "[scoring]") {
     auto reg = make_registry();
     auto& score = reg.ctx().get<ScoreState>();
+    auto& display = reg.ctx().get<ScoreDisplay>();
     score.score = 100;
-    score.displayed_score = 99;
+    display.displayed = 99;
 
     // Very large dt that would normally overshoot
     scoring_system(reg, 10.0f);
     popup_feedback_system(reg, 10.0f);
     energy_system(reg, 10.0f);
 
-    // displayed_score should not exceed score (capped)
+    // displayed should not exceed score (capped)
     // Note: score increases by dt * PTS_PER_SECOND too
-    CHECK(score.displayed_score <= score.score);
+    CHECK(display.displayed <= score.score);
 }
 
 // On-beat shape gate scores at base points (timing only, no burnout multiplier).

--- a/tests/test_world_systems.cpp
+++ b/tests/test_world_systems.cpp
@@ -257,8 +257,9 @@ TEST_CASE("game_state: enter_playing clears entities and creates player", "[game
 TEST_CASE("game_state: enter_game_over updates high score", "[gamestate]") {
     auto reg = make_registry();
     auto& score = reg.ctx().get<ScoreState>();
+    auto& current = reg.ctx().get<CurrentSongHighScore>();
     score.score = 5000;
-    score.high_score = 3000;
+    current.value = 3000;
 
     auto& gs = reg.ctx().get<GameState>();
     gs.transition_pending = true;
@@ -266,7 +267,7 @@ TEST_CASE("game_state: enter_game_over updates high score", "[gamestate]") {
 
     game_state_system(reg, 0.016f);
 
-    CHECK(score.high_score == 5000);
+    CHECK(current.value == 5000);
     CHECK(gs.phase == GamePhase::GameOver);
     const auto& terminal = reg.ctx().get<TerminalResultState>();
     CHECK(terminal.new_best);
@@ -291,8 +292,9 @@ TEST_CASE("game_state: enter_game_over pushes Crash SFX", "[gamestate]") {
 TEST_CASE("game_state: enter_game_over preserves high score if lower", "[gamestate]") {
     auto reg = make_registry();
     auto& score = reg.ctx().get<ScoreState>();
+    auto& current = reg.ctx().get<CurrentSongHighScore>();
     score.score = 1000;
-    score.high_score = 5000;
+    current.value = 5000;
 
     auto& gs = reg.ctx().get<GameState>();
     gs.transition_pending = true;
@@ -300,7 +302,7 @@ TEST_CASE("game_state: enter_game_over preserves high score if lower", "[gamesta
 
     game_state_system(reg, 0.016f);
 
-    CHECK(score.high_score == 5000);
+    CHECK(current.value == 5000);
     const auto& terminal = reg.ctx().get<TerminalResultState>();
     CHECK_FALSE(terminal.new_best);
     CHECK(terminal.previous_best == 5000);


### PR DESCRIPTION
## Summary

`ScoreState` bundled five fields across three different cadences/owners — the last queued sub-item on issue #1194's `scoring.h` SPLIT (explicitly deferred by PR #1233). Decomposed into three ctx-bound singletons, each owned by the system that writes it:

| Singleton | Fields | Cadence / owner |
|---|---|---|
| `ScoreState` (kept, shrunk) | `score`, `chain_count`, `passive_score_remainder` | per-frame, `scoring_system` |
| `ScoreDisplay` (new) | `displayed` | per-frame, `scoring_system` tween → HUD read |
| `CurrentSongHighScore` (new) | `value` | per-session snapshot — set at `setup_play_session`, mutated at terminal phase, read by end screens / HUD |

Same precedent as PR #1230 (`high_score.h` → 3 singletons) and PR #1231 (`song_state.h` → 4 singletons): split along lifecycle/owner, not along struct-field count. The two new singletons are single-field by design (semantic-tag ctx singletons, not entity wrappers — distinct from the wrapper-noise case tracked in #1198).

## Changes

**Production** (8 files):
- `app/components/scoring.h` — shrink ScoreState; add ScoreDisplay + CurrentSongHighScore with cadence docs
- `app/game_loop.cpp` — `reset_ctx_singleton<>` the two new singletons at boot
- `app/systems/play_session.cpp` — erase/emplace mirror plus snapshot of best-for-current-song into `CurrentSongHighScore::value`
- `app/systems/scoring_system.cpp` — tween block reads ScoreState::score, writes ScoreDisplay::displayed
- `app/systems/game_state_terminal_phase_system.cpp` — terminal-phase "new best" path now reads/writes `CurrentSongHighScore::value`
- `app/ui/screen_controllers/gameplay_hud_screen_controller.cpp` — HUD reads ScoreDisplay::displayed + CurrentSongHighScore::value (with safe null-guards)
- `app/ui/screen_controllers/game_over_screen_controller.cpp` — end-screen reads CurrentSongHighScore::value
- `app/ui/screen_controllers/song_complete_screen_controller.cpp` — same

**Tests** (9 files):
- `tests/test_helpers.h` — `make_registry()` emplaces the two new singletons
- `tests/test_components.cpp` — split component-defaults asserts (2 new TEST_CASEs); `make_registry` ctx singleton roll-call extended
- `tests/test_scoring_system.cpp`, `test_world_systems.cpp`, `test_game_state_extended.cpp`, `test_haptic_system.cpp`, `test_high_score_integration.cpp`, `test_game_over_screen_controller.cpp`, `test_redfoot_testflight_ui.cpp` — every read/write site patched to the new singleton

## Validation

- 904 Catch2 tests / 2961 assertions pass (+2 component-defaults TEST_CASEs; was 902/2959 on `main` before this PR)
- Zero warnings under unity AND non-unity Clang `-Wall -Wextra -Werror` builds

## Closes / refs

Refs #1194 (closes the deferred `ScoreState` field-level cadence sub-item from PR #1233). Remaining #1194 follow-ups continue to be: `game_state.h` SPLIT (blocked on #1202/#1204 enum eradication ordering) and the `WorldTransform` / `MotionVelocity` / `UIPosition` collision-strategy choice (folds into #1198).