### PR TITLE
Migrate EndScreenChoice enum to per-choice ctx tags (refs #1202, #1204)

### DIFF
--- a/app/components/game_state.h
+++ b/app/components/game_state.h
@@ -14,15 +14,24 @@ enum class GamePhase : uint8_t {
     Tutorial     = 7
 };
 
-enum class EndScreenChoice : uint8_t { None = 0, Restart = 1, LevelSelect = 2, MainMenu = 3 };
-
 struct GameState {
     GamePhase phase            = GamePhase::Title;
     float     phase_timer      = 0.0f;
     bool      transition_pending = false;
     GamePhase next_phase       = GamePhase::Title;
-    EndScreenChoice end_choice = EndScreenChoice::None;
 };
+
+// ── End-screen menu choice (per-choice ctx tables) ───────────
+// Per Fabian's existential processing (issue #1202/#1204), each former
+// EndScreenChoice value is its own zero-column table on `registry.ctx()`.
+// Presence of an EndChoice* tag signals the player's selection on a Game
+// Over or Song Complete screen; absence of all three is the "no choice
+// yet" state (what EndScreenChoice::None represented). One transform per
+// tag in `game_state_end_screen_system` consumes the choice when the
+// per-phase input delay has elapsed; until then the tag persists.
+struct EndChoiceRestart {};
+struct EndChoiceLevelSelect {};
+struct EndChoiceMainMenu {};
 
 struct LevelSelectState {
     int selected_level      = 0;

--- a/app/systems/game_state_end_screen_system.cpp
+++ b/app/systems/game_state_end_screen_system.cpp
@@ -4,26 +4,57 @@
 
 namespace {
 
-GamePhase resolve_end_screen_phase(EndScreenChoice choice) {
-    if (choice == EndScreenChoice::Restart) return GamePhase::Playing;
-    if (choice == EndScreenChoice::LevelSelect) return GamePhase::LevelSelect;
-    return GamePhase::Title;
+bool end_screen_input_ready(const GameState& gs) {
+    const bool game_over_ready =
+        gs.phase == GamePhase::GameOver && gs.phase_timer > constants::GAME_OVER_INPUT_DELAY;
+    const bool song_complete_ready =
+        gs.phase == GamePhase::SongComplete && gs.phase_timer > constants::SONG_COMPLETE_INPUT_DELAY;
+    return game_over_ready || song_complete_ready;
+}
+
+void erase_end_choice_tags(entt::registry& reg) {
+    if (reg.ctx().find<EndChoiceRestart>())     reg.ctx().erase<EndChoiceRestart>();
+    if (reg.ctx().find<EndChoiceLevelSelect>()) reg.ctx().erase<EndChoiceLevelSelect>();
+    if (reg.ctx().find<EndChoiceMainMenu>())    reg.ctx().erase<EndChoiceMainMenu>();
+}
+
+// One transform per former enum value (Fabian's "transform per tag" mechanic).
+// Each is gated by tag presence AND the shared input-ready predicate, so a
+// choice latched during the input-delay window persists until the delay
+// elapses — matching the pre-migration semantics. The handlers are mutually
+// exclusive in practice because input routing only ever emplaces one tag per
+// press; erase_end_choice_tags on consumption keeps that invariant explicit.
+void apply_end_choice_restart(entt::registry& reg) {
+    if (!reg.ctx().find<EndChoiceRestart>()) return;
+    auto& gs = reg.ctx().get<GameState>();
+    if (!end_screen_input_ready(gs)) return;
+    gs.transition_pending = true;
+    gs.next_phase = GamePhase::Playing;
+    erase_end_choice_tags(reg);
+}
+
+void apply_end_choice_level_select(entt::registry& reg) {
+    if (!reg.ctx().find<EndChoiceLevelSelect>()) return;
+    auto& gs = reg.ctx().get<GameState>();
+    if (!end_screen_input_ready(gs)) return;
+    gs.transition_pending = true;
+    gs.next_phase = GamePhase::LevelSelect;
+    erase_end_choice_tags(reg);
+}
+
+void apply_end_choice_main_menu(entt::registry& reg) {
+    if (!reg.ctx().find<EndChoiceMainMenu>()) return;
+    auto& gs = reg.ctx().get<GameState>();
+    if (!end_screen_input_ready(gs)) return;
+    gs.transition_pending = true;
+    gs.next_phase = GamePhase::Title;
+    erase_end_choice_tags(reg);
 }
 
 }  // namespace
 
 void game_state_end_screen_system(entt::registry& reg, [[maybe_unused]] float dt) {
-    auto& gs = reg.ctx().get<GameState>();
-    const bool game_over_ready =
-        gs.phase == GamePhase::GameOver && gs.phase_timer > constants::GAME_OVER_INPUT_DELAY;
-    const bool song_complete_ready =
-        gs.phase == GamePhase::SongComplete && gs.phase_timer > constants::SONG_COMPLETE_INPUT_DELAY;
-    if (!(game_over_ready || song_complete_ready) ||
-        gs.end_choice == EndScreenChoice::None) {
-        return;
-    }
-
-    gs.transition_pending = true;
-    gs.next_phase = resolve_end_screen_phase(gs.end_choice);
-    gs.end_choice = EndScreenChoice::None;
+    apply_end_choice_restart(reg);
+    apply_end_choice_level_select(reg);
+    apply_end_choice_main_menu(reg);
 }

--- a/app/systems/game_state_routing.cpp
+++ b/app/systems/game_state_routing.cpp
@@ -32,11 +32,11 @@ bool game_state_handle_end_screen_press(entt::registry& reg, const ButtonPressEv
     }
 
     if (action == MenuActionKind::Restart) {
-        gs.end_choice = EndScreenChoice::Restart;
+        reg.ctx().insert_or_assign(EndChoiceRestart{});
     } else if (action == MenuActionKind::GoLevelSelect) {
-        gs.end_choice = EndScreenChoice::LevelSelect;
+        reg.ctx().insert_or_assign(EndChoiceLevelSelect{});
     } else if (action == MenuActionKind::GoMainMenu) {
-        gs.end_choice = EndScreenChoice::MainMenu;
+        reg.ctx().insert_or_assign(EndChoiceMainMenu{});
     }
     return true;
 }

--- a/app/systems/play_session.cpp
+++ b/app/systems/play_session.cpp
@@ -173,6 +173,9 @@ void setup_play_session(entt::registry& reg) {
         erase_ctx_if_exists<EnergyState>(reg);
         erase_ctx_if_exists<SongResults>(reg);
         erase_ctx_if_exists<EnergyDepletedDeath>(reg);
+        erase_ctx_if_exists<EndChoiceRestart>(reg);
+        erase_ctx_if_exists<EndChoiceLevelSelect>(reg);
+        erase_ctx_if_exists<EndChoiceMainMenu>(reg);
         lss.confirmed = false;
         auto& gs = reg.ctx().get<GameState>();
         enter_phase(gs, GamePhase::LevelSelect);
@@ -246,9 +249,13 @@ void setup_play_session(entt::registry& reg) {
         results.total_notes = count_result_notes(beatmap);
         assign_or_emplace_ctx(reg, results);
     }
-    // Clear any death-cause tags carried over from a previous run; absence
-    // of all *Death ctx tags is the "no terminal cause recorded yet" state.
+    // Clear any death-cause and end-screen-choice tags carried over from a
+    // previous run; absence of all *Death and EndChoice* ctx tags is the
+    // "no terminal cause / no choice recorded yet" state.
     erase_ctx_if_exists<EnergyDepletedDeath>(reg);
+    erase_ctx_if_exists<EndChoiceRestart>(reg);
+    erase_ctx_if_exists<EndChoiceLevelSelect>(reg);
+    erase_ctx_if_exists<EndChoiceMainMenu>(reg);
 
     // Load stored high score for this song+difficulty into CurrentSongHighScore
     if (auto* hs = reg.ctx().find<HighScoreState>()) {

--- a/app/ui/screen_controllers/game_over_screen_controller.cpp
+++ b/app/ui/screen_controllers/game_over_screen_controller.cpp
@@ -92,5 +92,5 @@ void render_game_over_screen_ui(entt::registry& reg) {
     auto& gs = reg.ctx().get<GameState>();
     if (gs.phase_timer <= constants::GAME_OVER_INPUT_DELAY) return;
 
-    dispatch_end_screen_choice(gs, controller.state());
+    dispatch_end_screen_choice(reg, controller.state());
 }

--- a/app/ui/screen_controllers/screen_controller_base.h
+++ b/app/ui/screen_controllers/screen_controller_base.h
@@ -52,14 +52,17 @@ inline Rectangle offset_rect(Vector2 anchor, float x, float y, float w, float h)
 
 // Generic end-screen choice dispatcher. Used by game_over and song_complete controllers.
 // LayoutState must have RestartButtonPressed, LevelSelectButtonPressed, MenuButtonPressed fields.
+// Each branch emplaces the corresponding zero-column ctx table; absence of all three
+// is the "no choice yet" state. game_state_end_screen_system consumes the tag once
+// the per-phase input delay has elapsed.
 template<typename LayoutState>
-inline void dispatch_end_screen_choice(GameState& gs, const LayoutState& state) {
+inline void dispatch_end_screen_choice(entt::registry& reg, const LayoutState& state) {
     if (state.RestartButtonPressed)
-        gs.end_choice = EndScreenChoice::Restart;
+        reg.ctx().insert_or_assign(EndChoiceRestart{});
     else if (state.LevelSelectButtonPressed)
-        gs.end_choice = EndScreenChoice::LevelSelect;
+        reg.ctx().insert_or_assign(EndChoiceLevelSelect{});
     else if (state.MenuButtonPressed)
-        gs.end_choice = EndScreenChoice::MainMenu;
+        reg.ctx().insert_or_assign(EndChoiceMainMenu{});
 }
 
 #endif // SCREEN_CONTROLLER_BASE_H

--- a/app/ui/screen_controllers/song_complete_screen_controller.cpp
+++ b/app/ui/screen_controllers/song_complete_screen_controller.cpp
@@ -78,5 +78,5 @@ void render_song_complete_screen_ui(entt::registry& reg) {
     auto& gs = reg.ctx().get<GameState>();
     if (gs.phase_timer <= constants::SONG_COMPLETE_INPUT_DELAY) return;
 
-    dispatch_end_screen_choice(gs, controller.state());
+    dispatch_end_screen_choice(reg, controller.state());
 }

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -499,21 +499,19 @@ enum class GamePhase : uint8_t {
     Tutorial     = 7
 };
 
-enum class EndScreenChoice : uint8_t {
-    None = 0,
-    Restart = 1,
-    LevelSelect = 2,
-    MainMenu = 3
-};
-
 /// Singleton: governs which systems run and screen transitions.
 struct GameState {
     GamePhase  phase;
     float      phase_timer;          // seconds in current phase
     bool       transition_pending;   // set to request a phase change
     GamePhase  next_phase;           // destination of pending transition
-    EndScreenChoice end_choice;      // pending end-screen menu action
 };
+
+// End-screen menu choice — per-choice zero-column tables on registry.ctx().
+// Absence of all three is the "no choice yet" state. See §"Terminal Phases".
+struct EndChoiceRestart {};
+struct EndChoiceLevelSelect {};
+struct EndChoiceMainMenu {};
 ```
 
 Active phase responsibilities:
@@ -853,9 +851,12 @@ not route into it. Its continue action transitions to `Playing`.
 
 ### Terminal Phases
 
-`GameOver` and `SongComplete` are terminal result screens. End-screen UI writes
-`GameState::end_choice`; `game_state_end_screen_system` converts it to the next
-phase (`Playing`, `LevelSelect`, or `Title`) and queues the deferred transition.
+`GameOver` and `SongComplete` are terminal result screens. End-screen UI
+emplaces one of the per-choice ctx tags (`EndChoiceRestart`,
+`EndChoiceLevelSelect`, `EndChoiceMainMenu`); `game_state_end_screen_system`
+runs one transform per tag, converts the choice to the next phase
+(`Playing`, `LevelSelect`, or `Title`), queues the deferred transition, and
+erases the tag. While all three tags are absent, no choice is pending.
 
 ---
 
@@ -1053,8 +1054,7 @@ int main(int argc, char* argv[]) {
         .phase = GamePhase::Title,
         .phase_timer = 0.0f,
         .transition_pending = false,
-        .next_phase = GamePhase::Title,
-        .end_choice = EndScreenChoice::None
+        .next_phase = GamePhase::Title
     });
     reg.ctx().emplace<AudioQueue>();
 

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -137,13 +137,15 @@ TEST_CASE("game_state: song_complete button choice restart", "[gamestate]") {
     auto& gs = reg.ctx().get<GameState>();
     gs.phase = GamePhase::SongComplete;
     gs.phase_timer = 1.0f;
-    gs.end_choice = EndScreenChoice::Restart;
+    reg.ctx().emplace<EndChoiceRestart>();
 
     game_state_system(reg, 0.016f);
 
     CHECK(gs.transition_pending);
     CHECK(gs.next_phase == GamePhase::Playing);
-    CHECK(gs.end_choice == EndScreenChoice::None);
+    CHECK(reg.ctx().find<EndChoiceRestart>() == nullptr);
+    CHECK(reg.ctx().find<EndChoiceLevelSelect>() == nullptr);
+    CHECK(reg.ctx().find<EndChoiceMainMenu>() == nullptr);
 }
 
 TEST_CASE("game_state: song_complete button choice level_select", "[gamestate]") {
@@ -151,13 +153,15 @@ TEST_CASE("game_state: song_complete button choice level_select", "[gamestate]")
     auto& gs = reg.ctx().get<GameState>();
     gs.phase = GamePhase::SongComplete;
     gs.phase_timer = 1.0f;
-    gs.end_choice = EndScreenChoice::LevelSelect;
+    reg.ctx().emplace<EndChoiceLevelSelect>();
 
     game_state_system(reg, 0.016f);
 
     CHECK(gs.transition_pending);
     CHECK(gs.next_phase == GamePhase::LevelSelect);
-    CHECK(gs.end_choice == EndScreenChoice::None);
+    CHECK(reg.ctx().find<EndChoiceRestart>() == nullptr);
+    CHECK(reg.ctx().find<EndChoiceLevelSelect>() == nullptr);
+    CHECK(reg.ctx().find<EndChoiceMainMenu>() == nullptr);
 }
 
 TEST_CASE("game_state: song_complete button choice main_menu", "[gamestate]") {
@@ -165,7 +169,7 @@ TEST_CASE("game_state: song_complete button choice main_menu", "[gamestate]") {
     auto& gs = reg.ctx().get<GameState>();
     gs.phase = GamePhase::SongComplete;
     gs.phase_timer = 1.0f;
-    gs.end_choice = EndScreenChoice::MainMenu;
+    reg.ctx().emplace<EndChoiceMainMenu>();
 
     game_state_system(reg, 0.016f);
 
@@ -178,7 +182,7 @@ TEST_CASE("game_state: song_complete ignores choice during delay", "[gamestate]"
     auto& gs = reg.ctx().get<GameState>();
     gs.phase = GamePhase::SongComplete;
     gs.phase_timer = 0.2f;  // < 0.5s delay
-    gs.end_choice = EndScreenChoice::Restart;
+    reg.ctx().emplace<EndChoiceRestart>();
 
     game_state_system(reg, 0.016f);
 
@@ -392,7 +396,7 @@ TEST_CASE("game_state: game_over restart button triggers playing", "[gamestate]"
     auto& gs = reg.ctx().get<GameState>();
     gs.phase = GamePhase::GameOver;
     gs.phase_timer = 0.5f;
-    gs.end_choice = EndScreenChoice::Restart;
+    reg.ctx().emplace<EndChoiceRestart>();
 
     game_state_system(reg, 0.016f);
 
@@ -405,7 +409,7 @@ TEST_CASE("game_state: game_over main_menu button triggers title", "[gamestate]"
     auto& gs = reg.ctx().get<GameState>();
     gs.phase = GamePhase::GameOver;
     gs.phase_timer = 0.5f;
-    gs.end_choice = EndScreenChoice::MainMenu;
+    reg.ctx().emplace<EndChoiceMainMenu>();
 
     game_state_system(reg, 0.016f);
 
@@ -418,13 +422,15 @@ TEST_CASE("game_state: game_over level_select button triggers level_select", "[g
     auto& gs = reg.ctx().get<GameState>();
     gs.phase = GamePhase::GameOver;
     gs.phase_timer = 0.5f;
-    gs.end_choice = EndScreenChoice::LevelSelect;
+    reg.ctx().emplace<EndChoiceLevelSelect>();
 
     game_state_system(reg, 0.016f);
 
     CHECK(gs.transition_pending);
     CHECK(gs.next_phase == GamePhase::LevelSelect);
-    CHECK(gs.end_choice == EndScreenChoice::None);
+    CHECK(reg.ctx().find<EndChoiceRestart>() == nullptr);
+    CHECK(reg.ctx().find<EndChoiceLevelSelect>() == nullptr);
+    CHECK(reg.ctx().find<EndChoiceMainMenu>() == nullptr);
 }
 
 TEST_CASE("game_state: game_over ignores choice at readiness boundary", "[gamestate]") {
@@ -432,12 +438,14 @@ TEST_CASE("game_state: game_over ignores choice at readiness boundary", "[gamest
     auto& gs = reg.ctx().get<GameState>();
     gs.phase = GamePhase::GameOver;
     gs.phase_timer = 0.4f;
-    gs.end_choice = EndScreenChoice::Restart;
+    reg.ctx().emplace<EndChoiceRestart>();
 
     game_state_system(reg, 0.0f);
 
     CHECK_FALSE(gs.transition_pending);
-    CHECK(gs.end_choice == EndScreenChoice::Restart);
+    // Tag persists across the input-delay window so the press is honored
+    // once the delay elapses (pre-migration semantics).
+    CHECK(reg.ctx().find<EndChoiceRestart>() != nullptr);
 }
 
 TEST_CASE("game_state: game_over ignores missing end choice", "[gamestate]") {
@@ -445,12 +453,16 @@ TEST_CASE("game_state: game_over ignores missing end choice", "[gamestate]") {
     auto& gs = reg.ctx().get<GameState>();
     gs.phase = GamePhase::GameOver;
     gs.phase_timer = 0.5f;
-    gs.end_choice = EndScreenChoice::None;
+    REQUIRE(reg.ctx().find<EndChoiceRestart>() == nullptr);
+    REQUIRE(reg.ctx().find<EndChoiceLevelSelect>() == nullptr);
+    REQUIRE(reg.ctx().find<EndChoiceMainMenu>() == nullptr);
 
     game_state_system(reg, 0.016f);
 
     CHECK_FALSE(gs.transition_pending);
-    CHECK(gs.end_choice == EndScreenChoice::None);
+    CHECK(reg.ctx().find<EndChoiceRestart>() == nullptr);
+    CHECK(reg.ctx().find<EndChoiceLevelSelect>() == nullptr);
+    CHECK(reg.ctx().find<EndChoiceMainMenu>() == nullptr);
 }
 
 TEST_CASE("game_state: game_over restart enters fresh play session on next tick", "[gamestate][play_session]") {
@@ -458,7 +470,7 @@ TEST_CASE("game_state: game_over restart enters fresh play session on next tick"
     auto& gs = reg.ctx().get<GameState>();
     gs.phase = GamePhase::GameOver;
     gs.phase_timer = 0.5f;
-    gs.end_choice = EndScreenChoice::Restart;
+    reg.ctx().emplace<EndChoiceRestart>();
 
     auto stale = reg.create();
     reg.emplace<ObstacleTag>(stale);

--- a/tests/test_world_systems.cpp
+++ b/tests/test_world_systems.cpp
@@ -171,7 +171,9 @@ TEST_CASE("game_state: song complete keyboard confirm waits for button debounce"
     game_state_system(reg, 0.0f);
 
     CHECK_FALSE(gs.transition_pending);
-    CHECK(gs.end_choice == EndScreenChoice::None);
+    CHECK(reg.ctx().find<EndChoiceRestart>() == nullptr);
+    CHECK(reg.ctx().find<EndChoiceLevelSelect>() == nullptr);
+    CHECK(reg.ctx().find<EndChoiceMainMenu>() == nullptr);
 }
 
 TEST_CASE("game_state: game over ignores touch during delay", "[gamestate]") {


### PR DESCRIPTION
Per Fabian's existential processing (Principle 1: *Control-flow enums become tables, not switch statements*), each former `EndScreenChoice` value becomes its own zero-column ctx table. The discriminator-on-`GameState` field is gone; the per-choice handlers each view their own table.

Continues the enum-eradication track for #1202 / #1204 after:
- PR #1242 (Layer — pure delete)
- PR #1243 (WindowPhase → per-phase tags)
- PR #1244 (MeshType → per-kind tags + struct)
- PR #1245 (DeathCause → per-cause ctx tags)
- PR #1246 (GamePhaseBit — pure delete)

## Per-value schema decisions

Each former value carries no data, so all three target zero-column ctx tables (Principle 2: a tag is the degenerate-zero-column case of a table). Mirrors the `EnergyDepletedDeath` precedent (#1245).

| Former value | Target |
| --- | --- |
| `EndScreenChoice::None` | absence of all three ctx tags |
| `EndScreenChoice::Restart` | `EndChoiceRestart {}` |
| `EndScreenChoice::LevelSelect` | `EndChoiceLevelSelect {}` |
| `EndScreenChoice::MainMenu` | `EndChoiceMainMenu {}` |

`GameState::end_choice` was a nullable column meaningful only across the `GameOver`/`SongComplete` phase boundary — a 1NF violation per Principle 3. It dies with the enum.

## Dispatch eliminated

`resolve_end_screen_phase()` (a 2-case `switch`-shaped `if`-chain on `EndScreenChoice`) is gone. `game_state_end_screen_system` is now three `apply_end_choice_*` transforms, one per former enum value (Principle 1's *one system per former case*):

```cpp
void apply_end_choice_restart(entt::registry& reg) {
    if (!reg.ctx().find<EndChoiceRestart>()) return;
    auto& gs = reg.ctx().get<GameState>();
    if (!end_screen_input_ready(gs)) return;
    gs.transition_pending = true;
    gs.next_phase = GamePhase::Playing;
    erase_end_choice_tags(reg);
}
// + apply_end_choice_level_select, apply_end_choice_main_menu
```

`end_screen_input_ready()` is data-only guard logic (phase-timer check), not dispatch — no `switch` on phase. `erase_end_choice_tags()` keeps the one-tag-at-a-time invariant explicit (input routing already enforces this on emplace).

## Acceptance criteria (from #1202 / #1204)

- ✅ Enum declaration deleted (22 → 21 in `app/`).
- ✅ One ctx table per former value (`None` = absence; Restart/LevelSelect/MainMenu = presence of corresponding zero-column tag).
- ✅ No `switch` on the former enum anywhere in `app/`.
- ✅ No `if (x == EndScreenChoice::*)` discriminator branches.
- ✅ Previously branched system split into three per-tag transforms.
- ✅ Zero-warning build under both unity **AND** non-unity Clang `-Wall -Wextra -Werror`.
- ✅ All 896 tests pass (2929 assertions, +13 from new tag presence/absence checks).

## Semantic-preservation note

The pre-migration `end_choice` field had a subtle property: a choice pressed during the `GAME_OVER_INPUT_DELAY` / `SONG_COMPLETE_INPUT_DELAY` window was **held** (not consumed) until the delay expired. The new per-transform mechanic preserves this exactly: each transform's tag-presence + `end_screen_input_ready` guard means the tag persists across the readiness boundary, and only the `gs.phase_timer > delay` branch triggers consumption. Explicit regression coverage in `test_game_state_extended.cpp`:

```cpp
TEST_CASE("game_state: game_over ignores choice at readiness boundary", "[gamestate]") {
    // ...
    reg.ctx().emplace<EndChoiceRestart>();
    game_state_system(reg, 0.0f);
    CHECK_FALSE(gs.transition_pending);
    // Tag persists across the input-delay window so the press is honored
    // once the delay elapses (pre-migration semantics).
    CHECK(reg.ctx().find<EndChoiceRestart>() != nullptr);
}
```

## Remaining enums in the migration order (per #1202)

`Shape` (largest blast radius next), `ObstacleKind` (22 files), `GamePhase` (blocked on `game_state.h` SPLIT), `TimingTier`, `VMode`, `TestPlayerSkill`, `ActionDoneBit`.

The `app/.allowed-enums.txt` CI guard from #1204 still needs to land separately.
