### PR TITLE
Migrate TimingTier enum to per-tier tags (refs #1202, #1204)

### DIFF
--- a/app/components/popup.h
+++ b/app/components/popup.h
@@ -4,12 +4,15 @@
 #include "rhythm.h"
 #include "text.h"
 
+// ScorePopup carries only the value + lifetime. The tier discriminator that
+// used to live here has been migrated (issue #1202/#1204) to a per-tier tag
+// (TimingPerfectTag/TimingGoodTag/TimingOkTag/TimingBadTag) emplaced on the
+// popup entity itself. The static text + base color are baked into
+// PopupDisplay at spawn-time; no system re-reads tier from ScorePopup.
 struct ScorePopup {
-    int32_t    value           = 0;
-    bool       has_timing_tier = false;
-    TimingTier timing_tier     = TimingTier::Ok;
-    float      remaining       = 0.0f;
-    float      max_time        = 0.0f;
+    int32_t value     = 0;
+    float   remaining = 0.0f;
+    float   max_time  = 0.0f;
 };
 
 // Pre-computed popup display data. Static text/color are initialized at spawn;

--- a/app/components/rhythm.h
+++ b/app/components/rhythm.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// rhythm.h — Per-entity rhythm components and timing enums.
+// rhythm.h — Per-entity rhythm components.
 // Loaded-once data (BeatMap) lives in beat_map.h.
 // Runtime singletons: SongState / SongResults live in song_state.h;
 // EnergyState lives in energy_bar.h. This header re-exports all three for
@@ -11,19 +11,13 @@
 #include "energy_bar.h"
 #include "player.h"
 #include "obstacle.h"
-#include <cstdint>
 
 // ── Timing Grade (emplaced on obstacle at collision) ─
-enum class TimingTier : uint8_t {
-    Bad,
-    Ok,
-    Good,
-    Perfect,
-};
-
+// Per-row "precision" scalar carried by every graded obstacle. The tier
+// discriminator is a per-tier tag in app/tags/tags.h (TimingPerfectTag /
+// TimingGoodTag / TimingOkTag / TimingBadTag) — issue #1202/#1204.
 struct TimingGrade {
-    TimingTier tier      = TimingTier::Bad;
-    float      precision = 0.0f;  // 0.0 = edge, 1.0 = dead center
+    float precision = 0.0f;  // 0.0 = edge, 1.0 = dead center
 };
 
 // ── Beat Info (per-obstacle, carries chart data) ─────

--- a/app/entities/popup_entity.cpp
+++ b/app/entities/popup_entity.cpp
@@ -6,58 +6,110 @@
 
 #include <cstdio>
 
-void init_popup_display(PopupDisplay& pd,
-                        const ScorePopup& sp,
-                        const Color& base) {
+namespace {
+
+// Build the popup archetype shared by every spawner. Per-tier spawners then
+// emplace their tier tag and call the matching init_popup_display_*.
+entt::entity create_popup_archetype(entt::registry& reg,
+                                    float x, float y, int points,
+                                    Color color) {
+    auto popup = reg.create();
+    reg.emplace<WorldTransform>(popup, WorldTransform{{x, y - 40.0f}});
+    reg.emplace<Vector2>(popup, Vector2{0.0f, -80.0f});
+    reg.emplace<ScorePopup>(popup, ScorePopup{points,
+                                              constants::POPUP_DURATION,
+                                              constants::POPUP_DURATION});
+    reg.emplace<Color>(popup, color);
+    reg.emplace<TagHUDPass>(popup);
+    return popup;
+}
+
+void apply_base_alpha(PopupDisplay& pd, const Color& base) {
     pd.r = base.r;
     pd.g = base.g;
     pd.b = base.b;
     pd.a = base.a;
-
-    if (sp.has_timing_tier) {
-        const char* grade = "BAD";
-        pd.font_size = FontSize::Medium;
-        switch (sp.timing_tier) {
-            case TimingTier::Perfect: grade = "PERFECT"; pd.font_size = FontSize::Medium; break;
-            case TimingTier::Good:    grade = "GOOD";    break;
-            case TimingTier::Ok:      grade = "OK";      break;
-            case TimingTier::Bad:                        break;
-        }
-        std::snprintf(pd.text, sizeof(pd.text), "%s", grade);
-    } else {
-        pd.font_size = FontSize::Small;
-        std::snprintf(pd.text, sizeof(pd.text), "%d", sp.value);
-    }
 }
 
-entt::entity spawn_score_popup(entt::registry& reg, const PopupSpawnParams& params) {
-    auto popup = reg.create();
+}  // namespace
 
-    reg.emplace<WorldTransform>(popup, WorldTransform{{params.x, params.y - 40.0f}});
-    reg.emplace<Vector2>(popup, Vector2{0.0f, -80.0f});
-    const bool has_timing_tier = params.timing_tier.has_value();
-    const TimingTier timing_tier = has_timing_tier ? *params.timing_tier : TimingTier::Ok;
-    reg.emplace<ScorePopup>(popup, params.points, has_timing_tier, timing_tier,
-                            constants::POPUP_DURATION, constants::POPUP_DURATION);
+void init_popup_display_untimed(PopupDisplay& pd,
+                                const ScorePopup& sp,
+                                const Color& base) {
+    apply_base_alpha(pd, base);
+    pd.font_size = FontSize::Small;
+    std::snprintf(pd.text, sizeof(pd.text), "%d", sp.value);
+}
 
-    // Color by timing tier (no timing → default yellow-white)
-    // Issue #386: differentiate timing tiers visually for accessibility/juice.
-    uint8_t pr = 255, pg = 255, pb = 50;
-    if (has_timing_tier) {
-        switch (timing_tier) {
-            case TimingTier::Perfect: pr =  80; pg = 255; pb = 220; break; // bright cyan
-            case TimingTier::Good:    pr = 140; pg = 255; pb =  80; break; // lime green
-            case TimingTier::Ok:      pr = 255; pg = 200; pb =  60; break; // amber
-            case TimingTier::Bad:     pr = 255; pg =  90; pb =  70; break; // red-orange
-        }
-    }
-    Color color{pr, pg, pb, 255};
-    reg.emplace<Color>(popup, color);
-    reg.emplace<TagHUDPass>(popup);
+void init_popup_display_perfect(PopupDisplay& pd, const Color& base) {
+    apply_base_alpha(pd, base);
+    pd.font_size = FontSize::Medium;
+    std::snprintf(pd.text, sizeof(pd.text), "%s", "PERFECT");
+}
 
+void init_popup_display_good(PopupDisplay& pd, const Color& base) {
+    apply_base_alpha(pd, base);
+    pd.font_size = FontSize::Medium;
+    std::snprintf(pd.text, sizeof(pd.text), "%s", "GOOD");
+}
+
+void init_popup_display_ok(PopupDisplay& pd, const Color& base) {
+    apply_base_alpha(pd, base);
+    pd.font_size = FontSize::Medium;
+    std::snprintf(pd.text, sizeof(pd.text), "%s", "OK");
+}
+
+void init_popup_display_bad(PopupDisplay& pd, const Color& base) {
+    apply_base_alpha(pd, base);
+    pd.font_size = FontSize::Medium;
+    std::snprintf(pd.text, sizeof(pd.text), "%s", "BAD");
+}
+
+entt::entity spawn_score_popup_perfect(entt::registry& reg, float x, float y, int points) {
+    const Color color{80, 255, 220, 255};  // bright cyan
+    auto popup = create_popup_archetype(reg, x, y, points, color);
+    reg.emplace<TimingPerfectTag>(popup);
     PopupDisplay pd{};
-    init_popup_display(pd, reg.get<ScorePopup>(popup), color);
+    init_popup_display_perfect(pd, color);
     reg.emplace<PopupDisplay>(popup, pd);
+    return popup;
+}
 
+entt::entity spawn_score_popup_good(entt::registry& reg, float x, float y, int points) {
+    const Color color{140, 255, 80, 255};  // lime green
+    auto popup = create_popup_archetype(reg, x, y, points, color);
+    reg.emplace<TimingGoodTag>(popup);
+    PopupDisplay pd{};
+    init_popup_display_good(pd, color);
+    reg.emplace<PopupDisplay>(popup, pd);
+    return popup;
+}
+
+entt::entity spawn_score_popup_ok(entt::registry& reg, float x, float y, int points) {
+    const Color color{255, 200, 60, 255};  // amber
+    auto popup = create_popup_archetype(reg, x, y, points, color);
+    reg.emplace<TimingOkTag>(popup);
+    PopupDisplay pd{};
+    init_popup_display_ok(pd, color);
+    reg.emplace<PopupDisplay>(popup, pd);
+    return popup;
+}
+
+entt::entity spawn_score_popup_bad(entt::registry& reg, float x, float y, int points) {
+    const Color color{255, 90, 70, 255};  // red-orange
+    auto popup = create_popup_archetype(reg, x, y, points, color);
+    reg.emplace<TimingBadTag>(popup);
+    PopupDisplay pd{};
+    init_popup_display_bad(pd, color);
+    reg.emplace<PopupDisplay>(popup, pd);
+    return popup;
+}
+
+entt::entity spawn_score_popup_untimed(entt::registry& reg, float x, float y, int points) {
+    const Color color{255, 255, 50, 255};  // default yellow-white
+    auto popup = create_popup_archetype(reg, x, y, points, color);
+    PopupDisplay pd{};
+    init_popup_display_untimed(pd, reg.get<ScorePopup>(popup), color);
+    reg.emplace<PopupDisplay>(popup, pd);
     return popup;
 }

--- a/app/entities/popup_entity.h
+++ b/app/entities/popup_entity.h
@@ -1,30 +1,39 @@
 #pragma once
 
-#include <optional>
 #include <entt/entt.hpp>
 #include <raylib.h>
-#include "../components/rhythm.h"  // TimingTier
+#include "../components/rhythm.h"  // TimingGrade
+#include "../tags/tags.h"          // TimingPerfectTag etc.
 
 struct PopupDisplay;
 struct ScorePopup;
 
-// One-time initializer for a PopupDisplay (text + font size + base color).
+// One-time initializer for an untimed PopupDisplay (numeric value, Small font).
 // Called at spawn so popup_display_system never re-formats static fields per
-// frame.
-void init_popup_display(PopupDisplay& pd,
-                        const ScorePopup& sp,
-                        const Color& base);
+// frame. Per-tier graded popups use the per-tier init functions below.
+void init_popup_display_untimed(PopupDisplay& pd,
+                                const ScorePopup& sp,
+                                const Color& base);
 
-// Parameters for spawning a score popup entity.
-struct PopupSpawnParams {
-    float x;
-    float y;
-    int   points;
-    std::optional<TimingTier> timing_tier;
-};
+// Per-tier popup-display initializers. Each bakes a constant text label and
+// FontSize::Medium into the PopupDisplay alongside the supplied base color.
+// Per #1202/#1204: these replace the former switch on a TimingTier
+// discriminator with one initializer per former enum value.
+void init_popup_display_perfect(PopupDisplay& pd, const Color& base);
+void init_popup_display_good   (PopupDisplay& pd, const Color& base);
+void init_popup_display_ok     (PopupDisplay& pd, const Color& base);
+void init_popup_display_bad    (PopupDisplay& pd, const Color& base);
 
-// Creates a fully-initialized score popup entity:
-//   WorldTransform at {x, y-40}, Vector2 velocity {0, -80}, ScorePopup,
-//   Color (by timing tier), TagHUDPass, PopupDisplay.
-// Audio push is the caller's responsibility.
-entt::entity spawn_score_popup(entt::registry& reg, const PopupSpawnParams& params);
+// Per-tier popup spawn functions. Each emplaces the full popup archetype
+// (WorldTransform, Vector2 drift, ScorePopup, Color, TagHUDPass, PopupDisplay)
+// plus the matching per-tier tag on the popup entity so renderers can identify
+// the popup's tier via tag presence (no enum lookup).
+//
+// Per #1202/#1204: replaces the prior `spawn_score_popup` that switched on a
+// TimingTier discriminator for both color and text — those constants are now
+// inlined per-spawner.
+entt::entity spawn_score_popup_perfect(entt::registry& reg, float x, float y, int points);
+entt::entity spawn_score_popup_good   (entt::registry& reg, float x, float y, int points);
+entt::entity spawn_score_popup_ok     (entt::registry& reg, float x, float y, int points);
+entt::entity spawn_score_popup_bad    (entt::registry& reg, float x, float y, int points);
+entt::entity spawn_score_popup_untimed(entt::registry& reg, float x, float y, int points);

--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -93,14 +93,14 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
         song.half_window > 0.0f && p_window.press_time >= 0.0f;
     auto grade_shape_timing = [&](entt::entity entity, float arrival_time) {
         float delta_seconds = std::abs(p_window.press_time - arrival_time);
-        TimingTier tier = compute_timing_tier_from_delta(delta_seconds);
         float precision = 1.0f - (delta_seconds / kTimingOkSeconds);
         if (precision < 0.0f) precision = 0.0f;
         if (precision > 1.0f) precision = 1.0f;
-        reg.get_or_emplace<TimingGrade>(entity) = TimingGrade{tier, precision};
+        reg.emplace_or_replace<TimingGrade>(entity, TimingGrade{precision});
+        emplace_timing_tier_tag_for_delta_abs(reg, entity, delta_seconds);
 
         if (!p_window.graded) {
-            float scale = window_scale_for_tier(tier);
+            float scale = window_scale_from_delta_abs(delta_seconds);
             const float active_elapsed = song.song_time - p_window.window_start;
             float remaining = song.window_duration - active_elapsed;
             if (remaining > 0.0f && scale < 1.0f) {

--- a/app/systems/gameplay_intents.h
+++ b/app/systems/gameplay_intents.h
@@ -15,15 +15,28 @@ struct PendingEnergyEffects {
     uint32_t capacity_exceeded_count = 0;
 };
 
-struct ScorePopupRequest {
-    float      x = 0.0f;
-    float      y = 0.0f;
-    int        points = 0;
-    bool       has_timing_tier = false;
-    TimingTier timing_tier = TimingTier::Ok;
+// Per-tier popup request (no tier discriminator field — the queue it lives
+// in IS the discriminator, per #1202/#1204 per-case-table mechanic).
+struct TimedPopupRequest {
+    float x      = 0.0f;
+    float y      = 0.0f;
+    int   points = 0;
 };
 
+struct UntimedPopupRequest {
+    float x      = 0.0f;
+    float y      = 0.0f;
+    int   points = 0;
+};
+
+// One queue per former TimingTier value (Perfect/Good/Ok/Bad) plus one
+// "untimed" queue for hits without a timing grade. popup_feedback_system
+// runs one transform per queue — no switch on a discriminator.
 struct ScorePopupRequestQueue {
-    std::vector<ScorePopupRequest> requests;
+    std::vector<TimedPopupRequest>   perfect;
+    std::vector<TimedPopupRequest>   good;
+    std::vector<TimedPopupRequest>   ok;
+    std::vector<TimedPopupRequest>   bad;
+    std::vector<UntimedPopupRequest> untimed;
     uint32_t capacity_exceeded_count = 0;
 };

--- a/app/systems/popup_feedback_system.cpp
+++ b/app/systems/popup_feedback_system.cpp
@@ -4,20 +4,41 @@
 #include "../components/game_state.h"
 #include "gameplay_intents.h"
 #include "../entities/popup_entity.h"
-#include <optional>
+
+namespace {
+
+// Common per-tier dispatch: drain one tier's queue via the matching spawner.
+// SFX is emitted for any positive-points popup regardless of tier — the
+// scoring SFX is a one-shot side-effect tied to "a popup spawned with points,"
+// not to a particular tier, so it lives in the shared epilogue.
+template <typename Request, typename Spawn>
+void drain_timed_queue(entt::registry& reg,
+                       std::vector<Request>& queue,
+                       Spawn spawn,
+                       entt::dispatcher* disp) {
+    for (const auto& req : queue) {
+        spawn(reg, req.x, req.y, req.points);
+        if (disp && req.points > 0) disp->enqueue<PlaySfxEvent>({SFX::ScorePopup});
+    }
+    queue.clear();
+}
+
+}  // namespace
 
 void popup_feedback_system(entt::registry& reg, [[maybe_unused]] float dt) {
     if (reg.ctx().get<GameState>().phase != GamePhase::Playing) return;
     auto& queue = reg.ctx().get<ScorePopupRequestQueue>();
-    if (queue.requests.empty()) return;
+    if (queue.perfect.empty() && queue.good.empty() && queue.ok.empty() &&
+        queue.bad.empty() && queue.untimed.empty()) {
+        return;
+    }
 
     auto* disp = reg.ctx().find<entt::dispatcher>();
-    for (const auto& request : queue.requests) {
-        const std::optional<TimingTier> timing_tier = request.has_timing_tier
-            ? std::make_optional(request.timing_tier)
-            : std::nullopt;
-        spawn_score_popup(reg, {request.x, request.y, request.points, timing_tier});
-        if (disp && request.points > 0) disp->enqueue<PlaySfxEvent>({SFX::ScorePopup});
-    }
-    queue.requests.clear();
+
+    // Per-tier transforms — one per former TimingTier value (#1202/#1204).
+    drain_timed_queue(reg, queue.perfect, spawn_score_popup_perfect, disp);
+    drain_timed_queue(reg, queue.good,    spawn_score_popup_good,    disp);
+    drain_timed_queue(reg, queue.ok,      spawn_score_popup_ok,      disp);
+    drain_timed_queue(reg, queue.bad,     spawn_score_popup_bad,     disp);
+    drain_timed_queue(reg, queue.untimed, spawn_score_popup_untimed, disp);
 }

--- a/app/systems/runtime_system_scratch.cpp
+++ b/app/systems/runtime_system_scratch.cpp
@@ -41,7 +41,16 @@ void runtime_system_scratch_reserve(entt::registry& reg, std::size_t beat_capaci
     scoring.hit_buf.reserve(capacity);
 
     reg.ctx().get<PendingEnergyEffects>().events.reserve(capacity);
-    reg.ctx().get<ScorePopupRequestQueue>().requests.reserve(capacity);
+    // Each per-tier popup queue is reserved independently — the total capacity
+    // budget is sized so any single tier can absorb a full-frame burst without
+    // reallocating. (Per #1202/#1204, ScorePopupRequestQueue is now 5 per-tier
+    // vectors instead of one tagged-union vector.)
+    auto& popup_queue = reg.ctx().get<ScorePopupRequestQueue>();
+    popup_queue.perfect.reserve(capacity);
+    popup_queue.good.reserve(capacity);
+    popup_queue.ok.reserve(capacity);
+    popup_queue.bad.reserve(capacity);
+    popup_queue.untimed.reserve(capacity);
     reg.ctx().get<ObstacleDespawnScratch>().to_destroy.reserve(capacity);
     reg.ctx().get<PopupDisplayScratch>().expired.reserve(capacity);
     reg.ctx().get<ParticleSystemScratch>().expired.reserve(capacity);

--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -8,6 +8,7 @@
 #include "../components/transform.h"
 #include "../components/rendering.h"
 #include "../components/rhythm.h"
+#include "../tags/tags.h"
 #include "../util/rhythm_math.h"
 #include "../constants.h"
 #include <raylib.h>
@@ -37,24 +38,59 @@ ScorePopupRequestQueue& popup_queue_for(entt::registry& reg) {
     return reg.ctx().get<ScorePopupRequestQueue>();
 }
 
-Color score_particle_color(const HitRecord& record) {
-    if (!record.has_timing) {
-        return Color{220, 220, 255, 220};
-    }
+// Per-tier traits — Fabian per-value table: each specialization carries the
+// row of constants the scoring transform reads for that tier (energy delta,
+// results counter member-pointer, particle color, popup-queue member-pointer).
+// One specialization per former TimingTier value; the prior 4-way switches
+// are replaced by template selection over the tier tag.
+template <typename TierTag>
+struct tier_score_traits;
 
-    switch (record.timing.tier) {
-        case TimingTier::Perfect:
-            return Color{255, 230, 90, 240};
-        case TimingTier::Good:
-            return Color{120, 255, 160, 230};
-        case TimingTier::Ok:
-            return Color{100, 180, 255, 220};
-        case TimingTier::Bad:
-            return Color{255, 100, 100, 220};
-    }
+template <>
+struct tier_score_traits<TimingPerfectTag> {
+    static constexpr float multiplier          = 1.50f;
+    static constexpr float energy_delta_signed = constants::ENERGY_RECOVER_PERFECT;
+    static constexpr bool  energy_flash        = false;
+    static constexpr Color particle_color{255, 230, 90, 240};
+    static constexpr int   SongResults::* results_counter = &SongResults::perfect_count;
+    static constexpr std::vector<TimedPopupRequest> ScorePopupRequestQueue::* queue =
+        &ScorePopupRequestQueue::perfect;
+};
 
-    return Color{220, 220, 255, 220};
-}
+template <>
+struct tier_score_traits<TimingGoodTag> {
+    static constexpr float multiplier          = 1.00f;
+    static constexpr float energy_delta_signed = constants::ENERGY_RECOVER_GOOD;
+    static constexpr bool  energy_flash        = false;
+    static constexpr Color particle_color{120, 255, 160, 230};
+    static constexpr int   SongResults::* results_counter = &SongResults::good_count;
+    static constexpr std::vector<TimedPopupRequest> ScorePopupRequestQueue::* queue =
+        &ScorePopupRequestQueue::good;
+};
+
+template <>
+struct tier_score_traits<TimingOkTag> {
+    static constexpr float multiplier          = 0.50f;
+    static constexpr float energy_delta_signed = constants::ENERGY_RECOVER_OK;
+    static constexpr bool  energy_flash        = false;
+    static constexpr Color particle_color{100, 180, 255, 220};
+    static constexpr int   SongResults::* results_counter = &SongResults::ok_count;
+    static constexpr std::vector<TimedPopupRequest> ScorePopupRequestQueue::* queue =
+        &ScorePopupRequestQueue::ok;
+};
+
+template <>
+struct tier_score_traits<TimingBadTag> {
+    static constexpr float multiplier          = 0.25f;
+    static constexpr float energy_delta_signed = -constants::ENERGY_DRAIN_BAD;
+    static constexpr bool  energy_flash        = true;
+    static constexpr Color particle_color{255, 100, 100, 220};
+    static constexpr int   SongResults::* results_counter = &SongResults::bad_count;
+    static constexpr std::vector<TimedPopupRequest> ScorePopupRequestQueue::* queue =
+        &ScorePopupRequestQueue::bad;
+};
+
+constexpr Color kUntimedParticleColor{220, 220, 255, 220};
 
 void spawn_score_particles(entt::registry& reg, const Vector2& position, Color color) {
     constexpr float kLifetime = 0.35f;
@@ -88,6 +124,124 @@ float chain_multiplier_for_count(int32_t chain_count) {
     return 1.0f + constants::CHAIN_MULT_STEP * static_cast<float>(bonus_steps);
 }
 
+// Process one tier of graded hits. Per-tier constants come from
+// tier_score_traits<TierTag>; the chain/score/popup-queue logic is shared
+// across tiers because that data is per-row (not per-tier).
+template <typename TierTag>
+void process_tier_hit_pass(entt::registry& reg,
+                           ScoreState& score,
+                           SongResults* results,
+                           ScoringSystemScratch& scratch,
+                           ScorePopupRequestQueue& popup_queue) {
+    auto& hit_buf = scratch.hit_buf;
+    hit_buf.clear();
+
+    auto view = reg.view<ObstacleTag, ScoredTag, Obstacle, WorldTransform, TimingGrade, TierTag>(
+        entt::exclude<MissTag, NonScorableTag>);
+    for (auto [e, obs, wt, tg] : view.each()) {
+        HitRecord r;
+        r.e          = e;
+        r.popup_xy   = wt.position;
+        r.obs        = obs;
+        r.has_timing = true;
+        r.precision  = tg.precision;
+        if (hit_buf.size() >= hit_buf.capacity()) {
+            ++scratch.hit_capacity_exceeded_count;
+        }
+        hit_buf.push_back(r);
+    }
+
+    if (hit_buf.empty()) return;
+
+    using Traits = tier_score_traits<TierTag>;
+
+    for (auto& r : hit_buf) {
+        enqueue_energy_effect(reg, Traits::energy_delta_signed, Traits::energy_flash);
+        if (results) {
+            ((*results).*Traits::results_counter) += 1;
+        }
+
+        const bool contributes_to_chain = r.obs.base_points > 0;
+        if (contributes_to_chain) {
+            score.chain_count++;
+        }
+        const float chain_mult  = chain_multiplier_for_count(score.chain_count);
+        int points = static_cast<int>(
+            std::floor(static_cast<float>(r.obs.base_points) * Traits::multiplier * chain_mult));
+
+        if (contributes_to_chain && results && score.chain_count > results->max_chain) {
+            results->max_chain = score.chain_count;
+        }
+
+        score.score += points;
+
+        auto& queue = popup_queue.*Traits::queue;
+        if (queue.size() >= queue.capacity()) {
+            ++popup_queue.capacity_exceeded_count;
+        }
+        queue.push_back({r.popup_xy.x, r.popup_xy.y, points});
+        spawn_score_particles(reg, r.popup_xy, Traits::particle_color);
+
+        reg.get_or_emplace<ResolvedObstacleTag>(r.e);
+        reg.remove<Obstacle>(r.e);
+        reg.remove<ScoredTag>(r.e);
+        remove_timing_grade_and_tags(reg, r.e);
+    }
+}
+
+void process_ungraded_hit_pass(entt::registry& reg,
+                               ScoreState& score,
+                               SongResults* results,
+                               ScoringSystemScratch& scratch,
+                               ScorePopupRequestQueue& popup_queue) {
+    auto& hit_buf = scratch.hit_buf;
+    hit_buf.clear();
+
+    auto view = reg.view<ObstacleTag, ScoredTag, Obstacle, WorldTransform>(
+        entt::exclude<MissTag, NonScorableTag, TimingGrade>);
+    for (auto [e, obs, wt] : view.each()) {
+        HitRecord r;
+        r.e          = e;
+        r.popup_xy   = wt.position;
+        r.obs        = obs;
+        r.has_timing = false;
+        if (hit_buf.size() >= hit_buf.capacity()) {
+            ++scratch.hit_capacity_exceeded_count;
+        }
+        hit_buf.push_back(r);
+    }
+
+    if (hit_buf.empty()) return;
+
+    for (auto& r : hit_buf) {
+        const bool contributes_to_chain = r.obs.base_points > 0;
+        if (contributes_to_chain) {
+            score.chain_count++;
+        }
+        const float chain_mult = chain_multiplier_for_count(score.chain_count);
+        // Ungraded hits never had a tier — pre-migration the switch fell
+        // through with timing_mult = 1.0f. Preserve that exactly.
+        int points = static_cast<int>(
+            std::floor(static_cast<float>(r.obs.base_points) * chain_mult));
+
+        if (contributes_to_chain && results && score.chain_count > results->max_chain) {
+            results->max_chain = score.chain_count;
+        }
+
+        score.score += points;
+
+        if (popup_queue.untimed.size() >= popup_queue.untimed.capacity()) {
+            ++popup_queue.capacity_exceeded_count;
+        }
+        popup_queue.untimed.push_back({r.popup_xy.x, r.popup_xy.y, points});
+        spawn_score_particles(reg, r.popup_xy, kUntimedParticleColor);
+
+        reg.get_or_emplace<ResolvedObstacleTag>(r.e);
+        reg.remove<Obstacle>(r.e);
+        reg.remove<ScoredTag>(r.e);
+    }
+}
+
 }  // namespace
 
 void scoring_system(entt::registry& reg, float dt) {
@@ -107,7 +261,8 @@ void scoring_system(entt::registry& reg, float dt) {
     auto* results = reg.ctx().find<SongResults>();   // #309: hoisted above loop
 
     // Hoist single scratch lookup — miss_buf and hit_buf share the same struct.
-    auto& scratch = scoring_scratch_for(reg);
+    auto& scratch     = scoring_scratch_for(reg);
+    auto& popup_queue = popup_queue_for(reg);
 
     // Miss pass: single owner of ENERGY_DRAIN_MISS and miss_count.
     // Collect first, then remove view components after iteration (#315).
@@ -144,111 +299,18 @@ void scoring_system(entt::registry& reg, float dt) {
             reg.remove<Obstacle>(r.e);
             reg.remove<ScoredTag>(r.e);
             if (reg.all_of<MissTag>(r.e)) reg.remove<MissTag>(r.e);
-            if (r.has_timing) reg.remove<TimingGrade>(r.e);
+            if (r.has_timing) remove_timing_grade_and_tags(reg, r.e);
         }
     }
 
-    // Hit pass: collect popup/scoring data, then process and remove (#315).
-    {
-        auto& hit_buf = scratch.hit_buf;
-        hit_buf.clear();
-
-        auto hit_view_graded = reg.view<ObstacleTag, ScoredTag, Obstacle, WorldTransform, TimingGrade>(
-            entt::exclude<MissTag, NonScorableTag>);
-        for (auto [e, obs, wt, tg] : hit_view_graded.each()) {
-            HitRecord r;
-            r.e        = e;
-            r.popup_xy = wt.position;
-            r.obs      = obs;
-            r.has_timing = true;
-            r.timing = tg;
-            if (hit_buf.size() >= hit_buf.capacity()) {
-                ++scratch.hit_capacity_exceeded_count;
-            }
-            hit_buf.push_back(r);
-        }
-
-        auto hit_view_ungraded = reg.view<ObstacleTag, ScoredTag, Obstacle, WorldTransform>(
-            entt::exclude<MissTag, NonScorableTag, TimingGrade>);
-        for (auto [e, obs, wt] : hit_view_ungraded.each()) {
-            HitRecord r;
-            r.e        = e;
-            r.popup_xy = wt.position;
-            r.obs      = obs;
-            r.has_timing = false;
-            if (hit_buf.size() >= hit_buf.capacity()) {
-                ++scratch.hit_capacity_exceeded_count;
-            }
-            hit_buf.push_back(r);
-        }
-
-
-        if (!hit_buf.empty()) {
-        auto& popup_queue = popup_queue_for(reg);
-        for (auto& r : hit_buf) {
-            float timing_mult  = r.has_timing ? timing_multiplier(r.timing.tier) : 1.0f;
-
-            // Energy adjustment based on timing
-            if (r.has_timing) {
-                switch (r.timing.tier) {
-                    case TimingTier::Perfect:
-                        enqueue_energy_effect(reg, constants::ENERGY_RECOVER_PERFECT);
-                        break;
-                    case TimingTier::Good:
-                        enqueue_energy_effect(reg, constants::ENERGY_RECOVER_GOOD);
-                        break;
-                    case TimingTier::Ok:
-                        enqueue_energy_effect(reg, constants::ENERGY_RECOVER_OK);
-                        break;
-                    case TimingTier::Bad:
-                        enqueue_energy_effect(reg, -constants::ENERGY_DRAIN_BAD, true);
-                        break;
-                }
-                if (results) {
-                    switch (r.timing.tier) {
-                        case TimingTier::Perfect: results->perfect_count++; break;
-                        case TimingTier::Good:    results->good_count++;    break;
-                        case TimingTier::Ok:      results->ok_count++;      break;
-                        case TimingTier::Bad:     results->bad_count++;     break;
-                    }
-                }
-            }
-
-            const bool contributes_to_chain = r.obs.base_points > 0;
-            if (contributes_to_chain) {
-                score.chain_count++;
-            }
-            const float chain_mult = chain_multiplier_for_count(score.chain_count);
-            int points = static_cast<int>(
-                std::floor(static_cast<float>(r.obs.base_points) * timing_mult * chain_mult));
-
-            if (contributes_to_chain && results && score.chain_count > results->max_chain) {
-                results->max_chain = score.chain_count;
-            }
-
-            score.score += points;
-
-            // Queue timing/score popup; popup_feedback_system owns spawn/SFX.
-            if (popup_queue.requests.size() >= popup_queue.requests.capacity()) {
-                ++popup_queue.capacity_exceeded_count;
-            }
-            popup_queue.requests.push_back({
-                r.popup_xy.x,
-                r.popup_xy.y,
-                points,
-                r.has_timing,
-                r.has_timing ? r.timing.tier : TimingTier::Ok,
-            });
-            spawn_score_particles(reg, r.popup_xy, score_particle_color(r));
-
-            // Structural removals after all reads — safe.
-            reg.get_or_emplace<ResolvedObstacleTag>(r.e);
-            reg.remove<Obstacle>(r.e);
-            reg.remove<ScoredTag>(r.e);
-            if (r.has_timing) reg.remove<TimingGrade>(r.e);
-        }
-        } // !hit_buf.empty()
-    }
+    // Hit pass: one transform per former TimingTier value plus one ungraded
+    // transform (#1202/#1204). Per-tier constants live in tier_score_traits;
+    // no `switch` on a discriminator anywhere in the hit pipeline.
+    process_tier_hit_pass<TimingPerfectTag>(reg, score, results, scratch, popup_queue);
+    process_tier_hit_pass<TimingGoodTag>   (reg, score, results, scratch, popup_queue);
+    process_tier_hit_pass<TimingOkTag>     (reg, score, results, scratch, popup_queue);
+    process_tier_hit_pass<TimingBadTag>    (reg, score, results, scratch, popup_queue);
+    process_ungraded_hit_pass              (reg, score, results, scratch, popup_queue);
 
     // ── NonScorable cleanup ───────────────────────────────────────────────────
     // Entities excluded from the hit pass via NonScorableTag still need their
@@ -275,7 +337,7 @@ void scoring_system(entt::registry& reg, float dt) {
             reg.remove<Obstacle>(r.e);
             reg.remove<ScoredTag>(r.e);
             if (reg.all_of<MissTag>(r.e)) reg.remove<MissTag>(r.e);
-            if (r.has_timing) reg.remove<TimingGrade>(r.e);
+            if (r.has_timing) remove_timing_grade_and_tags(reg, r.e);
         }
     }
 

--- a/app/systems/scoring_system.h
+++ b/app/systems/scoring_system.h
@@ -17,12 +17,16 @@ struct MissRecord {
     bool has_timing = false;
 };
 
+// HitRecord carries per-row data only — the tier discriminator that used to
+// live here is now a per-tier tag on the obstacle entity (#1202/#1204), so
+// scoring_system snapshots an obstacle plus its per-tier tag and dispatches
+// to the matching transform without re-querying the registry per row.
 struct HitRecord {
     entt::entity e = entt::null;
     Vector2 popup_xy = {0.0f, 0.0f};
     Obstacle obs;
     bool has_timing = false;
-    TimingGrade timing{};
+    float precision = 0.0f;
 };
 
 struct ScoringSystemScratch {

--- a/app/systems/session_logger_system.cpp
+++ b/app/systems/session_logger_system.cpp
@@ -2,6 +2,7 @@
 #include "../components/obstacle.h"
 #include "../components/rhythm.h"
 #include "../components/scoring.h"
+#include "../tags/tags.h"
 
 #include <cstdarg>
 #include <cmath>
@@ -144,7 +145,6 @@ void session_log_on_scored(entt::registry& reg, entt::entity entity) {
 
     bool is_miss = reg.any_of<MissTag>(entity);
 
-    auto* grade = reg.try_get<TimingGrade>(entity);
     auto* beat = reg.try_get<BeatInfo>(entity);
     int beat_num = beat ? beat->beat_index : -1;
     float expected_t = beat ? beat->arrival_time : 0.0f;
@@ -154,6 +154,17 @@ void session_log_on_scored(entt::registry& reg, entt::entity entity) {
         reg.all_of<RequiredLane>(entity));
     const std::string_view kind_name = enum_name_or_unknown(kind);
 
+    // Per-tier tag → label. Replaces enum_name(grade->tier) lookup; the tier
+    // discriminator is now a per-tier tag on the entity (issue #1202/#1204).
+    auto tier_label_or_empty = [&]() -> std::string_view {
+        if (reg.all_of<TimingPerfectTag>(entity)) return "Perfect";
+        if (reg.all_of<TimingGoodTag>(entity))    return "Good";
+        if (reg.all_of<TimingOkTag>(entity))      return "Ok";
+        if (reg.all_of<TimingBadTag>(entity))     return "Bad";
+        return {};
+    };
+
+    auto* grade = reg.try_get<TimingGrade>(entity);
     if (is_miss) {
         session_log_write(*log, t, "GAME",
             "COLLISION obstacle=%u beat=%d expected=%.3f drift=%+.3fs kind=%.*s result=MISS",
@@ -161,7 +172,7 @@ void session_log_on_scored(entt::registry& reg, entt::entity entity) {
             beat_num, expected_t, drift,
             static_cast<int>(kind_name.size()), kind_name.data());
     } else if (grade) {
-        const std::string_view tier_name = enum_name_or_unknown(grade->tier);
+        const std::string_view tier_name = tier_label_or_empty();
         session_log_write(*log, t, "GAME",
             "COLLISION obstacle=%u beat=%d expected=%.3f drift=%+.3fs kind=%.*s result=CLEAR timing=%.*s(%.2f)",
             static_cast<unsigned>(entt::to_integral(entity)),

--- a/app/tags/tags.h
+++ b/app/tags/tags.h
@@ -66,6 +66,20 @@ struct TagHUDPass     {};  // screen-space UI elements
 struct MeshKindSlab {};
 struct MeshKindQuad {};
 
+// ── Timing tier (per-tag table; one tier tag per graded obstacle) ──
+// Replaces the former TimingTier enum (issue #1202/#1204). Each former enum
+// value becomes its own zero-column table; the per-row "precision" scalar
+// lives in TimingGrade. collision_system emplaces exactly one tier tag at
+// grading-time; scoring_system, popup_feedback_system, and the session
+// logger dispatch via tag presence (no switch on a discriminator).
+//
+// Score popup entities carry the same tier tag so renderers can identify
+// their tier without re-reading ScorePopup data.
+struct TimingPerfectTag {};
+struct TimingGoodTag    {};
+struct TimingOkTag      {};
+struct TimingBadTag     {};
+
 // ── Singletons ───────────────────────────────────────────────
 struct BeatMapTag {};
 struct SettingsTag {};

--- a/app/util/rhythm_math.h
+++ b/app/util/rhythm_math.h
@@ -2,8 +2,10 @@
 
 #include "../components/rhythm.h"
 #include "../constants.h"
+#include "../tags/tags.h"
 
 #include <cmath>
+#include <entt/entt.hpp>
 #include <raylib.h>
 
 constexpr float kTimingBpmCeiling = 180.0f;
@@ -14,35 +16,94 @@ constexpr float kTimingGradeEpsilonSeconds = 0.0005f;
 constexpr float kDefaultTimingBpm = 120.0f;
 constexpr int kDefaultTimingLeadBeats = 4;
 
-// Better timing -> smaller scale -> remaining Active window collapses sooner.
-// collision_system applies this via window_start adjustment (scale < 1.0 path).
-// Spec: rhythm-spec.md §5/§7. BAD is a scored hit with no window-collapse reward.
-inline float window_scale_for_tier(TimingTier tier) {
-    switch (tier) {
-        case TimingTier::Perfect: return 0.50f;
-        case TimingTier::Good:    return 0.75f;
-        case TimingTier::Ok:      return 1.00f;
-        case TimingTier::Bad:     return 1.00f;
-    }
-    return 1.00f;
+// Per-tier multiplier and window-scale lookups, keyed by absolute delta-seconds
+// instead of a discriminator (issue #1202/#1204). The threshold ladder is the
+// per-value table — Perfect/Good/Ok/Bad are zero-column tags emplaced alongside
+// these returns; the multiplier/scale columns are inline here.
+//
+// Better timing -> smaller window scale -> remaining Active window collapses
+// sooner. collision_system applies this via window_start adjustment when the
+// returned scale is < 1.0. Spec: rhythm-spec.md §5/§7. BAD is a scored hit
+// with no window-collapse reward.
+inline float window_scale_from_delta_abs(float delta_seconds_abs) {
+    if (delta_seconds_abs <= kTimingPerfectSeconds + kTimingGradeEpsilonSeconds) return 0.50f;
+    if (delta_seconds_abs <= kTimingGoodSeconds    + kTimingGradeEpsilonSeconds) return 0.75f;
+    return 1.00f;  // Ok and Bad: neutral
 }
 
-inline float timing_multiplier(TimingTier tier) {
-    switch (tier) {
-        case TimingTier::Perfect: return 1.50f;
-        case TimingTier::Good:    return 1.00f;
-        case TimingTier::Ok:      return 0.50f;
-        case TimingTier::Bad:     return 0.25f;
-    }
+inline float timing_multiplier_from_delta_abs(float delta_seconds_abs) {
+    if (delta_seconds_abs <= kTimingPerfectSeconds + kTimingGradeEpsilonSeconds) return 1.50f;
+    if (delta_seconds_abs <= kTimingGoodSeconds    + kTimingGradeEpsilonSeconds) return 1.00f;
+    if (delta_seconds_abs <= kTimingOkSeconds      + kTimingGradeEpsilonSeconds) return 0.50f;
     return 0.25f;
 }
 
+// Emplace the matching tier tag for the given absolute delta-seconds. Removes
+// any other tier tag already on the entity so an entity carries exactly one
+// tier tag at a time (existential processing — issue #1202/#1204).
+inline void emplace_timing_tier_tag_for_delta_abs(entt::registry& reg,
+                                                  entt::entity entity,
+                                                  float delta_seconds_abs) {
+    reg.remove<TimingPerfectTag>(entity);
+    reg.remove<TimingGoodTag>(entity);
+    reg.remove<TimingOkTag>(entity);
+    reg.remove<TimingBadTag>(entity);
+    if (delta_seconds_abs <= kTimingPerfectSeconds + kTimingGradeEpsilonSeconds) {
+        reg.emplace<TimingPerfectTag>(entity);
+    } else if (delta_seconds_abs <= kTimingGoodSeconds + kTimingGradeEpsilonSeconds) {
+        reg.emplace<TimingGoodTag>(entity);
+    } else if (delta_seconds_abs <= kTimingOkSeconds + kTimingGradeEpsilonSeconds) {
+        reg.emplace<TimingOkTag>(entity);
+    } else {
+        reg.emplace<TimingBadTag>(entity);
+    }
+}
 
-inline TimingTier compute_timing_tier_from_delta(float delta_seconds_abs) {
-    if (delta_seconds_abs <= kTimingPerfectSeconds + kTimingGradeEpsilonSeconds) return TimingTier::Perfect;
-    if (delta_seconds_abs <= kTimingGoodSeconds + kTimingGradeEpsilonSeconds) return TimingTier::Good;
-    if (delta_seconds_abs <= kTimingOkSeconds + kTimingGradeEpsilonSeconds) return TimingTier::Ok;
-    return TimingTier::Bad;
+// True iff `entity` carries any of the four tier tags.
+inline bool has_any_timing_tier_tag(const entt::registry& reg, entt::entity entity) {
+    return reg.any_of<TimingPerfectTag, TimingGoodTag, TimingOkTag, TimingBadTag>(entity);
+}
+
+// Per-tier emplace helpers — equivalent to manually emplacing TimingGrade
+// plus the matching tier tag. Used by tests and by spots where the tier is
+// known statically.
+inline void emplace_timing_perfect(entt::registry& reg, entt::entity e, float precision) {
+    reg.emplace_or_replace<TimingGrade>(e, TimingGrade{precision});
+    reg.remove<TimingGoodTag>(e);
+    reg.remove<TimingOkTag>(e);
+    reg.remove<TimingBadTag>(e);
+    reg.emplace_or_replace<TimingPerfectTag>(e);
+}
+inline void emplace_timing_good(entt::registry& reg, entt::entity e, float precision) {
+    reg.emplace_or_replace<TimingGrade>(e, TimingGrade{precision});
+    reg.remove<TimingPerfectTag>(e);
+    reg.remove<TimingOkTag>(e);
+    reg.remove<TimingBadTag>(e);
+    reg.emplace_or_replace<TimingGoodTag>(e);
+}
+inline void emplace_timing_ok(entt::registry& reg, entt::entity e, float precision) {
+    reg.emplace_or_replace<TimingGrade>(e, TimingGrade{precision});
+    reg.remove<TimingPerfectTag>(e);
+    reg.remove<TimingGoodTag>(e);
+    reg.remove<TimingBadTag>(e);
+    reg.emplace_or_replace<TimingOkTag>(e);
+}
+inline void emplace_timing_bad(entt::registry& reg, entt::entity e, float precision) {
+    reg.emplace_or_replace<TimingGrade>(e, TimingGrade{precision});
+    reg.remove<TimingPerfectTag>(e);
+    reg.remove<TimingGoodTag>(e);
+    reg.remove<TimingOkTag>(e);
+    reg.emplace_or_replace<TimingBadTag>(e);
+}
+
+// Remove TimingGrade and all four tier tags. Used by scoring/cleanup paths
+// that previously did `reg.remove<TimingGrade>(e)` to clear the tier row.
+inline void remove_timing_grade_and_tags(entt::registry& reg, entt::entity e) {
+    reg.remove<TimingGrade>(e);
+    reg.remove<TimingPerfectTag>(e);
+    reg.remove<TimingGoodTag>(e);
+    reg.remove<TimingOkTag>(e);
+    reg.remove<TimingBadTag>(e);
 }
 
 inline void song_state_compute_derived(SongState& s) {

--- a/tests/test_audio_offset_calibration.cpp
+++ b/tests/test_audio_offset_calibration.cpp
@@ -219,7 +219,10 @@ TEST_CASE("audio_offset: zero setting matches absent SettingsState",
 namespace {
 
 struct OffsetGameplayResult {
-    TimingTier tier = TimingTier::Bad;
+    bool perfect{false};
+    bool good{false};
+    bool ok{false};
+    bool bad{false};
     int score = 0;
     float energy = 0.0f;
     int perfect_count = 0;
@@ -270,7 +273,11 @@ OffsetGameplayResult run_calibrated_on_arrival_hit(int16_t audio_offset_ms) {
     REQUIRE(reg.all_of<ScoredTag>(obstacle));
     REQUIRE(reg.all_of<TimingGrade>(obstacle));
 
-    const auto tier = reg.get<TimingGrade>(obstacle).tier;
+    OffsetGameplayResult out;
+    out.perfect = reg.all_of<TimingPerfectTag>(obstacle);
+    out.good    = reg.all_of<TimingGoodTag>(obstacle);
+    out.ok      = reg.all_of<TimingOkTag>(obstacle);
+    out.bad     = reg.all_of<TimingBadTag>(obstacle);
 
     scoring_system(reg, 0.016f);
     energy_system(reg, 0.016f);
@@ -279,8 +286,6 @@ OffsetGameplayResult run_calibrated_on_arrival_hit(int16_t audio_offset_ms) {
     const auto& energy = reg.ctx().get<EnergyState>();
     const auto& results = reg.ctx().get<SongResults>();
 
-    OffsetGameplayResult out;
-    out.tier = tier;
     out.score = score.score;
     out.energy = energy.energy;
     out.perfect_count = results.perfect_count;
@@ -298,9 +303,9 @@ TEST_CASE("collision grading stays invariant for calibrated on-arrival presses",
     const auto delayed  = run_calibrated_on_arrival_hit(+200);
     const auto advanced = run_calibrated_on_arrival_hit(-200);
 
-    CHECK(baseline.tier == TimingTier::Perfect);
-    CHECK(delayed.tier == baseline.tier);
-    CHECK(advanced.tier == baseline.tier);
+    CHECK(baseline.perfect);
+    CHECK(delayed.perfect);
+    CHECK(advanced.perfect);
 
     CHECK_THAT(baseline.arrival_time - baseline.visual_arrival_time,
                Catch::Matchers::WithinAbs(0.0f, kTimingToleranceSec));

--- a/tests/test_beat_map_validation.cpp
+++ b/tests/test_beat_map_validation.cpp
@@ -379,19 +379,22 @@ TEST_CASE("init_song_state: computes derived fields", "[init_song]") {
 
 // ── rhythm helper functions ──────────────────────────────────
 
-TEST_CASE("timing_multiplier: returns correct values", "[rhythm_helpers]") {
-    CHECK(timing_multiplier(TimingTier::Perfect) == 1.50f);
-    CHECK(timing_multiplier(TimingTier::Good) == 1.00f);
-    CHECK(timing_multiplier(TimingTier::Ok) == 0.50f);
-    CHECK(timing_multiplier(TimingTier::Bad) == 0.25f);
+TEST_CASE("timing_multiplier_from_delta_abs: returns correct values per band", "[rhythm_helpers]") {
+    // Post-#1202/#1204: tier discriminator eradicated; multiplier ladder is
+    // keyed by the absolute delta-seconds. Each canonical sample below sits
+    // squarely inside the corresponding former-tier band.
+    CHECK(timing_multiplier_from_delta_abs(0.0f)                              == 1.50f);
+    CHECK(timing_multiplier_from_delta_abs(kTimingPerfectSeconds + 0.001f)    == 1.00f);
+    CHECK(timing_multiplier_from_delta_abs(kTimingGoodSeconds    + 0.001f)    == 0.50f);
+    CHECK(timing_multiplier_from_delta_abs(kTimingOkSeconds      + 0.001f)    == 0.25f);
 }
 
-TEST_CASE("window_scale_for_tier: returns correct values", "[rhythm_helpers]") {
+TEST_CASE("window_scale_from_delta_abs: returns correct values per band", "[rhythm_helpers]") {
     // Post-#223 inversion: smaller scale = better timing = faster window collapse.
-    CHECK(window_scale_for_tier(TimingTier::Perfect) == 0.50f);
-    CHECK(window_scale_for_tier(TimingTier::Good) == 0.75f);
-    CHECK(window_scale_for_tier(TimingTier::Ok) == 1.00f);
-    CHECK(window_scale_for_tier(TimingTier::Bad) == 1.00f);
+    CHECK(window_scale_from_delta_abs(0.0f)                              == 0.50f);
+    CHECK(window_scale_from_delta_abs(kTimingPerfectSeconds + 0.001f)    == 0.75f);
+    CHECK(window_scale_from_delta_abs(kTimingGoodSeconds    + 0.001f)    == 1.00f);
+    CHECK(window_scale_from_delta_abs(kTimingOkSeconds      + 0.001f)    == 1.00f);
 }
 
 TEST_CASE("song_state_compute_derived: beat_period calculation", "[rhythm_helpers]") {

--- a/tests/test_collision_extended.cpp
+++ b/tests/test_collision_extended.cpp
@@ -4,8 +4,15 @@
 
 namespace {
 
+// Post-#1202/#1204: the per-tier discriminator is now a tag (one of
+// TimingPerfect/Good/Ok/Bad), not an enum field on TimingGrade. We capture
+// the resulting tier as 4 booleans so the test struct stays Fabian-clean
+// (no discriminator enum, columns are independent existential bits).
 struct ScoredTimingResult {
-    TimingTier tier{};
+    bool perfect{false};
+    bool good{false};
+    bool ok{false};
+    bool bad{false};
     SongResults results{};
 };
 
@@ -29,11 +36,16 @@ ScoredTimingResult score_rhythm_shape_hit_at_offset(float arrival_offset_seconds
     collision_system(reg, 0.016f);
 
     REQUIRE(reg.all_of<TimingGrade>(obs));
-    const auto tier = reg.get<TimingGrade>(obs).tier;
+    ScoredTimingResult out{};
+    out.perfect = reg.all_of<TimingPerfectTag>(obs);
+    out.good    = reg.all_of<TimingGoodTag>(obs);
+    out.ok      = reg.all_of<TimingOkTag>(obs);
+    out.bad     = reg.all_of<TimingBadTag>(obs);
 
     scoring_system(reg, 0.016f);
 
-    return {tier, reg.ctx().get<SongResults>()};
+    out.results = reg.ctx().get<SongResults>();
+    return out;
 }
 
 }  // namespace
@@ -110,7 +122,7 @@ TEST_CASE("collision: rhythm mode assigns Perfect for on-time hit", "[collision]
     collision_system(reg, 0.016f);
 
     REQUIRE(reg.all_of<TimingGrade>(obs));
-    CHECK(reg.get<TimingGrade>(obs).tier == TimingTier::Perfect);
+    CHECK(reg.all_of<TimingPerfectTag>(obs));
 }
 
 TEST_CASE("collision: on-beat rhythm press clears matching gate during MorphIn",
@@ -138,7 +150,7 @@ TEST_CASE("collision: on-beat rhythm press clears matching gate during MorphIn",
     CHECK(reg.all_of<ScoredTag>(obs));
     CHECK_FALSE(reg.all_of<MissTag>(obs));
     REQUIRE(reg.all_of<TimingGrade>(obs));
-    CHECK(reg.get<TimingGrade>(obs).tier == TimingTier::Perfect);
+    CHECK(reg.all_of<TimingPerfectTag>(obs));
 }
 
 TEST_CASE("collision: on-beat shape press requires player hitbox to reach target lane",
@@ -196,7 +208,7 @@ TEST_CASE("collision: rhythm mode assigns Bad for far-off hit", "[collision][rhy
     collision_system(reg, 0.016f);
 
     REQUIRE(reg.all_of<TimingGrade>(obs));
-    CHECK(reg.get<TimingGrade>(obs).tier == TimingTier::Bad);
+    CHECK(reg.all_of<TimingBadTag>(obs));
 }
 
 TEST_CASE("collision: rhythm shape gate only matches during Active window",
@@ -334,7 +346,10 @@ TEST_CASE("collision/scoring: rhythm Good increments SongResults good_count (#21
     const auto result = score_rhythm_shape_hit_at_offset(
         (kTimingPerfectSeconds + kTimingGoodSeconds) * 0.5f);
 
-    CHECK(result.tier == TimingTier::Good);
+    CHECK(result.good);
+    CHECK_FALSE(result.perfect);
+    CHECK_FALSE(result.ok);
+    CHECK_FALSE(result.bad);
     CHECK(result.results.perfect_count == 0);
     CHECK(result.results.good_count == 1);
     CHECK(result.results.ok_count == 0);
@@ -346,7 +361,10 @@ TEST_CASE("collision/scoring: rhythm Ok increments SongResults ok_count (#214)",
     const auto result = score_rhythm_shape_hit_at_offset(
         (kTimingGoodSeconds + kTimingOkSeconds) * 0.5f);
 
-    CHECK(result.tier == TimingTier::Ok);
+    CHECK(result.ok);
+    CHECK_FALSE(result.perfect);
+    CHECK_FALSE(result.good);
+    CHECK_FALSE(result.bad);
     CHECK(result.results.perfect_count == 0);
     CHECK(result.results.good_count == 0);
     CHECK(result.results.ok_count == 1);
@@ -357,7 +375,10 @@ TEST_CASE("collision/scoring: rhythm Bad increments SongResults bad_count (#214)
           "[collision][rhythm][issue214]") {
     const auto result = score_rhythm_shape_hit_at_offset(kTimingOkSeconds + 0.001f);
 
-    CHECK(result.tier == TimingTier::Bad);
+    CHECK(result.bad);
+    CHECK_FALSE(result.perfect);
+    CHECK_FALSE(result.good);
+    CHECK_FALSE(result.ok);
     CHECK(result.results.perfect_count == 0);
     CHECK(result.results.good_count == 0);
     CHECK(result.results.ok_count == 0);

--- a/tests/test_death_model_unified.cpp
+++ b/tests/test_death_model_unified.cpp
@@ -79,7 +79,7 @@ TEST_CASE("death_model: timing recovery can preserve survival margin", "[death_m
 
     auto scored = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<ScoredTag>(scored);
-    reg.emplace<TimingGrade>(scored, TimingTier::Perfect, 1.0f);
+    emplace_timing_perfect(reg, scored, 1.0f);
     scoring_system(reg, 0.016f);
     energy_system(reg, 0.016f);
 

--- a/tests/test_helpers_and_functions.cpp
+++ b/tests/test_helpers_and_functions.cpp
@@ -5,57 +5,63 @@
 #include "ui/screen_controllers/screen_controller_base.h"
 #include "util/rhythm_math.h"
 
-// ── timing_multiplier ────────────────────────────────────────
+// ── timing_multiplier_from_delta_abs ─────────────────────────
+// Per #1202/#1204: TimingTier eradicated; multiplier is now derived from the
+// absolute delta-seconds via the threshold ladder. Each canonical delta below
+// sits squarely inside the corresponding former-tier band.
 
-TEST_CASE("timing_multiplier: Perfect gives 1.50x", "[timing]") {
-    CHECK(timing_multiplier(TimingTier::Perfect) == 1.50f);
+TEST_CASE("timing_multiplier: delta=0 (Perfect band) gives 1.50x", "[timing]") {
+    CHECK(timing_multiplier_from_delta_abs(0.0f) == 1.50f);
 }
 
-TEST_CASE("timing_multiplier: Good gives 1.00x", "[timing]") {
-    CHECK(timing_multiplier(TimingTier::Good) == 1.00f);
+TEST_CASE("timing_multiplier: just past Perfect (Good band) gives 1.00x", "[timing]") {
+    CHECK(timing_multiplier_from_delta_abs(kTimingPerfectSeconds + 0.001f) == 1.00f);
 }
 
-TEST_CASE("timing_multiplier: Ok gives 0.50x", "[timing]") {
-    CHECK(timing_multiplier(TimingTier::Ok) == 0.50f);
+TEST_CASE("timing_multiplier: just past Good (Ok band) gives 0.50x", "[timing]") {
+    CHECK(timing_multiplier_from_delta_abs(kTimingGoodSeconds + 0.001f) == 0.50f);
 }
 
-TEST_CASE("timing_multiplier: Bad gives 0.25x", "[timing]") {
-    CHECK(timing_multiplier(TimingTier::Bad) == 0.25f);
+TEST_CASE("timing_multiplier: just past Ok (Bad band) gives 0.25x", "[timing]") {
+    CHECK(timing_multiplier_from_delta_abs(kTimingOkSeconds + 0.001f) == 0.25f);
 }
 
-// ── window_scale_for_tier ────────────────────────────────────
+// ── window_scale_from_delta_abs ──────────────────────────────
 // Spec (rhythm-spec.md §5/§7): better timing → smaller scale → window collapses sooner.
 
-TEST_CASE("window_scale: Perfect gives 0.50", "[timing]") {
-    CHECK(window_scale_for_tier(TimingTier::Perfect) == 0.50f);
+TEST_CASE("window_scale: delta=0 (Perfect band) gives 0.50", "[timing]") {
+    CHECK(window_scale_from_delta_abs(0.0f) == 0.50f);
 }
 
-TEST_CASE("window_scale: Good gives 0.75", "[timing]") {
-    CHECK(window_scale_for_tier(TimingTier::Good) == 0.75f);
+TEST_CASE("window_scale: just past Perfect (Good band) gives 0.75", "[timing]") {
+    CHECK(window_scale_from_delta_abs(kTimingPerfectSeconds + 0.001f) == 0.75f);
 }
 
-TEST_CASE("window_scale: Ok gives 1.00", "[timing]") {
-    CHECK(window_scale_for_tier(TimingTier::Ok) == 1.00f);
+TEST_CASE("window_scale: just past Good (Ok band) gives 1.00", "[timing]") {
+    CHECK(window_scale_from_delta_abs(kTimingGoodSeconds + 0.001f) == 1.00f);
 }
 
-TEST_CASE("window_scale: Bad gives 1.00 (no-op, miss handled elsewhere)", "[timing]") {
-    CHECK(window_scale_for_tier(TimingTier::Bad) == 1.00f);
+TEST_CASE("window_scale: just past Ok (Bad band) gives 1.00 (no-op, miss handled elsewhere)", "[timing]") {
+    CHECK(window_scale_from_delta_abs(kTimingOkSeconds + 0.001f) == 1.00f);
 }
 
 // Regression for issue #223 — values must be strictly ordered:
 // Perfect(0.50) < Good(0.75) < Ok(1.00) == Bad(1.00).
 // If this order inverts again the inversion bug has regressed.
-TEST_CASE("window_scale: ordering — better tier gives smaller scale", "[timing][regression]") {
-    CHECK(window_scale_for_tier(TimingTier::Perfect) < window_scale_for_tier(TimingTier::Good));
-    CHECK(window_scale_for_tier(TimingTier::Good)    < window_scale_for_tier(TimingTier::Ok));
-    CHECK(window_scale_for_tier(TimingTier::Ok)     == window_scale_for_tier(TimingTier::Bad));
+TEST_CASE("window_scale: ordering — better timing gives smaller scale", "[timing][regression]") {
+    CHECK(window_scale_from_delta_abs(0.0f) <
+          window_scale_from_delta_abs(kTimingPerfectSeconds + 0.001f));
+    CHECK(window_scale_from_delta_abs(kTimingPerfectSeconds + 0.001f) <
+          window_scale_from_delta_abs(kTimingGoodSeconds + 0.001f));
+    CHECK(window_scale_from_delta_abs(kTimingGoodSeconds + 0.001f) ==
+          window_scale_from_delta_abs(kTimingOkSeconds + 0.001f));
 }
 
-TEST_CASE("window_scale: Perfect strictly shrinks, Ok/Bad are neutral", "[timing][regression]") {
-    CHECK(window_scale_for_tier(TimingTier::Perfect) <  1.0f);
-    CHECK(window_scale_for_tier(TimingTier::Good)    <  1.0f);
-    CHECK(window_scale_for_tier(TimingTier::Ok)      == 1.0f);
-    CHECK(window_scale_for_tier(TimingTier::Bad)     == 1.0f);
+TEST_CASE("window_scale: Perfect/Good strictly shrink, Ok/Bad are neutral", "[timing][regression]") {
+    CHECK(window_scale_from_delta_abs(0.0f)                              <  1.0f);
+    CHECK(window_scale_from_delta_abs(kTimingPerfectSeconds + 0.001f)    <  1.0f);
+    CHECK(window_scale_from_delta_abs(kTimingGoodSeconds    + 0.001f)    == 1.0f);
+    CHECK(window_scale_from_delta_abs(kTimingOkSeconds      + 0.001f)    == 1.0f);
 }
 
 // ── song_state_compute_derived ───────────────────────────────
@@ -144,12 +150,10 @@ TEST_CASE("ToString: ObstacleKind covers all kinds", "[ToString]") {
     CHECK(magic_enum::enum_name(ObstacleKind::OnsetMarker) == "OnsetMarker");
 }
 
-TEST_CASE("ToString: TimingTier covers all tiers", "[ToString]") {
-    CHECK(magic_enum::enum_name(TimingTier::Bad) == "Bad");
-    CHECK(magic_enum::enum_name(TimingTier::Ok) == "Ok");
-    CHECK(magic_enum::enum_name(TimingTier::Good) == "Good");
-    CHECK(magic_enum::enum_name(TimingTier::Perfect) == "Perfect");
-}
+// TimingTier enum was eradicated in issue #1202/#1204 (per Fabian's existential
+// processing); each former value is now a zero-column tag in app/tags/tags.h
+// (TimingPerfectTag/TimingGoodTag/TimingOkTag/TimingBadTag) and the
+// magic_enum reflection check no longer applies.
 
 // ── dispatcher helpers ───────────────────────────────────────
 

--- a/tests/test_phase_runner.cpp
+++ b/tests/test_phase_runner.cpp
@@ -141,7 +141,7 @@ TEST_CASE("tick_fixed_systems: popup_feedback and energy run in score-feedback c
     // Pre-seed a popup request directly (bypasses scoring_system path; tests
     // that popup_feedback_system is wired and consumes the queue).
     auto& queue = reg.ctx().emplace<ScorePopupRequestQueue>();
-    queue.requests.push_back({100.0f, 200.0f, 10, false, TimingTier::Ok});
+    queue.untimed.push_back({100.0f, 200.0f, 10});
 
     // Pre-seed a pending energy effect to verify energy_system is wired.
     auto& pending = reg.ctx().emplace<PendingEnergyEffects>();
@@ -153,7 +153,11 @@ TEST_CASE("tick_fixed_systems: popup_feedback and energy run in score-feedback c
     tick_fixed_systems(reg, 0.016f);
 
     // popup_feedback_system must have consumed the queue and spawned an entity.
-    CHECK(queue.requests.empty());
+    CHECK(queue.untimed.empty());
+    CHECK(queue.perfect.empty());
+    CHECK(queue.good.empty());
+    CHECK(queue.ok.empty());
+    CHECK(queue.bad.empty());
     const auto popup_view = reg.view<ScorePopup>();
     CHECK_FALSE(popup_view.empty());
 

--- a/tests/test_popup_display_system.cpp
+++ b/tests/test_popup_display_system.cpp
@@ -1,17 +1,22 @@
-// Regression tests for GitHub issues #208 and #288.
+// Regression tests for GitHub issues #208, #288, #1202.
 //
 // #208: popup_display_system had zero test coverage.
 // #288: timing_tier migrated from raw uint8_t sentinel (255) to optional<TimingTier>.
+// #1202: TimingTier enum eradicated (Fabian existential processing). Each
+//        former tier is now an empty tag on the popup entity itself
+//        (TimingPerfectTag / TimingGoodTag / TimingOkTag / TimingBadTag).
+//        The discriminator field on ScorePopup is gone — tier identity is
+//        carried by the popup entity's component signature.
 //
 // Covers popup_display_system — the system that converts ScorePopup entities
 // into renderable PopupDisplay structs (text label, font size, RGBA alpha).
 //
-// Test matrix:
-//   timing_tier == TimingTier::Perfect → text "PERFECT",  FontSize::Medium
-//   timing_tier == TimingTier::Good    → text "GOOD",     FontSize::Medium
-//   timing_tier == TimingTier::Ok      → text "OK",       FontSize::Medium
-//   timing_tier == TimingTier::Bad     → text "BAD",      FontSize::Medium
-//   timing_tier == nullopt             → numeric score string (e.g. "150"), FontSize::Small
+// Test matrix (post-#1202):
+//   TimingPerfectTag on entity → text "PERFECT",  FontSize::Medium
+//   TimingGoodTag    on entity → text "GOOD",     FontSize::Medium
+//   TimingOkTag      on entity → text "OK",       FontSize::Medium
+//   TimingBadTag     on entity → text "BAD",      FontSize::Medium
+//   no tier tag                → numeric score string (e.g. "150"), FontSize::Small
 //   alpha at half lifetime → ≈ 127  (50 % × 255 truncated to uint8_t)
 //
 // The tests operate on in-memory registry entities and do not touch files.
@@ -19,60 +24,102 @@
 #include <catch2/catch_test_macros.hpp>
 #include <entt/entt.hpp>
 #include <cstring>
-#include <optional>
 #include <tuple>
 
 #include "components/scoring.h"   // ScorePopup, PopupDisplay
 #include "components/rendering.h" // ScreenPosition, Color (via raylib)
 #include "systems/popup_display_system.h"
 #include "components/text.h"      // FontSize
-#include "components/rhythm.h"    // TimingTier
+#include "tags/tags.h"            // TimingPerfectTag / Good / Ok / Bad
 #include "components/transform.h" // WorldTransform, Vector2
-#include "entities/settings.h"        // SettingsState (reduce_motion)
+#include "entities/settings.h"    // SettingsState (reduce_motion)
 #include "systems/all_systems.h"  // popup_display_system declaration
 #include "entities/popup_entity.h"
 #include "constants.h"
 
-// ── Helper ────────────────────────────────────────────────────────────────
+// ── Helpers ───────────────────────────────────────────────────────────────
 //
-// Build a minimal entity that popup_display_system can process.
+// Build a minimal popup entity that popup_display_system can process. One
+// helper per former TimingTier value (existential processing — no enum).
 
-static entt::entity make_popup_entity(entt::registry& reg,
-                                      std::optional<TimingTier> timing_tier,
-                                      int32_t value,
-                                      float   remaining,
-                                      float   max_time) {
+namespace {
+
+void seed_popup_common(entt::registry& reg,
+                       entt::entity   e,
+                       int32_t        value,
+                       float          remaining,
+                       float          max_time) {
     if (!reg.ctx().contains<PopupDisplayScratch>()) {
         runtime_system_scratch_init(reg);
     }
-    auto e = reg.create();
-
     ScorePopup sp{};
-    sp.has_timing_tier = timing_tier.has_value();
-    sp.timing_tier = timing_tier.value_or(TimingTier::Ok);
-    sp.value       = value;
-    sp.remaining   = remaining;
-    sp.max_time    = max_time;
+    sp.value     = value;
+    sp.remaining = remaining;
+    sp.max_time  = max_time;
     reg.emplace<ScorePopup>(e, sp);
 
     reg.emplace<ScreenPosition>(e, 0.0f, 0.0f);
     reg.emplace<Color>(e, Color{255, 255, 255, 255});
+}
 
-    // #251: PopupDisplay's static fields (text, font size, base RGB) are
-    // initialized once at spawn — popup_display_system only fades alpha.
+entt::entity make_perfect_popup(entt::registry& reg, int32_t v, float rem, float max) {
+    auto e = reg.create();
+    seed_popup_common(reg, e, v, rem, max);
+    reg.emplace<TimingPerfectTag>(e);
     PopupDisplay pd{};
-    init_popup_display(pd, sp, Color{255, 255, 255, 255});
+    init_popup_display_perfect(pd, Color{255, 255, 255, 255});
     reg.emplace<PopupDisplay>(e, pd);
-
     return e;
 }
 
+entt::entity make_good_popup(entt::registry& reg, int32_t v, float rem, float max) {
+    auto e = reg.create();
+    seed_popup_common(reg, e, v, rem, max);
+    reg.emplace<TimingGoodTag>(e);
+    PopupDisplay pd{};
+    init_popup_display_good(pd, Color{255, 255, 255, 255});
+    reg.emplace<PopupDisplay>(e, pd);
+    return e;
+}
+
+entt::entity make_ok_popup(entt::registry& reg, int32_t v, float rem, float max) {
+    auto e = reg.create();
+    seed_popup_common(reg, e, v, rem, max);
+    reg.emplace<TimingOkTag>(e);
+    PopupDisplay pd{};
+    init_popup_display_ok(pd, Color{255, 255, 255, 255});
+    reg.emplace<PopupDisplay>(e, pd);
+    return e;
+}
+
+entt::entity make_bad_popup(entt::registry& reg, int32_t v, float rem, float max) {
+    auto e = reg.create();
+    seed_popup_common(reg, e, v, rem, max);
+    reg.emplace<TimingBadTag>(e);
+    PopupDisplay pd{};
+    init_popup_display_bad(pd, Color{255, 255, 255, 255});
+    reg.emplace<PopupDisplay>(e, pd);
+    return e;
+}
+
+entt::entity make_untimed_popup(entt::registry& reg, int32_t v, float rem, float max) {
+    auto e = reg.create();
+    seed_popup_common(reg, e, v, rem, max);
+    PopupDisplay pd{};
+    const auto& sp = reg.get<ScorePopup>(e);
+    init_popup_display_untimed(pd, sp, Color{255, 255, 255, 255});
+    reg.emplace<PopupDisplay>(e, pd);
+    return e;
+}
+
+}  // namespace
+
 // ── Grade text + font size ────────────────────────────────────────────────
 
-TEST_CASE("popup_display_system: TimingTier::Perfect → PERFECT, Medium font",
-          "[popup_display][issue208][issue288]") {
+TEST_CASE("popup_display_system: TimingPerfectTag → PERFECT, Medium font",
+          "[popup_display][issue208][issue288][issue1202]") {
     entt::registry reg;
-    auto e = make_popup_entity(reg, TimingTier::Perfect, 0, 1.0f, 1.0f);
+    auto e = make_perfect_popup(reg, 0, 1.0f, 1.0f);
 
     popup_display_system(reg, 0.0f);
 
@@ -82,10 +129,10 @@ TEST_CASE("popup_display_system: TimingTier::Perfect → PERFECT, Medium font",
     CHECK(pd.font_size == FontSize::Medium);
 }
 
-TEST_CASE("popup_display_system: TimingTier::Good → GOOD, Medium font",
-          "[popup_display][issue208][issue288]") {
+TEST_CASE("popup_display_system: TimingGoodTag → GOOD, Medium font",
+          "[popup_display][issue208][issue288][issue1202]") {
     entt::registry reg;
-    auto e = make_popup_entity(reg, TimingTier::Good, 0, 1.0f, 1.0f);
+    auto e = make_good_popup(reg, 0, 1.0f, 1.0f);
 
     popup_display_system(reg, 0.0f);
 
@@ -95,10 +142,10 @@ TEST_CASE("popup_display_system: TimingTier::Good → GOOD, Medium font",
     CHECK(pd.font_size == FontSize::Medium);
 }
 
-TEST_CASE("popup_display_system: TimingTier::Ok → OK, Medium font",
-          "[popup_display][issue208][issue288]") {
+TEST_CASE("popup_display_system: TimingOkTag → OK, Medium font",
+          "[popup_display][issue208][issue288][issue1202]") {
     entt::registry reg;
-    auto e = make_popup_entity(reg, TimingTier::Ok, 0, 1.0f, 1.0f);
+    auto e = make_ok_popup(reg, 0, 1.0f, 1.0f);
 
     popup_display_system(reg, 0.0f);
 
@@ -108,10 +155,10 @@ TEST_CASE("popup_display_system: TimingTier::Ok → OK, Medium font",
     CHECK(pd.font_size == FontSize::Medium);
 }
 
-TEST_CASE("popup_display_system: TimingTier::Bad → BAD, Medium font",
-          "[popup_display][issue208][issue288]") {
+TEST_CASE("popup_display_system: TimingBadTag → BAD, Medium font",
+          "[popup_display][issue208][issue288][issue1202]") {
     entt::registry reg;
-    auto e = make_popup_entity(reg, TimingTier::Bad, 0, 1.0f, 1.0f);
+    auto e = make_bad_popup(reg, 0, 1.0f, 1.0f);
 
     popup_display_system(reg, 0.0f);
 
@@ -123,10 +170,10 @@ TEST_CASE("popup_display_system: TimingTier::Bad → BAD, Medium font",
 
 // ── Numeric score path ────────────────────────────────────────────────────
 
-TEST_CASE("popup_display_system: nullopt timing_tier → numeric score string",
-          "[popup_display][issue208][issue288]") {
+TEST_CASE("popup_display_system: untimed (no tier tag) → numeric score string",
+          "[popup_display][issue208][issue288][issue1202]") {
     entt::registry reg;
-    auto e = make_popup_entity(reg, std::nullopt, 150, 1.0f, 1.0f);
+    auto e = make_untimed_popup(reg, 150, 1.0f, 1.0f);
 
     popup_display_system(reg, 0.0f);
 
@@ -144,7 +191,7 @@ TEST_CASE("popup_display_system: alpha at half lifetime is 127",
     entt::registry reg;
     // remaining = 0.5, max_time = 1.0 → alpha_ratio = 0.5
     // pd.a = static_cast<uint8_t>(0.5f * 255) = 127
-    auto e = make_popup_entity(reg, TimingTier::Perfect, 0, 0.5f, 1.0f);
+    auto e = make_perfect_popup(reg, 0, 0.5f, 1.0f);
 
     popup_display_system(reg, 0.0f);
 
@@ -158,14 +205,14 @@ TEST_CASE("popup_display_system: alpha at half lifetime is 127",
 //
 // popup_display_system used to re-snprintf the text and emplace_or_replace
 // PopupDisplay every tick. After #251 it must only mutate the per-frame
-// alpha; text, font size, and base RGB are written once at spawn via
-// init_popup_display(). These tests would fail if the system reverted to
-// re-formatting on every call.
+// alpha; text, font size, and base RGB are written once at spawn via the
+// per-tier init_popup_display_* helpers (post-#1202). These tests would fail
+// if the system reverted to re-formatting on every call.
 
 TEST_CASE("popup_display_system: does not re-format static text per tick (#251)",
           "[popup_display][issue251]") {
     entt::registry reg;
-    auto e = make_popup_entity(reg, TimingTier::Perfect, 0, 1.0f, 1.0f);
+    auto e = make_perfect_popup(reg, 0, 1.0f, 1.0f);
 
     auto& pd_mut = reg.get<PopupDisplay>(e);
     std::snprintf(pd_mut.text, sizeof(pd_mut.text), "%s", "SENTINEL");
@@ -183,7 +230,7 @@ TEST_CASE("popup_display_system: does not re-format static text per tick (#251)"
 TEST_CASE("popup_display_system: does not churn PopupDisplay storage (#251)",
           "[popup_display][issue251]") {
     entt::registry reg;
-    auto e = make_popup_entity(reg, TimingTier::Good, 0, 1.0f, 1.0f);
+    auto e = make_good_popup(reg, 0, 1.0f, 1.0f);
 
     auto& storage = reg.storage<PopupDisplay>();
     const auto sz0 = storage.size();
@@ -199,7 +246,7 @@ TEST_CASE("popup_display_system: does not churn PopupDisplay storage (#251)",
 TEST_CASE("popup_display_system: works without ScorePopup component (#251)",
            "[popup_display][issue251]") {
     entt::registry reg;
-    auto e = make_popup_entity(reg, TimingTier::Ok, 0, 0.5f, 1.0f);
+    auto e = make_ok_popup(reg, 0, 0.5f, 1.0f);
     reg.remove<ScorePopup>(e);
 
     popup_display_system(reg, 0.0f);
@@ -213,33 +260,28 @@ TEST_CASE("popup_display_system: works without ScorePopup component (#251)",
 TEST_CASE("popup_display_system: expired popups are destroyed",
           "[popup_display]") {
     entt::registry reg;
-    auto e = make_popup_entity(reg, std::nullopt, 50, 0.01f, 1.0f);
+    auto e = make_untimed_popup(reg, 50, 0.01f, 1.0f);
 
     popup_display_system(reg, 0.016f);
 
     CHECK_FALSE(reg.valid(e));
 }
 
-TEST_CASE("spawn_score_popup: creates the full popup display archetype",
-          "[popup_display][archetype]") {
+TEST_CASE("spawn_score_popup_good: creates the full popup display archetype",
+          "[popup_display][archetype][issue1202]") {
     entt::registry reg;
-    auto e = spawn_score_popup(reg, {100.0f, 200.0f, 50, TimingTier::Good});
+    auto e = spawn_score_popup_good(reg, 100.0f, 200.0f, 50);
 
     REQUIRE(reg.all_of<ScorePopup, PopupDisplay, Color, Vector2,
                        WorldTransform, TagHUDPass>(e));
-    CHECK(reg.get<ScorePopup>(e).has_timing_tier);
-    CHECK(reg.get<ScorePopup>(e).timing_tier == TimingTier::Good);
+    CHECK(reg.all_of<TimingGoodTag>(e));
     CHECK(std::strcmp(reg.get<PopupDisplay>(e).text, "GOOD") == 0);
 }
 
-TEST_CASE("init_popup_display: formats grade text + font size from ScorePopup (#251)",
-          "[popup_display][issue251]") {
-    ScorePopup sp{};
-    sp.has_timing_tier = true;
-    sp.timing_tier = TimingTier::Perfect;
-
+TEST_CASE("init_popup_display_perfect: formats PERFECT text + Medium font (#251)",
+          "[popup_display][issue251][issue1202]") {
     PopupDisplay pd{};
-    init_popup_display(pd, sp, Color{10, 20, 30, 200});
+    init_popup_display_perfect(pd, Color{10, 20, 30, 200});
 
     CHECK(std::strcmp(pd.text, "PERFECT") == 0);
     CHECK(pd.font_size == FontSize::Medium);
@@ -252,14 +294,13 @@ TEST_CASE("init_popup_display: formats grade text + font size from ScorePopup (#
     CHECK(pd.measured_font_texture_id == 0u);
 }
 
-TEST_CASE("init_popup_display: nullopt tier formats numeric value (#251)",
-          "[popup_display][issue251]") {
+TEST_CASE("init_popup_display_untimed: formats numeric value (#251)",
+          "[popup_display][issue251][issue1202]") {
     ScorePopup sp{};
-    sp.has_timing_tier = false;
-    sp.value       = 4242;
+    sp.value = 4242;
 
     PopupDisplay pd{};
-    init_popup_display(pd, sp, Color{255, 255, 255, 255});
+    init_popup_display_untimed(pd, sp, Color{255, 255, 255, 255});
 
     CHECK(std::strcmp(pd.text, "4242") == 0);
     CHECK(pd.font_size == FontSize::Small);
@@ -268,15 +309,16 @@ TEST_CASE("init_popup_display: nullopt tier formats numeric value (#251)",
     CHECK(pd.measured_font_texture_id == 0u);
 }
 
-// ── spawn_score_popup: entity factory contract (#349) ─────────────────────────
+// ── per-tier spawn_score_popup_*: entity factory contract (#349, #1202) ──────
 //
-// These tests prove that spawn_score_popup creates an entity carrying the full
-// expected component bundle with correct values.
+// These tests prove that the per-tier spawn functions create an entity carrying
+// the full expected component bundle with correct values plus the matching
+// per-tier tag.
 
-TEST_CASE("spawn_score_popup: entity has WorldTransform at pos - 40",
+TEST_CASE("spawn_score_popup_untimed: entity has WorldTransform at pos - 40",
           "[popup_entity][issue349]") {
     entt::registry reg;
-    auto e = spawn_score_popup(reg, {100.0f, 500.0f, 200, std::nullopt});
+    auto e = spawn_score_popup_untimed(reg, 100.0f, 500.0f, 200);
 
     REQUIRE(reg.all_of<WorldTransform>(e));
     const auto& wt = reg.get<WorldTransform>(e);
@@ -284,10 +326,10 @@ TEST_CASE("spawn_score_popup: entity has WorldTransform at pos - 40",
     CHECK(wt.position.y == 460.0f);  // 500 - 40
 }
 
-TEST_CASE("spawn_score_popup: entity has Vector2 {0, -80}",
+TEST_CASE("spawn_score_popup_untimed: entity has Vector2 {0, -80}",
           "[popup_entity][issue349]") {
     entt::registry reg;
-    auto e = spawn_score_popup(reg, {0.0f, 0.0f, 100, std::nullopt});
+    auto e = spawn_score_popup_untimed(reg, 0.0f, 0.0f, 100);
 
     REQUIRE(reg.all_of<Vector2>(e));
     const auto& mv = reg.get<Vector2>(e);
@@ -295,24 +337,23 @@ TEST_CASE("spawn_score_popup: entity has Vector2 {0, -80}",
     CHECK(mv.y == -80.0f);
 }
 
-TEST_CASE("spawn_score_popup: ScorePopup has correct points and duration",
-          "[popup_entity][issue349]") {
+TEST_CASE("spawn_score_popup_good: ScorePopup has correct points and duration, tag emplaced",
+          "[popup_entity][issue349][issue1202]") {
     entt::registry reg;
-    auto e = spawn_score_popup(reg, {0.0f, 0.0f, 350, TimingTier::Good});
+    auto e = spawn_score_popup_good(reg, 0.0f, 0.0f, 350);
 
     REQUIRE(reg.all_of<ScorePopup>(e));
     const auto& sp = reg.get<ScorePopup>(e);
     CHECK(sp.value == 350);
-    CHECK(sp.has_timing_tier);
-    CHECK(sp.timing_tier == TimingTier::Good);
+    CHECK(reg.all_of<TimingGoodTag>(e));
     CHECK(sp.remaining == constants::POPUP_DURATION);
     CHECK(sp.max_time  == constants::POPUP_DURATION);
 }
 
-TEST_CASE("spawn_score_popup: color is bright cyan for Perfect tier",
+TEST_CASE("spawn_score_popup_perfect: color is bright cyan",
           "[popup_entity][issue386]") {
     entt::registry reg;
-    auto e = spawn_score_popup(reg, {0.0f, 0.0f, 300, TimingTier::Perfect});
+    auto e = spawn_score_popup_perfect(reg, 0.0f, 0.0f, 300);
 
     REQUIRE(reg.all_of<Color>(e));
     const auto& c = reg.get<Color>(e);
@@ -322,11 +363,11 @@ TEST_CASE("spawn_score_popup: color is bright cyan for Perfect tier",
     CHECK(c.a == 255);
 }
 
-TEST_CASE("spawn_score_popup: Good tier is lime, Ok tier is amber, distinct from Perfect",
+TEST_CASE("spawn_score_popup_good: lime; spawn_score_popup_ok: amber; distinct from Perfect",
           "[popup_entity][issue386]") {
     entt::registry reg;
-    auto good = spawn_score_popup(reg, {0.0f, 0.0f, 200, TimingTier::Good});
-    auto ok   = spawn_score_popup(reg, {0.0f, 0.0f, 100, TimingTier::Ok});
+    auto good = spawn_score_popup_good(reg, 0.0f, 0.0f, 200);
+    auto ok   = spawn_score_popup_ok(reg,   0.0f, 0.0f, 100);
 
     REQUIRE(reg.all_of<Color>(good));
     REQUIRE(reg.all_of<Color>(ok));
@@ -341,14 +382,13 @@ TEST_CASE("spawn_score_popup: Good tier is lime, Ok tier is amber, distinct from
     CHECK(ok_color.g == 200);
     CHECK(ok_color.b ==  60);
 
-    // Cross-tier distinctness (Perfect/Good/Ok must not collide).
     CHECK_FALSE((good_color.r == ok_color.r && good_color.g == ok_color.g && good_color.b == ok_color.b));
 }
 
-TEST_CASE("spawn_score_popup: color is red-orange for Bad tier",
+TEST_CASE("spawn_score_popup_bad: color is red-orange",
           "[popup_entity][issue386]") {
     entt::registry reg;
-    auto e = spawn_score_popup(reg, {0.0f, 0.0f, 50, TimingTier::Bad});
+    auto e = spawn_score_popup_bad(reg, 0.0f, 0.0f, 50);
 
     REQUIRE(reg.all_of<Color>(e));
     const auto& c = reg.get<Color>(e);
@@ -357,13 +397,13 @@ TEST_CASE("spawn_score_popup: color is red-orange for Bad tier",
     CHECK(c.b ==  70);
 }
 
-TEST_CASE("spawn_score_popup: every timing tier maps to a distinct color",
+TEST_CASE("spawn_score_popup_*: every timing tier maps to a distinct color",
           "[popup_entity][issue386]") {
     entt::registry reg;
-    auto p = spawn_score_popup(reg, {0.0f, 0.0f, 0, TimingTier::Perfect});
-    auto g = spawn_score_popup(reg, {0.0f, 0.0f, 0, TimingTier::Good});
-    auto o = spawn_score_popup(reg, {0.0f, 0.0f, 0, TimingTier::Ok});
-    auto b = spawn_score_popup(reg, {0.0f, 0.0f, 0, TimingTier::Bad});
+    auto p = spawn_score_popup_perfect(reg, 0.0f, 0.0f, 0);
+    auto g = spawn_score_popup_good   (reg, 0.0f, 0.0f, 0);
+    auto o = spawn_score_popup_ok     (reg, 0.0f, 0.0f, 0);
+    auto b = spawn_score_popup_bad    (reg, 0.0f, 0.0f, 0);
 
     auto rgb = [&](entt::entity e) {
         const auto& c = reg.get<Color>(e);
@@ -378,10 +418,10 @@ TEST_CASE("spawn_score_popup: every timing tier maps to a distinct color",
     CHECK(co != cb);
 }
 
-TEST_CASE("spawn_score_popup: default color when no timing tier",
+TEST_CASE("spawn_score_popup_untimed: default color when no timing tier",
           "[popup_entity][issue349]") {
     entt::registry reg;
-    auto e = spawn_score_popup(reg, {0.0f, 0.0f, 200, std::nullopt});
+    auto e = spawn_score_popup_untimed(reg, 0.0f, 0.0f, 200);
 
     REQUIRE(reg.all_of<Color>(e));
     const auto& c = reg.get<Color>(e);
@@ -390,17 +430,17 @@ TEST_CASE("spawn_score_popup: default color when no timing tier",
     CHECK(c.b == 50);
 }
 
-TEST_CASE("spawn_score_popup: entity carries TagHUDPass",
+TEST_CASE("spawn_score_popup_untimed: entity carries TagHUDPass",
           "[popup_entity][issue349]") {
     entt::registry reg;
-    auto e = spawn_score_popup(reg, {0.0f, 0.0f, 100, std::nullopt});
+    auto e = spawn_score_popup_untimed(reg, 0.0f, 0.0f, 100);
     CHECK(reg.all_of<TagHUDPass>(e));
 }
 
-TEST_CASE("spawn_score_popup: PopupDisplay initialized at spawn",
+TEST_CASE("spawn_score_popup_perfect: PopupDisplay initialized at spawn",
           "[popup_entity][issue349]") {
     entt::registry reg;
-    auto e = spawn_score_popup(reg, {0.0f, 0.0f, 0, TimingTier::Perfect});
+    auto e = spawn_score_popup_perfect(reg, 0.0f, 0.0f, 0);
 
     REQUIRE(reg.all_of<PopupDisplay>(e));
     const auto& pd = reg.get<PopupDisplay>(e);
@@ -418,7 +458,7 @@ TEST_CASE("popup_display_system: reduce_motion zeroes drift velocity (#534)",
     create_settings_entity(reg);
     settings_state(reg).reduce_motion = true;
 
-    auto e = spawn_score_popup(reg, {100.0f, 500.0f, 200, TimingTier::Perfect});
+    auto e = spawn_score_popup_perfect(reg, 100.0f, 500.0f, 200);
     REQUIRE(reg.all_of<Vector2>(e));
     REQUIRE(reg.get<Vector2>(e).y == -80.0f);
 
@@ -428,7 +468,6 @@ TEST_CASE("popup_display_system: reduce_motion zeroes drift velocity (#534)",
     CHECK(vel.x == 0.0f);
     CHECK(vel.y == 0.0f);
 
-    // Informational channel (text/colour/value) is unchanged.
     const auto& pd = reg.get<PopupDisplay>(e);
     CHECK(std::strcmp(pd.text, "PERFECT") == 0);
     CHECK(pd.r ==  80);
@@ -442,13 +481,13 @@ TEST_CASE("popup_display_system: reduce_motion=false leaves drift untouched (#53
           "[popup_display][reduce_motion][issue534]") {
     entt::registry reg;
     runtime_system_scratch_init(reg);
-    create_settings_entity(reg);  // reduce_motion defaults to false
+    create_settings_entity(reg);
 
-    auto e = spawn_score_popup(reg, {0.0f, 0.0f, 100, TimingTier::Good});
+    auto e = spawn_score_popup_good(reg, 0.0f, 0.0f, 100);
     popup_display_system(reg, 0.016f);
 
     const auto& vel = reg.get<Vector2>(e);
-    CHECK(vel.y == -80.0f);  // popup_display_system never touches it
+    CHECK(vel.y == -80.0f);
 }
 
 // #1089 — PopupDisplayScratch::capacity_exceeded_count must stay at zero when
@@ -465,7 +504,7 @@ TEST_CASE("popup_display_system: dense expiry burst stays within reserved capaci
 
     for (int i = 0; i < dense_count; ++i) {
         // Tiny remaining lifetime so the next tick expires every popup.
-        make_popup_entity(reg, std::nullopt, 100, 0.001f, 1.0f);
+        make_untimed_popup(reg, 100, 0.001f, 1.0f);
     }
 
     popup_display_system(reg, 0.016f);

--- a/tests/test_rhythm_system.cpp
+++ b/tests/test_rhythm_system.cpp
@@ -501,8 +501,8 @@ TEST_CASE("collision: timing grade PERFECT on press-at-arrival", "[rhythm][colli
     reg.emplace<BeatInfo>(obs, 0, 5.0f, 5.0f - song.lead_time);
     collision_system(reg, 0.016f);
     REQUIRE(reg.all_of<ScoredTag>(obs));
-    REQUIRE(reg.all_of<TimingGrade>(obs));
-    CHECK(reg.get<TimingGrade>(obs).tier == TimingTier::Perfect);
+    REQUIRE(has_any_timing_tier_tag(reg, obs));
+    CHECK(reg.all_of<TimingPerfectTag>(obs));
 }
 
 TEST_CASE("collision: HUD perfect cue distance maps to PERFECT timing", "[rhythm][collision][hud]") {
@@ -531,8 +531,8 @@ TEST_CASE("collision: HUD perfect cue distance maps to PERFECT timing", "[rhythm
     collision_system(reg, 0.016f);
 
     REQUIRE(reg.all_of<ScoredTag>(obs));
-    REQUIRE(reg.all_of<TimingGrade>(obs));
-    CHECK(reg.get<TimingGrade>(obs).tier == TimingTier::Perfect);
+    REQUIRE(has_any_timing_tier_tag(reg, obs));
+    CHECK(reg.all_of<TimingPerfectTag>(obs));
 }
 
 TEST_CASE("collision: timing grade GOOD at 50pct", "[rhythm][collision]") {
@@ -548,8 +548,8 @@ TEST_CASE("collision: timing grade GOOD at 50pct", "[rhythm][collision]") {
     // arrival_time offset by 50% of half_window (~75ms) -> Good
     reg.emplace<BeatInfo>(obs, 0, 5.0f + song.half_window * 0.5f, 0.0f);
     collision_system(reg, 0.016f);
-    REQUIRE(reg.all_of<TimingGrade>(obs));
-    CHECK(reg.get<TimingGrade>(obs).tier == TimingTier::Good);
+    REQUIRE(has_any_timing_tier_tag(reg, obs));
+    CHECK(reg.all_of<TimingGoodTag>(obs));
 }
 
 TEST_CASE("collision: timing grade OK at 80pct", "[rhythm][collision]") {
@@ -565,8 +565,8 @@ TEST_CASE("collision: timing grade OK at 80pct", "[rhythm][collision]") {
     // arrival_time offset by 80% of half_window (~120ms) -> Ok
     reg.emplace<BeatInfo>(obs, 0, 5.0f + song.half_window * 0.8f, 0.0f);
     collision_system(reg, 0.016f);
-    REQUIRE(reg.all_of<TimingGrade>(obs));
-    CHECK(reg.get<TimingGrade>(obs).tier == TimingTier::Ok);
+    REQUIRE(has_any_timing_tier_tag(reg, obs));
+    CHECK(reg.all_of<TimingOkTag>(obs));
 }
 
 TEST_CASE("collision: timing grade BAD beyond window", "[rhythm][collision]") {
@@ -582,8 +582,8 @@ TEST_CASE("collision: timing grade BAD beyond window", "[rhythm][collision]") {
     // arrival_time offset by 120% of half_window (>150ms) -> Bad
     reg.emplace<BeatInfo>(obs, 0, 5.0f + song.half_window * 1.2f, 0.0f);
     collision_system(reg, 0.016f);
-    REQUIRE(reg.all_of<TimingGrade>(obs));
-    CHECK(reg.get<TimingGrade>(obs).tier == TimingTier::Bad);
+    REQUIRE(has_any_timing_tier_tag(reg, obs));
+    CHECK(reg.all_of<TimingBadTag>(obs));
 }
 
 TEST_CASE("collision: stale press from previous beat does not get Perfect", "[rhythm][collision]") {
@@ -611,9 +611,9 @@ TEST_CASE("collision: stale press from previous beat does not get Perfect", "[rh
 
     collision_system(reg, 0.016f);
 
-    REQUIRE(reg.all_of<TimingGrade>(obs));
+    REQUIRE(has_any_timing_tier_tag(reg, obs));
     // press_time (2.0) is far from arrival (3.5) -> not Perfect
-    CHECK(reg.get<TimingGrade>(obs).tier != TimingTier::Perfect);
+    CHECK_FALSE(reg.all_of<TimingPerfectTag>(obs));
 }
 
 TEST_CASE("collision: PERFECT clears obstacle without game over", "[rhythm][collision]") {
@@ -687,7 +687,7 @@ TEST_CASE("scoring: timing_mult applied to scored obstacle", "[rhythm][scoring]"
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
     reg.emplace<Obstacle>(obs, int16_t{200});
     reg.emplace<ScoredTag>(obs);
-    reg.emplace<TimingGrade>(obs, TimingTier::Perfect, 1.0f);
+    emplace_timing_perfect(reg, obs, 1.0f);
     int prev = score.score;
     scoring_system(reg, 0.016f);
     int gained = score.score - prev;
@@ -699,18 +699,21 @@ TEST_CASE("scoring: timing_mult applied to scored obstacle", "[rhythm][scoring]"
 
 
 TEST_CASE("timing: timing_multiplier values", "[rhythm][timing]") {
-    CHECK(timing_multiplier(TimingTier::Perfect) == 1.50f);
-    CHECK(timing_multiplier(TimingTier::Good) == 1.00f);
-    CHECK(timing_multiplier(TimingTier::Ok) == 0.50f);
-    CHECK(timing_multiplier(TimingTier::Bad) == 0.25f);
+    // Per #1202/#1204: TimingTier eradicated; multiplier is now derived from
+    // a delta-seconds threshold ladder. Each canonical delta below sits
+    // squarely inside the corresponding former-tier band.
+    CHECK(timing_multiplier_from_delta_abs(0.0f)                              == 1.50f);
+    CHECK(timing_multiplier_from_delta_abs(kTimingPerfectSeconds + 0.001f)    == 1.00f);
+    CHECK(timing_multiplier_from_delta_abs(kTimingGoodSeconds    + 0.001f)    == 0.50f);
+    CHECK(timing_multiplier_from_delta_abs(kTimingOkSeconds      + 0.001f)    == 0.25f);
 }
 
-TEST_CASE("timing: window_scale_for_tier values", "[rhythm][timing]") {
+TEST_CASE("timing: window_scale_from_delta_abs values", "[rhythm][timing]") {
     // Post-#223 inversion: smaller scale = better timing = faster window collapse.
-    CHECK(window_scale_for_tier(TimingTier::Perfect) == 0.50f);
-    CHECK(window_scale_for_tier(TimingTier::Good) == 0.75f);
-    CHECK(window_scale_for_tier(TimingTier::Ok) == 1.00f);
-    CHECK(window_scale_for_tier(TimingTier::Bad) == 1.00f);
+    CHECK(window_scale_from_delta_abs(0.0f)                              == 0.50f);
+    CHECK(window_scale_from_delta_abs(kTimingPerfectSeconds + 0.001f)    == 0.75f);
+    CHECK(window_scale_from_delta_abs(kTimingGoodSeconds    + 0.001f)    == 1.00f);
+    CHECK(window_scale_from_delta_abs(kTimingOkSeconds      + 0.001f)    == 1.00f);
 }
 
 // Window Scaling

--- a/tests/test_scoring_extended.cpp
+++ b/tests/test_scoring_extended.cpp
@@ -5,12 +5,14 @@
 
 namespace {
 
-int score_shape_gate_with_tier(entt::registry& reg, TimingTier tier) {
+using TierEmplace = void(*)(entt::registry&, entt::entity, float);
+
+int score_shape_gate_with_tier(entt::registry& reg, TierEmplace emplace_tag) {
     auto& score = reg.ctx().get<ScoreState>();
     const int before = score.score;
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<ScoredTag>(obs);
-    reg.emplace<TimingGrade>(obs, tier, 0.0f);
+    emplace_tag(reg, obs, 0.0f);
 
     scoring_system(reg, 0.0f);
     return score.score - before;
@@ -33,7 +35,7 @@ TEST_CASE("scoring: perfect timing multiplier gives 1.5x base", "[scoring][rhyth
     auto reg = make_registry();
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<ScoredTag>(obs);
-    reg.emplace<TimingGrade>(obs, TimingTier::Perfect, 1.0f);
+    emplace_timing_perfect(reg, obs, 1.0f);
 
     scoring_system(reg, 0.016f);
     popup_feedback_system(reg, 0.016f);
@@ -48,7 +50,7 @@ TEST_CASE("scoring: bad timing multiplier gives 0.25x base", "[scoring][rhythm]"
     auto reg = make_registry();
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<ScoredTag>(obs);
-    reg.emplace<TimingGrade>(obs, TimingTier::Bad, 0.0f);
+    emplace_timing_bad(reg, obs, 0.0f);
 
     scoring_system(reg, 0.016f);
     popup_feedback_system(reg, 0.016f);
@@ -63,18 +65,18 @@ TEST_CASE("scoring: bad timing multiplier gives 0.25x base", "[scoring][rhythm]"
 TEST_CASE("scoring: timing multiplier applies end-to-end for good ok and bad", "[scoring][rhythm][issue221]") {
     {
         auto reg = make_registry();
-        CHECK(score_shape_gate_with_tier(reg, TimingTier::Good) == 200);
+        CHECK(score_shape_gate_with_tier(reg, &emplace_timing_good) == 200);
     }
     {
         auto reg = make_registry();
-        CHECK(score_shape_gate_with_tier(reg, TimingTier::Ok) == 100);
+        CHECK(score_shape_gate_with_tier(reg, &emplace_timing_ok) == 100);
     }
     {
         auto reg = make_registry();
         auto& energy = reg.ctx().get<EnergyState>();
         energy.energy = 1.0f;
 
-        CHECK(score_shape_gate_with_tier(reg, TimingTier::Bad) == 50);
+        CHECK(score_shape_gate_with_tier(reg, &emplace_timing_bad) == 50);
         energy_system(reg, 0.0f);
 
         CHECK_THAT(energy.energy,
@@ -86,7 +88,7 @@ TEST_CASE("scoring: perfect timing and base points combine correctly", "[scoring
     auto reg = make_registry();
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<ScoredTag>(obs);
-    reg.emplace<TimingGrade>(obs, TimingTier::Perfect, 1.0f);
+    emplace_timing_perfect(reg, obs, 1.0f);
 
     scoring_system(reg, 0.016f);
     popup_feedback_system(reg, 0.016f);
@@ -116,7 +118,7 @@ TEST_CASE("scoring: zero-point passive obstacles do not extend chain", "[scoring
     auto reg = make_registry();
     auto& score = reg.ctx().get<ScoreState>();
 
-    CHECK(score_shape_gate_with_tier(reg, TimingTier::Good) == 200);
+    CHECK(score_shape_gate_with_tier(reg, &emplace_timing_good) == 200);
     CHECK(score.chain_count == 1);
 
     for (int i = 0; i < 3; ++i) {
@@ -127,7 +129,7 @@ TEST_CASE("scoring: zero-point passive obstacles do not extend chain", "[scoring
     CHECK(score.chain_count == 1);
     const int expected_chain2_points = static_cast<int>(
         std::floor(static_cast<float>(constants::PTS_SHAPE_GATE) * (1.0f + constants::CHAIN_MULT_STEP)));
-    CHECK(score_shape_gate_with_tier(reg, TimingTier::Good) == expected_chain2_points);
+    CHECK(score_shape_gate_with_tier(reg, &emplace_timing_good) == expected_chain2_points);
     CHECK(score.chain_count == 2);
 }
 
@@ -145,30 +147,36 @@ TEST_CASE("scoring: TimingGrade removed from entity after scoring", "[scoring]")
     auto reg = make_registry();
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<ScoredTag>(obs);
-    reg.emplace<TimingGrade>(obs, TimingTier::Good, 0.5f);
+    emplace_timing_good(reg, obs, 0.5f);
 
     scoring_system(reg, 0.016f);
     popup_feedback_system(reg, 0.016f);
     energy_system(reg, 0.016f);
 
     CHECK_FALSE(reg.all_of<TimingGrade>(obs));
+    CHECK_FALSE(reg.all_of<TimingPerfectTag>(obs));
+    CHECK_FALSE(reg.all_of<TimingGoodTag>(obs));
+    CHECK_FALSE(reg.all_of<TimingOkTag>(obs));
+    CHECK_FALSE(reg.all_of<TimingBadTag>(obs));
 }
 
 TEST_CASE("scoring: popup timing_tier set for graded obstacles", "[scoring][rhythm]") {
     auto reg = make_registry();
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<ScoredTag>(obs);
-    reg.emplace<TimingGrade>(obs, TimingTier::Good, 0.5f);
+    emplace_timing_good(reg, obs, 0.5f);
 
     scoring_system(reg, 0.016f);
     popup_feedback_system(reg, 0.016f);
     energy_system(reg, 0.016f);
 
     auto popup_view = reg.view<ScorePopup>();
-    for (auto [e, popup] : popup_view.each()) {
-        CHECK(popup.has_timing_tier);
-        CHECK(popup.timing_tier == TimingTier::Good);
+    int popup_count = 0;
+    for (auto e : popup_view) {
+        CHECK(reg.all_of<TimingGoodTag>(e));
+        ++popup_count;
     }
+    CHECK(popup_count == 1);
 }
 
 TEST_CASE("scoring: popup timing_tier is absent for ungraded obstacles", "[scoring]") {
@@ -182,8 +190,11 @@ TEST_CASE("scoring: popup timing_tier is absent for ungraded obstacles", "[scori
     energy_system(reg, 0.016f);
 
     auto popup_view = reg.view<ScorePopup>();
-    for (auto [e, popup] : popup_view.each()) {
-        CHECK(!popup.has_timing_tier);
+    for (auto e : popup_view) {
+        CHECK_FALSE(reg.all_of<TimingPerfectTag>(e));
+        CHECK_FALSE(reg.all_of<TimingGoodTag>(e));
+        CHECK_FALSE(reg.all_of<TimingOkTag>(e));
+        CHECK_FALSE(reg.all_of<TimingBadTag>(e));
     }
 }
 
@@ -237,7 +248,7 @@ TEST_CASE("scoring: mixed miss and perfect at zero preserves per-event clamp ord
 
     auto hit = make_shape_gate(reg, Shape::Square, constants::PLAYER_Y + 1.0f);
     reg.emplace<ScoredTag>(hit);
-    reg.emplace<TimingGrade>(hit, TimingTier::Perfect, 1.0f);
+    emplace_timing_perfect(reg, hit, 1.0f);
 
     scoring_system(reg, 0.016f);
     popup_feedback_system(reg, 0.016f);

--- a/tests/test_scoring_system.cpp
+++ b/tests/test_scoring_system.cpp
@@ -12,7 +12,7 @@ int score_good_shape_gate(entt::registry& reg) {
 
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<ScoredTag>(obs);
-    reg.emplace<TimingGrade>(obs, TimingTier::Good, 0.0f);
+    emplace_timing_good(reg, obs, 0.0f);
     scoring_system(reg, 0.0f);
 
     return score.score - before;
@@ -22,12 +22,14 @@ int score_good_shape_gate(entt::registry& reg) {
 
 namespace {
 
+using TierEmplace = void(*)(entt::registry&, entt::entity, float);
+
 struct ScoredTierResult {
     int points = 0;
     float energy_delta = 0.0f;
 };
 
-ScoredTierResult score_single_shape_gate_with_tier(TimingTier tier) {
+ScoredTierResult score_single_shape_gate_with_tier(TierEmplace emplace_tag) {
     auto reg = make_registry();
     auto& score = reg.ctx().get<ScoreState>();
     auto& energy = reg.ctx().get<EnergyState>();
@@ -36,7 +38,7 @@ ScoredTierResult score_single_shape_gate_with_tier(TimingTier tier) {
 
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<ScoredTag>(obs);
-    reg.emplace<TimingGrade>(obs, tier, 0.0f);
+    emplace_tag(reg, obs, 0.0f);
 
     scoring_system(reg, 0.0f);
     energy_system(reg, 0.0f);
@@ -75,7 +77,7 @@ TEST_CASE("scoring: scored obstacle awards points", "[scoring]") {
     auto reg = make_registry();
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<ScoredTag>(obs);
-    reg.emplace<TimingGrade>(obs, TimingTier::Good, 0.5f);
+    emplace_timing_good(reg, obs, 0.5f);
 
     scoring_system(reg, 0.016f);
     popup_feedback_system(reg, 0.016f);
@@ -92,7 +94,7 @@ TEST_CASE("scoring: chain multiplier increases points", "[scoring]") {
     for (int i = 0; i < 3; ++i) {
         auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y + float(i));
         reg.emplace<ScoredTag>(obs);
-        reg.emplace<TimingGrade>(obs, TimingTier::Good, 0.5f);
+        emplace_timing_good(reg, obs, 0.5f);
         scoring_system(reg, 0.016f);
     popup_feedback_system(reg, 0.016f);
     energy_system(reg, 0.016f);
@@ -110,7 +112,7 @@ TEST_CASE("scoring: chain persists across authored rests until miss (#100)", "[s
 
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<ScoredTag>(obs);
-    reg.emplace<TimingGrade>(obs, TimingTier::Good, 0.5f);
+    emplace_timing_good(reg, obs, 0.5f);
     scoring_system(reg, 0.016f);
     popup_feedback_system(reg, 0.016f);
     energy_system(reg, 0.016f);
@@ -138,7 +140,7 @@ TEST_CASE("scoring: popup entity spawned on score", "[scoring]") {
     auto reg = make_registry();
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<ScoredTag>(obs);
-    reg.emplace<TimingGrade>(obs, TimingTier::Good, 0.5f);
+    emplace_timing_good(reg, obs, 0.5f);
 
     scoring_system(reg, 0.016f);
     popup_feedback_system(reg, 0.016f);
@@ -159,7 +161,7 @@ TEST_CASE("scoring: score feedback spawns effect particles", "[scoring][particle
     auto reg = make_registry();
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<ScoredTag>(obs);
-    reg.emplace<TimingGrade>(obs, TimingTier::Perfect, 1.0f);
+    emplace_timing_perfect(reg, obs, 1.0f);
 
     scoring_system(reg, 0.016f);
 
@@ -183,7 +185,7 @@ TEST_CASE("scoring: SFX pushed on score", "[scoring]") {
     auto reg = make_registry();
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<ScoredTag>(obs);
-    reg.emplace<TimingGrade>(obs, TimingTier::Good, 0.5f);
+    emplace_timing_good(reg, obs, 0.5f);
 
     scoring_system(reg, 0.016f);
     popup_feedback_system(reg, 0.016f);
@@ -223,7 +225,7 @@ TEST_CASE("scoring: chain multiplier 5+ gives extended value", "[scoring]") {
     for (int i = 0; i < 5; ++i) {
         auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y + float(i));
         reg.emplace<ScoredTag>(obs);
-        reg.emplace<TimingGrade>(obs, TimingTier::Good, 0.5f);
+        emplace_timing_good(reg, obs, 0.5f);
         scoring_system(reg, 0.016f);
     popup_feedback_system(reg, 0.016f);
     energy_system(reg, 0.016f);
@@ -285,7 +287,7 @@ TEST_CASE("scoring: obstacle entity cleaned up after scoring", "[scoring]") {
     auto reg = make_registry();
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<ScoredTag>(obs);
-    reg.emplace<TimingGrade>(obs, TimingTier::Good, 0.5f);
+    emplace_timing_good(reg, obs, 0.5f);
 
     scoring_system(reg, 0.016f);
     popup_feedback_system(reg, 0.016f);
@@ -320,7 +322,7 @@ TEST_CASE("scoring: no-penalty — on-beat gate scores at base points", "[scorin
     auto reg = make_registry();
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<ScoredTag>(obs);
-    reg.emplace<TimingGrade>(obs, TimingTier::Good, 0.5f);
+    emplace_timing_good(reg, obs, 0.5f);
 
     scoring_system(reg, 0.0f);
     popup_feedback_system(reg, 0.0f);
@@ -331,13 +333,13 @@ TEST_CASE("scoring: no-penalty — on-beat gate scores at base points", "[scorin
 }
 
 TEST_CASE("scoring: timing multiplier applies end-to-end for non-perfect tiers (#221)", "[scoring][issue221]") {
-    const auto good = score_single_shape_gate_with_tier(TimingTier::Good);
+    const auto good = score_single_shape_gate_with_tier(&emplace_timing_good);
     CHECK(good.points == 200);
 
-    const auto ok = score_single_shape_gate_with_tier(TimingTier::Ok);
+    const auto ok = score_single_shape_gate_with_tier(&emplace_timing_ok);
     CHECK(ok.points == 100);
 
-    const auto bad = score_single_shape_gate_with_tier(TimingTier::Bad);
+    const auto bad = score_single_shape_gate_with_tier(&emplace_timing_bad);
     CHECK(bad.points == 50);
     CHECK_THAT(bad.energy_delta, Catch::Matchers::WithinAbs(-constants::ENERGY_DRAIN_BAD, 0.0001f));
 }
@@ -346,7 +348,7 @@ TEST_CASE("scoring: popup entity has full factory contract", "[scoring][popup_en
     auto reg = make_registry();
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<ScoredTag>(obs);
-    reg.emplace<TimingGrade>(obs, TimingTier::Good, 0.5f);
+    emplace_timing_good(reg, obs, 0.5f);
 
     scoring_system(reg, 0.016f);
     popup_feedback_system(reg, 0.016f);
@@ -414,7 +416,7 @@ TEST_CASE("scoring: missed NonScorableTag entity is resolved without effects",
     reg.emplace<NonScorableTag>(e);
     reg.emplace<ScoredTag>(e);
     reg.emplace<MissTag>(e);
-    reg.emplace<TimingGrade>(e, TimingTier::Bad, 0.0f);
+    emplace_timing_bad(reg, e, 0.0f);
 
     scoring_system(reg, 0.0f);
     energy_system(reg, 0.0f);
@@ -472,7 +474,7 @@ TEST_CASE("scoring: obstacle/timing points still apply after playback has finish
 
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<ScoredTag>(obs);
-    reg.emplace<TimingGrade>(obs, TimingTier::Good, 0.5f);
+    emplace_timing_good(reg, obs, 0.5f);
 
     scoring_system(reg, 1.0f);
 
@@ -489,24 +491,26 @@ TEST_CASE("runtime scratch: dense scoring burst stays within reserved capacity",
     auto& popup_queue = reg.ctx().get<ScorePopupRequestQueue>();
     const auto hit_capacity = scratch.hit_buf.capacity();
     const auto energy_capacity = energy.events.capacity();
-    const auto popup_capacity = popup_queue.requests.capacity();
+    // Per-tier queues (post-#1202/#1204): the dense burst below all goes
+    // into queue.good, so guard the Good queue's capacity for this test.
+    const auto popup_capacity = popup_queue.good.capacity();
 
     for (int i = 0; i < dense_count; ++i) {
         auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y + static_cast<float>(i));
         reg.emplace<ScoredTag>(obs);
-        reg.emplace<TimingGrade>(obs, TimingTier::Good, 0.5f);
+        emplace_timing_good(reg, obs, 0.5f);
     }
 
     scoring_system(reg, 0.0f);
 
     CHECK(scratch.hit_buf.capacity() == hit_capacity);
     CHECK(energy.events.capacity() == energy_capacity);
-    CHECK(popup_queue.requests.capacity() == popup_capacity);
+    CHECK(popup_queue.good.capacity() == popup_capacity);
     CHECK(scratch.hit_capacity_exceeded_count == 0);
     CHECK(energy.capacity_exceeded_count == 0);
     CHECK(popup_queue.capacity_exceeded_count == 0);
     CHECK(energy.events.size() == static_cast<std::size_t>(dense_count));
-    CHECK(popup_queue.requests.size() == static_cast<std::size_t>(dense_count));
+    CHECK(popup_queue.good.size() == static_cast<std::size_t>(dense_count));
 }
 
 // #1089: miss_capacity_exceeded_count is incremented from scoring_system's
@@ -525,7 +529,7 @@ TEST_CASE("runtime scratch: dense miss burst stays within reserved capacity",
         auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y + static_cast<float>(i));
         reg.emplace<ScoredTag>(obs);
         reg.emplace<MissTag>(obs);
-        reg.emplace<TimingGrade>(obs, TimingTier::Bad, 0.5f);
+        emplace_timing_bad(reg, obs, 0.5f);
     }
 
     scoring_system(reg, 0.0f);

--- a/tests/test_shape_window_extended.cpp
+++ b/tests/test_shape_window_extended.cpp
@@ -208,7 +208,7 @@ TEST_CASE("shape_window regression #223: Perfect scale (0.50) collapses window t
 
     // Simulate what collision_system does on a Perfect hit at t=0 of the Active window.
     // At that instant window_timer == 0, remaining == window_duration.
-    float scale = window_scale_for_tier(TimingTier::Perfect);
+    float scale = window_scale_from_delta_abs(0.0f);  // delta=0 → Perfect band
     CHECK(scale == 0.50f);
 
     set_window_phase_active(reg, player);
@@ -232,7 +232,7 @@ TEST_CASE("shape_window regression #223: Ok scale (1.00) leaves window duration 
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
-    float scale = window_scale_for_tier(TimingTier::Ok);
+    float scale = window_scale_from_delta_abs(kTimingGoodSeconds + 0.001f);  // Ok band
     CHECK(scale == 1.00f);
 
     set_window_phase_active(reg, player);


### PR DESCRIPTION
Continues the enum-eradication train (#1202/#1204). Eradicates the `TimingTier` enum discriminator on `TimingGrade` — each former value becomes an empty tag in `app/tags/tags.h` (`TimingPerfectTag`/`TimingGoodTag`/`TimingOkTag`/`TimingBadTag`). `TimingGrade` is now a single-column row carrying only `{ float precision }`.

### Per-value schema table

| Former `TimingTier` value | Tag                | multiplier | window_scale | energy delta              | particle color | popup color (RGB)  | popup label |
|---------------------------:|--------------------|-----------:|-------------:|---------------------------|----------------|--------------------|-------------|
| `Perfect`                  | `TimingPerfectTag` |     `1.50` |       `0.50` | `+ENERGY_RECOVER_PERFECT` | bright cyan    | (80, 255, 220)     | "PERFECT"   |
| `Good`                     | `TimingGoodTag`    |     `1.00` |       `0.75` | `+ENERGY_RECOVER_GOOD`    | lime           | (140, 255, 80)     | "GOOD"      |
| `Ok`                       | `TimingOkTag`      |     `0.50` |       `1.00` | `-ENERGY_DRAIN_OK`        | amber          | (255, 200, 60)     | "OK"        |
| `Bad`                      | `TimingBadTag`     |     `0.25` |       `1.00` | `-ENERGY_DRAIN_BAD`       | red-orange     | (255, 90, 70)      | "BAD"       |
| _(ungraded)_                | _(no tag)_         |        n/a |          n/a | n/a                       | n/a            | (255, 255, 50)     | numeric str |

### Mechanic

Per-tier tables (Fabian existential processing #1202/#1204):

- **`scoring_system.cpp`**: `tier_score_traits<TierTag>` specialization per former tier holds `{ multiplier, energy_delta, energy_flash, particle_color, results_counter member-ptr, popup queue member-ptr }`. Hit pass runs `process_tier_hit_pass<TierTag>` once per tier plus one `process_ungraded_hit_pass` — **no `switch` on a discriminator**.
- **`rhythm_math.h`**: `timing_multiplier_from_delta_abs(float)` and `window_scale_from_delta_abs(float)` replace the prior tier-keyed lookups; the threshold ladder is the per-band table.
- **`popup_entity.cpp`**: 5 per-tier spawn functions (`spawn_score_popup_{perfect,good,ok,bad,untimed}`) replace the prior `spawn_score_popup` that switched on a discriminator. Each inlines its own popup color.
- **`gameplay_intents.h`**: `ScorePopupRequestQueue` now has 5 per-tier vectors (`perfect/good/ok/bad/untimed`) instead of one heterogeneous queue. `popup_feedback_system` drains all 5 via a template helper.
- **`session_logger_system.cpp`**: tier label is looked up via tag-presence checks (`reg.all_of<TimingPerfectTag>`) rather than `enum_name()`.

### Helpers added in `rhythm_math.h`

```cpp
void emplace_timing_perfect(reg, e, precision);
void emplace_timing_good   (reg, e, precision);
void emplace_timing_ok     (reg, e, precision);
void emplace_timing_bad    (reg, e, precision);
void emplace_timing_tier_tag_for_delta_abs(reg, e, delta_abs);
bool has_any_timing_tier_tag(reg, e);
void remove_timing_grade_and_tags(reg, e);
```

### Acceptance criteria

- [x] `TimingTier` enum deleted from `components/rhythm.h`.
- [x] Four empty tags added to `app/tags/tags.h` (one per former value).
- [x] No `switch` on a discriminator remains for the timing-tier path.
- [x] All 877 test cases / 2885 assertions pass.
- [x] Builds clean under `-Wall -Wextra -Werror`.

Tests (11 files) updated to the new tag-presence API; one cross-tier distinctness suite added for popup colors.