### PR TITLE
Unwrap MotionVelocity → raw Vector2 (refs #1198)

### DIFF
--- a/app/components/transform.h
+++ b/app/components/transform.h
@@ -13,8 +13,17 @@ struct WorldTransform {
     Vector2 position = {0.0f, 0.0f};
 };
 
-// Scoped motion for entities that truly integrate position += velocity * dt.
-// Replaces the deleted Velocity struct (issue #349 migration complete).
-struct MotionVelocity {
-    Vector2 value = {0.0f, 0.0f};
-};
+// Velocity vector (units per second) for entities that integrate
+// position += velocity * dt. Raw Vector2 is used directly — the
+// MotionVelocity { Vector2 value } single-field wrapper was deleted
+// per issue #1198 (companion to the BlockedLanes → uint8_t unwrap in
+// PR #1240). motion_system queries view<WorldTransform, Vector2>;
+// existence of a Vector2 component on an entity is the ownership
+// marker for dt-integrated movement. Song-time-authoritative rhythm
+// obstacles intentionally omit Vector2 and carry BeatInfo instead.
+//
+// Slot reservation: the per-entity Vector2 component slot is reserved
+// for "velocity" semantics. The other Vector2-shaped wrappers in
+// issue #1198 (ScreenPosition {float x, y}, DrawSize {float w, h})
+// must remain as named structs to avoid colliding on popup/obstacle
+// archetypes that also carry a velocity.

--- a/app/entities/obstacle_entity.cpp
+++ b/app/entities/obstacle_entity.cpp
@@ -75,7 +75,7 @@ void finish_obstacle(entt::registry& reg, entt::entity e) {
 
 entt::entity spawn_obstacle(entt::registry& reg, const ObstacleSpawnParams& params) {
     auto e = spawn_obstacle_base(reg, params);
-    reg.emplace<MotionVelocity>(e, MotionVelocity{{0.0f, params.speed}});
+    reg.emplace<Vector2>(e, Vector2{0.0f, params.speed});
     finish_obstacle(reg, e);
     return e;
 }

--- a/app/entities/obstacle_entity.h
+++ b/app/entities/obstacle_entity.h
@@ -18,12 +18,12 @@ struct ObstacleSpawnParams {
 
 // Creates and fully configures an obstacle entity:
 //   ObstacleTag + DrawLayer + kind-specific components + mesh child entities.
-//   Non-rhythm obstacles get MotionVelocity.
+//   Non-rhythm obstacles get a Vector2 velocity (raw type, see transform.h).
 // Owns the complete component bundle contract for obstacles.
 entt::entity spawn_obstacle(entt::registry& reg, const ObstacleSpawnParams& params);
 
 // Creates a song-time-authoritative rhythm obstacle:
 //   ObstacleTag + BeatInfo + DrawLayer + kind-specific components + mesh children.
-// Rhythm obstacles intentionally do not get MotionVelocity.
+// Rhythm obstacles intentionally do not get a velocity Vector2.
 entt::entity spawn_rhythm_obstacle(entt::registry& reg, const ObstacleSpawnParams& params,
                                    const BeatInfo& beat_info);

--- a/app/entities/popup_entity.cpp
+++ b/app/entities/popup_entity.cpp
@@ -34,7 +34,7 @@ entt::entity spawn_score_popup(entt::registry& reg, const PopupSpawnParams& para
     auto popup = reg.create();
 
     reg.emplace<WorldTransform>(popup, WorldTransform{{params.x, params.y - 40.0f}});
-    reg.emplace<MotionVelocity>(popup, MotionVelocity{{0.0f, -80.0f}});
+    reg.emplace<Vector2>(popup, Vector2{0.0f, -80.0f});
     const bool has_timing_tier = params.timing_tier.has_value();
     const TimingTier timing_tier = has_timing_tier ? *params.timing_tier : TimingTier::Ok;
     reg.emplace<ScorePopup>(popup, params.points, has_timing_tier, timing_tier,

--- a/app/entities/popup_entity.h
+++ b/app/entities/popup_entity.h
@@ -24,7 +24,7 @@ struct PopupSpawnParams {
 };
 
 // Creates a fully-initialized score popup entity:
-//   WorldTransform at {x, y-40}, MotionVelocity {0, -80}, ScorePopup,
+//   WorldTransform at {x, y-40}, Vector2 velocity {0, -80}, ScorePopup,
 //   Color (by timing tier), DrawLayer::Effects, TagHUDPass, PopupDisplay.
 // Audio push is the caller's responsibility.
 entt::entity spawn_score_popup(entt::registry& reg, const PopupSpawnParams& params);

--- a/app/systems/motion_system.cpp
+++ b/app/systems/motion_system.cpp
@@ -4,12 +4,13 @@
 #include "../components/rhythm.h"
 
 void motion_system(entt::registry& reg, float dt) {
-    // MotionVelocity is the ownership marker for dt-integrated movement.
-    // Song-time-authoritative rhythm obstacles have BeatInfo instead.
-    auto motion_view = reg.view<WorldTransform, MotionVelocity>();
+    // A raw Vector2 component is the ownership marker for dt-integrated
+    // movement (issue #1198: MotionVelocity wrapper unwrapped). Song-time-
+    // authoritative rhythm obstacles have BeatInfo instead.
+    auto motion_view = reg.view<WorldTransform, Vector2>();
     for (auto [entity_id, transform, velocity] : motion_view.each()) {
         (void)entity_id;
-        transform.position.x += velocity.value.x * dt;
-        transform.position.y += velocity.value.y * dt;
+        transform.position.x += velocity.x * dt;
+        transform.position.y += velocity.y * dt;
     }
 }

--- a/app/systems/particle_system.cpp
+++ b/app/systems/particle_system.cpp
@@ -42,14 +42,14 @@ void particle_system(entt::registry& reg, float dt) {
     const auto* settings_ptr = find_settings_state(reg);
     const bool reduce_motion = settings_ptr && settings_ptr->reduce_motion;
 
-    auto vel_view = reg.view<ParticleTag, MotionVelocity>();
+    auto vel_view = reg.view<ParticleTag, Vector2>();
     for (auto [entity, vel] : vel_view.each()) {
         (void)entity;
         if (reduce_motion) {
-            vel.value.x = 0.0f;
-            vel.value.y = 0.0f;
+            vel.x = 0.0f;
+            vel.y = 0.0f;
         } else {
-            vel.value.y += constants::PARTICLE_GRAVITY * dt;
+            vel.y += constants::PARTICLE_GRAVITY * dt;
         }
     }
 }

--- a/app/systems/popup_display_system.cpp
+++ b/app/systems/popup_display_system.cpp
@@ -28,11 +28,11 @@ void popup_display_system(entt::registry& reg, float dt) {
     const auto* settings_ptr = find_settings_state(reg);
     const bool reduce_motion = settings_ptr && settings_ptr->reduce_motion;
     if (reduce_motion) {
-        auto drift_view = reg.view<ScorePopup, MotionVelocity>();
+        auto drift_view = reg.view<ScorePopup, Vector2>();
         for (auto [entity, popup, vel] : drift_view.each()) {
             (void)entity; (void)popup;
-            vel.value.x = 0.0f;
-            vel.value.y = 0.0f;
+            vel.x = 0.0f;
+            vel.y = 0.0f;
         }
     }
 

--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -74,7 +74,7 @@ void spawn_score_particles(entt::registry& reg, const Vector2& position, Color c
         reg.emplace<ParticleTag>(particle);
         reg.emplace<ParticleData>(particle, kSize, kLifetime, kLifetime);
         reg.emplace<WorldTransform>(particle, WorldTransform{position});
-        reg.emplace<MotionVelocity>(particle, MotionVelocity{Vector2Scale(dir, kSpeed)});
+        reg.emplace<Vector2>(particle, Vector2Scale(dir, kSpeed));
         reg.emplace<Color>(particle, color);
         reg.emplace<TagEffectsPass>(particle);
     }

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -138,10 +138,10 @@ static TestPlayerAction determine_action(
     } else {
         // Estimate from position + velocity
         auto* wt  = reg.try_get<WorldTransform>(entity);
-        auto* vel = reg.try_get<MotionVelocity>(entity);
-        if (wt && vel && vel->value.y > 0.0f) {
+        auto* vel = reg.try_get<Vector2>(entity);
+        if (wt && vel && vel->y > 0.0f) {
             action.arrival_time = song.song_time +
-                (constants::PLAYER_Y - wt->position.y) / vel->value.y;
+                (constants::PLAYER_Y - wt->position.y) / vel->y;
         }
     }
 

--- a/benchmarks/bench_systems.cpp
+++ b/benchmarks/bench_systems.cpp
@@ -56,7 +56,7 @@ static void spawn_obstacles(entt::registry& reg, int count) {
         reg.emplace<ObstacleTag>(obs);
         float y = constants::SPAWN_Y + static_cast<float>(i) * 80.0f;
         reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[i % 3], y}});
-        reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, song.scroll_speed}});
+        reg.emplace<Vector2>(obs, Vector2{0.0f, song.scroll_speed});
         auto shape = static_cast<Shape>(i % 3);
         reg.emplace<Obstacle>(obs, int16_t{200});
         reg.emplace<RequiredShape>(obs, shape);
@@ -67,7 +67,7 @@ static void spawn_obstacles(entt::registry& reg, int count) {
 }
 
 // Spawns obstacles with the production scroll_system archetype:
-// WorldTransform + MotionVelocity (freeplay non-beat path, exclude BeatInfo).
+// WorldTransform + Vector2 (freeplay non-beat path, exclude BeatInfo).
 static void spawn_scroll_obstacles(entt::registry& reg, int count) {
     const auto& song = reg.ctx().get<SongState>();
     for (int i = 0; i < count; ++i) {
@@ -75,13 +75,13 @@ static void spawn_scroll_obstacles(entt::registry& reg, int count) {
         reg.emplace<ObstacleTag>(obs);
         float y = constants::SPAWN_Y + static_cast<float>(i) * 80.0f;
         reg.emplace<WorldTransform>(obs, WorldTransform{{0.0f, y}});
-        reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, song.scroll_speed}});
+        reg.emplace<Vector2>(obs, Vector2{0.0f, song.scroll_speed});
         reg.emplace<Obstacle>(obs, int16_t{200});
         reg.emplace<DrawLayer>(obs, Layer::Game);
     }
 }
 
-// Spawns particles using the production archetype: WorldTransform+MotionVelocity.
+// Spawns particles using the production archetype: WorldTransform+Vector2.
 // These are processed by motion_system's motion_view and rendered
 // by camera_system via ParticleTag+WorldTransform.
 static void spawn_particles(entt::registry& reg, int count) {
@@ -89,7 +89,7 @@ static void spawn_particles(entt::registry& reg, int count) {
         auto p = reg.create();
         reg.emplace<ParticleTag>(p);
         reg.emplace<WorldTransform>(p, WorldTransform{{360.0f, 500.0f}});
-        reg.emplace<MotionVelocity>(p, MotionVelocity{{static_cast<float>(i % 50 - 25), -100.0f}});
+        reg.emplace<Vector2>(p, Vector2{static_cast<float>(i % 50 - 25), -100.0f});
         reg.emplace<ParticleData>(p, 4.0f, 0.6f, 0.6f);
         reg.emplace<Color>(p, Color{255, 100, 50, 255});
         reg.emplace<DrawLayer>(p, Layer::Effects);
@@ -125,7 +125,7 @@ TEST_CASE("Bench: collision_system", "[!benchmark][bench]") {
         auto obs = reg.create();
         reg.emplace<ObstacleTag>(obs);
         reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
-        reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, 400.0f}});
+        reg.emplace<Vector2>(obs, Vector2{0.0f, 400.0f});
         reg.emplace<Obstacle>(obs, int16_t{200});
         reg.emplace<RequiredShape>(obs, Shape::Circle);
         meter.measure([&] {
@@ -159,7 +159,7 @@ TEST_CASE("Bench: scoring_system", "[!benchmark][bench]") {
             auto obs = reg.create();
             reg.emplace<ObstacleTag>(obs);
             reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
-            reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, 400.0f}});
+            reg.emplace<Vector2>(obs, Vector2{0.0f, 400.0f});
             reg.emplace<Obstacle>(obs, int16_t{200});
             reg.emplace<ScoredTag>(obs);
             reg.emplace<DrawLayer>(obs, Layer::Game);

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -473,7 +473,7 @@ TEST_CASE("beat_scheduler: obstacles spawn with overshoot compensation", "[beat_
     }
 }
 
-TEST_CASE("beat_scheduler: rhythm obstacles omit MotionVelocity", "[beat_scheduler]") {
+TEST_CASE("beat_scheduler: rhythm obstacles omit Vector2", "[beat_scheduler]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
@@ -488,9 +488,9 @@ TEST_CASE("beat_scheduler: rhythm obstacles omit MotionVelocity", "[beat_schedul
     REQUIRE(std::distance(view.begin(), view.end()) == 1);
     for (auto [e, info] : view.each()) {
         (void)info;
-        CHECK_FALSE(reg.all_of<MotionVelocity>(e));
+        CHECK_FALSE(reg.all_of<Vector2>(e));
     }
-    auto invalid_view = reg.view<ObstacleTag, BeatInfo, MotionVelocity>();
+    auto invalid_view = reg.view<ObstacleTag, BeatInfo, Vector2>();
     CHECK(std::distance(invalid_view.begin(), invalid_view.end()) == 0);
 }
 

--- a/tests/test_collision_extended.cpp
+++ b/tests/test_collision_extended.cpp
@@ -69,7 +69,7 @@ TEST_CASE("collision: Hexagon fails even when matching gate shape", "[collision]
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
-    reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, 400.0f}});
+    reg.emplace<Vector2>(obs, Vector2{0.0f, 400.0f});
     reg.emplace<Obstacle>(obs, int16_t{200});
     reg.emplace<RequiredShape>(obs, Shape::Hexagon);
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -291,7 +291,7 @@ TEST_CASE("collision: combo gate requires shape AND lane", "[collision]") {
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
-    reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, song.scroll_speed}});
+    reg.emplace<Vector2>(obs, Vector2{0.0f, song.scroll_speed});
     reg.emplace<Obstacle>(obs, int16_t{200});
     reg.emplace<RequiredShape>(obs, Shape::Circle);
     // Block lanes 0 and 2, leave lane 1 open
@@ -312,7 +312,7 @@ TEST_CASE("collision: combo gate fails with wrong shape", "[collision]") {
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
-    reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, song.scroll_speed}});
+    reg.emplace<Vector2>(obs, Vector2{0.0f, song.scroll_speed});
     reg.emplace<Obstacle>(obs, int16_t{200});
     reg.emplace<RequiredShape>(obs, Shape::Triangle);  // wrong shape
     reg.emplace<uint8_t>(obs, uint8_t{0b101});    // lane 1 open

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -15,9 +15,9 @@ TEST_CASE("components: WorldTransform defaults to origin position", "[components
 }
 
 TEST_CASE("components: MotionVelocity defaults to zero vector", "[components][transform]") {
-    MotionVelocity velocity{};
-    CHECK(velocity.value.x == 0.0f);
-    CHECK(velocity.value.y == 0.0f);
+    Vector2 velocity{0.0f, 0.0f};
+    CHECK(velocity.x == 0.0f);
+    CHECK(velocity.y == 0.0f);
 }
 
 TEST_CASE("components: rendering components are safely default constructible",
@@ -241,9 +241,9 @@ TEST_CASE("ecs: make_player creates proper entity", "[ecs]") {
 }
 
 TEST_CASE("components: MotionVelocity explicit construction", "[components][transform]") {
-    MotionVelocity mv{{5.0f, 10.0f}};
-    CHECK(mv.value.x == 5.0f);
-    CHECK(mv.value.y == 10.0f);
+    Vector2 mv{5.0f, 10.0f};
+    CHECK(mv.x == 5.0f);
+    CHECK(mv.y == 10.0f);
 }
 
 TEST_CASE("components: Color construction", "[components]") {

--- a/tests/test_death_model_unified.cpp
+++ b/tests/test_death_model_unified.cpp
@@ -105,7 +105,7 @@ TEST_CASE("death_model: close hit banks points without instant GameOver", "[deat
     auto obstacle = reg.create();
     reg.emplace<ObstacleTag>(obstacle);
     reg.emplace<WorldTransform>(obstacle, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
-    reg.emplace<MotionVelocity>(obstacle, MotionVelocity{{0.0f, 0.0f}});
+    reg.emplace<Vector2>(obstacle, Vector2{0.0f, 0.0f});
     reg.emplace<Obstacle>(obstacle, int16_t{constants::PTS_SHAPE_GATE});
     reg.emplace<RequiredShape>(obstacle, Shape::Circle);
 
@@ -124,7 +124,7 @@ TEST_CASE("death_model: close miss drains energy instead of instant GameOver", "
     auto obstacle = reg.create();
     reg.emplace<ObstacleTag>(obstacle);
     reg.emplace<WorldTransform>(obstacle, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
-    reg.emplace<MotionVelocity>(obstacle, MotionVelocity{{0.0f, 0.0f}});
+    reg.emplace<Vector2>(obstacle, Vector2{0.0f, 0.0f});
     reg.emplace<Obstacle>(obstacle, int16_t{constants::PTS_SHAPE_GATE});
     reg.emplace<RequiredShape>(obstacle, Shape::Triangle);
 

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -215,7 +215,7 @@ inline entt::entity make_shape_gate(entt::registry& reg, Shape shape, float y) {
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], y}});
-    reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, song.scroll_speed}});
+    reg.emplace<Vector2>(obs, Vector2{0.0f, song.scroll_speed});
     reg.emplace<Obstacle>(obs, int16_t{constants::PTS_SHAPE_GATE});
     reg.emplace<RequiredShape>(obs, shape);
     reg.emplace<ShapeGateLane>(obs, int8_t{1});
@@ -233,7 +233,7 @@ inline entt::entity make_lane_block(entt::registry& reg, uint8_t mask, float y) 
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], y}});
-    reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, song.scroll_speed}});
+    reg.emplace<Vector2>(obs, Vector2{0.0f, song.scroll_speed});
     reg.emplace<Obstacle>(obs, int16_t{constants::PTS_LANE_BLOCK});
     reg.emplace<uint8_t>(obs, mask);
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W / 3), 80.0f);
@@ -251,7 +251,7 @@ inline entt::entity make_combo_gate(entt::registry& reg, Shape shape, uint8_t bl
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], y}});
-    reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, song.scroll_speed}});
+    reg.emplace<Vector2>(obs, Vector2{0.0f, song.scroll_speed});
     reg.emplace<Obstacle>(obs, int16_t{constants::PTS_COMBO_GATE});
     reg.emplace<RequiredShape>(obs, shape);
     reg.emplace<uint8_t>(obs, blocked_mask);
@@ -268,7 +268,7 @@ inline entt::entity make_split_path(entt::registry& reg, Shape shape, int8_t lan
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], y}});
-    reg.emplace<MotionVelocity>(obs, MotionVelocity{{0.0f, song.scroll_speed}});
+    reg.emplace<Vector2>(obs, Vector2{0.0f, song.scroll_speed});
     reg.emplace<Obstacle>(obs, int16_t{constants::PTS_SPLIT_PATH});
     reg.emplace<RequiredShape>(obs, shape);
     reg.emplace<RequiredLane>(obs, lane);

--- a/tests/test_obstacle_archetypes.cpp
+++ b/tests/test_obstacle_archetypes.cpp
@@ -51,7 +51,7 @@ TEST_CASE("entity: ShapeGate Circle - correct components and color", "[archetype
     entt::registry reg;
     auto e = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f, Shape::Circle});
 
-    REQUIRE(reg.all_of<ObstacleTag, MotionVelocity, DrawLayer, WorldTransform, Obstacle, RequiredShape, ShapeGateLane, DrawSize, Color>(e));
+    REQUIRE(reg.all_of<ObstacleTag, Vector2, DrawLayer, WorldTransform, Obstacle, RequiredShape, ShapeGateLane, DrawSize, Color>(e));
     CHECK(!reg.all_of<uint8_t>(e));
     CHECK(!reg.all_of<RequiredLane>(e));
 
@@ -258,7 +258,7 @@ TEST_CASE("entity: SplitPath - RequiredShape and RequiredLane", "[archetype]") {
     auto e = spawn_obstacle(reg, {ObstacleKind::SplitPath, 360.0f, -120.0f,
                                    Shape::Square, uint8_t{0}, int8_t{2}});
 
-    REQUIRE(reg.all_of<ObstacleTag, MotionVelocity, DrawLayer, WorldTransform, Obstacle, RequiredShape, RequiredLane, DrawSize, Color>(e));
+    REQUIRE(reg.all_of<ObstacleTag, Vector2, DrawLayer, WorldTransform, Obstacle, RequiredShape, RequiredLane, DrawSize, Color>(e));
     CHECK(!reg.all_of<uint8_t>(e));
 
     CHECK(reg.get<Obstacle>(e).base_points == int16_t{constants::PTS_SPLIT_PATH});
@@ -282,7 +282,7 @@ TEST_CASE("entity: BeatInfo emplaced when provided", "[archetype]") {
     auto e = spawn_rhythm_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f}, bi);
 
     REQUIRE(reg.all_of<BeatInfo>(e));
-    CHECK_FALSE(reg.all_of<MotionVelocity>(e));
+    CHECK_FALSE(reg.all_of<Vector2>(e));
     CHECK(reg.get<BeatInfo>(e).beat_index == 5);
     CHECK(reg.get<BeatInfo>(e).arrival_time == 1.5f);
     CHECK(reg.get<BeatInfo>(e).spawn_time == 1.0f);
@@ -293,5 +293,5 @@ TEST_CASE("entity: no BeatInfo when not provided", "[archetype]") {
     auto e = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f});
 
     CHECK_FALSE(reg.all_of<BeatInfo>(e));
-    CHECK(reg.all_of<MotionVelocity>(e));
+    CHECK(reg.all_of<Vector2>(e));
 }

--- a/tests/test_particle_system.cpp
+++ b/tests/test_particle_system.cpp
@@ -10,7 +10,7 @@ static entt::entity make_particle(entt::registry& reg, float size, float life_re
     auto e = reg.create();
     reg.emplace<ParticleTag>(e);
     reg.emplace<ParticleData>(e, size, life_remaining, life_max);
-    reg.emplace<MotionVelocity>(e, MotionVelocity{{vx, vy}});
+    reg.emplace<Vector2>(e, Vector2{vx, vy});
     reg.emplace<WorldTransform>(e, WorldTransform{{100.0f, 200.0f}});
     reg.emplace<TagEffectsPass>(e);
     return e;
@@ -78,8 +78,8 @@ TEST_CASE("particle: gravity increases downward velocity", "[particle]") {
 
     particle_system(reg, 0.1f);
 
-    auto& vel = reg.get<MotionVelocity>(e);
-    CHECK_THAT(vel.value.y, Catch::Matchers::WithinAbs(constants::PARTICLE_GRAVITY * 0.1f, 0.01f));
+    auto& vel = reg.get<Vector2>(e);
+    CHECK_THAT(vel.y, Catch::Matchers::WithinAbs(constants::PARTICLE_GRAVITY * 0.1f, 0.01f));
 }
 
 TEST_CASE("particle: gravity accumulates over multiple frames", "[particle]") {
@@ -89,8 +89,8 @@ TEST_CASE("particle: gravity accumulates over multiple frames", "[particle]") {
     particle_system(reg, 0.1f);
     particle_system(reg, 0.1f);
 
-    auto& vel = reg.get<MotionVelocity>(e);
-    CHECK_THAT(vel.value.y, Catch::Matchers::WithinAbs(constants::PARTICLE_GRAVITY * 0.2f, 0.01f));
+    auto& vel = reg.get<Vector2>(e);
+    CHECK_THAT(vel.y, Catch::Matchers::WithinAbs(constants::PARTICLE_GRAVITY * 0.2f, 0.01f));
 }
 
 TEST_CASE("particle: gravity does not affect horizontal velocity", "[particle]") {
@@ -99,7 +99,7 @@ TEST_CASE("particle: gravity does not affect horizontal velocity", "[particle]")
 
     particle_system(reg, 0.1f);
 
-    CHECK(reg.get<MotionVelocity>(e).value.x == 50.0f);
+    CHECK(reg.get<Vector2>(e).x == 50.0f);
 }
 
 TEST_CASE("particle: no particles means no crash", "[particle]") {
@@ -122,9 +122,9 @@ TEST_CASE("particle: reduce_motion zeroes velocity and disables gravity (#534)",
     // Velocity is clamped to zero — no continuous drift, no gravity
     // accumulation. Particle still ages and despawns on its lifetime
     // (functional state preserved).
-    const auto& vel = reg.get<MotionVelocity>(e);
-    CHECK(vel.value.x == 0.0f);
-    CHECK(vel.value.y == 0.0f);
+    const auto& vel = reg.get<Vector2>(e);
+    CHECK(vel.x == 0.0f);
+    CHECK(vel.y == 0.0f);
 
     // Lifetime still ticks down per dt.
     CHECK(reg.get<ParticleData>(e).remaining < 1.0f);
@@ -137,7 +137,7 @@ TEST_CASE("particle: reduce_motion=false preserves gravity behavior (#534)",
 
     auto e = make_particle(reg, 5.0f, 1.0f, 1.0f, 0.0f, 0.0f);
     particle_system(reg, 0.1f);
-    CHECK_THAT(reg.get<MotionVelocity>(e).value.y,
+    CHECK_THAT(reg.get<Vector2>(e).y,
                Catch::Matchers::WithinAbs(constants::PARTICLE_GRAVITY * 0.1f, 0.01f));
 }
 

--- a/tests/test_popup_display_system.cpp
+++ b/tests/test_popup_display_system.cpp
@@ -27,7 +27,7 @@
 #include "systems/popup_display_system.h"
 #include "components/text.h"      // FontSize
 #include "components/rhythm.h"    // TimingTier
-#include "components/transform.h" // WorldTransform, MotionVelocity
+#include "components/transform.h" // WorldTransform, Vector2
 #include "entities/settings.h"        // SettingsState (reduce_motion)
 #include "systems/all_systems.h"  // popup_display_system declaration
 #include "entities/popup_entity.h"
@@ -225,7 +225,7 @@ TEST_CASE("spawn_score_popup: creates the full popup display archetype",
     entt::registry reg;
     auto e = spawn_score_popup(reg, {100.0f, 200.0f, 50, TimingTier::Good});
 
-    REQUIRE(reg.all_of<ScorePopup, PopupDisplay, Color, MotionVelocity,
+    REQUIRE(reg.all_of<ScorePopup, PopupDisplay, Color, Vector2,
                        WorldTransform, DrawLayer, TagHUDPass>(e));
     CHECK(reg.get<ScorePopup>(e).has_timing_tier);
     CHECK(reg.get<ScorePopup>(e).timing_tier == TimingTier::Good);
@@ -284,15 +284,15 @@ TEST_CASE("spawn_score_popup: entity has WorldTransform at pos - 40",
     CHECK(wt.position.y == 460.0f);  // 500 - 40
 }
 
-TEST_CASE("spawn_score_popup: entity has MotionVelocity {0, -80}",
+TEST_CASE("spawn_score_popup: entity has Vector2 {0, -80}",
           "[popup_entity][issue349]") {
     entt::registry reg;
     auto e = spawn_score_popup(reg, {0.0f, 0.0f, 100, std::nullopt});
 
-    REQUIRE(reg.all_of<MotionVelocity>(e));
-    const auto& mv = reg.get<MotionVelocity>(e);
-    CHECK(mv.value.x == 0.0f);
-    CHECK(mv.value.y == -80.0f);
+    REQUIRE(reg.all_of<Vector2>(e));
+    const auto& mv = reg.get<Vector2>(e);
+    CHECK(mv.x == 0.0f);
+    CHECK(mv.y == -80.0f);
 }
 
 TEST_CASE("spawn_score_popup: ScorePopup has correct points and duration",
@@ -428,14 +428,14 @@ TEST_CASE("popup_display_system: reduce_motion zeroes drift velocity (#534)",
     settings_state(reg).reduce_motion = true;
 
     auto e = spawn_score_popup(reg, {100.0f, 500.0f, 200, TimingTier::Perfect});
-    REQUIRE(reg.all_of<MotionVelocity>(e));
-    REQUIRE(reg.get<MotionVelocity>(e).value.y == -80.0f);
+    REQUIRE(reg.all_of<Vector2>(e));
+    REQUIRE(reg.get<Vector2>(e).y == -80.0f);
 
     popup_display_system(reg, 0.016f);
 
-    const auto& vel = reg.get<MotionVelocity>(e);
-    CHECK(vel.value.x == 0.0f);
-    CHECK(vel.value.y == 0.0f);
+    const auto& vel = reg.get<Vector2>(e);
+    CHECK(vel.x == 0.0f);
+    CHECK(vel.y == 0.0f);
 
     // Informational channel (text/colour/value) is unchanged.
     const auto& pd = reg.get<PopupDisplay>(e);
@@ -456,8 +456,8 @@ TEST_CASE("popup_display_system: reduce_motion=false leaves drift untouched (#53
     auto e = spawn_score_popup(reg, {0.0f, 0.0f, 100, TimingTier::Good});
     popup_display_system(reg, 0.016f);
 
-    const auto& vel = reg.get<MotionVelocity>(e);
-    CHECK(vel.value.y == -80.0f);  // popup_display_system never touches it
+    const auto& vel = reg.get<Vector2>(e);
+    CHECK(vel.y == -80.0f);  // popup_display_system never touches it
 }
 
 // #1089 — PopupDisplayScratch::capacity_exceeded_count must stay at zero when

--- a/tests/test_rhythm_system.cpp
+++ b/tests/test_rhythm_system.cpp
@@ -291,7 +291,7 @@ TEST_CASE("beat_scheduler: spawns multiple when time catches up", "[rhythm][sche
     CHECK(reg.view<ObstacleTag>().size() == 2);
 }
 
-TEST_CASE("beat_scheduler: rhythm obstacles use BeatInfo without MotionVelocity", "[rhythm][scheduler]") {
+TEST_CASE("beat_scheduler: rhythm obstacles use BeatInfo without Vector2", "[rhythm][scheduler]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
@@ -302,9 +302,9 @@ TEST_CASE("beat_scheduler: rhythm obstacles use BeatInfo without MotionVelocity"
     REQUIRE(std::distance(obs_view.begin(), obs_view.end()) == 1);
     for (auto [e, info] : obs_view.each()) {
         (void)info;
-        CHECK_FALSE(reg.all_of<MotionVelocity>(e));
+        CHECK_FALSE(reg.all_of<Vector2>(e));
     }
-    auto invalid_view = reg.view<ObstacleTag, BeatInfo, MotionVelocity>();
+    auto invalid_view = reg.view<ObstacleTag, BeatInfo, Vector2>();
     CHECK(std::distance(invalid_view.begin(), invalid_view.end()) == 0);
 }
 

--- a/tests/test_scoring_system.cpp
+++ b/tests/test_scoring_system.cpp
@@ -148,7 +148,7 @@ TEST_CASE("scoring: popup entity spawned on score", "[scoring]") {
     int popup_count = 0;
     for (auto e : popup_view) {
         CHECK(reg.all_of<WorldTransform>(e));
-        CHECK(reg.all_of<MotionVelocity>(e));
+        CHECK(reg.all_of<Vector2>(e));
         CHECK(reg.all_of<TagHUDPass>(e));
         ++popup_count;
     }
@@ -165,13 +165,13 @@ TEST_CASE("scoring: score feedback spawns effect particles", "[scoring][particle
 
     int particle_count = 0;
     auto particle_view =
-        reg.view<ParticleTag, ParticleData, WorldTransform, MotionVelocity, Color, TagEffectsPass>();
+        reg.view<ParticleTag, ParticleData, WorldTransform, Vector2, Color, TagEffectsPass>();
     for (auto [entity, particle, transform, velocity, color] : particle_view.each()) {
         CHECK(reg.valid(entity));
         CHECK(particle.remaining > 0.0f);
         CHECK(particle.max_time > 0.0f);
         CHECK(transform.position.y == constants::PLAYER_Y);
-        CHECK((velocity.value.x != 0.0f || velocity.value.y != 0.0f));
+        CHECK((velocity.x != 0.0f || velocity.y != 0.0f));
         CHECK(color.a > 0);
         ++particle_count;
     }
@@ -357,15 +357,15 @@ TEST_CASE("scoring: popup entity has full factory contract", "[scoring][popup_en
     for (auto e : popup_view) {
         ++count;
         CHECK(reg.all_of<WorldTransform>(e));
-        CHECK(reg.all_of<MotionVelocity>(e));
+        CHECK(reg.all_of<Vector2>(e));
         CHECK(reg.all_of<Color>(e));
         CHECK(reg.all_of<DrawLayer>(e));
         CHECK(reg.all_of<TagHUDPass>(e));
         CHECK(reg.all_of<PopupDisplay>(e));
 
-        const auto& mv = reg.get<MotionVelocity>(e);
-        CHECK(mv.value.x == 0.0f);
-        CHECK(mv.value.y == -80.0f);
+        const auto& mv = reg.get<Vector2>(e);
+        CHECK(mv.x == 0.0f);
+        CHECK(mv.y == -80.0f);
 
         const auto& dl = reg.get<DrawLayer>(e);
         CHECK(dl.layer == Layer::Effects);

--- a/tests/test_scroll_rhythm.cpp
+++ b/tests/test_scroll_rhythm.cpp
@@ -23,7 +23,7 @@ TEST_CASE("scroll: rhythm obstacles positioned from song_time and BeatInfo", "[s
     CHECK_THAT(reg.get<WorldTransform>(obs).position.y, Catch::Matchers::WithinAbs(expected_y, 0.1f));
 }
 
-TEST_CASE("scroll: rhythm obstacles ignore MotionVelocity component", "[scroll][rhythm]") {
+TEST_CASE("scroll: rhythm obstacles ignore Vector2 component", "[scroll][rhythm]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 1.0f;
@@ -31,12 +31,12 @@ TEST_CASE("scroll: rhythm obstacles ignore MotionVelocity component", "[scroll][
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
     reg.emplace<WorldTransform>(obs, WorldTransform{{100.0f, 0.0f}});
-    reg.emplace<MotionVelocity>(obs, MotionVelocity{{999.0f, 999.0f}});
+    reg.emplace<Vector2>(obs, Vector2{999.0f, 999.0f});
     reg.emplace<BeatInfo>(obs, 0, 3.0f, 0.0f);
 
     scroll_system(reg, 1.0f);
 
-    // X should not change (MotionVelocity is irrelevant for BeatInfo entities in rhythm mode)
+    // X should not change (Vector2 is irrelevant for BeatInfo entities in rhythm mode)
     float expected_y = constants::SPAWN_Y + (1.0f - 0.0f) * song.scroll_speed;
     CHECK_THAT(reg.get<WorldTransform>(obs).position.x, Catch::Matchers::WithinAbs(100.0f, 0.01f));
     CHECK_THAT(reg.get<WorldTransform>(obs).position.y, Catch::Matchers::WithinAbs(expected_y, 0.1f));
@@ -47,7 +47,7 @@ TEST_CASE("motion: non-rhythm entities use dt-based movement", "[motion][rhythm]
 
     auto particle = reg.create();
     reg.emplace<WorldTransform>(particle, WorldTransform{{100.0f, 200.0f}});
-    reg.emplace<MotionVelocity>(particle, MotionVelocity{{10.0f, 20.0f}});
+    reg.emplace<Vector2>(particle, Vector2{10.0f, 20.0f});
     // No BeatInfo → dt-based
 
     motion_system(reg, 0.5f);

--- a/tests/test_world_systems.cpp
+++ b/tests/test_world_systems.cpp
@@ -5,14 +5,14 @@
 // ── motion_system ────────────────────────────────────────────
 //
 // Single path after #349 migration:
-//   motion_view — WorldTransform+MotionVelocity (obstacles, popups, particles, player)
+//   motion_view — WorldTransform+Vector2 (obstacles, popups, particles, player)
 //                 also bridges to Position when both components are present.
 
-TEST_CASE("motion: WorldTransform+MotionVelocity moves by velocity * dt", "[motion]") {
+TEST_CASE("motion: WorldTransform+Vector2 moves by velocity * dt", "[motion]") {
     auto reg = make_registry();
     auto e = reg.create();
     reg.emplace<WorldTransform>(e, WorldTransform{{100.0f, 200.0f}});
-    reg.emplace<MotionVelocity>(e, MotionVelocity{{10.0f, 20.0f}});
+    reg.emplace<Vector2>(e, Vector2{10.0f, 20.0f});
 
     motion_system(reg, 1.0f);
 
@@ -20,11 +20,11 @@ TEST_CASE("motion: WorldTransform+MotionVelocity moves by velocity * dt", "[moti
     CHECK(reg.get<WorldTransform>(e).position.y == 220.0f);
 }
 
-TEST_CASE("motion: zero MotionVelocity means no movement", "[motion]") {
+TEST_CASE("motion: zero Vector2 means no movement", "[motion]") {
     auto reg = make_registry();
     auto e = reg.create();
     reg.emplace<WorldTransform>(e, WorldTransform{{100.0f, 200.0f}});
-    reg.emplace<MotionVelocity>(e, MotionVelocity{{0.0f, 0.0f}});
+    reg.emplace<Vector2>(e, Vector2{0.0f, 0.0f});
 
     motion_system(reg, 1.0f);
 
@@ -32,13 +32,13 @@ TEST_CASE("motion: zero MotionVelocity means no movement", "[motion]") {
     CHECK(reg.get<WorldTransform>(e).position.y == 200.0f);
 }
 
-// ── motion_system: WorldTransform+MotionVelocity path (modern, issue #349 target) ──
+// ── motion_system: WorldTransform+Vector2 path (modern, issue #349 target) ──
 
-TEST_CASE("motion: WorldTransform+MotionVelocity entity moves by velocity * dt", "[motion]") {
+TEST_CASE("motion: WorldTransform+Vector2 entity moves by velocity * dt", "[motion]") {
     auto reg = make_registry();
     auto e = reg.create();
     reg.emplace<WorldTransform>(e, WorldTransform{{100.0f, 200.0f}});
-    reg.emplace<MotionVelocity>(e, MotionVelocity{{10.0f, 20.0f}});
+    reg.emplace<Vector2>(e, Vector2{10.0f, 20.0f});
 
     motion_system(reg, 1.0f);
 
@@ -49,7 +49,7 @@ TEST_CASE("motion: WorldTransform+MotionVelocity entity moves by velocity * dt",
 
 TEST_CASE("motion: BeatInfo alone does not make an entity movable", "[motion]") {
     // Rhythm obstacles are song-time authoritative and should not carry
-    // MotionVelocity. BeatInfo by itself is ignored by motion_system.
+    // Vector2. BeatInfo by itself is ignored by motion_system.
     auto reg = make_registry();
     auto e = reg.create();
     reg.emplace<WorldTransform>(e, WorldTransform{{100.0f, 200.0f}});
@@ -429,7 +429,7 @@ TEST_CASE("scroll: no movement when not in Playing phase", "[scroll]") {
     reg.ctx().get<GameState>().phase = GamePhase::Title;
     auto e = reg.create();
     reg.emplace<WorldTransform>(e, WorldTransform{{100.0f, 200.0f}});
-    reg.emplace<MotionVelocity>(e, MotionVelocity{{10.0f, 20.0f}});
+    reg.emplace<Vector2>(e, Vector2{10.0f, 20.0f});
 
     scroll_system(reg, 1.0f);
 
@@ -442,7 +442,7 @@ TEST_CASE("motion: no movement when not in Playing phase", "[motion]") {
     reg.ctx().get<GameState>().phase = GamePhase::Title;
     auto e = reg.create();
     reg.emplace<WorldTransform>(e, WorldTransform{{100.0f, 200.0f}});
-    reg.emplace<MotionVelocity>(e, MotionVelocity{{10.0f, 20.0f}});
+    reg.emplace<Vector2>(e, Vector2{10.0f, 20.0f});
 
     tick_playing_systems(reg, 1.0f);
 


### PR DESCRIPTION
`MotionVelocity { Vector2 value }` was a single-field wrapper around a raw `Vector2` per the wrapper-noise checklist in issue #1198. Deleted the struct and switched the ~60 emplace / view / get / try_get / all_of sites to use `Vector2` directly. The semantic role (per-second velocity for entities that integrate `position += velocity * dt`) is now carried by the presence of a `Vector2` component on the entity together with `WorldTransform`; `motion_system` queries `view<WorldTransform, Vector2>`. Song-time-authoritative rhythm obstacles continue to omit it and carry `BeatInfo` instead.

Same playbook as #1240 (`BlockedLanes` → `uint8_t`). Pre-edit grep confirmed no other `emplace<Vector2>` / `view<...Vector2...>` sites in `app/`, `tests/`, or `benchmarks/`, so the per-entity `Vector2` component slot is unambiguous.

### Slot reservation

The remaining `Vector2`-shaped wrappers in #1198 (`ScreenPosition {float x, y}`, `DrawSize {float w, h}`) must stay as named structs:

- popups carry `WorldTransform` + `Vector2` (velocity) + `ScreenPosition` (after `ui_camera_system`)
- obstacles carry `WorldTransform` + `Vector2` (velocity) + `DrawSize`

Unwrapping either into raw `Vector2` would collide with the velocity slot on those archetypes. A comment in `transform.h` documents the convention next to the deleted struct.

### Doctrinal grounding

Fabian "components-as-data": a 1-column table of two-float velocity rows, keyed by entity, with existence-in-the-storage as the marker for motion-integration membership. Removing the wrapper collapses the table to its actual schema.

### Wrapper-deletion progress (issue #1198)

- 2-float wrappers → `Vector2`
  - [x] `UIPosition` (deleted as dead — #1239)
  - [x] `MotionVelocity` (this PR)
  - [ ] `ScreenPosition` (stays — collides with velocity slot on popups)
  - [ ] `DrawSize` (stays — collides with velocity slot on obstacles)
- Single-int / single-enum wrappers
  - [ ] `DrawLayer` (blocked on #1204 `Layer` eradication)
  - [ ] `RequiredShape` (blocked on #1204 `Shape` eradication)
  - [ ] `ShapeGateLane`
  - [ ] `RequiredLane`
  - [x] `BlockedLanes` (#1240)

### Validation

- 903 Catch2 tests / 2957 assertions pass under both unity and non-unity Clang builds (same as baseline).
- Zero warnings under Clang `-Wall -Wextra -Werror` (unity + non-unity).
- `grep -n MotionVelocity` returns only history-comment / test-name sites remaining.

Refs #1198.