### PR TITLE
Migrate TestPlayerSkill enum to per-skill SkillConfig constants (refs #1202, #1204)

### DIFF
--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -131,7 +131,7 @@ void log_persistence_result(const char* operation, const persistence::Result& re
 
 bool game_loop_init(entt::registry& reg,
                     bool test_player_mode,
-                    TestPlayerSkill test_skill,
+                    SkillConfig test_skill,
                     const char* difficulty,
                     int selected_level) {
     // Platform: window + audio

--- a/app/game_loop.h
+++ b/app/game_loop.h
@@ -2,15 +2,13 @@
 #include <cstdint>
 #include <entt/entt.hpp>
 #include "util/level_content_config.h"
-
-// Forward-declare to avoid including test_player.h in the header.
-enum class TestPlayerSkill : uint8_t;
+#include "systems/test_player.h"
 
 // Initialize platform (window, audio), all game singletons, cameras, meshes, UI.
 // Returns false when platform initialization fails and the run loop must not start.
 bool game_loop_init(entt::registry& reg,
                     bool test_player_mode = false,
-                    TestPlayerSkill test_skill = {},
+                    SkillConfig test_skill = SKILL_PRO,
                     const char* difficulty = "medium",
                     int selected_level = content_config::DEFAULT_LEVEL_INDEX);
 

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -38,7 +38,7 @@ bool missing_option_value(int argc, char* argv[], int option_index) {
 int main(int argc, char* argv[]) {
 
     // ── Parse CLI args ───────────────────────────────────────
-    TestPlayerSkill test_skill = TestPlayerSkill::Pro;
+    SkillConfig test_skill = SKILL_PRO;
     bool test_player_mode = false;
     const char* difficulty = "medium";
     int selected_level = content_config::DEFAULT_LEVEL_INDEX;
@@ -50,9 +50,9 @@ int main(int argc, char* argv[]) {
             }
             test_player_mode = true;
             ++i;
-            if (std::strcmp(argv[i], "pro") == 0)       test_skill = TestPlayerSkill::Pro;
-            else if (std::strcmp(argv[i], "good") == 0)  test_skill = TestPlayerSkill::Good;
-            else if (std::strcmp(argv[i], "bad") == 0)   test_skill = TestPlayerSkill::Bad;
+            if (std::strcmp(argv[i], "pro") == 0)       test_skill = SKILL_PRO;
+            else if (std::strcmp(argv[i], "good") == 0)  test_skill = SKILL_GOOD;
+            else if (std::strcmp(argv[i], "bad") == 0)   test_skill = SKILL_BAD;
             else {
                 std::fprintf(stderr, "Unknown skill: %s (use pro|good|bad)\n", argv[i]);
                 return 1;

--- a/app/systems/test_player.h
+++ b/app/systems/test_player.h
@@ -6,21 +6,24 @@
 #include <cstdint>
 #include <random>
 
-// ── Skill levels ─────────────────────────────────────────────
-enum class TestPlayerSkill : uint8_t { Pro = 0, Good = 1, Bad = 2 };
-
+// ── Skill config (per-skill data row) ────────────────────────
+// Per Fabian's existential-processing canon (.squad/decisions.md
+// § DoD source-text grounding, Principle 4) and #1204's table-aware
+// mechanic, the former `TestPlayerSkill` enum was a pure lookup-key
+// index into a 3-row `SKILL_TABLE[]`. Both the enum and the index
+// dispatch are deleted; each former enum value is now a named
+// `SkillConfig` constant that callers pick directly.
 struct SkillConfig {
-    float vision_range;   // px from PLAYER_Y upward
-    float reaction_min;   // seconds
-    float reaction_max;   // seconds
-    bool  aim_perfect;    // true = delay shape presses to hit Perfect window
+    float       vision_range;   // px from PLAYER_Y upward
+    float       reaction_min;   // seconds
+    float       reaction_max;   // seconds
+    bool        aim_perfect;    // true = delay shape presses to hit Perfect window
+    const char* name;           // CLI key + session-log key
 };
 
-inline constexpr SkillConfig SKILL_TABLE[] = {
-    { 800.0f, 0.300f, 0.500f, true  },   // Pro
-    { 600.0f, 0.500f, 0.800f, false },   // Good
-    { 400.0f, 0.800f, 1.200f, false },   // Bad
-};
+inline constexpr SkillConfig SKILL_PRO  { 800.0f, 0.300f, 0.500f, true,  "pro"  };
+inline constexpr SkillConfig SKILL_GOOD { 600.0f, 0.500f, 0.800f, false, "good" };
+inline constexpr SkillConfig SKILL_BAD  { 400.0f, 0.800f, 1.200f, false, "bad"  };
 
 // ── Queued action (value type, NOT a component) ──────────────
 // Sentinel values encode "no action needed":
@@ -57,8 +60,8 @@ struct TestPlayerAction {
 // Warm state (accessed during perception): skill, rng.
 struct TestPlayerState {
     // ── Hot ──────────────────────────────────────────────────
-    TestPlayerSkill skill   = TestPlayerSkill::Pro;
-    bool            active  = false;
+    SkillConfig skill   = SKILL_PRO;
+    bool        active  = false;
 
     // Delay between consecutive lane swipes (simulates human re-swipe time)
     static constexpr float SWIPE_COOLDOWN = 0.125f;  // 125ms (midpoint of 100-150ms)

--- a/app/systems/test_player_session.cpp
+++ b/app/systems/test_player_session.cpp
@@ -30,7 +30,7 @@ int difficulty_index_or_default(const char* difficulty) {
 }
 }
 
-void test_player_init(entt::registry& reg, TestPlayerSkill skill,
+void test_player_init(entt::registry& reg, SkillConfig skill,
                       const char* difficulty,
                       int selected_level) {
     auto& lss = reg.ctx().get<LevelSelectState>();
@@ -54,11 +54,10 @@ void test_player_init(entt::registry& reg, TestPlayerSkill skill,
     }
     tp_state.rng.seed(seed);
 
-    static const char* skill_names[] = { "pro", "good", "bad" };
     const char* level_key = content_config::LEVEL_KEYS[lss.selected_level];
     const char* difficulty_key = content_config::DIFFICULTY_KEYS[lss.selected_difficulty];
     TraceLog(LOG_INFO, "TEST PLAYER: skill=%s level=%s difficulty=%s",
-             skill_names[static_cast<int>(skill)], level_key, difficulty_key);
+             skill.name, level_key, difficulty_key);
 
     auto& slog = reg.ctx().get<SessionLog>();
     session_log_close(slog);
@@ -70,14 +69,14 @@ void test_player_init(entt::registry& reg, TestPlayerSkill skill,
     std::snprintf(log_filename, sizeof(log_filename),
         "%ssession_%s_%s_%s_rt%010llu_n%04u.log",
         GetApplicationDirectory(),
-        skill_names[static_cast<int>(skill)],
+        skill.name,
         level_key,
         difficulty_key,
         runtime_millis, sequence);
     session_log_open(slog, log_filename);
     if (slog.file) {
         std::fprintf(slog.file, "skill=%s level=%s difficulty=%s seed=%u\n\n",
-                     skill_names[static_cast<int>(skill)], level_key,
+                     skill.name, level_key,
                      difficulty_key, seed);
         std::fflush(slog.file);
     }

--- a/app/systems/test_player_session.h
+++ b/app/systems/test_player_session.h
@@ -14,6 +14,6 @@ struct TestPlayerSessionState {
     uint32_t log_sequence = 0;
 };
 
-void test_player_init(entt::registry& reg, TestPlayerSkill skill,
+void test_player_init(entt::registry& reg, SkillConfig skill,
                       const char* difficulty,
                       int selected_level = content_config::DEFAULT_LEVEL_INDEX);

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -90,7 +90,7 @@ static bool test_player_action_done(const TestPlayerAction& action) {
 }
 
 static const SkillConfig& test_player_config(const TestPlayerState& state) {
-    return SKILL_TABLE[static_cast<int>(state.skill)];
+    return state.skill;
 }
 
 static void test_player_push_action(TestPlayerState& state, const TestPlayerAction& action) {

--- a/tests/smoke/startup_shutdown_smoke.cpp
+++ b/tests/smoke/startup_shutdown_smoke.cpp
@@ -57,7 +57,7 @@ int main(int argc, char** argv) {
 
     entt::registry reg;
     for (int cycle = 0; cycle < cycles; ++cycle) {
-        game_loop_init(reg, false, TestPlayerSkill::Pro, "medium");
+        game_loop_init(reg, false, SKILL_PRO, "medium");
         if (!IsWindowReady()) {
             std::fprintf(stderr, "SKIPPED: OpenGL window context is unavailable\n");
             return 77;

--- a/tests/test_test_player_system.cpp
+++ b/tests/test_test_player_system.cpp
@@ -6,7 +6,7 @@
 #include "systems/session_logger_system.h"
 #include <cstdio>
 #include <string>
-static entt::registry make_test_player_registry(TestPlayerSkill skill = TestPlayerSkill::Pro) {
+static entt::registry make_test_player_registry(SkillConfig skill = SKILL_PRO) {
     entt::registry reg = make_rhythm_registry();
     auto& tp = reg.ctx().emplace<TestPlayerState>();
     tp.skill = skill;
@@ -57,16 +57,16 @@ TEST_CASE("test_player: init level fallback uses canonical default", "[test_play
     auto reg = make_test_player_registry();
     reg.ctx().emplace<SessionLog>();
 
-    test_player_init(reg, TestPlayerSkill::Pro, "medium", content_config::DEFAULT_LEVEL_INDEX);
+    test_player_init(reg, SKILL_PRO, "medium", content_config::DEFAULT_LEVEL_INDEX);
     CHECK(reg.ctx().get<LevelSelectState>().selected_level == content_config::DEFAULT_LEVEL_INDEX);
 
-    test_player_init(reg, TestPlayerSkill::Pro, "medium", 1);
+    test_player_init(reg, SKILL_PRO, "medium", 1);
     CHECK(reg.ctx().get<LevelSelectState>().selected_level == 1);
 
-    test_player_init(reg, TestPlayerSkill::Pro, "medium", -1);
+    test_player_init(reg, SKILL_PRO, "medium", -1);
     CHECK(reg.ctx().get<LevelSelectState>().selected_level == content_config::DEFAULT_LEVEL_INDEX);
 
-    test_player_init(reg, TestPlayerSkill::Pro, "medium", content_config::LEVEL_COUNT);
+    test_player_init(reg, SKILL_PRO, "medium", content_config::LEVEL_COUNT);
     CHECK(reg.ctx().get<LevelSelectState>().selected_level == content_config::DEFAULT_LEVEL_INDEX);
 
     session_log_close(reg.ctx().get<SessionLog>());
@@ -138,7 +138,7 @@ TEST_CASE("test_player: shape+lane action is not blocked by own shape press", "[
 }
 
 TEST_CASE("test_player: pro executes lane before shape for shape+lane actions", "[test_player]") {
-    auto reg = make_test_player_registry(TestPlayerSkill::Pro);
+    auto reg = make_test_player_registry(SKILL_PRO);
     make_rhythm_player(reg);
     make_shape_gate_at_lane(reg, Shape::Circle, 0, constants::PLAYER_Y - 600.0f);
 
@@ -173,7 +173,7 @@ TEST_CASE("test_player: pro executes lane before shape for shape+lane actions", 
 
 TEST_CASE("test_player: ignores visual obstacle leftovers without Obstacle payload",
           "[test_player][regression][issue865]") {
-    auto reg = make_test_player_registry(TestPlayerSkill::Pro);
+    auto reg = make_test_player_registry(SKILL_PRO);
     make_rhythm_player(reg);
 
     auto visual_leftover = reg.create();


### PR DESCRIPTION
Per Fabian's existential-processing canon (.squad/decisions.md § DoD source-text grounding, Principle 4) and #1204's table-aware mechanic, the former `TestPlayerSkill` enum was a **pure lookup-key index** into a 3-row `SKILL_TABLE[]`. Both the enum and the index-dispatch are deleted; each former enum value is now a named `SkillConfig` constant that callers pick directly.

## Per-value schema

| Former value | Per-value data | Target |
| --- | --- | --- |
| `TestPlayerSkill::Pro`  | vision_range, reaction_min, reaction_max, aim_perfect, name | `inline constexpr SkillConfig SKILL_PRO  { 800.0f, 0.300f, 0.500f, true,  "pro"  };` |
| `TestPlayerSkill::Good` | same shape                                                   | `inline constexpr SkillConfig SKILL_GOOD { 600.0f, 0.500f, 0.800f, false, "good" };` |
| `TestPlayerSkill::Bad`  | same shape                                                   | `inline constexpr SkillConfig SKILL_BAD  { 400.0f, 0.800f, 1.200f, false, "bad"  };` |

`TestPlayerState.skill` changes from `TestPlayerSkill` (a discriminator) to `SkillConfig` (the materialized row itself). The 3-element `SKILL_TABLE[]` array and the `SKILL_TABLE[static_cast<int>(state.skill)]` indexed dispatch in `test_player_system.cpp` both disappear — `state.skill` already _is_ the row.

## Behavioural change: zero

The CLI parser (`main.cpp`) still maps `pro`/`good`/`bad` strings to the same numeric tunables as before, just via direct constant assignment instead of via an enum that then re-indexes into the same table. Likewise, the test_player session logger's `"pro"`/`"good"`/`"bad"` log keys now come from `skill.name` instead of a parallel `static const char* skill_names[]` lookup keyed by the same enum — Principle 3 (no separate columns keyed by the same discriminator).

## Acceptance criteria from #1202

- ✅ Enum declaration deleted (`enum class` count in `app/`: 20 → 19 vs. pre-cycle baseline post-#1249).
- ✅ One per-value table row per former enum value (`SKILL_PRO` / `SKILL_GOOD` / `SKILL_BAD`), all materialized as `inline constexpr SkillConfig` constants.
- ✅ No `switch` on the former enum anywhere in `app/` (none existed pre-migration).
- ✅ No `if (x == TestPlayerSkill::*)` discriminator branches.
- ✅ The previously discriminator-driven call site (`SKILL_TABLE[static_cast<int>(state.skill)]`) is replaced by direct `state.skill` row access.
- ✅ Build warning-free under both **unity AND non-unity** Clang `-Wall -Wextra -Werror`.
- ✅ All tests pass — **896 cases / 2932 assertions** (same as baseline; no test count change because none of the existing tests asserted on the enum itself, they all asserted on observable system behaviour which is preserved).

## Files changed

App:
- `app/systems/test_player.h` — delete `enum class TestPlayerSkill` + `SKILL_TABLE[]`; add `SKILL_PRO`/`SKILL_GOOD`/`SKILL_BAD`; add `name` field to `SkillConfig`; change `TestPlayerState::skill` type to `SkillConfig`.
- `app/systems/test_player_system.cpp` — `test_player_config()` returns `state.skill` directly.
- `app/systems/test_player_session.{h,cpp}` — `test_player_init` takes `SkillConfig` instead of enum; delete parallel `skill_names[]` array; use `skill.name` for log/filename.
- `app/game_loop.{h,cpp}` — drop forward-decl of enum; include `systems/test_player.h` (small header); default arg becomes `SkillConfig test_skill = SKILL_PRO`.
- `app/main.cpp` — CLI `pro`/`good`/`bad` string match assigns named constants directly.

Tests:
- `tests/test_test_player_system.cpp` — `TestPlayerSkill::Pro` → `SKILL_PRO` (and signature change for `make_test_player_registry`).
- `tests/smoke/startup_shutdown_smoke.cpp` — same.

Refs #1202 (enum eradication umbrella), #1204 (table-aware mechanic).
