### PR TITLE
Migrate DeathCause enum to per-cause ctx tags (refs #1202, #1204)

### DIFF
--- a/app/components/game_state.h
+++ b/app/components/game_state.h
@@ -55,19 +55,16 @@ struct LevelSelectState {
     bool confirmed          = false;
 };
 
-// ── Game Over Cause (singleton) ─────────────────────
-// Tracks the most recent reason the player's run ended.  Set by the
-// system that triggered the end-of-run condition (currently only
-// energy depletion) and read by the Game Over screen to surface a
+// ── Game-over cause (per-cause ctx tables) ──────────────────
+// Per Fabian's existential processing, each former DeathCause value is its
+// own zero-column table on `registry.ctx()`. Presence of a *Death tag is the
+// data; absence of all *Death tags means "no terminal cause recorded" (what
+// the former DeathCause::None sentinel represented).
+//
+// The system that triggers the end-of-run condition emplaces the matching
+// tag; the Game Over screen controller reads tag presence to surface a
 // one-line, platform-neutral, colorblind-safe reason.
-enum class DeathCause : uint8_t {
-    None = 0,
-    EnergyDepleted = 1,
-};
-
-struct GameOverState {
-    DeathCause cause = DeathCause::None;
-};
+struct EnergyDepletedDeath {};
 
 // ── Terminal Result Snapshot (singleton) ─────────────────────
 // Captured by game_state_terminal_phase_system at the moment of song

--- a/app/components/scoring.h
+++ b/app/components/scoring.h
@@ -2,11 +2,12 @@
 
 #include <cstdint>
 
-// TerminalResultState relocated to game_state.h (it pairs with GameOverState /
-// terminal phase). ScorePopup / PopupDisplay relocated to popup.h (popup-entity
-// data, distinct from score-state singletons). Re-included here for source
-// back-compat with consumers that previously got them via scoring.h; new code
-// should include the canonical headers directly.
+// TerminalResultState relocated to game_state.h (it pairs with the
+// EnergyDepletedDeath ctx tag and the rest of the terminal-phase singletons).
+// ScorePopup / PopupDisplay relocated to popup.h (popup-entity data, distinct
+// from score-state singletons). Re-included here for source back-compat with
+// consumers that previously got them via scoring.h; new code should include
+// the canonical headers directly.
 #include "game_state.h"
 #include "popup.h"
 

--- a/app/components/song_state.h
+++ b/app/components/song_state.h
@@ -5,7 +5,8 @@
 #include <cstddef>
 
 // EnergyState lives in components/energy_bar.h (gameplay-resource singleton).
-// GameOverState / DeathCause live in components/game_state.h (terminal-phase data).
+// EnergyDepletedDeath (and future *Death ctx tags) live in components/game_state.h
+// (terminal-phase data).
 // Only song-lifecycle singletons (timing/playback state and song-scope result
 // tallies) remain in this header.
 

--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -188,7 +188,6 @@ bool game_loop_init(entt::registry& reg,
     reset_ctx_singleton<CurrentSongHighScore>(reg);
     reset_ctx_singleton<LevelSelectState>(reg);
     reset_ctx_singleton<EnergyState>(reg);
-    reset_ctx_singleton<GameOverState>(reg);
     reset_ctx_singleton<SongResults>(reg);
     reset_ctx_singleton<TestPlayerState>(reg);
     reset_ctx_singleton<TestPlayerSessionState>(reg);

--- a/app/systems/energy_system.cpp
+++ b/app/systems/energy_system.cpp
@@ -11,10 +11,7 @@ void request_energy_depleted_game_over(entt::registry& reg) {
     auto& gs = reg.ctx().get<GameState>();
     if (gs.transition_pending) return;
 
-    auto* gos = reg.ctx().find<GameOverState>();
-    if (gos) {
-        gos->cause = DeathCause::EnergyDepleted;
-    }
+    reg.ctx().insert_or_assign(EnergyDepletedDeath{});
     gs.transition_pending = true;
     gs.next_phase = GamePhase::GameOver;
 }

--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -167,10 +167,7 @@ void game_state_system(entt::registry& reg, float dt) {
         auto* energy = reg.ctx().find<EnergyState>();
         auto* song = reg.ctx().find<SongState>();
         if (energy && energy->energy <= 0.0f) {
-            auto* gos = reg.ctx().find<GameOverState>();
-            if (gos) {
-                gos->cause = DeathCause::EnergyDepleted;
-            }
+            reg.ctx().insert_or_assign(EnergyDepletedDeath{});
             gs.transition_pending = true;
             gs.next_phase = GamePhase::GameOver;
             return;

--- a/app/systems/play_session.cpp
+++ b/app/systems/play_session.cpp
@@ -172,7 +172,7 @@ void setup_play_session(entt::registry& reg) {
         erase_ctx_if_exists<SongState>(reg);
         erase_ctx_if_exists<EnergyState>(reg);
         erase_ctx_if_exists<SongResults>(reg);
-        erase_ctx_if_exists<GameOverState>(reg);
+        erase_ctx_if_exists<EnergyDepletedDeath>(reg);
         lss.confirmed = false;
         auto& gs = reg.ctx().get<GameState>();
         enter_phase(gs, GamePhase::LevelSelect);
@@ -246,7 +246,9 @@ void setup_play_session(entt::registry& reg) {
         results.total_notes = count_result_notes(beatmap);
         assign_or_emplace_ctx(reg, results);
     }
-    assign_or_emplace_ctx(reg, GameOverState{});
+    // Clear any death-cause tags carried over from a previous run; absence
+    // of all *Death ctx tags is the "no terminal cause recorded yet" state.
+    erase_ctx_if_exists<EnergyDepletedDeath>(reg);
 
     // Load stored high score for this song+difficulty into CurrentSongHighScore
     if (auto* hs = reg.ctx().find<HighScoreState>()) {

--- a/app/ui/screen_controllers/game_over_screen_controller.cpp
+++ b/app/ui/screen_controllers/game_over_screen_controller.cpp
@@ -58,27 +58,16 @@ void draw_game_over_scoreboard(entt::registry& reg, const GameOverLayoutState& s
         draw_game_over_value(state.Anchor01, 110, 712, 500, 24, value, 18);
     }
 
-    if (const auto* gos = reg.ctx().find<GameOverState>()) {
-        const char* reason = death_cause_text(gos->cause);
-        if (reason && reason[0] != '\0') {
-            const float reason_y = (reg.ctx().find<TerminalResultState>() &&
-                                    reg.ctx().get<TerminalResultState>().new_best)
-                ? 742.0f
-                : 685.0f;
-            draw_game_over_value(state.Anchor01, 110, reason_y, 500, 40, reason, 22);
-        }
+    if (reg.ctx().find<EnergyDepletedDeath>()) {
+        const float reason_y = (reg.ctx().find<TerminalResultState>() &&
+                                reg.ctx().get<TerminalResultState>().new_best)
+            ? 742.0f
+            : 685.0f;
+        draw_game_over_value(state.Anchor01, 110, reason_y, 500, 40, "ENERGY DEPLETED", 22);
     }
 }
 
 } // anonymous namespace
-
-const char* death_cause_text(DeathCause cause) {
-    switch (cause) {
-        case DeathCause::EnergyDepleted: return "ENERGY DEPLETED";
-        case DeathCause::None:
-        default:                          return "";
-    }
-}
 
 void set_game_over_screen_test_hooks(GameOverLayoutRenderHook layout_render_hook,
                                      GameOverValueDrawHook value_draw_hook) {

--- a/app/ui/screen_controllers/game_over_screen_controller.h
+++ b/app/ui/screen_controllers/game_over_screen_controller.h
@@ -8,10 +8,6 @@
 void init_game_over_screen_ui();
 void render_game_over_screen_ui(entt::registry& reg);
 
-// Maps a DeathCause to a short, colorblind-safe, platform-neutral one-line
-// reason string suitable for the Game Over ReasonSlot. Returns "" for None.
-const char* death_cause_text(DeathCause cause);
-
 using GameOverLayoutRenderHook = void (*)(struct GameOverLayoutState* state);
 using GameOverValueDrawHook = void (*)(Vector2 anchor, float x, float y, float w, float h,
                                        const char* text, int text_size);

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -134,7 +134,6 @@ TEST_CASE("ecs: make_registry creates all singletons", "[ecs]") {
     // Scoring persistence / end-screen
     static_cast<void>(reg.ctx().get<HighScoreState>());
     static_cast<void>(reg.ctx().get<HighScorePersistence>());
-    static_cast<void>(reg.ctx().get<GameOverState>());
     SUCCEED("all required ctx singletons exist in registry context");
 }
 

--- a/tests/test_energy_system.cpp
+++ b/tests/test_energy_system.cpp
@@ -106,7 +106,7 @@ TEST_CASE("energy: game_state triggers game over when energy reaches zero", "[en
     auto& gs = reg.ctx().get<GameState>();
     CHECK(gs.transition_pending);
     CHECK(gs.next_phase == GamePhase::GameOver);
-    CHECK(reg.ctx().get<GameOverState>().cause == DeathCause::EnergyDepleted);
+    CHECK(reg.ctx().find<EnergyDepletedDeath>() != nullptr);
 }
 
 TEST_CASE("energy: no action when SongState not present", "[energy]") {
@@ -136,7 +136,7 @@ TEST_CASE("energy: depleted energy requests game over when song is not playing",
     auto& gs = reg.ctx().get<GameState>();
     CHECK(gs.transition_pending);
     CHECK(gs.next_phase == GamePhase::GameOver);
-    CHECK(reg.ctx().get<GameOverState>().cause == DeathCause::EnergyDepleted);
+    CHECK(reg.ctx().find<EnergyDepletedDeath>() != nullptr);
 }
 
 TEST_CASE("energy: no action when EnergyState not present", "[energy]") {

--- a/tests/test_game_over_screen_controller.cpp
+++ b/tests/test_game_over_screen_controller.cpp
@@ -46,19 +46,25 @@ struct ScopedGameOverHooks {
 
 } // namespace
 
-TEST_CASE("game_over: death_cause_text maps terminal causes to platform-neutral strings",
+TEST_CASE("game_over: ENERGY DEPLETED reason renders when EnergyDepletedDeath tag is present",
           "[game_over][ui]") {
-    // None → empty (suppresses ReasonSlot rendering).
-    CHECK(std::strlen(death_cause_text(DeathCause::None)) == 0);
+    auto reg = make_registry();
+    ScopedGameOverHooks hooks;
 
-    // Real causes must produce a non-empty, ASCII-only one-liner.
-    for (auto cause : { DeathCause::EnergyDepleted }) {
-        const char* txt = death_cause_text(cause);
-        REQUIRE(txt != nullptr);
-        CHECK(std::strlen(txt) > 0);
-        // Stay short enough to fit ReasonSlot (500px @ 22pt) — sanity bound.
-        CHECK(std::strlen(txt) < 32u);
-    }
+    // Absent tag: no reason text appears.
+    REQUIRE(reg.ctx().find<EnergyDepletedDeath>() == nullptr);
+    auto& gs = reg.ctx().get<GameState>();
+    gs.phase = GamePhase::GameOver;
+    gs.phase_timer = 0.0f;
+
+    render_game_over_screen_ui(reg);
+    CHECK_FALSE(has_bound_text("ENERGY DEPLETED"));
+
+    // Present tag: ENERGY DEPLETED reason is bound.
+    g_captured_values.clear();
+    reg.ctx().emplace<EnergyDepletedDeath>();
+    render_game_over_screen_ui(reg);
+    CHECK(has_bound_text("ENERGY DEPLETED"));
 }
 
 TEST_CASE("game_over: score / high score / cause are visible via registry singletons "
@@ -72,8 +78,7 @@ TEST_CASE("game_over: score / high score / cause are visible via registry single
     score.score = 12345;
     current.value = 99999;
 
-    auto& gos = reg.ctx().insert_or_assign(GameOverState{});
-    gos.cause = DeathCause::EnergyDepleted;
+    reg.ctx().insert_or_assign(EnergyDepletedDeath{});
 
     auto& gs = reg.ctx().get<GameState>();
     gs.phase = GamePhase::GameOver;
@@ -85,9 +90,7 @@ TEST_CASE("game_over: score / high score / cause are visible via registry single
     CHECK(s.score      == 12345);
     CHECK(reg.ctx().get<CurrentSongHighScore>().value == 99999);
 
-    const auto& g = reg.ctx().get<GameOverState>();
-    CHECK(g.cause == DeathCause::EnergyDepleted);
-    CHECK(std::strlen(death_cause_text(g.cause)) > 0);
+    CHECK(reg.ctx().find<EnergyDepletedDeath>() != nullptr);
 }
 
 TEST_CASE("game_over: render binds score/high-score/reason into scoreboard draw path",
@@ -100,8 +103,7 @@ TEST_CASE("game_over: render binds score/high-score/reason into scoreboard draw 
     score.score = 31415;
     current.value = 92653;
 
-    auto& gos = reg.ctx().get<GameOverState>();
-    gos.cause = DeathCause::EnergyDepleted;
+    reg.ctx().insert_or_assign(EnergyDepletedDeath{});
 
     auto& gs = reg.ctx().get<GameState>();
     gs.phase = GamePhase::GameOver;
@@ -124,8 +126,7 @@ TEST_CASE("game_over: render binds new-best badge and previous score", "[game_ov
     current.value = 5000;
     reg.ctx().insert_or_assign(TerminalResultState{true, 3000});
 
-    auto& gos = reg.ctx().get<GameOverState>();
-    gos.cause = DeathCause::EnergyDepleted;
+    reg.ctx().insert_or_assign(EnergyDepletedDeath{});
 
     auto& gs = reg.ctx().get<GameState>();
     gs.phase = GamePhase::GameOver;
@@ -137,7 +138,7 @@ TEST_CASE("game_over: render binds new-best badge and previous score", "[game_ov
     CHECK(has_bound_text("PREV 3000"));
 }
 
-TEST_CASE("game_over: render omits empty reason binding for DeathCause::None", "[game_over][ui]") {
+TEST_CASE("game_over: render omits empty reason binding when no death-cause tag present", "[game_over][ui]") {
     auto reg = make_registry();
     ScopedGameOverHooks hooks;
 
@@ -146,8 +147,7 @@ TEST_CASE("game_over: render omits empty reason binding for DeathCause::None", "
     score.score = 7;
     current.value = 11;
 
-    auto& gos = reg.ctx().get<GameOverState>();
-    gos.cause = DeathCause::None;
+    REQUIRE(reg.ctx().find<EnergyDepletedDeath>() == nullptr);
 
     auto& gs = reg.ctx().get<GameState>();
     gs.phase = GamePhase::GameOver;

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -30,14 +30,13 @@ TEST_CASE("game_state: energy depletion beats song complete after playback finis
     song.finished = true;
     song.playing = false;
     reg.ctx().get<EnergyState>().energy = 0.0f;
-    auto& game_over = reg.ctx().get<GameOverState>();
-    game_over.cause = DeathCause::None;
+    REQUIRE(reg.ctx().find<EnergyDepletedDeath>() == nullptr);
 
     game_state_system(reg, 0.016f);
 
     CHECK(gs.transition_pending);
     CHECK(gs.next_phase == GamePhase::GameOver);
-    CHECK(game_over.cause == DeathCause::EnergyDepleted);
+    CHECK(reg.ctx().find<EnergyDepletedDeath>() != nullptr);
 }
 
 TEST_CASE("game_state: song complete waits for obstacles to clear", "[gamestate]") {

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -51,7 +51,6 @@ inline entt::registry make_registry() {
     reg.ctx().emplace<HighScoreState>();
     reg.ctx().emplace<HighScorePersistence>();
     reg.ctx().emplace<HighScoreSession>();
-    reg.ctx().emplace<GameOverState>();
     runtime_system_scratch_init(reg);
     return reg;
 }

--- a/tests/test_phase_runner.cpp
+++ b/tests/test_phase_runner.cpp
@@ -180,7 +180,7 @@ TEST_CASE("tick_fixed_systems: energy depletion requests GameOver before next Pl
     REQUIRE(energy.energy == 0.0f);
     REQUIRE(gs.transition_pending);
     REQUIRE(gs.next_phase == GamePhase::GameOver);
-    CHECK(reg.ctx().get<GameOverState>().cause == DeathCause::EnergyDepleted);
+    CHECK(reg.ctx().find<EnergyDepletedDeath>() != nullptr);
     CHECK(pending.events.empty());
 
     auto late_miss = reg.create();
@@ -228,5 +228,5 @@ TEST_CASE("tick_fixed_systems: fatal final drain wins after song finishes",
     REQUIRE(energy.energy == 0.0f);
     REQUIRE(gs.transition_pending);
     CHECK(gs.next_phase == GamePhase::GameOver);
-    CHECK(reg.ctx().get<GameOverState>().cause == DeathCause::EnergyDepleted);
+    CHECK(reg.ctx().find<EnergyDepletedDeath>() != nullptr);
 }

--- a/tests/test_redfoot_testflight_ui.cpp
+++ b/tests/test_redfoot_testflight_ui.cpp
@@ -4,7 +4,8 @@
 // These tests now focus on runtime-live coverage only:
 //   * Schema/content checks that remain relevant to current UI flows.
 //   * Wiring checks that scoring leaves non-terminal misses alone and
-//     game_state_system sets terminal GameOverState.cause.
+//     game_state_system emplaces EnergyDepletedDeath into reg.ctx() on
+//     terminal energy depletion.
 
 #include <catch2/catch_test_macros.hpp>
 #include <entt/entity/registry.hpp>
@@ -115,7 +116,6 @@ TEST_CASE("redfoot/#168: collision miss is non-terminal cause context",
     reg.ctx().emplace<CurrentSongHighScore>();
     reg.ctx().emplace<SongResults>();
     reg.ctx().emplace<SongState>();
-    reg.ctx().emplace<GameOverState>();
     runtime_system_scratch_init(reg);
 
     spawn_aligned_player(reg, constants::PLAYER_Y);
@@ -125,8 +125,7 @@ TEST_CASE("redfoot/#168: collision miss is non-terminal cause context",
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
 
-    auto& gos = reg.ctx().get<GameOverState>();
-    CHECK(gos.cause == DeathCause::None);
+    CHECK(reg.ctx().find<EnergyDepletedDeath>() == nullptr);
 }
 
 TEST_CASE("redfoot/#168: energy depletion falls back to ENERGY DEPLETED",
@@ -137,13 +136,11 @@ TEST_CASE("redfoot/#168: energy depletion falls back to ENERGY DEPLETED",
     auto& energy = reg.ctx().emplace<EnergyState>();
     auto& song = reg.ctx().emplace<SongState>();
     song.playing = true;
-    reg.ctx().emplace<GameOverState>();  // cause stays None
     energy.energy = 0.0f;
 
     game_state_system(reg, 0.016f);
 
-    auto& gos = reg.ctx().get<GameOverState>();
-    CHECK(gos.cause == DeathCause::EnergyDepleted);
+    CHECK(reg.ctx().find<EnergyDepletedDeath>() != nullptr);
 }
 
 TEST_CASE("redfoot/#168: energy depletion writes terminal cause",
@@ -154,11 +151,10 @@ TEST_CASE("redfoot/#168: energy depletion writes terminal cause",
     auto& energy = reg.ctx().emplace<EnergyState>();
     auto& song = reg.ctx().emplace<SongState>();
     song.playing = true;
-    auto& gos = reg.ctx().emplace<GameOverState>();
-    gos.cause = DeathCause::None;
+    REQUIRE(reg.ctx().find<EnergyDepletedDeath>() == nullptr);
     energy.energy = 0.0f;
 
     game_state_system(reg, 0.016f);
 
-    CHECK(gos.cause == DeathCause::EnergyDepleted);
+    CHECK(reg.ctx().find<EnergyDepletedDeath>() != nullptr);
 }

--- a/tests/test_scoring_system.cpp
+++ b/tests/test_scoring_system.cpp
@@ -433,8 +433,7 @@ TEST_CASE("scoring: missed NonScorableTag entity is resolved without effects",
 
 TEST_CASE("scoring: missed obstacle drains energy without setting terminal death cause", "[scoring]") {
     auto reg = make_registry();
-    auto& gos = reg.ctx().get<GameOverState>();
-    REQUIRE(gos.cause == DeathCause::None);
+    REQUIRE(reg.ctx().find<EnergyDepletedDeath>() == nullptr);
 
     auto e = reg.create();
     reg.emplace<ObstacleTag>(e);
@@ -445,7 +444,7 @@ TEST_CASE("scoring: missed obstacle drains energy without setting terminal death
 
     scoring_system(reg, 0.0f);
 
-    CHECK(gos.cause == DeathCause::None);
+    CHECK(reg.ctx().find<EnergyDepletedDeath>() == nullptr);
 }
 
 TEST_CASE("scoring: passive accrual stops once song playback has finished", "[scoring][issue445]") {


### PR DESCRIPTION
Eradicates `DeathCause` (24 -> 23 enums in `app/`) via per-cause ctx tags, continuing the issue #1202 / #1204 migration order. This is the smallest unmigrated control-flow enum left after WindowPhase (#1243), Layer (#1242), and MeshType (#1244).

## Per-value schema decision (per #1204)

| Former enum value | Per-value data | Target |
| --- | --- | --- |
| `DeathCause::None` | none | absence of every `*Death` ctx tag (zero rows) |
| `DeathCause::EnergyDepleted` | none | zero-column ctx-singleton table `EnergyDepletedDeath {}` |

Both former values are pure identity. `DeathCause::None` was a *sentinel* for "no terminal cause recorded yet" -- under Fabian's mechanic, that is exactly "no row in any per-cause table," i.e. absence of the tag.

## Mechanic

`GameOverState { DeathCause cause = None; }` -- a singleton holding a *slot* the energy system later mutated -- becomes pure existential processing:

- Terminal cause occurs -> `reg.ctx().insert_or_assign(EnergyDepletedDeath{})`
- UI checks cause -> `if (reg.ctx().find<EnergyDepletedDeath>()) draw "ENERGY DEPLETED"`
- Reset on new run -> `erase_ctx_if_exists<EnergyDepletedDeath>(reg)`

No `switch`, no discriminator, no pre-allocated slot. The `death_cause_text(DeathCause)` helper (4-case switch) is deleted; the one binding site inlines the string. When a second cause is added, the inline form trivially extends to one tag-presence check per cause (per the transform-per-tag pattern Fabian describes).

## Acceptance criteria (per #1204)

- [x] Enum declaration deleted.
- [x] Per former value -> ctx-singleton struct (None = absence; EnergyDepleted = `EnergyDepletedDeath`).
- [x] No `switch` on the former enum anywhere in `app/`.
- [x] No `if (x.kind == DeathCause::*)` discriminator branches.
- [x] System split into per-tag transform (one tag-presence check at the UI binding site; no per-cause function).
- [x] Build is warning-free (Clang `-Wall -Wextra -Werror`).
- [x] All 901 tests pass (2948 assertions) -- no semantic changes.
- [x] Cyclomatic ratchet trends down: one fewer enum-driven `switch` in `app/`.

## Touched sites

- `app/components/game_state.h` -- delete `enum class DeathCause`, delete `struct GameOverState`, add `struct EnergyDepletedDeath {}`.
- `app/ui/screen_controllers/game_over_screen_controller.{h,cpp}` -- delete `death_cause_text` declaration + switch body; inline the tag-presence check at the binding site.
- `app/systems/energy_system.cpp`, `app/systems/game_state_system.cpp` -- emit `EnergyDepletedDeath` ctx tag instead of mutating `gos->cause`.
- `app/systems/play_session.cpp` -- session error reset / new-session setup erase any prior `*Death` ctx tags (replaces the old "reset cause to None" assign + pre-emplace).
- `app/game_loop.cpp` -- drop `reset_ctx_singleton<GameOverState>` at startup (no longer required; absent = None).
- `tests/test_*.cpp`, `tests/test_helpers.h` -- assert tag presence/absence rather than enum equality.

## Test results

```
All tests passed (2948 assertions in 901 test cases)
```

Baseline pre-migration was 2947 assertions; the +1 is from explicit `REQUIRE(reg.ctx().find<EnergyDepletedDeath>() == nullptr)` preconditions added where tests previously relied on `GameOverState`'s default-init.

## Follow-up

Remaining control-flow enums per #1202 migration order: `Shape`, `ObstacleKind`, `GamePhase` (biggest), `TimingTier`, `VMode`, `EndScreenChoice`, `TestPlayerSkill`, `ActionDoneBit`, `GamePhaseBit`. Each is its own PR per the canon.

Refs: #1202, #1204
