### PR TITLE
Migrate VMode enum to per-state component tables (refs #1202, #1204)

### DIFF
--- a/app/components/player.h
+++ b/app/components/player.h
@@ -35,14 +35,24 @@ struct Lane {
     float  lerp_t  = 1.0f;
 };
 
-enum class VMode : uint8_t {
-    Grounded = 0,
-    Jumping  = 1,
-    Sliding  = 2
-};
-
-struct VerticalState {
-    VMode mode     = VMode::Grounded;
+// ── Vertical motion state (per-state component tables) ──────
+// Per Fabian's existential processing (issue #1202/#1204), each former
+// VMode value becomes its own component table on the player entity:
+//   - `Jumping` present  → entity is mid-jump  (timer + parabolic y_offset)
+//   - `Sliding` present  → entity is mid-slide (timer; y_offset always 0,
+//     visual squash is handled in the render system)
+//   - Absence of both    → grounded (default state — no data needed)
+//
+// State transitions are table operations:
+//   start jump:  reg.emplace<Jumping>(e, {JUMP_DURATION, 0.0f});
+//   end jump:    reg.remove<Jumping>(e);
+// `player_movement_system` splits per-state ticks (jumping / sliding)
+// into separate transforms operating on their own filtered views.
+struct Jumping {
     float timer    = 0.0f;
     float y_offset = 0.0f;
+};
+
+struct Sliding {
+    float timer = 0.0f;
 };

--- a/app/entities/obstacle_entity.h
+++ b/app/entities/obstacle_entity.h
@@ -2,7 +2,7 @@
 
 #include <entt/entt.hpp>
 #include "../components/obstacle.h"
-#include "../components/player.h"  // Shape, VMode
+#include "../components/player.h"  // Shape
 #include "../components/rhythm.h"  // BeatInfo
 
 // Full construction parameters for an obstacle entity.

--- a/app/entities/player_entity.cpp
+++ b/app/entities/player_entity.cpp
@@ -26,7 +26,8 @@ entt::entity create_player_entity(entt::registry& reg) {
         // Idle phase = absence of all ShapeWindow*Tag (per #1202/#1204).
     }
     reg.emplace<Lane>(player);
-    reg.emplace<VerticalState>(player);
+    // Vertical motion is grounded by default — no Jumping/Sliding component
+    // is emplaced (Grounded == absence of both per #1202/#1204).
     reg.emplace<Color>(player, Color{80, 180, 255, 255});
     reg.emplace<DrawSize>(player, constants::PLAYER_SIZE, constants::PLAYER_SIZE);
     reg.emplace<TagWorldPass>(player);

--- a/app/systems/camera_system.cpp
+++ b/app/systems/camera_system.cpp
@@ -295,11 +295,12 @@ void game_camera_system(entt::registry& reg, [[maybe_unused]] float dt) {
 
     // 3. Player shape transform
     {
-        auto view = reg.view<PlayerTag, WorldTransform, PlayerShape, VerticalState, Color>();
-        for (auto [entity, transform, pshape, vstate, col] : view.each()) {
-            float y_3d = -vstate.y_offset;
+        auto view = reg.view<PlayerTag, WorldTransform, PlayerShape, Color>();
+        for (auto [entity, transform, pshape, col] : view.each()) {
+            const auto* jump = reg.try_get<Jumping>(entity);
+            float y_3d = jump ? -jump->y_offset : 0.0f;
             float sz = constants::PLAYER_SIZE;
-            if (vstate.mode == VMode::Sliding) sz *= 0.5f;
+            if (reg.all_of<Sliding>(entity)) sz *= 0.5f;
             const int shape_idx = shape_index(pshape.current);
             if (shape_idx < 0) {
                 TraceLog(LOG_WARNING, "game_camera_system skipped invalid PlayerShape %d",

--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -53,12 +53,12 @@ bool shape_gate_lane_match(int8_t obstacle_lane, int player_lane) {
 }  // namespace
 
 void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
-    auto player_view = reg.view<PlayerTag, WorldTransform, PlayerShape, ShapeWindow, Lane, VerticalState>();
+    auto player_view = reg.view<PlayerTag, WorldTransform, PlayerShape, ShapeWindow, Lane>();
     if (player_view.begin() == player_view.end()) return;
 
     auto player_entity = *player_view.begin();
-    auto [p_transform, p_shape, p_window, p_lane, p_vstate] =
-        player_view.get<WorldTransform, PlayerShape, ShapeWindow, Lane, VerticalState>(player_entity);
+    auto [p_transform, p_shape, p_window, p_lane] =
+        player_view.get<WorldTransform, PlayerShape, ShapeWindow, Lane>(player_entity);
     lane_utils::normalize(p_lane, &p_transform);
 
     auto& song = reg.ctx().get<SongState>();
@@ -67,7 +67,10 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
     // Frame-constant precomputes — both values are invariant across all obstacle
     // loops since player transform and vertical state don't change mid-frame.
     // Precomputing here avoids redundant addition + Vector2 construction per obstacle.
-    const float player_timing_y = p_transform.position.y + p_vstate.y_offset;
+    // Only Jumping carries a y_offset; Sliding and Grounded leave it at 0.
+    const auto* p_jump = reg.try_get<Jumping>(player_entity);
+    const float player_y_offset = p_jump ? p_jump->y_offset : 0.0f;
+    const float player_timing_y = p_transform.position.y + player_y_offset;
     const int player_lane       = lane_utils::nearest_lane_for_x(p_transform.position.x);
 
     // resolve: tag entity as scored (cleared) or missed.

--- a/app/systems/player_input_system.cpp
+++ b/app/systems/player_input_system.cpp
@@ -26,8 +26,8 @@ void push_haptic(entt::registry& reg, HapticEvent event) {
 
 void player_input_handle_go(entt::registry& reg, const GoEvent& evt) {
     if (!gameplay_input_enabled(reg)) return;
-    auto view = reg.view<PlayerTag, PlayerShape, ShapeWindow, Lane, VerticalState>();
-    for (auto [entity, pshape, swindow, lane, vstate] : view.each()) {
+    auto view = reg.view<PlayerTag, PlayerShape, ShapeWindow, Lane>();
+    for (auto [entity, pshape, swindow, lane] : view.each()) {
         lane_utils::normalize(lane);
         const bool horizontal_input = evt.dir == Direction::Left || evt.dir == Direction::Right;
         const bool lane_switch_active =
@@ -42,20 +42,16 @@ void player_input_handle_go(entt::registry& reg, const GoEvent& evt) {
             }
         }
 
+        const bool grounded = !reg.any_of<Jumping, Sliding>(entity);
         if (delta != 0) {
             lane.target = lane.current + delta;
             lane.lerp_t = 0.0f;
             push_haptic(reg, HapticEvent::LaneSwitch);
-        } else if (!horizontal_input && evt.dir == Direction::Up && vstate.mode == VMode::Grounded) {
-            vstate.mode = VMode::Jumping;
-            vstate.timer = constants::JUMP_DURATION;
-            vstate.y_offset = 0.0f;
-        } else if (!horizontal_input && evt.dir == Direction::Down && vstate.mode == VMode::Grounded) {
-            vstate.mode = VMode::Sliding;
-            vstate.timer = constants::SLIDE_DURATION;
-            vstate.y_offset = 0.0f;
+        } else if (!horizontal_input && evt.dir == Direction::Up && grounded) {
+            reg.emplace<Jumping>(entity, Jumping{constants::JUMP_DURATION, 0.0f});
+        } else if (!horizontal_input && evt.dir == Direction::Down && grounded) {
+            reg.emplace<Sliding>(entity, Sliding{constants::SLIDE_DURATION});
         }
-        (void)entity;
         (void)pshape;
         (void)swindow;
     }

--- a/app/systems/player_movement_system.cpp
+++ b/app/systems/player_movement_system.cpp
@@ -9,12 +9,52 @@
 #include "../util/lane_utils.h"
 #include <raymath.h>
 
+namespace {
+
+// Tick all jumping entities: advance the parabolic-arc timer, update
+// y_offset, and remove the Jumping component when the jump lands
+// (firing the JumpLand haptic). Per Fabian, this is the "Jumping"
+// table's per-row transform; entities without a Jumping row are not
+// touched.
+void tick_jumping(entt::registry& reg, float dt) {
+    auto view = reg.view<PlayerTag, Jumping>();
+    for (auto [entity, jump] : view.each()) {
+        jump.timer -= dt;
+        const float half = constants::JUMP_DURATION / 2.0f;
+        const float t = constants::JUMP_DURATION - jump.timer;
+        const float normalized = t / half - 1.0f;
+        jump.y_offset = -constants::JUMP_HEIGHT * (1.0f - normalized * normalized);
+
+        if (jump.timer <= 0.0f) {
+            if (auto* disp = reg.ctx().find<entt::dispatcher>()) {
+                disp->enqueue<PlayHapticEvent>({HapticEvent::JumpLand});
+            }
+            reg.remove<Jumping>(entity);
+        }
+    }
+}
+
+// Tick all sliding entities: advance the slide timer and remove the
+// Sliding component when the slide completes. Slide has no vertical
+// offset — the visual squash is applied by the render system.
+void tick_sliding(entt::registry& reg, float dt) {
+    auto view = reg.view<PlayerTag, Sliding>();
+    for (auto [entity, slide] : view.each()) {
+        slide.timer -= dt;
+        if (slide.timer <= 0.0f) {
+            reg.remove<Sliding>(entity);
+        }
+    }
+}
+
+}  // namespace
+
 void player_movement_system(entt::registry& reg, float dt) {
     auto* song = reg.ctx().find<SongState>();
     const bool rhythm_mode = (song != nullptr && (song->playing || song->finished));
 
-    auto view = reg.view<PlayerTag, WorldTransform, PlayerShape, Lane, VerticalState>();
-    for (auto [entity, transform, pshape, lane, vstate] : view.each()) {
+    auto view = reg.view<PlayerTag, WorldTransform, PlayerShape, Lane>();
+    for (auto [entity, transform, pshape, lane] : view.each()) {
         lane_utils::normalize(lane, &transform);
 
         // Morph animation — freeplay only.
@@ -43,32 +83,12 @@ void player_movement_system(entt::registry& reg, float dt) {
                 transform.position.x = constants::LANE_X[lane.current];
             }
         }
-
-        // Vertical movement
-        if (vstate.mode != VMode::Grounded) {
-            vstate.timer -= dt;
-
-            if (vstate.mode == VMode::Jumping) {
-                // Parabolic jump: peak at half duration
-                float half = constants::JUMP_DURATION / 2.0f;
-                float t = constants::JUMP_DURATION - vstate.timer;
-                float normalized = t / half - 1.0f;
-                vstate.y_offset = -constants::JUMP_HEIGHT * (1.0f - normalized * normalized);
-            } else if (vstate.mode == VMode::Sliding) {
-                vstate.y_offset = 0.0f; // visual handled in render (squash)
-            }
-
-            if (vstate.timer <= 0.0f) {
-                const bool was_jumping = (vstate.mode == VMode::Jumping);
-                if (was_jumping) {
-                    if (auto* disp = reg.ctx().find<entt::dispatcher>()) {
-                        disp->enqueue<PlayHapticEvent>({HapticEvent::JumpLand});
-                    }
-                }
-                vstate.mode     = VMode::Grounded;
-                vstate.timer    = 0.0f;
-                vstate.y_offset = 0.0f;
-            }
-        }
+        (void)entity;
     }
+
+    // Per-state vertical-motion transforms (issue #1202/#1204).
+    // Grounded entities have neither Jumping nor Sliding, so no transform
+    // runs for them.
+    tick_jumping(reg, dt);
+    tick_sliding(reg, dt);
 }

--- a/app/systems/test_player.h
+++ b/app/systems/test_player.h
@@ -24,16 +24,17 @@ inline constexpr SkillConfig SKILL_TABLE[] = {
 
 // ── Queued action (value type, NOT a component) ──────────────
 // Sentinel values encode "no action needed":
-//   target_shape  = Hexagon   → no shape change
-//   target_lane   = -1        → no lane change
-//   target_vertical = Grounded → no jump/slide
+//   target_shape  = Hexagon         → no shape change
+//   target_lane   = -1              → no lane change
+//   !wants_jump && !wants_slide     → no vertical action
 //
 // Per-sub-action completion is tracked as three independent boolean
 // columns (formerly an `ActionDoneBit` bitmask). Per Fabian's existential-
 // processing canon (.squad/decisions.md § DoD source-text grounding,
 // Principle 4), control-flow discriminators — including bitmask
-// discriminators — become per-case tables. For a value type, that's
-// per-case columns on the same row.
+// discriminators and the former `VMode target_vertical` enum — become
+// per-case tables. For a value type, that's per-case columns on the
+// same row.
 struct TestPlayerAction {
     entt::entity obstacle       = entt::null;
     float        timer          = 0.0f;
@@ -42,7 +43,8 @@ struct TestPlayerAction {
 
     Shape  target_shape         = Shape::Hexagon;
     int8_t target_lane          = -1;
-    VMode  target_vertical      = VMode::Grounded;
+    bool   wants_jump           = false;
+    bool   wants_slide          = false;
 
     bool shape_done    = false;
     bool lane_done     = false;

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -76,7 +76,7 @@ static bool valid_scroll_speed(float scroll_speed) {
 }
 
 static bool test_player_needs_vertical(const TestPlayerAction& action) {
-    return action.target_vertical != VMode::Grounded && !test_player_vertical_done(action);
+    return (action.wants_jump || action.wants_slide) && !test_player_vertical_done(action);
 }
 
 static bool test_player_action_done(const TestPlayerAction& action) {
@@ -84,7 +84,7 @@ static bool test_player_action_done(const TestPlayerAction& action) {
                             test_player_shape_done(action);
     const bool lane_done = !lane_utils::is_valid(action.target_lane) ||
                            test_player_lane_done(action);
-    const bool vertical_done = (action.target_vertical == VMode::Grounded) ||
+    const bool vertical_done = !(action.wants_jump || action.wants_slide) ||
                                test_player_vertical_done(action);
     return shape_done && lane_done && vertical_done;
 }
@@ -255,13 +255,18 @@ void test_player_system(entt::registry& reg, float dt) {
     const auto& cfg = test_player_config(*state);
 
     // ── Find player ──────────────────────────────────────────
-    auto player_view = reg.view<PlayerTag, WorldTransform, PlayerShape, ShapeWindow, Lane, VerticalState>();
+    auto player_view = reg.view<PlayerTag, WorldTransform, PlayerShape, ShapeWindow, Lane>();
     if (player_view.begin() == player_view.end()) return;
 
     auto player_entity = *player_view.begin();
-    auto [p_transform, p_shape, p_window, p_lane, p_vstate] =
-        player_view.get<WorldTransform, PlayerShape, ShapeWindow, Lane, VerticalState>(player_entity);
+    auto [p_transform, p_shape, p_window, p_lane] =
+        player_view.get<WorldTransform, PlayerShape, ShapeWindow, Lane>(player_entity);
     lane_utils::normalize(p_lane, &p_transform);
+
+    // Per-frame constant: player's vertical offset (Grounded/Sliding → 0,
+    // Jumping → parabolic arc) used in collision-zone math below.
+    const auto* p_jump = reg.try_get<Jumping>(player_entity);
+    const float player_y_offset = p_jump ? p_jump->y_offset : 0.0f;
 
     // ── PERCEIVE: scan obstacles in vision range ─────────────
     // Compute the "effective lane" — where the player will be after
@@ -292,7 +297,7 @@ void test_player_system(entt::registry& reg, float dt) {
         // Lane dodges and vertical-only actions react ASAP — no delay.
         bool has_shape = (action.target_shape != Shape::Hexagon);
         bool has_lane_or_vertical = (lane_utils::is_valid(action.target_lane) ||
-                                     action.target_vertical != VMode::Grounded);
+                                     action.wants_jump || action.wants_slide);
 
         if (cfg.aim_perfect && has_shape) {
             float ideal_press = action.arrival_time - kProPressLeadSeconds;
@@ -338,8 +343,8 @@ void test_player_system(entt::registry& reg, float dt) {
                 "PLAN action=%.*s%s%s react=%.3fs arrival=%.3fs",
                 static_cast<int>(action_shape_name.size()), action_shape_name.data(),
                 lane_utils::is_valid(action.target_lane) ? "+lane" : "",
-                action.target_vertical != VMode::Grounded ?
-                    (action.target_vertical == VMode::Jumping ? "+jump" : "+slide") : "",
+                action.wants_jump  ? "+jump"  :
+                action.wants_slide ? "+slide" : "",
                 action.timer, action.arrival_time);
         }
     }
@@ -439,7 +444,7 @@ void test_player_system(entt::registry& reg, float dt) {
             for (auto [ze, obstacle, zwt] : zone_view.each()) {
                 (void)obstacle;
                 if (ze == action.obstacle) continue; // don't self-block
-                float zdist = p_transform.position.y - zwt.position.y + p_vstate.y_offset;
+                float zdist = p_transform.position.y - zwt.position.y + player_y_offset;
                 if (zdist >= -constants::COLLISION_MARGIN && zdist <= constants::COLLISION_MARGIN * 3.0f) {
                     zone_blocked = true;
                     break;
@@ -461,7 +466,7 @@ void test_player_system(entt::registry& reg, float dt) {
             for (auto [oe, obstacle, owt] : closer_view.each()) {
                 (void)obstacle;
                 if (oe == action.obstacle) continue;
-                float odist = p_transform.position.y - owt.position.y + p_vstate.y_offset;
+                float odist = p_transform.position.y - owt.position.y + player_y_offset;
                 if (odist <= 0.0f) continue;
 
                 auto* obeat = reg.try_get<BeatInfo>(oe);
@@ -527,23 +532,23 @@ void test_player_system(entt::registry& reg, float dt) {
             for (auto [ze, obstacle, zwt] : zone_view.each()) {
                 (void)obstacle;
                 if (ze == action.obstacle) continue;
-                float zdist = p_transform.position.y - zwt.position.y + p_vstate.y_offset;
+                float zdist = p_transform.position.y - zwt.position.y + player_y_offset;
                 if (zdist >= -constants::COLLISION_MARGIN && zdist <= constants::COLLISION_MARGIN * 3.0f) {
                     vert_zone_blocked = true;
                     break;
                 }
             }
         }
-        if (test_player_needs_vertical(action) && p_vstate.mode == VMode::Grounded
+        if (test_player_needs_vertical(action) && !reg.any_of<Jumping, Sliding>(player_entity)
             && !vert_zone_blocked && !vert_blocked_by_shape) {
-            if (action.target_vertical == VMode::Jumping) {
+            if (action.wants_jump) {
                 disp.enqueue<GoEvent>({Direction::Up});
                 if (log) {
                     session_log_write(*log, song_time, "PLAYER",
                         "EXECUTE Go(Up) for obstacle=%u beat=%d",
                         static_cast<unsigned>(entt::to_integral(action.obstacle)), act_beat);
                 }
-            } else if (action.target_vertical == VMode::Sliding) {
+            } else if (action.wants_slide) {
                 disp.enqueue<GoEvent>({Direction::Down});
                 if (log) {
                     session_log_write(*log, song_time, "PLAYER",

--- a/benchmarks/bench_systems.cpp
+++ b/benchmarks/bench_systems.cpp
@@ -42,7 +42,7 @@ static entt::entity make_bench_player(entt::registry& reg) {
     reg.emplace<PlayerShape>(p);
     reg.emplace<ShapeWindow>(p);
     reg.emplace<Lane>(p);
-    reg.emplace<VerticalState>(p);
+    // Grounded = absence of Jumping/Sliding (#1202/#1204).
     reg.emplace<Color>(p, Color{80, 180, 255, 255});
     reg.emplace<DrawSize>(p, constants::PLAYER_SIZE, constants::PLAYER_SIZE);
     return p;

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -64,11 +64,14 @@ TEST_CASE("components: Lane defaults to center", "[components]") {
     CHECK(l.lerp_t == 1.0f);
 }
 
-TEST_CASE("components: VerticalState defaults to grounded", "[components]") {
-    VerticalState vs{};
-    CHECK(vs.mode == VMode::Grounded);
-    CHECK(vs.timer == 0.0f);
-    CHECK(vs.y_offset == 0.0f);
+TEST_CASE("components: player defaults to grounded (no Jumping/Sliding)", "[components]") {
+    // Per #1202/#1204: Grounded == absence of Jumping and Sliding tables.
+    // Confirm the structs default to a no-op state (timer 0).
+    Jumping j{};
+    CHECK(j.timer == 0.0f);
+    CHECK(j.y_offset == 0.0f);
+    Sliding s{};
+    CHECK(s.timer == 0.0f);
 }
 
 TEST_CASE("components: InputState stores transient input flags", "[components]") {
@@ -231,7 +234,8 @@ TEST_CASE("ecs: make_player creates proper entity", "[ecs]") {
     CHECK(reg.all_of<PlayerShape>(p));
     CHECK(reg.all_of<ShapeWindow>(p));
     CHECK(reg.all_of<Lane>(p));
-    CHECK(reg.all_of<VerticalState>(p));
+    // Grounded = no Jumping or Sliding component (#1202/#1204).
+    CHECK_FALSE(reg.any_of<Jumping, Sliding>(p));
     CHECK(reg.all_of<Color>(p));
     CHECK(reg.all_of<DrawSize>(p));
     CHECK(reg.all_of<TagWorldPass>(p));

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -189,7 +189,7 @@ inline entt::entity make_player(entt::registry& reg) {
     reg.emplace<PlayerShape>(player);
     reg.emplace<ShapeWindow>(player);
     reg.emplace<Lane>(player);
-    reg.emplace<VerticalState>(player);
+    // Grounded == absence of Jumping/Sliding (issue #1202/#1204).
     reg.emplace<Color>(player, Color{80, 180, 255, 255});
     reg.emplace<DrawSize>(player, constants::PLAYER_SIZE, constants::PLAYER_SIZE);
     reg.emplace<TagWorldPass>(player);

--- a/tests/test_input_pipeline_behavior.cpp
+++ b/tests/test_input_pipeline_behavior.cpp
@@ -103,28 +103,26 @@ TEST_CASE("pipeline: swipe up starts jump in same pipeline call",
           "[input_pipeline]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& vstate = reg.get<VerticalState>(player);
-    REQUIRE(vstate.mode == VMode::Grounded);
+    REQUIRE_FALSE(reg.any_of<Jumping, Sliding>(player));
 
     push_go(reg, Direction::Up);
     run_pipeline(reg);
 
-    CHECK(vstate.mode == VMode::Jumping);
-    CHECK(vstate.timer == constants::JUMP_DURATION);
+    REQUIRE(reg.all_of<Jumping>(player));
+    CHECK(reg.get<Jumping>(player).timer == constants::JUMP_DURATION);
 }
 
 TEST_CASE("pipeline: swipe down starts slide in same pipeline call",
           "[input_pipeline]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& vstate = reg.get<VerticalState>(player);
-    REQUIRE(vstate.mode == VMode::Grounded);
+    REQUIRE_FALSE(reg.any_of<Jumping, Sliding>(player));
 
     push_go(reg, Direction::Down);
     run_pipeline(reg);
 
-    CHECK(vstate.mode == VMode::Sliding);
-    CHECK(vstate.timer == constants::SLIDE_DURATION);
+    REQUIRE(reg.all_of<Sliding>(player));
+    CHECK(reg.get<Sliding>(player).timer == constants::SLIDE_DURATION);
 }
 
 TEST_CASE("pipeline: swipe right at right boundary does not wrap lane",
@@ -345,13 +343,12 @@ TEST_CASE("pipeline: pending phase transition blocks queued go input",
     auto player = make_rhythm_player(reg);
     auto& gs = reg.ctx().get<GameState>();
     auto& lane = reg.get<Lane>(player);
-    auto& vstate = reg.get<VerticalState>(player);
 
     REQUIRE(gs.phase == GamePhase::Playing);
     REQUIRE(lane.current == 1);
     lane.target = lane.current;
     REQUIRE(lane.target == 1);
-    REQUIRE(vstate.mode == VMode::Grounded);
+    REQUIRE_FALSE(reg.any_of<Jumping, Sliding>(player));
 
     gs.transition_pending = true;
     gs.next_phase = GamePhase::Paused;
@@ -363,7 +360,7 @@ TEST_CASE("pipeline: pending phase transition blocks queued go input",
     CHECK(gs.phase == GamePhase::Paused);
     CHECK_FALSE(gs.transition_pending);
     CHECK(lane.target == 1);
-    CHECK(vstate.mode == VMode::Grounded);
+    CHECK_FALSE(reg.any_of<Jumping, Sliding>(player));
 }
 
 TEST_CASE("pipeline: gameplay HUD shape tap uses slot rectangle bounds",

--- a/tests/test_perspective.cpp
+++ b/tests/test_perspective.cpp
@@ -182,7 +182,7 @@ TEST_CASE("game_camera_system rejects invalid PlayerShape before mesh lookup", "
     reg.emplace<PlayerTag>(player);
     reg.emplace<WorldTransform>(player, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
     reg.emplace<PlayerShape>(player, PlayerShape{static_cast<Shape>(255), 1.0f});
-    reg.emplace<VerticalState>(player);
+    // Vertical motion: grounded = absence of Jumping/Sliding (#1202/#1204).
     reg.emplace<Color>(player, WHITE);
     reg.emplace<ModelTransform>(player, ModelTransform{MatrixIdentity(), WHITE});
     reg.emplace<MeshKindShape>(player, MeshKindShape{255});

--- a/tests/test_player_action_rhythm.cpp
+++ b/tests/test_player_action_rhythm.cpp
@@ -215,7 +215,7 @@ TEST_CASE("player_action: jump works in rhythm mode", "[player_rhythm]") {
 
     run_semantic_input_tick(reg, 0.016f);
 
-    CHECK(reg.get<VerticalState>(player).mode == VMode::Jumping);
+    CHECK(reg.all_of<Jumping>(player));
 }
 
 // ── #213: GoEvents consumed exactly once per frame ────────────────

--- a/tests/test_player_archetype.cpp
+++ b/tests/test_player_archetype.cpp
@@ -17,7 +17,8 @@ TEST_CASE("player_entity: canonical component set present", "[archetype][player]
     CHECK(reg.all_of<PlayerShape>(p));
     CHECK(reg.all_of<ShapeWindow>(p));
     CHECK(reg.all_of<Lane>(p));
-    CHECK(reg.all_of<VerticalState>(p));
+    // Grounded = absence of Jumping/Sliding (#1202/#1204).
+    CHECK_FALSE(reg.any_of<Jumping, Sliding>(p));
     CHECK(reg.all_of<Color>(p));
     CHECK(reg.all_of<DrawSize>(p));
     CHECK(reg.all_of<TagWorldPass>(p));
@@ -62,8 +63,9 @@ TEST_CASE("player_entity: Lane defaults to center (1), Grounded vertical", "[arc
     auto reg = make_registry();
     auto p = create_player_entity(reg);
 
-    CHECK(reg.get<Lane>(p).current        == int8_t{1});
-    CHECK(reg.get<VerticalState>(p).mode  == VMode::Grounded);
+    CHECK(reg.get<Lane>(p).current == int8_t{1});
+    // Grounded = absence of Jumping/Sliding (#1202/#1204).
+    CHECK_FALSE(reg.any_of<Jumping, Sliding>(p));
 }
 
 TEST_CASE("player_entity: rejects duplicate canonical players", "[archetype][player]") {

--- a/tests/test_player_systems.cpp
+++ b/tests/test_player_systems.cpp
@@ -138,9 +138,8 @@ TEST_CASE("player_action: swipe up starts jump", "[player]") {
 
     run_semantic_input_tick(reg, 0.016f);
 
-    auto& vs = reg.get<VerticalState>(player);
-    CHECK(vs.mode == VMode::Jumping);
-    CHECK(vs.timer == constants::JUMP_DURATION);
+    REQUIRE(reg.all_of<Jumping>(player));
+    CHECK(reg.get<Jumping>(player).timer == constants::JUMP_DURATION);
 }
 
 TEST_CASE("player_action: swipe down starts slide", "[player]") {
@@ -151,23 +150,21 @@ TEST_CASE("player_action: swipe down starts slide", "[player]") {
 
     run_semantic_input_tick(reg, 0.016f);
 
-    auto& vs = reg.get<VerticalState>(player);
-    CHECK(vs.mode == VMode::Sliding);
-    CHECK(vs.timer == constants::SLIDE_DURATION);
+    REQUIRE(reg.all_of<Sliding>(player));
+    CHECK(reg.get<Sliding>(player).timer == constants::SLIDE_DURATION);
 }
 
 TEST_CASE("player_action: cannot jump while already jumping", "[player]") {
     auto reg = make_registry();
     auto p = make_player(reg);
-    reg.get<VerticalState>(p).mode  = VMode::Jumping;
-    reg.get<VerticalState>(p).timer = 0.2f;
+    reg.emplace<Jumping>(p, Jumping{0.2f, 0.0f});
 
     reg.ctx().get<entt::dispatcher>().enqueue<GoEvent>({Direction::Up});
 
     run_semantic_input_tick(reg, 0.016f);
 
     // Timer should not reset
-    CHECK(reg.get<VerticalState>(p).timer == 0.2f);
+    CHECK(reg.get<Jumping>(p).timer == 0.2f);
 }
 
 // ── player_movement_system ───────────────────────────────────
@@ -267,42 +264,40 @@ TEST_CASE("player_movement: normalizes invalid target lane", "[player][issue900]
 TEST_CASE("player_movement: jump creates negative y_offset", "[player]") {
     auto reg = make_registry();
     auto p = make_player(reg);
-    reg.get<VerticalState>(p).mode  = VMode::Jumping;
-    reg.get<VerticalState>(p).timer = constants::JUMP_DURATION;
+    reg.emplace<Jumping>(p, Jumping{constants::JUMP_DURATION, 0.0f});
 
     // Advance halfway through jump
     float half_jump = constants::JUMP_DURATION / 2.0f;
     player_movement_system(reg, half_jump);
 
-    CHECK(reg.get<VerticalState>(p).y_offset < 0.0f);
+    REQUIRE(reg.all_of<Jumping>(p));
+    CHECK(reg.get<Jumping>(p).y_offset < 0.0f);
 }
 
 TEST_CASE("player_movement: jump returns to grounded", "[player]") {
     auto reg = make_registry();
     auto p = make_player(reg);
-    reg.get<VerticalState>(p).mode  = VMode::Jumping;
-    reg.get<VerticalState>(p).timer = constants::JUMP_DURATION;
+    reg.emplace<Jumping>(p, Jumping{constants::JUMP_DURATION, 0.0f});
 
     // Advance past jump duration
     for (int i = 0; i < 60; ++i) {
         player_movement_system(reg, 0.016f);
     }
 
-    CHECK(reg.get<VerticalState>(p).mode == VMode::Grounded);
-    CHECK(reg.get<VerticalState>(p).y_offset == 0.0f);
+    // Grounded = no Jumping/Sliding components.
+    CHECK_FALSE(reg.any_of<Jumping, Sliding>(p));
 }
 
 TEST_CASE("player_movement: slide returns to grounded", "[player]") {
     auto reg = make_registry();
     auto p = make_player(reg);
-    reg.get<VerticalState>(p).mode  = VMode::Sliding;
-    reg.get<VerticalState>(p).timer = constants::SLIDE_DURATION;
+    reg.emplace<Sliding>(p, Sliding{constants::SLIDE_DURATION});
 
     for (int i = 0; i < 60; ++i) {
         player_movement_system(reg, 0.016f);
     }
 
-    CHECK(reg.get<VerticalState>(p).mode == VMode::Grounded);
+    CHECK_FALSE(reg.any_of<Jumping, Sliding>(p));
 }
 
 TEST_CASE("player_action: not in Playing phase skips processing", "[player]") {
@@ -314,9 +309,9 @@ TEST_CASE("player_action: not in Playing phase skips processing", "[player]") {
 
     run_semantic_input_tick(reg, 0.016f);
 
-    auto view = reg.view<PlayerTag, VerticalState>();
-    for (auto [e, vs] : view.each()) {
-        CHECK(vs.mode == VMode::Grounded);
+    auto view = reg.view<PlayerTag>();
+    for (auto p : view) {
+        CHECK_FALSE(reg.any_of<Jumping, Sliding>(p));
     }
 }
 
@@ -334,43 +329,42 @@ TEST_CASE("player_movement: not in Playing phase skips processing", "[player]") 
 TEST_CASE("player_action: cannot slide while already sliding", "[player]") {
     auto reg = make_registry();
     auto p = make_player(reg);
-    reg.get<VerticalState>(p).mode  = VMode::Sliding;
-    reg.get<VerticalState>(p).timer = 0.3f;
+    reg.emplace<Sliding>(p, Sliding{0.3f});
 
     reg.ctx().get<entt::dispatcher>().enqueue<GoEvent>({Direction::Down});
 
     run_semantic_input_tick(reg, 0.016f);
 
     // Timer should not reset
-    CHECK(reg.get<VerticalState>(p).timer == 0.3f);
+    CHECK(reg.get<Sliding>(p).timer == 0.3f);
 }
 
 TEST_CASE("player_action: cannot slide while jumping", "[player]") {
     auto reg = make_registry();
     auto p = make_player(reg);
-    reg.get<VerticalState>(p).mode  = VMode::Jumping;
-    reg.get<VerticalState>(p).timer = 0.2f;
+    reg.emplace<Jumping>(p, Jumping{0.2f, 0.0f});
 
     reg.ctx().get<entt::dispatcher>().enqueue<GoEvent>({Direction::Down});
 
     run_semantic_input_tick(reg, 0.016f);
 
-    CHECK(reg.get<VerticalState>(p).mode == VMode::Jumping);
-    CHECK(reg.get<VerticalState>(p).timer == 0.2f);
+    REQUIRE(reg.all_of<Jumping>(p));
+    CHECK_FALSE(reg.all_of<Sliding>(p));
+    CHECK(reg.get<Jumping>(p).timer == 0.2f);
 }
 
 TEST_CASE("player_action: cannot jump while sliding", "[player]") {
     auto reg = make_registry();
     auto p = make_player(reg);
-    reg.get<VerticalState>(p).mode  = VMode::Sliding;
-    reg.get<VerticalState>(p).timer = 0.3f;
+    reg.emplace<Sliding>(p, Sliding{0.3f});
 
     reg.ctx().get<entt::dispatcher>().enqueue<GoEvent>({Direction::Up});
 
     run_semantic_input_tick(reg, 0.016f);
 
-    CHECK(reg.get<VerticalState>(p).mode == VMode::Sliding);
-    CHECK(reg.get<VerticalState>(p).timer == 0.3f);
+    REQUIRE(reg.all_of<Sliding>(p));
+    CHECK_FALSE(reg.all_of<Jumping>(p));
+    CHECK(reg.get<Sliding>(p).timer == 0.3f);
 }
 
 TEST_CASE("player_movement: morph_t clamps at 1.0", "[player]") {
@@ -387,38 +381,39 @@ TEST_CASE("player_movement: morph_t clamps at 1.0", "[player]") {
 TEST_CASE("player_movement: slide keeps y_offset at 0", "[player]") {
     auto reg = make_registry();
     auto p = make_player(reg);
-    reg.get<VerticalState>(p).mode  = VMode::Sliding;
-    reg.get<VerticalState>(p).timer = constants::SLIDE_DURATION;
+    reg.emplace<Sliding>(p, Sliding{constants::SLIDE_DURATION});
 
     player_movement_system(reg, 0.1f);
 
-    CHECK(reg.get<VerticalState>(p).y_offset == 0.0f);
+    // Slide has no y_offset field — semantic check: player still on ground.
+    REQUIRE(reg.all_of<Sliding>(p));
+    CHECK_FALSE(reg.all_of<Jumping>(p));
 }
 
 TEST_CASE("player_movement: grounded state has no timer change", "[player]") {
     auto reg = make_registry();
     auto p = make_player(reg);
-    // Default is Grounded
-    CHECK(reg.get<VerticalState>(p).mode == VMode::Grounded);
+    // Default = no Jumping/Sliding tags = grounded.
+    REQUIRE_FALSE(reg.any_of<Jumping, Sliding>(p));
 
     player_movement_system(reg, 0.016f);
 
-    CHECK(reg.get<VerticalState>(p).timer == 0.0f);
-    CHECK(reg.get<VerticalState>(p).y_offset == 0.0f);
+    // Grounded entities don't gain any vertical-motion tags.
+    CHECK_FALSE(reg.any_of<Jumping, Sliding>(p));
 }
 
 TEST_CASE("player_movement: jump arc peaks at half duration", "[player]") {
     auto reg = make_registry();
     auto p = make_player(reg);
-    reg.get<VerticalState>(p).mode  = VMode::Jumping;
-    reg.get<VerticalState>(p).timer = constants::JUMP_DURATION;
+    reg.emplace<Jumping>(p, Jumping{constants::JUMP_DURATION, 0.0f});
 
     // Advance exactly to the peak (half duration)
     float half = constants::JUMP_DURATION / 2.0f;
     player_movement_system(reg, half);
 
     // At peak, y_offset should be at max negative (JUMP_HEIGHT)
-    float y_off = reg.get<VerticalState>(p).y_offset;
+    REQUIRE(reg.all_of<Jumping>(p));
+    float y_off = reg.get<Jumping>(p).y_offset;
     CHECK(y_off < 0.0f);
     CHECK_THAT(y_off, Catch::Matchers::WithinAbs(-constants::JUMP_HEIGHT, 1.0f));
 }

--- a/tests/test_redfoot_testflight_ui.cpp
+++ b/tests/test_redfoot_testflight_ui.cpp
@@ -94,7 +94,7 @@ void spawn_aligned_player(entt::registry& reg, float y) {
     // Idle phase = absence of all ShapeWindow*Tag (#1202/#1204).
     Lane lane{}; lane.current = 1; lane.target = -1;
     reg.emplace<Lane>(p, lane);
-    reg.emplace<VerticalState>(p);
+    // Grounded = absence of Jumping/Sliding (#1202/#1204).
 }
 
 entt::entity spawn_obstacle(entt::registry& reg, float y) {


### PR DESCRIPTION
Per Fabian's existential-processing canon (.squad/decisions.md § DoD source-text grounding, Principle 4 — "discriminators become tables"), each former `VMode` enum value now lives in its own component table on the player entity. "Grounded" is the absence of any vertical-state tag.

## Per-value schema

| Former value      | New component                                       | Notes                                                              |
| ----------------- | --------------------------------------------------- | ------------------------------------------------------------------ |
| `VMode::Grounded` | (no tag — absence)                                  | Default state; zero memory.                                        |
| `VMode::Jumping`  | `struct Jumping { float timer; float y_offset; }`   | Carries parabolic arc data. Drives camera y_offset + collision.    |
| `VMode::Sliding`  | `struct Sliding { float timer; }`                   | No `y_offset` (was always 0); render squash via `all_of<Sliding>`. |

Transitions are table operations:

```cpp
// start jump
reg.emplace<Jumping>(e, JUMP_DURATION, 0.0f);
// end jump
reg.remove<Jumping>(e);
```

## Behavioural split (existential processing)

`player_movement_system` no longer dispatches on a `VMode` discriminator. It now invokes per-state transforms on filtered views:

- `tick_jumping(reg, dt)` — iterates `view<Jumping>`, advances timer, updates parabolic `y_offset`, removes the tag at completion.
- `tick_sliding(reg, dt)` — iterates `view<Sliding>`, advances timer, removes the tag at completion.

Camera (`camera_system`) and collision (`collision_system`) read jump offset via `reg.try_get<Jumping>(e)->y_offset` and check Sliding via `reg.all_of<Sliding>(e)`. Player input (`player_input_system`) starts a state by emplacing the tag iff `!reg.any_of<Jumping, Sliding>(e)` (grounded gate).

## `TestPlayerAction.target_vertical`

`target_vertical` was a value-type sentinel on a non-entity struct, so the per-case-column precedent from #1248 (`ActionDoneBit`) applies: replaced `VMode target_vertical` with two boolean columns `wants_jump` / `wants_slide` (neither = grounded).

## Acceptance criteria

- [x] `VMode` enum deleted.
- [x] `VerticalState` component deleted.
- [x] No `switch` / `==` discriminator on `VMode` remains in `app/`.
- [x] `player_movement_system` split into per-state transforms (existential processing).
- [x] Zero warnings (`clang -Wall -Wextra -Werror`).
- [x] All tests pass — **896 cases / 2932 assertions** (+3 vs baseline, from new `Jumping`/`Sliding` default-construct test).

## Files changed

App:
- `app/components/player.h` — delete `VMode` + `VerticalState`; add `Jumping`, `Sliding`.
- `app/systems/player_input_system.cpp`
- `app/systems/player_movement_system.cpp` — split into per-tag transforms.
- `app/systems/camera_system.cpp`
- `app/systems/collision_system.cpp`
- `app/systems/test_player.h` — `target_vertical` → `wants_jump` / `wants_slide`.
- `app/systems/test_player_system.cpp`
- `app/entities/player_entity.cpp`
- `app/entities/obstacle_entity.h` (doc-comment update)

Tests / bench:
- `benchmarks/bench_systems.cpp`
- `tests/test_components.cpp`
- `tests/test_helpers.h`
- `tests/test_input_pipeline_behavior.cpp`
- `tests/test_perspective.cpp`
- `tests/test_player_action_rhythm.cpp`
- `tests/test_player_archetype.cpp`
- `tests/test_player_systems.cpp`
- `tests/test_redfoot_testflight_ui.cpp`

Refs #1202 (enum eradication umbrella), #1204 (table-aware mechanic).
