### PR TITLE
Delete dead DrawLayer + Layer enum (refs #1198)

### DIFF
--- a/app/components/rendering.h
+++ b/app/components/rendering.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <cstdint>
-
 #include "tags/tags.h"
 
 // Back-compat shim. The junk-drawer "rendering.h" was split (issue #1194):
@@ -12,8 +10,11 @@
 // Re-included here so existing `#include "components/rendering.h"` sites keep
 // compiling; new code should include the canonical header directly.
 //
-// The wrapper-noise types DrawSize / DrawLayer / Layer / ScreenPosition remain
-// here pending the wrapper deletion sweep (issue #1198).
+// The wrapper-noise types DrawSize / ScreenPosition remain here pending the
+// wrapper deletion sweep (issue #1198). DrawLayer + the Layer enum were
+// deleted as dead in the same sweep — render-pass dispatch already uses the
+// TagWorldPass / TagEffectsPass / TagHUDPass tags (see app/tags/tags.h), no
+// production system ever queried DrawLayer.
 #include "camera_resources.h"
 #include "obstacle.h"
 #include "render_mesh.h"
@@ -21,17 +22,6 @@
 struct DrawSize {
     float w = 64.0f;
     float h = 64.0f;
-};
-
-enum class Layer : uint8_t {
-    Background = 0,
-    Game       = 1,
-    Effects    = 2,
-    HUD        = 3
-};
-
-struct DrawLayer {
-    Layer layer = Layer::Game;
 };
 
 // Screen-space position computed by ui_camera_system for UI rendering.

--- a/app/entities/energy_bar_entity.cpp
+++ b/app/entities/energy_bar_entity.cpp
@@ -15,7 +15,6 @@ entt::entity create_energy_bar_entity(entt::registry& reg) {
     reg.emplace<EnergyBarTag>(energy_bar);
     reg.emplace<EnergyBarLayout>(energy_bar);
     reg.emplace<EnergyBarVisual>(energy_bar);
-    reg.emplace<DrawLayer>(energy_bar, Layer::HUD);
     reg.emplace<TagHUDPass>(energy_bar);
     return energy_bar;
 }

--- a/app/entities/obstacle_entity.cpp
+++ b/app/entities/obstacle_entity.cpp
@@ -29,7 +29,6 @@ entt::entity spawn_obstacle_base(entt::registry& reg, const ObstacleSpawnParams&
 
     auto e = reg.create();
     reg.emplace<WorldTransform>(e, WorldTransform{{params.x, params.y}});
-    reg.emplace<DrawLayer>(e, Layer::Game);
     reg.emplace<TagWorldPass>(e);
 
     switch (params.kind) {

--- a/app/entities/obstacle_entity.h
+++ b/app/entities/obstacle_entity.h
@@ -17,13 +17,13 @@ struct ObstacleSpawnParams {
 };
 
 // Creates and fully configures an obstacle entity:
-//   ObstacleTag + DrawLayer + kind-specific components + mesh child entities.
+//   ObstacleTag + TagWorldPass + kind-specific components + mesh child entities.
 //   Non-rhythm obstacles get a Vector2 velocity (raw type, see transform.h).
 // Owns the complete component bundle contract for obstacles.
 entt::entity spawn_obstacle(entt::registry& reg, const ObstacleSpawnParams& params);
 
 // Creates a song-time-authoritative rhythm obstacle:
-//   ObstacleTag + BeatInfo + DrawLayer + kind-specific components + mesh children.
+//   ObstacleTag + BeatInfo + TagWorldPass + kind-specific components + mesh children.
 // Rhythm obstacles intentionally do not get a velocity Vector2.
 entt::entity spawn_rhythm_obstacle(entt::registry& reg, const ObstacleSpawnParams& params,
                                    const BeatInfo& beat_info);

--- a/app/entities/player_entity.cpp
+++ b/app/entities/player_entity.cpp
@@ -29,7 +29,6 @@ entt::entity create_player_entity(entt::registry& reg) {
     reg.emplace<VerticalState>(player);
     reg.emplace<Color>(player, Color{80, 180, 255, 255});
     reg.emplace<DrawSize>(player, constants::PLAYER_SIZE, constants::PLAYER_SIZE);
-    reg.emplace<DrawLayer>(player, Layer::Game);
     reg.emplace<TagWorldPass>(player);
     return player;
 }

--- a/app/entities/popup_entity.cpp
+++ b/app/entities/popup_entity.cpp
@@ -53,7 +53,6 @@ entt::entity spawn_score_popup(entt::registry& reg, const PopupSpawnParams& para
     }
     Color color{pr, pg, pb, 255};
     reg.emplace<Color>(popup, color);
-    reg.emplace<DrawLayer>(popup, Layer::Effects);
     reg.emplace<TagHUDPass>(popup);
 
     PopupDisplay pd{};

--- a/app/entities/popup_entity.h
+++ b/app/entities/popup_entity.h
@@ -25,6 +25,6 @@ struct PopupSpawnParams {
 
 // Creates a fully-initialized score popup entity:
 //   WorldTransform at {x, y-40}, Vector2 velocity {0, -80}, ScorePopup,
-//   Color (by timing tier), DrawLayer::Effects, TagHUDPass, PopupDisplay.
+//   Color (by timing tier), TagHUDPass, PopupDisplay.
 // Audio push is the caller's responsibility.
 entt::entity spawn_score_popup(entt::registry& reg, const PopupSpawnParams& params);

--- a/benchmarks/bench_systems.cpp
+++ b/benchmarks/bench_systems.cpp
@@ -45,7 +45,6 @@ static entt::entity make_bench_player(entt::registry& reg) {
     reg.emplace<VerticalState>(p);
     reg.emplace<Color>(p, Color{80, 180, 255, 255});
     reg.emplace<DrawSize>(p, constants::PLAYER_SIZE, constants::PLAYER_SIZE);
-    reg.emplace<DrawLayer>(p, Layer::Game);
     return p;
 }
 
@@ -61,7 +60,6 @@ static void spawn_obstacles(entt::registry& reg, int count) {
         reg.emplace<Obstacle>(obs, int16_t{200});
         reg.emplace<RequiredShape>(obs, shape);
         reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);
-        reg.emplace<DrawLayer>(obs, Layer::Game);
         reg.emplace<Color>(obs, Color{255, 255, 255, 255});
     }
 }
@@ -77,7 +75,6 @@ static void spawn_scroll_obstacles(entt::registry& reg, int count) {
         reg.emplace<WorldTransform>(obs, WorldTransform{{0.0f, y}});
         reg.emplace<Vector2>(obs, Vector2{0.0f, song.scroll_speed});
         reg.emplace<Obstacle>(obs, int16_t{200});
-        reg.emplace<DrawLayer>(obs, Layer::Game);
     }
 }
 
@@ -92,7 +89,6 @@ static void spawn_particles(entt::registry& reg, int count) {
         reg.emplace<Vector2>(p, Vector2{static_cast<float>(i % 50 - 25), -100.0f});
         reg.emplace<ParticleData>(p, 4.0f, 0.6f, 0.6f);
         reg.emplace<Color>(p, Color{255, 100, 50, 255});
-        reg.emplace<DrawLayer>(p, Layer::Effects);
     }
 }
 
@@ -162,7 +158,6 @@ TEST_CASE("Bench: scoring_system", "[!benchmark][bench]") {
             reg.emplace<Vector2>(obs, Vector2{0.0f, 400.0f});
             reg.emplace<Obstacle>(obs, int16_t{200});
             reg.emplace<ScoredTag>(obs);
-            reg.emplace<DrawLayer>(obs, Layer::Game);
             reg.emplace<Color>(obs, Color{255, 255, 255, 255});
         }
         meter.measure([&] { scoring_system(reg, DT); });

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -552,18 +552,10 @@ struct DrawSize {
     float h;
 };
 
-/// Draw layer for z-ordering. 1 byte.
-/// Render system iterates layers 0→3.
-enum class Layer : uint8_t {
-    Background = 0,
-    Game       = 1,
-    Effects    = 2,
-    HUD        = 3
-};
-
-struct DrawLayer {
-    Layer layer;
-};
+/// Render-pass membership for an entity is carried by the
+/// TagWorldPass / TagEffectsPass / TagHUDPass tags (see app/tags/tags.h).
+/// DrawLayer + the Layer enum were deleted (issue #1198) — no production
+/// system ever queried them; the pass tags drive all render dispatch.
 ```
 
 ### 2.11 — COLD: Particles
@@ -644,7 +636,6 @@ NonScorableTag       0     WARM       miss_detection/scoring exclusions, visual-
 OnsetMarkerTag       0     WARM       obstacle_render_entity, session_logger
 Color                4     COLD       render
 DrawSize             8     COLD       render
-DrawLayer            1     COLD       render
 PopupDisplay        36     COLD       popup_display (fade), ui_render
 ParticleTag          0     COLD       render (filter)
 EnergyBarTag         0     COLD       energy_bar_system (filter), gameplay_hud (filter)
@@ -887,7 +878,7 @@ In code, reusable construction lives in `app/entities/` factory functions
 │ VerticalState      { mode: Grounded, timer: 0, y_off: 0 }│
 │ Color              { r: 80, g: 180, b: 255, a: 255 }     │
 │ DrawSize           { w: 64, h: 64 }                       │
-│ DrawLayer          { layer: Game }                         │
+│ TagWorldPass       (tag, 0 bytes)                         │
 └───────────────────────────────────────────────────────────┘
 Total: ~97 bytes per entity (1 entity)
 ```
@@ -904,7 +895,7 @@ Total: ~97 bytes per entity (1 entity)
 │ ShapeGateLane      { lane: 1 }                             │
 │ Color              { r: 50, g: 205, b: 50, a: 255 }      │
 │ DrawSize           { w: 720, h: 80 }                       │
-│ DrawLayer          { layer: Game }                          │
+│ TagWorldPass       (tag, 0 bytes)                          │
 └───────────────────────────────────────────────────────────┘
 Total: ~43 bytes per entity (5–15 active)
 ```
@@ -923,7 +914,7 @@ read by `collision_system` so a player must be in the gate's lane to clear it.
 │ BlockedLanes       { mask: 0b010 }                         │
 │ Color              { r: 255, g: 60, b: 60, a: 255 }       │
 │ DrawSize           { w: 240, h: 80 }                       │
-│ DrawLayer          { layer: Game }                         │
+│ TagWorldPass       (tag, 0 bytes)                         │
 └───────────────────────────────────────────────────────────┘
 Total: ~41 bytes per entity
 ```
@@ -948,7 +939,7 @@ LowBar/HighBar entity archetypes are historical only. The current runtime enum, 
 │ BlockedLanes       { mask: 0b110 }                         │
 │ Color              { r: 200, g: 100, b: 255, a: 255 }    │
 │ DrawSize           { w: 720, h: 80 }                       │
-│ DrawLayer          { layer: Game }                          │
+│ TagWorldPass       (tag, 0 bytes)                          │
 └───────────────────────────────────────────────────────────┘
 Total: ~43 bytes per entity
 ```
@@ -965,7 +956,7 @@ Total: ~43 bytes per entity
 │ RequiredLane       { lane: 2 }                             │
 │ Color              { r: 255, g: 215, b: 0, a: 255 }      │
 │ DrawSize           { w: 720, h: 80 }                       │
-│ DrawLayer          { layer: Game }                          │
+│ TagWorldPass       (tag, 0 bytes)                          │
 └───────────────────────────────────────────────────────────┘
 Total: ~44 bytes per entity
 ```
@@ -982,7 +973,7 @@ Total: ~44 bytes per entity
 │ NonScorableTag     (tag, 0 bytes)                         │
 │ Color              { r: 255, g: 255, b: 255, a: 80 }      │
 │ DrawSize           { w: 720, h: 80 }                       │
-│ DrawLayer          { layer: Game }                         │
+│ TagWorldPass       (tag, 0 bytes)                         │
 └───────────────────────────────────────────────────────────┘
 Total: ~40 bytes per entity
 ```
@@ -1004,7 +995,7 @@ during normal play.
 │ MotionVelocity     { value: {0.0, -80.0} } (floats up)   │
 │ ScorePopup         { value: 600, tier: 3, remaining: 1.2 } │
 │ Color              { r: 255, g: 200, b: 50, a: 255 }     │
-│ DrawLayer          { layer: Effects }                      │
+│ TagHUDPass         (tag, 0 bytes)                          │
 └───────────────────────────────────────────────────────────┘
 Total: ~33 bytes per entity (0–5 active)
 ```
@@ -1018,7 +1009,7 @@ Total: ~33 bytes per entity (0–5 active)
 │ MotionVelocity     { value: {rand, rand} } (random burst) │
 │ ParticleData       { size: 4.0, remaining: 0.6, max_time: 0.6 } │
 │ Color              { r: 255, g: 100, b: 50, a: 255 }     │
-│ DrawLayer          { layer: Effects }                      │
+│ TagEffectsPass     (tag, 0 bytes)                          │
 └───────────────────────────────────────────────────────────┘
 Total: ~37 bytes per entity (0–50 active)
 ```
@@ -1670,7 +1661,8 @@ app/
 │   ├── scoring.h                ← ScoreState, ScorePopup
 │   ├── input_events.h           ← Direction, ButtonPressEvent, GoEvent, MenuActionKind (in systems/)
 │   ├── game_state.h             ← GameState, GamePhase, LevelSelectState
-│   ├── rendering.h              ← DrawSize, DrawLayer, screen/model transforms
+│   ├── rendering.h              ← DrawSize, ScreenPosition; back-compat shim
+│   │                              for the camera/mesh splits (issue #1194)
 │   ├── particle.h               ← ParticleData, ParticleTag
 │   ├── rhythm.h                 ← BeatInfo, TimingGrade, TimingTier
 │   └── song_state.h             ← SongState
@@ -1756,7 +1748,7 @@ entt::entity spawn_rhythm_shape_gate(entt::registry& reg, Shape required,
     reg.emplace<RequiredShape>(e, required);
     reg.emplace<Color>(e, shape_color(required));
     reg.emplace<DrawSize>(e, static_cast<float>(constants::SCREEN_W), 80.0f);
-    reg.emplace<DrawLayer>(e, Layer::Game);
+    reg.emplace<TagWorldPass>(e);
     return e;
 }
 ```

--- a/tests/test_collision_extended.cpp
+++ b/tests/test_collision_extended.cpp
@@ -73,7 +73,6 @@ TEST_CASE("collision: Hexagon fails even when matching gate shape", "[collision]
     reg.emplace<Obstacle>(obs, int16_t{200});
     reg.emplace<RequiredShape>(obs, Shape::Hexagon);
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);
-    reg.emplace<DrawLayer>(obs, Layer::Game);
     reg.emplace<Color>(obs, Color{255, 255, 255, 255});
 
     collision_system(reg, 0.016f);

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -297,7 +297,6 @@ TEST_CASE("collision: combo gate requires shape AND lane", "[collision]") {
     // Block lanes 0 and 2, leave lane 1 open
     reg.emplace<uint8_t>(obs, uint8_t{0b101});
     reg.emplace<DrawSize>(obs, 720.0f, 80.0f);
-    reg.emplace<DrawLayer>(obs, Layer::Game);
     reg.emplace<Color>(obs, Color{200, 100, 255, 255});
 
     collision_system(reg, 0.016f);
@@ -317,7 +316,6 @@ TEST_CASE("collision: combo gate fails with wrong shape", "[collision]") {
     reg.emplace<RequiredShape>(obs, Shape::Triangle);  // wrong shape
     reg.emplace<uint8_t>(obs, uint8_t{0b101});    // lane 1 open
     reg.emplace<DrawSize>(obs, 720.0f, 80.0f);
-    reg.emplace<DrawLayer>(obs, Layer::Game);
     reg.emplace<Color>(obs, Color{200, 100, 255, 255});
 
     collision_system(reg, 0.016f);

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -236,7 +236,6 @@ TEST_CASE("ecs: make_player creates proper entity", "[ecs]") {
     CHECK(reg.all_of<VerticalState>(p));
     CHECK(reg.all_of<Color>(p));
     CHECK(reg.all_of<DrawSize>(p));
-    CHECK(reg.all_of<DrawLayer>(p));
     CHECK(reg.all_of<TagWorldPass>(p));
 }
 

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -193,7 +193,6 @@ inline entt::entity make_player(entt::registry& reg) {
     reg.emplace<VerticalState>(player);
     reg.emplace<Color>(player, Color{80, 180, 255, 255});
     reg.emplace<DrawSize>(player, constants::PLAYER_SIZE, constants::PLAYER_SIZE);
-    reg.emplace<DrawLayer>(player, Layer::Game);
     reg.emplace<TagWorldPass>(player);
     return player;
 }
@@ -220,7 +219,6 @@ inline entt::entity make_shape_gate(entt::registry& reg, Shape shape, float y) {
     reg.emplace<RequiredShape>(obs, shape);
     reg.emplace<ShapeGateLane>(obs, int8_t{1});
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);
-    reg.emplace<DrawLayer>(obs, Layer::Game);
     reg.emplace<TagWorldPass>(obs);
     reg.emplace<Color>(obs, Color{255, 255, 255, 255});
     return obs;
@@ -237,7 +235,6 @@ inline entt::entity make_lane_block(entt::registry& reg, uint8_t mask, float y) 
     reg.emplace<Obstacle>(obs, int16_t{constants::PTS_LANE_BLOCK});
     reg.emplace<uint8_t>(obs, mask);
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W / 3), 80.0f);
-    reg.emplace<DrawLayer>(obs, Layer::Game);
     reg.emplace<TagWorldPass>(obs);
     reg.emplace<Color>(obs, Color{255, 60, 60, 255});
     return obs;
@@ -256,7 +253,6 @@ inline entt::entity make_combo_gate(entt::registry& reg, Shape shape, uint8_t bl
     reg.emplace<RequiredShape>(obs, shape);
     reg.emplace<uint8_t>(obs, blocked_mask);
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);
-    reg.emplace<DrawLayer>(obs, Layer::Game);
     reg.emplace<TagWorldPass>(obs);
     reg.emplace<Color>(obs, Color{200, 100, 255, 255});
     return obs;
@@ -273,7 +269,6 @@ inline entt::entity make_split_path(entt::registry& reg, Shape shape, int8_t lan
     reg.emplace<RequiredShape>(obs, shape);
     reg.emplace<RequiredLane>(obs, lane);
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);
-    reg.emplace<DrawLayer>(obs, Layer::Game);
     reg.emplace<TagWorldPass>(obs);
     reg.emplace<Color>(obs, Color{255, 215, 0, 255});
     return obs;

--- a/tests/test_obstacle_archetypes.cpp
+++ b/tests/test_obstacle_archetypes.cpp
@@ -51,7 +51,7 @@ TEST_CASE("entity: ShapeGate Circle - correct components and color", "[archetype
     entt::registry reg;
     auto e = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f, Shape::Circle});
 
-    REQUIRE(reg.all_of<ObstacleTag, Vector2, DrawLayer, WorldTransform, Obstacle, RequiredShape, ShapeGateLane, DrawSize, Color>(e));
+    REQUIRE(reg.all_of<ObstacleTag, Vector2, WorldTransform, Obstacle, RequiredShape, ShapeGateLane, DrawSize, Color>(e));
     CHECK(!reg.all_of<uint8_t>(e));
     CHECK(!reg.all_of<RequiredLane>(e));
 
@@ -258,7 +258,7 @@ TEST_CASE("entity: SplitPath - RequiredShape and RequiredLane", "[archetype]") {
     auto e = spawn_obstacle(reg, {ObstacleKind::SplitPath, 360.0f, -120.0f,
                                    Shape::Square, uint8_t{0}, int8_t{2}});
 
-    REQUIRE(reg.all_of<ObstacleTag, Vector2, DrawLayer, WorldTransform, Obstacle, RequiredShape, RequiredLane, DrawSize, Color>(e));
+    REQUIRE(reg.all_of<ObstacleTag, Vector2, WorldTransform, Obstacle, RequiredShape, RequiredLane, DrawSize, Color>(e));
     CHECK(!reg.all_of<uint8_t>(e));
 
     CHECK(reg.get<Obstacle>(e).base_points == int16_t{constants::PTS_SPLIT_PATH});

--- a/tests/test_player_archetype.cpp
+++ b/tests/test_player_archetype.cpp
@@ -20,7 +20,6 @@ TEST_CASE("player_entity: canonical component set present", "[archetype][player]
     CHECK(reg.all_of<VerticalState>(p));
     CHECK(reg.all_of<Color>(p));
     CHECK(reg.all_of<DrawSize>(p));
-    CHECK(reg.all_of<DrawLayer>(p));
     CHECK(reg.all_of<TagWorldPass>(p));
 }
 
@@ -48,12 +47,6 @@ TEST_CASE("player_entity: ShapeWindow starts Idle targeting Hexagon", "[archetyp
     auto& sw = reg.get<ShapeWindow>(p);
     CHECK(sw.target_shape == Shape::Hexagon);
     CHECK(sw.phase        == WindowPhase::Idle);
-}
-
-TEST_CASE("player_entity: DrawLayer is Game", "[archetype][player]") {
-    auto reg = make_registry();
-    auto p = create_player_entity(reg);
-    CHECK(reg.get<DrawLayer>(p).layer == Layer::Game);
 }
 
 TEST_CASE("player_entity: DrawSize matches PLAYER_SIZE", "[archetype][player]") {

--- a/tests/test_popup_display_system.cpp
+++ b/tests/test_popup_display_system.cpp
@@ -226,7 +226,7 @@ TEST_CASE("spawn_score_popup: creates the full popup display archetype",
     auto e = spawn_score_popup(reg, {100.0f, 200.0f, 50, TimingTier::Good});
 
     REQUIRE(reg.all_of<ScorePopup, PopupDisplay, Color, Vector2,
-                       WorldTransform, DrawLayer, TagHUDPass>(e));
+                       WorldTransform, TagHUDPass>(e));
     CHECK(reg.get<ScorePopup>(e).has_timing_tier);
     CHECK(reg.get<ScorePopup>(e).timing_tier == TimingTier::Good);
     CHECK(std::strcmp(reg.get<PopupDisplay>(e).text, "GOOD") == 0);
@@ -388,15 +388,6 @@ TEST_CASE("spawn_score_popup: default color when no timing tier",
     CHECK(c.r == 255);
     CHECK(c.g == 255);
     CHECK(c.b == 50);
-}
-
-TEST_CASE("spawn_score_popup: DrawLayer is Effects",
-          "[popup_entity][issue349]") {
-    entt::registry reg;
-    auto e = spawn_score_popup(reg, {0.0f, 0.0f, 100, std::nullopt});
-
-    REQUIRE(reg.all_of<DrawLayer>(e));
-    CHECK(reg.get<DrawLayer>(e).layer == Layer::Effects);
 }
 
 TEST_CASE("spawn_score_popup: entity carries TagHUDPass",

--- a/tests/test_scoring_system.cpp
+++ b/tests/test_scoring_system.cpp
@@ -359,16 +359,12 @@ TEST_CASE("scoring: popup entity has full factory contract", "[scoring][popup_en
         CHECK(reg.all_of<WorldTransform>(e));
         CHECK(reg.all_of<Vector2>(e));
         CHECK(reg.all_of<Color>(e));
-        CHECK(reg.all_of<DrawLayer>(e));
         CHECK(reg.all_of<TagHUDPass>(e));
         CHECK(reg.all_of<PopupDisplay>(e));
 
         const auto& mv = reg.get<Vector2>(e);
         CHECK(mv.x == 0.0f);
         CHECK(mv.y == -80.0f);
-
-        const auto& dl = reg.get<DrawLayer>(e);
-        CHECK(dl.layer == Layer::Effects);
     }
     CHECK(count == 1);
 }


### PR DESCRIPTION
## Summary

`DrawLayer { Layer layer }` from the wrapper-noise checklist in #1198 is the next dead component to evict. **No production system ever queried it** — render-pass dispatch uses the existing `TagWorldPass` / `TagEffectsPass` / `TagHUDPass` tags (see `app/tags/tags.h`). The component and its `Layer` enum were carrying decorative state nothing read.

Same shape as the `UIPosition` deletion in PR #1239 — when the wrapper is around dead data, deletion is the strict improvement over the unwrap that would just rename a dead slot.

### Symptom of deadness

`popup_entity` emplaces `DrawLayer{Layer::Effects}` alongside `TagHUDPass`. The layer value (`Effects`) and the active render pass tag (`HUDPass`) disagree, because nothing on the read side ever checked `DrawLayer`. The pass tag wins; the layer value never mattered.

### Pre-edit audit (no read sites)

| Audit | Result |
|---|---|
| `rg 'view<[^>]*DrawLayer' app/` | **0 matches** |
| `rg '(get\|try_get\|any_of)<.*DrawLayer' app/` | **0 matches** |
| `rg 'Layer::' app/` | only inside `emplace<DrawLayer>(..., Layer::X)` |

All read sites in tests were assertions about a value nothing in production cared about.

## Changes

- **app/components/rendering.h** — delete `Layer` enum + `DrawLayer` struct, update the back-compat shim doc-comment to reflect the removal
- **app/entities/** — remove `emplace<DrawLayer>` from 5 entity factories (obstacle, popup, player, energy_bar, plus the obstacle_entity base helper)
- **app/entities/{obstacle,popup}_entity.h** — drop `DrawLayer` from doc-comment contracts
- **tests/** — remove `emplace<DrawLayer>`, `all_of<DrawLayer>`, and `get<DrawLayer>` in 6 test files + `test_helpers.h`; delete two test cases that asserted DrawLayer value contracts (`player_entity: DrawLayer is Game`, `spawn_score_popup: DrawLayer is Effects`)
- **benchmarks/bench_systems.cpp** — remove 5 `emplace<DrawLayer>` calls from the bench-archetype helpers
- **design-docs/architecture.md** — remove `DrawLayer` / `Layer` from the component table, 8 entity-archetype diagrams, the file-map, and the example spawner; entity diagrams now correctly show the pass-membership tag instead

## Validation

- `cmake --build build` → clean, **zero warnings** (`-Wall -Wextra -Werror` honored)
- `shapeshifter_tests --reporter=compact` → **2950 assertions in 901 test cases pass** (delta from 2957/903 = the 7 DrawLayer-specific assertions and 2 dedicated test cases that were deleted as covering deleted behaviour)
- `shapeshifter_startup_shutdown_smoke` → passes

## Issue #1198 checklist update

- 2-float wrappers → `Vector2`
  - [x] `UIPosition` (deleted as dead — PR #1239)
  - [x] `MotionVelocity` (unwrapped to raw `Vector2` — PR #1241)
  - [ ] `ScreenPosition` (blocked: `Vector2` slot now reserved for velocity)
  - [ ] `DrawSize` (blocked: `Vector2` slot now reserved for velocity)
- Single-int / single-enum wrappers
  - [x] **`DrawLayer` (deleted as dead — this PR)**
  - [ ] `RequiredShape`
  - [ ] `ShapeGateLane`
  - [ ] `RequiredLane`
  - [x] `BlockedLanes` (unwrapped to raw `uint8_t` — PR #1240)