### PR TITLE
Unwrap BlockedLanes -> raw uint8_t (refs #1198)

### DIFF
--- a/app/components/obstacle.h
+++ b/app/components/obstacle.h
@@ -59,9 +59,12 @@ struct ShapeGateLane {
     int8_t lane = 0;
 };
 
-struct BlockedLanes {
-    uint8_t mask = 0;
-};
+// Lane block mask: bit i set ⇒ lane i is blocked (0/1/2 are lane indices).
+// Stored as a raw uint8_t component per wrapper-noise removal (issue #1198);
+// the entity's ObstacleTag + archetype shape (presence/absence of
+// RequiredShape / RequiredLane) carries the semantic role. No other
+// uint8_t-typed component is emplaced anywhere in the codebase, so the slot
+// is unambiguous.
 
 struct RequiredLane {
     int8_t lane = 0;

--- a/app/entities/obstacle_render_entity.cpp
+++ b/app/entities/obstacle_render_entity.cpp
@@ -97,7 +97,7 @@ void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical) {
         ? ObstacleKind::OnsetMarker
         : obstacle_kind_from_components(
             reg.all_of<RequiredShape>(logical),
-            reg.all_of<BlockedLanes>(logical),
+            reg.all_of<uint8_t>(logical),
             reg.all_of<RequiredLane>(logical));
 
     switch (kind) {
@@ -118,10 +118,10 @@ void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical) {
         case ObstacleKind::LaneBlock: {
             // Legacy component fixture path. Active beatmaps and obstacle
             // factories reject LaneBlock; retained for focused ECS tests.
-            auto* blocked = reg.try_get<BlockedLanes>(logical);
+            auto* blocked = reg.try_get<uint8_t>(logical);
             if (blocked)
                 for (int i = 0; i < constants::LANE_COUNT; ++i)
-                    if ((blocked->mask >> i) & 1)
+                    if ((*blocked >> i) & 1)
                         add_slab_child(reg, logical, constants::LANE_X[i]-dsz.w/2,
                                        dsz.w, dsz.h, constants::OBSTACLE_3D_HEIGHT, col);
             break;
@@ -129,7 +129,7 @@ void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical) {
         case ObstacleKind::ComboGate: {
             // Legacy component fixture path. Active beatmaps and obstacle
             // factories reject ComboGate; retained for focused ECS tests.
-            auto* blocked = reg.try_get<BlockedLanes>(logical);
+            auto* blocked = reg.try_get<uint8_t>(logical);
             auto* req = reg.try_get<RequiredShape>(logical);
             uint8_t mesh_index = 0;
             if (req) {
@@ -137,14 +137,14 @@ void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical) {
             }
             if (blocked)
                 for (int i = 0; i < constants::LANE_COUNT; ++i)
-                    if ((blocked->mask >> i) & 1)
+                    if ((*blocked >> i) & 1)
                         add_slab_child(reg, logical, constants::LANE_X[i]-120,
                                        240.0f, dsz.h, constants::OBSTACLE_3D_HEIGHT, col);
             if (req) {
                 int open = 1;
                 if (blocked)
                     for (int i = 0; i < constants::LANE_COUNT; ++i)
-                        if (!((blocked->mask >> i) & 1)) { open = i; break; }
+                        if (!((*blocked >> i) & 1)) { open = i; break; }
                 add_shape_child(reg, logical, mesh_index, constants::LANE_X[open],
                                  0.0f, 30, {255, 255, 255, 180});
             }

--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -132,11 +132,11 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
     // Legacy LaneBlock fixture: BlockedLanes only (no RequiredShape).
     // Active beatmaps and obstacle factories reject this kind.
     {
-        auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, BlockedLanes>(
+        auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, uint8_t>(
             entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredShape>);
         for (auto [e, obstacle, wt, blocked] : view.each()) {
             (void)obstacle;
-            resolve(e, wt.position.y, !((blocked.mask >> player_lane) & 1));
+            resolve(e, wt.position.y, !((blocked >> player_lane) & 1));
         }
     }
 
@@ -144,7 +144,7 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
     // ShapeGate: RequiredShape only (no BlockedLanes, no RequiredLane)
     {
         auto rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, ShapeGateLane, BeatInfo>(
-            entt::exclude<ScoredTag, ResolvedObstacleTag, BlockedLanes, RequiredLane>);
+            entt::exclude<ScoredTag, ResolvedObstacleTag, uint8_t, RequiredLane>);
         for (auto [e, obstacle, wt, req, lane, info] : rhythm_view.each()) {
             (void)obstacle;
             const bool lane_ok = shape_gate_lane_match(lane.lane, player_lane);
@@ -152,7 +152,7 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
         }
 
         auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, ShapeGateLane>(
-            entt::exclude<ScoredTag, ResolvedObstacleTag, BlockedLanes, RequiredLane, BeatInfo>);
+            entt::exclude<ScoredTag, ResolvedObstacleTag, uint8_t, RequiredLane, BeatInfo>);
         for (auto [e, obstacle, wt, req, lane] : view.each()) {
             (void)obstacle;
             const bool lane_ok = shape_gate_lane_match(lane.lane, player_lane);
@@ -160,7 +160,7 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
         }
 
         auto fallback_rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, BeatInfo>(
-            entt::exclude<ScoredTag, ResolvedObstacleTag, BlockedLanes, RequiredLane, ShapeGateLane>);
+            entt::exclude<ScoredTag, ResolvedObstacleTag, uint8_t, RequiredLane, ShapeGateLane>);
         for (auto [e, obstacle, wt, req, info] : fallback_rhythm_view.each()) {
             (void)obstacle;
             const bool lane_ok = lane_utils::nearest_lane_for_x(wt.position.x) == player_lane;
@@ -168,7 +168,7 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
         }
 
         auto fallback_view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape>(
-            entt::exclude<ScoredTag, ResolvedObstacleTag, BlockedLanes, RequiredLane, BeatInfo, ShapeGateLane>);
+            entt::exclude<ScoredTag, ResolvedObstacleTag, uint8_t, RequiredLane, BeatInfo, ShapeGateLane>);
         for (auto [e, obstacle, wt, req] : fallback_view.each()) {
             (void)obstacle;
             const bool lane_ok = lane_utils::nearest_lane_for_x(wt.position.x) == player_lane;
@@ -179,19 +179,19 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
     // Legacy ComboGate fixture: RequiredShape + BlockedLanes (no RequiredLane).
     // Active beatmaps and obstacle factories reject this kind.
     {
-        auto rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, BlockedLanes, BeatInfo>(
+        auto rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, uint8_t, BeatInfo>(
             entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredLane>);
         for (auto [e, obstacle, wt, req, blocked, info] : rhythm_view.each()) {
             (void)obstacle;
-            const bool lane_ok = !((blocked.mask >> player_lane) & 1);
+            const bool lane_ok = !((blocked >> player_lane) & 1);
             resolve_shape_obstacle(e, wt, req.shape, lane_ok, &info);
         }
 
-        auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, BlockedLanes>(
+        auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, uint8_t>(
             entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredLane, BeatInfo>);
         for (auto [e, obstacle, wt, req, blocked] : view.each()) {
             (void)obstacle;
-            const bool lane_ok = !((blocked.mask >> player_lane) & 1);
+            const bool lane_ok = !((blocked >> player_lane) & 1);
             resolve_shape_obstacle(e, wt, req.shape, lane_ok, nullptr);
         }
     }

--- a/app/systems/session_logger_system.cpp
+++ b/app/systems/session_logger_system.cpp
@@ -119,7 +119,7 @@ void session_log_on_obstacle_spawn(entt::registry& reg, entt::entity entity) {
         ? ObstacleKind::OnsetMarker
         : obstacle_kind_from_components(
             reg.all_of<RequiredShape>(entity),
-            reg.all_of<BlockedLanes>(entity),
+            reg.all_of<uint8_t>(entity),
             reg.all_of<RequiredLane>(entity));
     const std::string_view kind_name = enum_name_or_unknown(kind);
     const std::string_view shape_name = req ? enum_name_or_unknown(req->shape) : std::string_view{"-"};
@@ -152,7 +152,7 @@ void session_log_on_scored(entt::registry& reg, entt::entity entity) {
     float drift = beat ? (t - beat->arrival_time) : 0.0f;
     const ObstacleKind kind = obstacle_kind_from_components(
         reg.all_of<RequiredShape>(entity),
-        reg.all_of<BlockedLanes>(entity),
+        reg.all_of<uint8_t>(entity),
         reg.all_of<RequiredLane>(entity));
     const std::string_view kind_name = enum_name_or_unknown(kind);
 

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -153,7 +153,7 @@ static TestPlayerAction determine_action(
         // ShapeGate: player must also be in the lane where the shape hole is.
         // The hole is at obs_pos.x — find which lane that corresponds to.
         auto* obs_wt = reg.try_get<WorldTransform>(entity);
-        if (obs_wt && !reg.all_of<BlockedLanes>(entity) && !reg.all_of<RequiredLane>(entity)) {
+        if (obs_wt && !reg.all_of<uint8_t>(entity) && !reg.all_of<RequiredLane>(entity)) {
             for (int i = 0; i < constants::LANE_COUNT; ++i) {
                 if (!lane_centers_overlap(obs_wt->position.x, constants::LANE_X[i])) continue;
                 if (i != player_lane) {
@@ -165,9 +165,9 @@ static TestPlayerAction determine_action(
     }
 
     // Lane requirement (BlockedLanes — find unblocked)
-    auto* blocked = reg.try_get<BlockedLanes>(entity);
+    auto* blocked = reg.try_get<uint8_t>(entity);
     if (blocked) {
-        int8_t safe = nearest_unblocked_lane(blocked->mask, player_lane);
+        int8_t safe = nearest_unblocked_lane(*blocked, player_lane);
         if (safe != player_lane) {
             action.target_lane = safe;
         }
@@ -319,7 +319,7 @@ void test_player_system(entt::registry& reg, float dt) {
             int beat_num = beat_info ? beat_info->beat_index : -1;
             const ObstacleKind kind = obstacle_kind_from_components(
                 reg.all_of<RequiredShape>(entity),
-                reg.all_of<BlockedLanes>(entity),
+                reg.all_of<uint8_t>(entity),
                 reg.all_of<RequiredLane>(entity));
             const std::string_view kind_name = enum_name_or_unknown(kind);
             const std::string_view shape_name = enum_name_or_unknown(action.target_shape);
@@ -473,8 +473,8 @@ void test_player_system(entt::registry& reg, float dt) {
                 }
 
                 // Closer obstacle — check if proposed lane is safe for it
-                auto* oblocked = reg.try_get<BlockedLanes>(oe);
-                if (oblocked && ((oblocked->mask >> next_lane) & 1)) {
+                auto* oblocked = reg.try_get<uint8_t>(oe);
+                if (oblocked && ((*oblocked >> next_lane) & 1)) {
                     move_would_fail_closer = true;
                     break;
                 }

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -85,7 +85,7 @@ TEST_CASE("beat_scheduler: spawns ShapeGate when time passes spawn_time", "[beat
     auto view = reg.view<ObstacleTag, Obstacle, RequiredShape, ShapeGateLane>();
     for (auto [e, obs, rs, lane] : view.each()) {
         (void)obs;
-        CHECK_FALSE(reg.all_of<BlockedLanes>(e));
+        CHECK_FALSE(reg.all_of<uint8_t>(e));
         CHECK_FALSE(reg.all_of<RequiredLane>(e));
         CHECK(rs.shape == Shape::Circle);
         CHECK(lane.lane == int8_t{1});
@@ -326,7 +326,7 @@ TEST_CASE("beat_scheduler: spawns OnsetMarker as visible non-scorable cue",
         cue = e;
         CHECK(obstacle.base_points == int16_t{0});
         CHECK_FALSE(reg.all_of<RequiredShape>(e));
-        CHECK_FALSE(reg.all_of<BlockedLanes>(e));
+        CHECK_FALSE(reg.all_of<uint8_t>(e));
         CHECK_FALSE(reg.all_of<RequiredLane>(e));
         REQUIRE(children.count == 1);
         const auto child = children.children[0];

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -295,7 +295,7 @@ TEST_CASE("collision: combo gate requires shape AND lane", "[collision]") {
     reg.emplace<Obstacle>(obs, int16_t{200});
     reg.emplace<RequiredShape>(obs, Shape::Circle);
     // Block lanes 0 and 2, leave lane 1 open
-    reg.emplace<BlockedLanes>(obs, uint8_t{0b101});
+    reg.emplace<uint8_t>(obs, uint8_t{0b101});
     reg.emplace<DrawSize>(obs, 720.0f, 80.0f);
     reg.emplace<DrawLayer>(obs, Layer::Game);
     reg.emplace<Color>(obs, Color{200, 100, 255, 255});
@@ -315,7 +315,7 @@ TEST_CASE("collision: combo gate fails with wrong shape", "[collision]") {
     reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, song.scroll_speed}});
     reg.emplace<Obstacle>(obs, int16_t{200});
     reg.emplace<RequiredShape>(obs, Shape::Triangle);  // wrong shape
-    reg.emplace<BlockedLanes>(obs, uint8_t{0b101});    // lane 1 open
+    reg.emplace<uint8_t>(obs, uint8_t{0b101});    // lane 1 open
     reg.emplace<DrawSize>(obs, 720.0f, 80.0f);
     reg.emplace<DrawLayer>(obs, Layer::Game);
     reg.emplace<Color>(obs, Color{200, 100, 255, 255});

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -278,12 +278,12 @@ TEST_CASE("ecs: make_combo_gate creates proper entity", "[ecs]") {
     CHECK(reg.all_of<WorldTransform>(obs));
     CHECK(reg.all_of<Obstacle>(obs));
     CHECK(reg.all_of<RequiredShape>(obs));
-    CHECK(reg.all_of<BlockedLanes>(obs));
+    CHECK(reg.all_of<uint8_t>(obs));
     CHECK(obstacle_kind_from_components(reg.all_of<RequiredShape>(obs),
-                                        reg.all_of<BlockedLanes>(obs),
+                                        reg.all_of<uint8_t>(obs),
                                         reg.all_of<RequiredLane>(obs)) == ObstacleKind::ComboGate);
     CHECK(reg.get<RequiredShape>(obs).shape == Shape::Circle);
-    CHECK(reg.get<BlockedLanes>(obs).mask == 0b101);
+    CHECK(reg.get<uint8_t>(obs) == 0b101);
 }
 
 TEST_CASE("ecs: make_split_path creates proper entity", "[ecs]") {
@@ -295,7 +295,7 @@ TEST_CASE("ecs: make_split_path creates proper entity", "[ecs]") {
     CHECK(reg.all_of<RequiredShape>(obs));
     CHECK(reg.all_of<RequiredLane>(obs));
     CHECK(obstacle_kind_from_components(reg.all_of<RequiredShape>(obs),
-                                        reg.all_of<BlockedLanes>(obs),
+                                        reg.all_of<uint8_t>(obs),
                                         reg.all_of<RequiredLane>(obs)) == ObstacleKind::SplitPath);
     CHECK(reg.get<RequiredShape>(obs).shape == Shape::Triangle);
     CHECK(reg.get<RequiredLane>(obs).lane == 2);

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -235,7 +235,7 @@ inline entt::entity make_lane_block(entt::registry& reg, uint8_t mask, float y) 
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], y}});
     reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, song.scroll_speed}});
     reg.emplace<Obstacle>(obs, int16_t{constants::PTS_LANE_BLOCK});
-    reg.emplace<BlockedLanes>(obs, mask);
+    reg.emplace<uint8_t>(obs, mask);
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W / 3), 80.0f);
     reg.emplace<DrawLayer>(obs, Layer::Game);
     reg.emplace<TagWorldPass>(obs);
@@ -254,7 +254,7 @@ inline entt::entity make_combo_gate(entt::registry& reg, Shape shape, uint8_t bl
     reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, song.scroll_speed}});
     reg.emplace<Obstacle>(obs, int16_t{constants::PTS_COMBO_GATE});
     reg.emplace<RequiredShape>(obs, shape);
-    reg.emplace<BlockedLanes>(obs, blocked_mask);
+    reg.emplace<uint8_t>(obs, blocked_mask);
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);
     reg.emplace<DrawLayer>(obs, Layer::Game);
     reg.emplace<TagWorldPass>(obs);

--- a/tests/test_obstacle_archetypes.cpp
+++ b/tests/test_obstacle_archetypes.cpp
@@ -52,7 +52,7 @@ TEST_CASE("entity: ShapeGate Circle - correct components and color", "[archetype
     auto e = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f, Shape::Circle});
 
     REQUIRE(reg.all_of<ObstacleTag, MotionVelocity, DrawLayer, WorldTransform, Obstacle, RequiredShape, ShapeGateLane, DrawSize, Color>(e));
-    CHECK(!reg.all_of<BlockedLanes>(e));
+    CHECK(!reg.all_of<uint8_t>(e));
     CHECK(!reg.all_of<RequiredLane>(e));
 
     CHECK(reg.get<Obstacle>(e).base_points == int16_t{constants::PTS_SHAPE_GATE});
@@ -163,7 +163,7 @@ TEST_CASE("entity: mesh factory rejects invalid RequiredShape before children", 
         entt::registry reg;
         auto parent = make_mesh_factory_obstacle(reg);
         reg.emplace<RequiredShape>(parent, invalid_shape);
-        reg.emplace<BlockedLanes>(parent, uint8_t{0b101});
+        reg.emplace<uint8_t>(parent, uint8_t{0b101});
 
         CHECK_THROWS_AS(spawn_obstacle_meshes(reg, parent), std::logic_error);
         check_no_mesh_children(reg, parent);
@@ -259,7 +259,7 @@ TEST_CASE("entity: SplitPath - RequiredShape and RequiredLane", "[archetype]") {
                                    Shape::Square, uint8_t{0}, int8_t{2}});
 
     REQUIRE(reg.all_of<ObstacleTag, MotionVelocity, DrawLayer, WorldTransform, Obstacle, RequiredShape, RequiredLane, DrawSize, Color>(e));
-    CHECK(!reg.all_of<BlockedLanes>(e));
+    CHECK(!reg.all_of<uint8_t>(e));
 
     CHECK(reg.get<Obstacle>(e).base_points == int16_t{constants::PTS_SPLIT_PATH});
     CHECK(reg.get<RequiredShape>(e).shape == Shape::Square);

--- a/tests/test_test_player_system.cpp
+++ b/tests/test_test_player_system.cpp
@@ -283,7 +283,7 @@ TEST_CASE("test_player: invalid scroll speed treats undated closer obstacles as 
     reg.emplace<Obstacle>(closer, int16_t{constants::PTS_LANE_BLOCK});
     reg.emplace<WorldTransform>(closer,
                                WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y - 300.0f}});
-    reg.emplace<BlockedLanes>(closer, uint8_t{0b001});
+    reg.emplace<uint8_t>(closer, uint8_t{0b001});
 
     auto& tp = reg.ctx().get<TestPlayerState>();
     TestPlayerAction action;


### PR DESCRIPTION
## Summary

`BlockedLanes { uint8_t mask }` was a single-field wrapper around a raw `uint8_t` per the wrapper-noise checklist in #1198. Deleted the struct and switched the ~30 emplace / view / get / try_get / all_of sites to use `uint8_t` directly.

The semantic role (lane-block mask on legacy LaneBlock / ComboGate obstacle archetypes) is now carried by the entity's `ObstacleTag` plus the surrounding component shape (presence/absence of `RequiredShape` / `RequiredLane`) rather than by the wrapper name — matching the existing dispatch in `obstacle_kind_from_components()`.

This is the **first true wrapper-to-raw-type swap** from the #1198 checklist (`UIPosition` was previously dropped as dead in #1239 rather than unwrapped).

## Why this wrapper

| Wrapper | Issue note | Status |
|---|---|---|
| `UIPosition` | 2-float, dead | already deleted (#1239) |
| `MotionVelocity` / `ScreenPosition` / `DrawSize` | all become raw `Vector2` — only **one** can be unwrapped per archetype (slot collision) | deferred |
| `DrawLayer` / `RequiredShape` | wraps `Layer` / `Shape` enum — both on #1204 eradication kill list | deferred |
| `ShapeGateLane` / `RequiredLane` | both `int8_t lane` — mutually exclusive on entities, but unwrapping both to `int8_t` loses the type-level distinction | deferred (needs follow-up audit) |
| **`BlockedLanes`** | **`uint8_t mask`, unique raw type, no slot collision, no enum-eradication dependency** | **this PR** |

`uint8_t` is the only raw primitive type with no other `emplace<>` site in the codebase — verified by:

```
grep -E 'emplace<(uint8_t|int8_t)>' app/ tests/  # → no matches
```

so the slot is unambiguous and no archetype audit was required.

## Mechanic

`obstacle.h`:
```diff
-struct BlockedLanes {
-    uint8_t mask = 0;
-};
+// Lane block mask: bit i set ⇒ lane i is blocked (0/1/2 are lane indices).
+// Stored as a raw uint8_t component per wrapper-noise removal (#1198);
+// the entity's ObstacleTag + archetype shape carries the semantic role.
```

Call-site shape:

| Before | After |
|---|---|
| `reg.emplace<BlockedLanes>(e, mask)` | `reg.emplace<uint8_t>(e, mask)` |
| `reg.try_get<BlockedLanes>(e)` → `b->mask` | `reg.try_get<uint8_t>(e)` → `*b` |
| `reg.get<BlockedLanes>(e).mask` | `reg.get<uint8_t>(e)` |
| `reg.all_of<BlockedLanes>(e)` | `reg.all_of<uint8_t>(e)` |
| `view<…, BlockedLanes>` → `blocked.mask` | `view<…, uint8_t>` → `blocked` |
| `entt::exclude<…, BlockedLanes, …>` | `entt::exclude<…, uint8_t, …>` |

## Doctrinal grounding

Per Fabian's *DoD* — "Relational Databases" / "Existential Processing":

> "A tag is the degenerate case — a zero-column table where existence-in-the-table IS the data."

`BlockedLanes` was a 1-column table; unwrapped, the column **is** the row data, the entity ID is the primary key, and existence in `storage<uint8_t>` is the row. Same relational form, one fewer wrapper layer.

The added comment in `obstacle.h` documents the slot-uniqueness constraint so a future `emplace<uint8_t>` regression is caught at review.

## Wrapper-deletion progress (#1198)

- 2-float wrappers → `Vector2`
  - [x] `UIPosition` (deleted as dead — PR #1239)
  - [ ] `MotionVelocity`
  - [ ] `ScreenPosition`
  - [ ] `DrawSize`
- Single-int / single-enum wrappers → raw type
  - [ ] `DrawLayer` (blocked on #1204 `Layer` eradication)
  - [ ] `RequiredShape` (blocked on #1204 `Shape` eradication)
  - [ ] `ShapeGateLane`
  - [ ] `RequiredLane`
  - [x] **`BlockedLanes`** ← this PR

## Validation

- **903 Catch2 tests / 2957 assertions pass** under both unity (`build/`) and non-unity (`build-nounity/`) builds.
- **Zero warnings** under Clang `-Wall -Wextra -Werror` for both configurations.
- `grep -n BlockedLanes app/ tests/` returns **only comment-mention sites**; no live references remain.

Closes one checkbox on #1198.
