### PR TITLE
Split settings.{h,cpp} god-class along its 6 concerns (closes #1195)

### DIFF
--- a/app/components/settings.h
+++ b/app/components/settings.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "../systems/persistence_policy_system.h"
+
+// Settings entity component data — read by gameplay/UI systems each frame.
+//
+// Field bounds enforced by settings::clamp_audio_offset / clamp_ftue_run_count
+// (see systems/settings_system.h). Values outside the constants below get
+// pulled back into range on load.
+struct SettingsState {
+    static constexpr int16_t MIN_AUDIO_OFFSET_MS = -250;
+    static constexpr int16_t MAX_AUDIO_OFFSET_MS = 250;
+    static constexpr int16_t AUDIO_OFFSET_STEP_MS = 10;
+    static constexpr uint8_t MIN_FTUE_RUN_COUNT = 0;
+    static constexpr uint8_t MAX_FTUE_RUN_COUNT = 5;
+
+    // Audio offset in milliseconds, bounded [-250, 250]
+    // Positive offset delays beat timing; negative offset advances it.
+    int16_t audio_offset_ms = 0;
+
+    // Haptics enabled (default true, opt-out)
+    bool haptics_enabled = true;
+
+    // Reduce motion for accessibility
+    bool reduce_motion = false;
+
+    // Minimal TestFlight FTUE progress.
+    // 0 = tutorial incomplete; 1+ = tutorial completed/unlocked.
+    uint8_t ftue_run_count = 0;
+};
+
+// Persistence I/O bookkeeping for the settings file (path + last load/save
+// results + dirty bit). Lives on the singleton settings entity alongside
+// SettingsState; mutated by systems/settings_system.
+struct SettingsPersistence {
+    std::string path;
+    persistence::Result last_load{};
+    persistence::Result last_save{};
+    bool dirty{false};
+};

--- a/app/entities/settings.h
+++ b/app/entities/settings.h
@@ -1,75 +1,11 @@
 #pragma once
 
-#include <entt/entt.hpp>
-#include <nlohmann/json.hpp>
-#include <cstdint>
-#include <filesystem>
-#include <string>
-
-#include "../systems/persistence_policy_system.h"
-#include "tags/tags.h"
-
-struct SettingsState {
-    static constexpr int16_t MIN_AUDIO_OFFSET_MS = -250;
-    static constexpr int16_t MAX_AUDIO_OFFSET_MS = 250;
-    static constexpr int16_t AUDIO_OFFSET_STEP_MS = 10;
-    static constexpr uint8_t MIN_FTUE_RUN_COUNT = 0;
-    static constexpr uint8_t MAX_FTUE_RUN_COUNT = 5;
-
-    // Audio offset in milliseconds, bounded [-250, 250]
-    // Positive offset delays beat timing; negative offset advances it.
-    int16_t audio_offset_ms = 0;
-
-    // Haptics enabled (default true, opt-out)
-    bool haptics_enabled = true;
-
-    // Reduce motion for accessibility
-    bool reduce_motion = false;
-
-    // Minimal TestFlight FTUE progress.
-    // 0 = tutorial incomplete; 1+ = tutorial completed/unlocked.
-    uint8_t ftue_run_count = 0;
-};
-
-struct SettingsPersistence {
-    std::string path;
-    persistence::Result last_load{};
-    persistence::Result last_save{};
-    bool dirty{false};
-};
-
-// Creates the singleton settings entity and returns its handle.
-// Throws std::logic_error if the registry already has a SettingsTag entity.
-entt::entity create_settings_entity(entt::registry& reg,
-                                    SettingsState state = {},
-                                    SettingsPersistence persistence = {});
-
-SettingsState* find_settings_state(entt::registry& reg);
-const SettingsState* find_settings_state(const entt::registry& reg);
-SettingsState& settings_state(entt::registry& reg);
-const SettingsState& settings_state(const entt::registry& reg);
-
-SettingsPersistence* find_settings_persistence(entt::registry& reg);
-const SettingsPersistence* find_settings_persistence(const entt::registry& reg);
-SettingsPersistence& settings_persistence(entt::registry& reg);
-const SettingsPersistence& settings_persistence(const entt::registry& reg);
-
-void destroy_settings_entity(entt::registry& reg);
-
-namespace settings {
-
-persistence::Result load_settings(SettingsState& state, const std::filesystem::path& path);
-persistence::Result save_settings(const SettingsState& state, const std::filesystem::path& path);
-void mark_dirty_and_save(SettingsPersistence& persistence_state, const SettingsState& state);
-persistence::Result get_settings_file_path(
-    std::filesystem::path& out_path,
-    const std::filesystem::path& root_override = {});
-nlohmann::json settings_to_json(const SettingsState& state);
-bool settings_from_json(const nlohmann::json& obj, SettingsState& state);
-void clamp_audio_offset(SettingsState& state);
-void clamp_ftue_run_count(SettingsState& state);
-void mark_ftue_complete(SettingsState& state);
-float audio_offset_seconds(const SettingsState& state);
-bool ftue_complete(const SettingsState& state);
-
-} // namespace settings
+// Back-compat shim. The original `entities/settings.h` god-file split into
+// component data, an entity factory, and a system per #1194 / #1195.
+// New code should include the canonical headers directly:
+//   - components/settings.h        — SettingsState, SettingsPersistence
+//   - entities/settings_entity.h   — create/destroy_settings_entity()
+//   - systems/settings_system.h    — accessors, namespace settings { … }
+#include "../components/settings.h"
+#include "settings_entity.h"
+#include "../systems/settings_system.h"

--- a/app/entities/settings_entity.cpp
+++ b/app/entities/settings_entity.cpp
@@ -1,0 +1,34 @@
+#include "settings_entity.h"
+
+#include <stdexcept>
+#include <utility>
+
+#include "tags/tags.h"
+
+entt::entity create_settings_entity(entt::registry& reg,
+                                    SettingsState state,
+                                    SettingsPersistence persistence) {
+    auto existing = reg.view<SettingsTag>();
+    if (existing.begin() != existing.end()) {
+        throw std::logic_error("SettingsTag entity already exists");
+    }
+
+    auto entity = reg.create();
+    reg.emplace<SettingsTag>(entity);
+    reg.emplace<SettingsState>(entity, state);
+    reg.emplace<SettingsPersistence>(entity, std::move(persistence));
+    return entity;
+}
+
+void destroy_settings_entity(entt::registry& reg) {
+    auto view = reg.view<SettingsTag>();
+    auto it = view.begin();
+    if (it == view.end()) {
+        return;
+    }
+    const auto entity = *it;
+    if (++it != view.end()) {
+        throw std::logic_error("multiple Settings entities exist");
+    }
+    reg.destroy(entity);
+}

--- a/app/entities/settings_entity.h
+++ b/app/entities/settings_entity.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <entt/entt.hpp>
+
+#include "../components/settings.h"
+
+// Creates the singleton settings entity and returns its handle.
+// Throws std::logic_error if the registry already has a SettingsTag entity.
+entt::entity create_settings_entity(entt::registry& reg,
+                                    SettingsState state = {},
+                                    SettingsPersistence persistence = {});
+
+void destroy_settings_entity(entt::registry& reg);

--- a/app/systems/settings_system.cpp
+++ b/app/systems/settings_system.cpp
@@ -1,26 +1,13 @@
-#include "settings.h"
-#include <fstream>
+#include "settings_system.h"
+
 #include <algorithm>
 #include <cstdint>
+#include <fstream>
 #include <limits>
 #include <stdexcept>
 #include <system_error>
-#include <utility>
 
-entt::entity create_settings_entity(entt::registry& reg,
-                                    SettingsState state,
-                                    SettingsPersistence persistence) {
-    auto existing = reg.view<SettingsTag>();
-    if (existing.begin() != existing.end()) {
-        throw std::logic_error("SettingsTag entity already exists");
-    }
-
-    auto entity = reg.create();
-    reg.emplace<SettingsTag>(entity);
-    reg.emplace<SettingsState>(entity, state);
-    reg.emplace<SettingsPersistence>(entity, std::move(persistence));
-    return entity;
-}
+#include "tags/tags.h"
 
 SettingsState* find_settings_state(entt::registry& reg) {
     auto view = reg.view<SettingsTag, SettingsState>();
@@ -100,19 +87,6 @@ const SettingsPersistence& settings_persistence(const entt::registry& reg) {
         return *persistence;
     }
     throw std::logic_error("Settings entity is missing; call create_settings_entity() first");
-}
-
-void destroy_settings_entity(entt::registry& reg) {
-    auto view = reg.view<SettingsTag>();
-    auto it = view.begin();
-    if (it == view.end()) {
-        return;
-    }
-    const auto entity = *it;
-    if (++it != view.end()) {
-        throw std::logic_error("multiple Settings entities exist");
-    }
-    reg.destroy(entity);
 }
 
 namespace settings {

--- a/app/systems/settings_system.h
+++ b/app/systems/settings_system.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <entt/entt.hpp>
+#include <filesystem>
+#include <nlohmann/json.hpp>
+
+#include "../components/settings.h"
+
+// Singleton accessors over the SettingsTag entity. find_* return nullptr when
+// the entity is absent; the reference-returning forms throw std::logic_error.
+SettingsState* find_settings_state(entt::registry& reg);
+const SettingsState* find_settings_state(const entt::registry& reg);
+SettingsState& settings_state(entt::registry& reg);
+const SettingsState& settings_state(const entt::registry& reg);
+
+SettingsPersistence* find_settings_persistence(entt::registry& reg);
+const SettingsPersistence* find_settings_persistence(const entt::registry& reg);
+SettingsPersistence& settings_persistence(entt::registry& reg);
+const SettingsPersistence& settings_persistence(const entt::registry& reg);
+
+namespace settings {
+
+persistence::Result load_settings(SettingsState& state, const std::filesystem::path& path);
+persistence::Result save_settings(const SettingsState& state, const std::filesystem::path& path);
+void mark_dirty_and_save(SettingsPersistence& persistence_state, const SettingsState& state);
+persistence::Result get_settings_file_path(
+    std::filesystem::path& out_path,
+    const std::filesystem::path& root_override = {});
+nlohmann::json settings_to_json(const SettingsState& state);
+bool settings_from_json(const nlohmann::json& obj, SettingsState& state);
+void clamp_audio_offset(SettingsState& state);
+void clamp_ftue_run_count(SettingsState& state);
+void mark_ftue_complete(SettingsState& state);
+float audio_offset_seconds(const SettingsState& state);
+bool ftue_complete(const SettingsState& state);
+
+} // namespace settings

--- a/tests/test_wasm_beforeunload_lifecycle.cpp
+++ b/tests/test_wasm_beforeunload_lifecycle.cpp
@@ -81,7 +81,7 @@ TEST_CASE("wasm persistence uses explicit IDBFS policy and save flush hooks", "[
     const fs::path root = find_repo_root();
     const std::string cmake_source = read_file(root / "CMakeLists.txt");
     const std::string policy_source = read_file(root / "app" / "systems" / "persistence_policy_system.cpp");
-    const std::string settings_source = read_file(root / "app" / "entities" / "settings.cpp");
+    const std::string settings_source = read_file(root / "app" / "systems" / "settings_system.cpp");
     const std::string high_score_source = read_file(root / "app" / "systems" / "high_score_system.cpp");
 
     CHECK(cmake_source.find("-sFORCE_FILESYSTEM=1") != std::string::npos);


### PR DESCRIPTION
Per the audit in #1194 / #1195, `app/entities/settings.{h,cpp}` bundled six concerns in one translation unit:

1. Component data (`SettingsState`, `SettingsPersistence`)
2. Entity factory (`create_settings_entity`)
3. Accessor wrappers (`settings_state`, `find_settings_state`, `settings_persistence`, `find_settings_persistence`, `destroy_settings_entity`)
4. `namespace settings { … }` (load/save/mark_dirty_and_save/mark_ftue_complete/clamp/audio_offset_seconds/ftue_complete)
5. JSON serialization (`settings_to_json`/`settings_from_json`)
6. Filesystem I/O (`get_settings_file_path`)

The Acme/God-class pattern Fabian's chapter explicitly warns about.

## Split

Mirrors the `high_score` precedent from #1230:

| Type / function                          | New home                         |
|------------------------------------------|----------------------------------|
| `SettingsState`, `SettingsPersistence` | `components/settings.h`            |
| `create_settings_entity()`, `destroy_settings_entity()` | `entities/settings_entity.{h,cpp}` |
| `find_settings_state()`, `settings_state()`, `find_settings_persistence()`, `settings_persistence()` | `systems/settings_system.{h,cpp}`  |
| `namespace settings { load_settings, save_settings, mark_dirty_and_save, mark_ftue_complete, get_settings_file_path, settings_to_json, settings_from_json, clamp_audio_offset, clamp_ftue_run_count, audio_offset_seconds, ftue_complete }` | `systems/settings_system.{h,cpp}` |

`entities/settings.h` stays as a back-compat shim re-including the three new headers (same approach as `rhythm.h` after #1231, `scoring.h` after #1233, `rendering.h` after #1236). All 22 existing consumers continue to compile without changes.

`tests/test_wasm_beforeunload_lifecycle.cpp` patched to read the new `systems/settings_system.cpp` path for its `prepare_for_persistence_read` / `flush_persistence_writes` source-contract assertions.

## Validation

- 904 Catch2 tests / 2961 assertions pass
- Zero warnings under both **unity** AND **non-unity** Clang `-Wall -Wextra -Werror` builds
- macOS native target

## Refs

- Refs #1194 (parent audit)
- Closes #1195 (this concrete site; `beat_map.{h,cpp}` similar treatment remains as a follow-up)
- Refs #1203 (relational-normalization parent)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>