### PR TITLE
Migrate MeshType enum to per-kind tags (refs #1202, #1204)

### DIFF
--- a/app/components/render_mesh.h
+++ b/app/components/render_mesh.h
@@ -11,17 +11,28 @@
 // obstacles, popups, particles, mesh children) — not obstacle-specific.
 //
 // Relocated out of app/components/rendering.h (issue #1194 SPLIT).
-
-enum class MeshType : uint8_t { Shape, Slab, Quad };
+//
+// Per-mesh dispatch lives on its own per-kind table (existential processing,
+// issue #1202/#1204). A drawable entity carries `ModelTransform` plus one of:
+//   - `MeshKindShape{mesh_index}` (defined here — carries the shape lookup index)
+//   - `MeshKindSlab` (empty tag in app/tags/tags.h)
+//   - `MeshKindQuad` (empty tag in app/tags/tags.h)
+// The renderer iterates one view per kind tag; no `switch` on a discriminator.
 
 struct ModelTransform {
-    Matrix   mat = MatrixIdentity();
-    Color    tint{255, 255, 255, 255};
-    uint8_t  mesh_index = 0;  // index into ShapeMeshes.shapes[] for Shape type
-    MeshType mesh_type = MeshType::Shape;
+    Matrix mat = MatrixIdentity();
+    Color  tint{255, 255, 255, 255};
+};
+
+// Shape-kind row: column is the index into ShapeMeshes.shapes[]. Non-empty
+// (1NF) so it lives here, not in app/tags/tags.h (which is empty tags only).
+struct MeshKindShape {
+    uint8_t mesh_index = 0;
 };
 
 // Visual mesh child; game_camera_system resolves parent transform + offsets.
+// Pair with one of MeshKindShape / MeshKindSlab on the same entity to pick
+// the matrix builder and renderer.
 struct MeshChild {
     entt::entity parent = entt::null;
     float x = 0.0f;             // absolute X position in game coords
@@ -30,6 +41,4 @@ struct MeshChild {
     float depth = 0.0f;         // slab depth (game coords)
     float height = 0.0f;        // slab height (game coords)
     Color tint{255, 255, 255, 255};
-    uint8_t mesh_index = 0;  // index into ShapeMeshes.shapes[] for Shape type
-    MeshType mesh_type = MeshType::Shape;
 };

--- a/app/components/rendering.h
+++ b/app/components/rendering.h
@@ -4,17 +4,18 @@
 
 // Back-compat shim. The junk-drawer "rendering.h" was split (issue #1194):
 //   ScreenTransform                -> components/camera_resources.h
-//   MeshType / ModelTransform /
-//     MeshChild                    -> components/render_mesh.h
+//   ModelTransform / MeshChild     -> components/render_mesh.h
 //   ObstacleChildren               -> components/obstacle.h
 // Re-included here so existing `#include "components/rendering.h"` sites keep
 // compiling; new code should include the canonical header directly.
 //
 // The wrapper-noise types DrawSize / ScreenPosition remain here pending the
 // wrapper deletion sweep (issue #1198). DrawLayer + the Layer enum were
-// deleted as dead in the same sweep — render-pass dispatch already uses the
-// TagWorldPass / TagEffectsPass / TagHUDPass tags (see app/tags/tags.h), no
-// production system ever queried DrawLayer.
+// deleted as dead in the same sweep, and the MeshType enum was migrated to
+// per-kind tables (MeshKindShape / MeshKindSlab / MeshKindQuad) per issue
+// #1202/#1204 — render-pass dispatch already uses the TagWorldPass /
+// TagEffectsPass / TagHUDPass tags (see app/tags/tags.h), no production
+// system ever queried DrawLayer.
 #include "camera_resources.h"
 #include "obstacle.h"
 #include "render_mesh.h"

--- a/app/entities/obstacle_render_entity.cpp
+++ b/app/entities/obstacle_render_entity.cpp
@@ -68,7 +68,8 @@ static entt::entity add_slab_child(entt::registry& reg, entt::entity parent,
     require_child_capacity(reg, parent);
     auto e = reg.create();
     PendingEntity pending{reg, e};
-    reg.emplace<MeshChild>(e, MeshChild{parent, x, 0.0f, w, d, h, tint, 0, MeshType::Slab});
+    reg.emplace<MeshChild>(e, MeshChild{parent, x, 0.0f, w, d, h, tint});
+    reg.emplace<MeshKindSlab>(e);
     reg.emplace<TagWorldPass>(e);
     append_child(reg, parent, e);
     pending.release();
@@ -81,8 +82,8 @@ static entt::entity add_shape_child(entt::registry& reg, entt::entity parent,
     require_child_capacity(reg, parent);
     auto e = reg.create();
     PendingEntity pending{reg, e};
-    reg.emplace<MeshChild>(e, MeshChild{parent, cx, z_offset, size, 0.0f, 0.0f, tint,
-                                        mesh_index, MeshType::Shape});
+    reg.emplace<MeshChild>(e, MeshChild{parent, cx, z_offset, size, 0.0f, 0.0f, tint});
+    reg.emplace<MeshKindShape>(e, MeshKindShape{mesh_index});
     reg.emplace<TagWorldPass>(e);
     append_child(reg, parent, e);
     pending.release();

--- a/app/systems/camera_system.cpp
+++ b/app/systems/camera_system.cpp
@@ -237,41 +237,55 @@ void game_camera_system(entt::registry& reg, [[maybe_unused]] float dt) {
 
 
     // 1. MeshChild transforms (multi-slab obstacles, ghost shapes)
+    // 1. MeshChild transforms (multi-slab obstacles, ghost shapes)
+    //    Existential processing: one transform per kind tag (issue #1202/#1204).
+    //    Stale children are batched across both tag views and destroyed once.
     {
-        auto view = reg.view<MeshChild>();
         auto* scratch = reg.ctx().find<MeshChildCleanupScratch>();
         if (!scratch) scratch = &reg.ctx().emplace<MeshChildCleanupScratch>();
         auto& stale_children = scratch->stale_children;
         stale_children.clear();
-        for (auto [entity, mc] : view.each()) {
+
+        auto record_stale_or_compute_z = [&](entt::entity entity, const MeshChild& mc,
+                                             float& out_z) -> bool {
             auto* parent_wt = reg.try_get<WorldTransform>(mc.parent);
             if (!parent_wt) {
                 if (stale_children.size() >= stale_children.capacity()) {
                     ++scratch->capacity_exceeded_count;
                 }
                 stale_children.push_back(entity);
+                return false;
+            }
+            out_z = parent_wt->position.y + mc.z_offset;
+            return true;
+        };
+
+        // Slab children: no per-kind columns.
+        for (auto [entity, mc] : reg.view<MeshChild, MeshKindSlab>().each()) {
+            float z = 0.0f;
+            if (!record_stale_or_compute_z(entity, mc, z)) continue;
+            reg.get_or_emplace<ModelTransform>(entity) =
+                ModelTransform{slab_matrix(mc.x, z, mc.width, mc.height, mc.depth),
+                                mc.tint};
+        }
+
+        // Shape children: kind row carries mesh_index column.
+        for (auto [entity, mc, kind] : reg.view<MeshChild, MeshKindShape>().each()) {
+            float z = 0.0f;
+            if (!record_stale_or_compute_z(entity, mc, z)) continue;
+            if (kind.mesh_index >= kShapeCount) {
+                TraceLog(LOG_WARNING, "game_camera_system skipped invalid MeshChild shape index %u",
+                         static_cast<unsigned>(kind.mesh_index));
+                reg.remove<ModelTransform>(entity);
                 continue;
             }
-            float z = parent_wt->position.y + mc.z_offset;
-
-            if (mc.mesh_type == MeshType::Slab) {
-                reg.get_or_emplace<ModelTransform>(entity) =
-                    ModelTransform{slab_matrix(mc.x, z, mc.width, mc.height, mc.depth),
-                                    mc.tint, 0, MeshType::Slab};
-            } else {
-                if (mc.mesh_index >= kShapeCount) {
-                    TraceLog(LOG_WARNING, "game_camera_system skipped invalid MeshChild shape index %u",
-                             static_cast<unsigned>(mc.mesh_index));
-                    reg.remove<ModelTransform>(entity);
-                    continue;
-                }
-                const auto& props = mesh_config.props[mc.mesh_index];
-                reg.get_or_emplace<ModelTransform>(entity) =
-                    ModelTransform{make_shape_matrix(mc.mesh_index, mc.x, 0.0f, z,
-                                                      mc.width, props.radius_scale),
-                                     mc.tint, mc.mesh_index, MeshType::Shape};
-            }
+            const auto& props = mesh_config.props[kind.mesh_index];
+            reg.get_or_emplace<ModelTransform>(entity) =
+                ModelTransform{make_shape_matrix(kind.mesh_index, mc.x, 0.0f, z,
+                                                  mc.width, props.radius_scale),
+                                 mc.tint};
         }
+
         for (auto entity : stale_children) {
             if (reg.valid(entity)) {
                 reg.destroy(entity);
@@ -291,6 +305,7 @@ void game_camera_system(entt::registry& reg, [[maybe_unused]] float dt) {
                 TraceLog(LOG_WARNING, "game_camera_system skipped invalid PlayerShape %d",
                          static_cast<int>(pshape.current));
                 reg.remove<ModelTransform>(entity);
+                reg.remove<MeshKindShape>(entity);
                 continue;
             }
             const auto mesh_index = static_cast<uint8_t>(shape_idx);
@@ -298,7 +313,8 @@ void game_camera_system(entt::registry& reg, [[maybe_unused]] float dt) {
             reg.get_or_emplace<ModelTransform>(entity) =
                 ModelTransform{make_shape_matrix(mesh_index, transform.position.x, y_3d,
                                                  transform.position.y, sz, props.radius_scale),
-                               col, mesh_index, MeshType::Shape};
+                               col};
+            reg.get_or_emplace<MeshKindShape>(entity).mesh_index = mesh_index;
         }
     }
 
@@ -313,7 +329,8 @@ void game_camera_system(entt::registry& reg, [[maybe_unused]] float dt) {
                 MatrixScale(sz, 1, sz),
                 MatrixTranslate(transform.position.x - half, 0, transform.position.y - half));
             reg.get_or_emplace<ModelTransform>(entity) =
-                ModelTransform{mat, col, 0, MeshType::Quad};
+                ModelTransform{mat, col};
+            reg.get_or_emplace<MeshKindQuad>(entity);
         }
     }
 

--- a/app/systems/game_render_system.cpp
+++ b/app/systems/game_render_system.cpp
@@ -3,46 +3,55 @@
 #include "floor_render_system.h"
 #include "../components/render_mesh.h"
 #include "../components/game_state.h"
+#include "../tags/tags.h"
 #include "../util/shape_lane_mapping.h"
 #include "camera_system.h"
 #include <raylib.h>
 #include <rlgl.h>
 
-static void draw_model_transform(const camera::ShapeMeshes& sm, const ModelTransform& mt) {
-    // Use a per-draw local copy so the shared material is never mutated.
+static void draw_shape(const camera::ShapeMeshes& sm, const ModelTransform& mt,
+                       const MeshKindShape& kind) {
+    if (kind.mesh_index >= kShapeCount) return;
     Material mat = sm.material;
     mat.maps[MATERIAL_MAP_DIFFUSE].color = mt.tint;
-    switch (mt.mesh_type) {
-        case MeshType::Slab:
-            DrawMesh(sm.slab, mat, mt.mat);
-            break;
-        case MeshType::Shape:
-            if (mt.mesh_index >= kShapeCount) return;
-            DrawMesh(sm.shapes[mt.mesh_index], mat, mt.mat);
-            break;
-        case MeshType::Quad:
-            DrawMesh(sm.quad, mat, mt.mat);
-            break;
+    DrawMesh(sm.shapes[kind.mesh_index], mat, mt.mat);
+}
+
+static void draw_slab(const camera::ShapeMeshes& sm, const ModelTransform& mt) {
+    Material mat = sm.material;
+    mat.maps[MATERIAL_MAP_DIFFUSE].color = mt.tint;
+    DrawMesh(sm.slab, mat, mt.mat);
+}
+
+static void draw_quad(const camera::ShapeMeshes& sm, const ModelTransform& mt) {
+    Material mat = sm.material;
+    mat.maps[MATERIAL_MAP_DIFFUSE].color = mt.tint;
+    DrawMesh(sm.quad, mat, mt.mat);
+}
+
+// Per Fabian existential processing (issue #1202/#1204), the former
+// `switch(mesh_type)` is replaced by one transform per mesh-kind tag.
+template <typename PassTag>
+static void draw_pass(const entt::registry& reg, const camera::ShapeMeshes& sm) {
+    for (auto [_, mt, kind] :
+             reg.view<const ModelTransform, const PassTag, const MeshKindShape>().each()) {
+        draw_shape(sm, mt, kind);
+    }
+    for (auto [_, mt] :
+             reg.view<const ModelTransform, const PassTag, const MeshKindSlab>().each()) {
+        draw_slab(sm, mt);
+    }
+    for (auto [_, mt] :
+             reg.view<const ModelTransform, const PassTag, const MeshKindQuad>().each()) {
+        draw_quad(sm, mt);
     }
 }
 
 static void draw_meshes(const entt::registry& reg) {
     const auto* sm = reg.ctx().find<camera::ShapeMeshes>();
     if (!sm) return;
-
-    {
-        auto view = reg.view<const ModelTransform, const TagWorldPass>();
-        for (auto [entity, mt] : view.each()) {
-            draw_model_transform(*sm, mt);
-        }
-    }
-
-    {
-        auto view = reg.view<const ModelTransform, const TagEffectsPass>();
-        for (auto [entity, mt] : view.each()) {
-            draw_model_transform(*sm, mt);
-        }
-    }
+    draw_pass<TagWorldPass>(reg, *sm);
+    draw_pass<TagEffectsPass>(reg, *sm);
 }
 
 

--- a/app/tags/tags.h
+++ b/app/tags/tags.h
@@ -58,6 +58,14 @@ struct TagWorldPass   {};  // drawn in BeginMode3D (3D world geometry)
 struct TagEffectsPass {};  // particles, post-process overlays
 struct TagHUDPass     {};  // screen-space UI elements
 
+// ── Mesh kind (per-tag table; pair with ModelTransform/MeshChild) ──
+// Replaces the former MeshType enum (issue #1202/#1204). Each kind drives
+// its own renderer transform — no `switch` on a discriminator. The Shape
+// kind carries an extra column (mesh_index) so it lives as a real struct
+// in app/components/render_mesh.h; the other two are zero-column tables.
+struct MeshKindSlab {};
+struct MeshKindQuad {};
+
 // ── Singletons ───────────────────────────────────────────────
 struct BeatMapTag {};
 struct SettingsTag {};

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -332,8 +332,8 @@ TEST_CASE("beat_scheduler: spawns OnsetMarker as visible non-scorable cue",
         const auto child = children.children[0];
         REQUIRE(reg.valid(child));
         REQUIRE(reg.all_of<MeshChild>(child));
+        CHECK(reg.all_of<MeshKindSlab>(child));
         const auto& mesh = reg.get<MeshChild>(child);
-        CHECK(mesh.mesh_type == MeshType::Slab);
         CHECK_THAT(mesh.width, Catch::Matchers::WithinAbs(constants::SCREEN_W_F, 0.01f));
 
         wt.position.y = constants::DESTROY_Y + 10.0f;

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -27,8 +27,9 @@ TEST_CASE("components: rendering components are safely default constructible",
     CHECK(model.tint.g == 255);
     CHECK(model.tint.b == 255);
     CHECK(model.tint.a == 255);
-    CHECK(model.mesh_index == uint8_t{0});
-    CHECK(model.mesh_type == MeshType::Shape);
+
+    MeshKindShape kind{};
+    CHECK(kind.mesh_index == uint8_t{0});
 
     MeshChild child{};
     const bool parent_is_null = child.parent == entt::null;
@@ -42,8 +43,6 @@ TEST_CASE("components: rendering components are safely default constructible",
     CHECK(child.tint.g == 255);
     CHECK(child.tint.b == 255);
     CHECK(child.tint.a == 255);
-    CHECK(child.mesh_index == uint8_t{0});
-    CHECK(child.mesh_type == MeshType::Shape);
 
     ObstacleChildren children{};
     CHECK(children.count == 0);

--- a/tests/test_obstacle_archetypes.cpp
+++ b/tests/test_obstacle_archetypes.cpp
@@ -106,8 +106,9 @@ TEST_CASE("entity: obstacle mesh overflow does not create orphan MeshChild", "[a
         auto child = reg.create();
         reg.emplace<MeshChild>(child, MeshChild{
             parent, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f,
-            Color{255, 255, 255, 255}, 0, MeshType::Slab
+            Color{255, 255, 255, 255}
         });
+        reg.emplace<MeshKindSlab>(child);
         children.children[children.count++] = child;
     }
     reg.emplace<ObstacleTag>(parent);

--- a/tests/test_perspective.cpp
+++ b/tests/test_perspective.cpp
@@ -124,9 +124,10 @@ TEST_CASE("game_camera_system drops stale MeshChild parents without crashing", "
     auto child = reg.create();
     reg.emplace<MeshChild>(
         child,
-        MeshChild{parent, 10.0f, 0.0f, 20.0f, 30.0f, 40.0f, WHITE, 0, MeshType::Slab}
+        MeshChild{parent, 10.0f, 0.0f, 20.0f, 30.0f, 40.0f, WHITE}
     );
-    reg.emplace<ModelTransform>(child, ModelTransform{MatrixIdentity(), WHITE, 0, MeshType::Slab});
+    reg.emplace<MeshKindSlab>(child);
+    reg.emplace<ModelTransform>(child, ModelTransform{MatrixIdentity(), WHITE});
     reg.emplace<TagWorldPass>(child);
 
     reg.destroy(parent);
@@ -163,9 +164,10 @@ TEST_CASE("game_camera_system rejects invalid MeshChild shape index", "[camera3d
     auto child = reg.create();
     reg.emplace<MeshChild>(
         child,
-        MeshChild{parent, 10.0f, 0.0f, 20.0f, 30.0f, 40.0f, WHITE, 255, MeshType::Shape}
+        MeshChild{parent, 10.0f, 0.0f, 20.0f, 30.0f, 40.0f, WHITE}
     );
-    reg.emplace<ModelTransform>(child, ModelTransform{MatrixIdentity(), WHITE, 255, MeshType::Shape});
+    reg.emplace<MeshKindShape>(child, MeshKindShape{255});
+    reg.emplace<ModelTransform>(child, ModelTransform{MatrixIdentity(), WHITE});
     reg.emplace<TagWorldPass>(child);
 
     REQUIRE_NOTHROW(game_camera_system(reg, 0.0f));
@@ -182,7 +184,8 @@ TEST_CASE("game_camera_system rejects invalid PlayerShape before mesh lookup", "
     reg.emplace<PlayerShape>(player, PlayerShape{static_cast<Shape>(255), 1.0f});
     reg.emplace<VerticalState>(player);
     reg.emplace<Color>(player, WHITE);
-    reg.emplace<ModelTransform>(player, ModelTransform{MatrixIdentity(), WHITE, 255, MeshType::Shape});
+    reg.emplace<ModelTransform>(player, ModelTransform{MatrixIdentity(), WHITE});
+    reg.emplace<MeshKindShape>(player, MeshKindShape{255});
     reg.emplace<TagWorldPass>(player);
 
     REQUIRE_NOTHROW(game_camera_system(reg, 0.0f));
@@ -214,9 +217,10 @@ TEST_CASE("game_camera_system: dense stale-parent cleanup stays within reserved 
         auto child = reg.create();
         reg.emplace<MeshChild>(
             child,
-            MeshChild{parent, static_cast<float>(i), 0.0f, 20.0f, 30.0f, 40.0f, WHITE, 0, MeshType::Slab}
+            MeshChild{parent, static_cast<float>(i), 0.0f, 20.0f, 30.0f, 40.0f, WHITE}
         );
-        reg.emplace<ModelTransform>(child, ModelTransform{MatrixIdentity(), WHITE, 0, MeshType::Slab});
+        reg.emplace<MeshKindSlab>(child);
+        reg.emplace<ModelTransform>(child, ModelTransform{MatrixIdentity(), WHITE});
         reg.emplace<TagWorldPass>(child);
         reg.destroy(parent);  // make MeshChild stale so cleanup path runs
     }

--- a/tests/test_pr43_regression.cpp
+++ b/tests/test_pr43_regression.cpp
@@ -92,10 +92,10 @@ TEST_CASE("MeshChild: depth field stores DrawSize.h (scroll-axis) for LaneBlock"
     const float expected_depth  = reg.get<DrawSize>(obs).h;
     const float expected_height = constants::OBSTACLE_3D_HEIGHT;
 
-    auto view = reg.view<MeshChild>();
+    auto view = reg.view<MeshChild, MeshKindSlab>();
     int count = 0;
     for (auto [e, mc] : view.each()) {
-        if (mc.mesh_type != MeshType::Slab) continue;
+        (void)e;
         // depth must equal the DrawSize.h (scroll-axis thickness)
         CHECK_THAT(mc.depth,  WithinAbs(expected_depth,  1e-3f));
         // height must equal the 3D height constant (vertical Y dimension)
@@ -127,11 +127,13 @@ TEST_CASE("MeshChild: ShapeGate renders shape-only (no side slabs)",
 
     int slab_count = 0;
     int shape_count = 0;
-    auto view = reg.view<MeshChild>();
-    for (auto [e, mc] : view.each()) {
-        (void)e;
-        if (mc.mesh_type == MeshType::Slab) ++slab_count;
-        if (mc.mesh_type == MeshType::Shape) ++shape_count;
+    for (auto [e, mc] : reg.view<MeshChild, MeshKindSlab>().each()) {
+        (void)e; (void)mc;
+        ++slab_count;
+    }
+    for (auto [e, mc, kind] : reg.view<MeshChild, MeshKindShape>().each()) {
+        (void)e; (void)mc; (void)kind;
+        ++shape_count;
     }
     REQUIRE(slab_count == 0);
     REQUIRE(shape_count >= 1);


### PR DESCRIPTION
Step "MeshType" of the enum eradication checklist in #1202 / #1204.

## Mechanic

Per the corrected mechanic in #1204, each former enum value becomes its own component table; the schema follows the data the case actually carries:

| Former value     | Per-value data                                   | Target                                                                            |
| ---              | ---                                              | ---                                                                               |
| `MeshType::Shape` | `mesh_index` (into `ShapeMeshes.shapes[]`)      | real struct `MeshKindShape { uint8_t mesh_index; }` in `components/render_mesh.h` |
| `MeshType::Slab`  | none                                            | empty tag `MeshKindSlab` in `tags/tags.h`                                         |
| `MeshType::Quad`  | none                                            | empty tag `MeshKindQuad` in `tags/tags.h`                                         |

`ModelTransform` and `MeshChild` lose their `mesh_type` / `mesh_index` fields; each drawable entity carries one mesh-kind tag alongside its `ModelTransform` / `MeshChild`.

## Switches & if-branches eliminated

- `game_render_system.cpp` — the single `switch(mt.mesh_type)` is replaced by a templated `draw_pass<PassTag>` with three view loops (`view<ModelTransform, PassTag, MeshKindShape>`, …Slab, …Quad). One transform per kind.
- `camera_system.cpp` — the `if (mc.mesh_type == MeshType::Slab) … else …` MeshChild loop splits into two transforms (`view<MeshChild, MeshKindSlab>` and `view<MeshChild, MeshKindShape>`). Stale-children cleanup buffer is shared across both transforms so the issue #1089 capacity-exceeded accounting is preserved.

## Order semantics

- Per-pass order (`TagWorldPass` before `TagEffectsPass`) is preserved.
- Within a pass, the entity-creation-order interleave between shape/slab/quad is no longer preserved (we now draw all shapes, then all slabs, then all quads inside a pass). Today no obstacle archetype mixes kinds (ShapeGate is shape-only, LaneBlock is slab-only — verified by `test_pr43_regression`'s shape/slab counting tests), so the visual ordering is unaffected.

## Producers updated

- `obstacle_render_entity.cpp` — `add_slab_child` emplaces `MeshKindSlab`; `add_shape_child` emplaces `MeshKindShape{mesh_index}`.
- `camera_system.cpp` — the player gets `MeshKindShape` emplaced/updated each frame as its morph index changes; particles get `MeshKindQuad` emplaced alongside their `ModelTransform`.

## Test changes

- `test_components` — default-construction assertions split into `ModelTransform` + `MeshKindShape`.
- `test_obstacle_archetypes` / `test_perspective` — emplace the appropriate kind tag alongside `MeshChild` / `ModelTransform`.
- `test_pr43_regression` / `test_beat_scheduler_system` — query by kind tag instead of filtering on `mt.mesh_type`.

## Acceptance (per #1204)

- [x] The `MeshType` enum is deleted.
- [x] Empty tags (`MeshKindSlab`, `MeshKindQuad`) live in `app/tags/tags.h`.
- [x] Real struct (`MeshKindShape`) lives in `app/components/render_mesh.h`.
- [x] No `switch` on `mesh_type` in `app/`.
- [x] No `if (mc.mesh_type == MeshType::…)` style branches remain.
- [x] One transform per kind in the systems that previously branched.
- [x] Build warning-free (Clang `-Wall -Wextra -Werror`, unity and non-unity).
- [x] All existing tests pass (901 Catch2 cases / 2947 assertions).
- [x] No semantic changes — runtime behaviour is identical.

## Cyclomatic ratchet

One `switch` (3 cases) deleted from `game_render_system.cpp`; one `if-else` deleted from `camera_system.cpp`. Net branch count goes down.

## Next in the eradication order

`Shape` (step 1) remains the largest pending; `ObstacleKind` (step 2) is next-smallest of the unmigrated. The `app/.allowed-enums.txt` CI guard from #1204 still needs its own follow-up PR.

Refs #1202, #1204.
