### PR TITLE
Delete dead UIPosition component (refs #1198)

### DIFF
--- a/app/components/transform.h
+++ b/app/components/transform.h
@@ -18,9 +18,3 @@ struct WorldTransform {
 struct MotionVelocity {
     Vector2 value = {0.0f, 0.0f};
 };
-
-// Screen-space UI placement. UI entities should use this instead of
-// WorldTransform so they do not enter world movement/collision/camera views.
-struct UIPosition {
-    Vector2 value = {0.0f, 0.0f};
-};

--- a/app/entities/energy_bar_entity.cpp
+++ b/app/entities/energy_bar_entity.cpp
@@ -2,7 +2,6 @@
 
 #include "../components/energy_bar.h"
 #include "../components/rendering.h"
-#include "../components/transform.h"
 
 #include <stdexcept>
 
@@ -14,7 +13,6 @@ entt::entity create_energy_bar_entity(entt::registry& reg) {
 
     auto energy_bar = reg.create();
     reg.emplace<EnergyBarTag>(energy_bar);
-    reg.emplace<UIPosition>(energy_bar);
     reg.emplace<EnergyBarLayout>(energy_bar);
     reg.emplace<EnergyBarVisual>(energy_bar);
     reg.emplace<DrawLayer>(energy_bar, Layer::HUD);

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -1659,7 +1659,7 @@ app/
 ├── constants.h                  ← all tuning knobs (§1)
 │
 ├── components/                  ← all component structs
-│   ├── transform.h              ← WorldTransform, MotionVelocity, UIPosition
+│   ├── transform.h              ← WorldTransform, MotionVelocity
 │   ├── window_phase.h           ← WindowPhase (shared by player.h and rhythm.h)
 │   ├── player.h                 ← PlayerTag, PlayerShape, ShapeWindow, Lane, VerticalState
 │   ├── obstacle.h               ← obstacle tags (ScoredTag, MissTag,

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -52,14 +52,6 @@ TEST_CASE("components: rendering components are safely default constructible",
     }
 }
 
-TEST_CASE("components: UIPosition is distinct screen-space placement", "[components][transform][ui]") {
-    UIPosition position{};
-    CHECK(position.value.x == 0.0f);
-    CHECK(position.value.y == 0.0f);
-    CHECK_FALSE((std::is_same_v<UIPosition, WorldTransform>));
-    CHECK_FALSE((std::is_same_v<UIPosition, ScreenPosition>));
-}
-
 TEST_CASE("components: PlayerShape defaults to Circle", "[components]") {
     PlayerShape ps{};
     CHECK(ps.current == Shape::Circle);


### PR DESCRIPTION
## What

`UIPosition` is emplaced once on the energy-bar singleton with default zero value but **never read** — no `view<UIPosition>`, no `get<UIPosition>`, no reference taken. The screen-space placement role for the energy bar is served entirely by `EnergyBarLayout`.

Issue #1198 lists `UIPosition` as a Vector2-shaped wrapper to swap to raw `Vector2`. Since the field is dead, this PR deletes it outright rather than replacing it with an unused raw emplace — same pattern as #1235 (drop dead `WorldTransform.rotation/scale`).

## Why this is safe

```
$ rg 'UIPosition' app/ tests/
app/components/transform.h:24:struct UIPosition { ... };
app/entities/energy_bar_entity.cpp:17:    reg.emplace<UIPosition>(energy_bar);
tests/test_components.cpp:55-61: TEST_CASE("components: UIPosition is distinct screen-space placement")
```

Only three sites:
- The definition
- A single emplace with default value
- A type-identity test asserting the default value and that `UIPosition` is not the same type as `WorldTransform`/`ScreenPosition`

No system queries it. The test only existed to assert the type was distinct from its neighbours — vacuously true once the type is gone.

## Changes

- Delete `UIPosition` struct from `app/components/transform.h`
- Drop the unused emplace from `app/entities/energy_bar_entity.cpp` and remove the now-unused `transform.h` include there
- Delete the type-identity test in `tests/test_components.cpp`
- Update the `components/` inventory in `design-docs/architecture.md`

## Verification

Both unity and non-unity Clang builds compile with `-Wall -Wextra -Werror`, zero warnings.

```
$ ./build/shapeshifter_tests
All tests passed (2957 assertions in 903 test cases)
```

## Refs

- #1198 — ECS wrapper-noise components (this clears `UIPosition` from the table)
- #1194 — transform.h SPLIT verdict (continuation of the wrapper-collision strategy work)
- #1235 — precedent for deleting dead components rather than swapping to raw types

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>