### PR TITLE
refactor(obstacle): eradicate ObstacleKind enum via per-kind tag tables (#1202, #1204)

### DIFF
--- a/app/components/beat_map.h
+++ b/app/components/beat_map.h
@@ -1,19 +1,23 @@
 #pragma once
 
-#include "obstacle.h"
 #include "player.h"
 #include <cstdint>
 #include <string>
 #include <vector>
 
-// ── Beat Entry (one entry in the beat map) ──────────
+// ── Beat Entry (one row in a per-kind beat vector) ──────────
+// The former `ObstacleKind kind` discriminator (issue #1202/#1204) was
+// removed: the kind is identified by which per-kind vector in `BeatMap`
+// the row lives in (`shape_gate_beats` / `split_path_beats` /
+// `onset_marker_beats`). For OnsetMarker rows `shape` is unused (defaults
+// to Circle); for ShapeGate rows `lane` is positional only; for SplitPath
+// rows `lane` is the required dodge lane.
 struct BeatEntry {
-    int          beat_index   = 0;
-    ObstacleKind kind         = ObstacleKind::ShapeGate;
-    Shape        shape        = Shape::Circle;
-    int8_t       lane         = 1;
-    float        time_sec     = 0.0f;
-    bool         has_time_sec = false;
+    int    beat_index   = 0;
+    Shape  shape        = Shape::Circle;
+    int8_t lane         = 1;
+    float  time_sec     = 0.0f;
+    bool   has_time_sec = false;
 };
 
 // ── Beat Map (the full chart, loaded from JSON) ─────
@@ -28,6 +32,13 @@ struct BeatEntry {
 // This is a cold asset singleton. Copy construction and copy assignment are
 // deleted so accidental duplication of the heap-allocated beat array is a
 // compile-time error. Use std::move() when transferring ownership.
+//
+// The chart is normalized per Fabian's relational mechanic (#1204): each
+// former `ObstacleKind` value gets its own table (vector). Cross-kind
+// ordering (e.g. monotonic beat indices) is validated by merging the
+// per-kind vectors in beat-index order; intra-kind rules walk only the
+// relevant vector. Each per-kind vector is independently `stable_sort`-ed
+// by beat_index after parsing.
 struct BeatMap {
     std::string song_id;
     std::string title;
@@ -39,7 +50,9 @@ struct BeatMap {
     std::string difficulty;
     std::vector<float> beat_times;
 
-    std::vector<BeatEntry> beats;
+    std::vector<BeatEntry> shape_gate_beats;
+    std::vector<BeatEntry> split_path_beats;
+    std::vector<BeatEntry> onset_marker_beats;
 
     BeatMap()                          = default;
     BeatMap(const BeatMap&)            = delete;

--- a/app/components/obstacle.h
+++ b/app/components/obstacle.h
@@ -6,42 +6,12 @@
 #include "player.h"
 #include "tags/tags.h"
 
-enum class ObstacleKind : uint8_t {
-    ShapeGate,
-    SplitPath,
-    OnsetMarker,
-};
-
-constexpr bool obstacle_kind_is_active_runtime_spawnable(ObstacleKind kind) {
-    return kind == ObstacleKind::ShapeGate ||
-           kind == ObstacleKind::SplitPath ||
-           kind == ObstacleKind::OnsetMarker;
-}
-
-constexpr bool obstacle_kind_is_active_blocking_beatmap_kind(ObstacleKind kind) {
-    return kind == ObstacleKind::ShapeGate || kind == ObstacleKind::SplitPath;
-}
-
-constexpr bool obstacle_kind_is_active_beatmap_spawnable(ObstacleKind kind) {
-    return obstacle_kind_is_active_blocking_beatmap_kind(kind) ||
-           kind == ObstacleKind::OnsetMarker;
-}
-
 struct Obstacle {
     int16_t      base_points = 200;
 
     constexpr Obstacle() = default;
     constexpr explicit Obstacle(int16_t points) : base_points(points) {}
 };
-
-constexpr ObstacleKind obstacle_kind_from_components(bool has_required_shape,
-                                                     bool has_required_lane) {
-    if (has_required_lane) {
-        return ObstacleKind::SplitPath;
-    }
-    (void)has_required_shape;
-    return ObstacleKind::ShapeGate;
-}
 
 struct RequiredShape {
     Shape shape = Shape::Circle;

--- a/app/components/song_state.h
+++ b/app/components/song_state.h
@@ -39,8 +39,14 @@ struct SongState {
     bool   restart_music = false;  // set true by setup_play_session; consumed/cleared
                                    //   on the next tick by song_playback_system
 
-    // ── Beat-schedule cursor (per-frame, reset at session init) ─────────────
-    size_t next_spawn_idx = 0;     // advanced each frame by beat_scheduler_system
+    // ── Beat-schedule cursors (per-kind, reset at session init) ─────────────
+    // Replaces the former `next_spawn_idx` single cursor (issue #1202/#1204).
+    // beat_scheduler_system runs one per-kind transform per cursor; each
+    // cursor advances independently over its own per-kind vector in
+    // BeatMap.
+    size_t next_shape_gate_idx    = 0;
+    size_t next_split_path_idx    = 0;
+    size_t next_onset_marker_idx  = 0;
 };
 
 // ── Song Results (singleton, accumulates during play) ─

--- a/app/entities/beat_map.cpp
+++ b/app/entities/beat_map.cpp
@@ -24,17 +24,7 @@ std::string constants_path_for_app_dir(const std::string& app_dir) {
     return app_dir + "/" + kValidationConstantsPath;
 }
 
-bool kind_requires_shape(const ObstacleKind kind) {
-    return kind == ObstacleKind::ShapeGate || kind == ObstacleKind::SplitPath;
-}
 
-bool kind_requires_lane(const ObstacleKind kind) {
-    return kind == ObstacleKind::ShapeGate || kind == ObstacleKind::SplitPath;
-}
-
-bool is_supported_beatmap_kind(const ObstacleKind kind) {
-    return obstacle_kind_is_active_runtime_spawnable(kind);
-}
 
 std::string type_error_message(const char* field, const char* expected, const json& value) {
     return std::string("'") + field + "' must be " + expected + " (got " + value.type_name() + ")";
@@ -265,18 +255,29 @@ ValidationConstants load_validation_constants(const std::string& app_dir) {
     return vc;
 }
 
-static std::optional<ObstacleKind> parse_kind(const std::string& s) {
-    if (s == "shape_gate")       return ObstacleKind::ShapeGate;
-    if (s == "split_path")       return ObstacleKind::SplitPath;
-    if (s == "onset_marker")     return ObstacleKind::OnsetMarker;
-    return std::nullopt;
-}
-
 static std::optional<Shape> parse_shape(const std::string& s) {
     if (s == "circle")   return Shape::Circle;
     if (s == "square")   return Shape::Square;
     if (s == "triangle") return Shape::Triangle;
     return std::nullopt;
+}
+
+// ── Per-kind beat-entry sinks (issue #1202/#1204) ───────────
+// Parsing dispatches into per-kind vectors directly by the JSON `kind`
+// string. No discriminator enum is reintroduced — see `parse_beat_map`
+// below where each known kind string has its own dispatch branch.
+bool kind_string_requires_shape(std::string_view kind_str) {
+    return kind_str == "shape_gate" || kind_str == "split_path";
+}
+
+bool kind_string_requires_lane(std::string_view kind_str) {
+    return kind_str == "shape_gate" || kind_str == "split_path";
+}
+
+bool kind_string_is_supported(std::string_view kind_str) {
+    return kind_str == "shape_gate" ||
+           kind_str == "split_path" ||
+           kind_str == "onset_marker";
 }
 
 bool parse_beat_map(const std::string& json_str, BeatMap& out,
@@ -296,7 +297,9 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
     }
 
     // ── Metadata ─────────────────────────────────────────────
-    out.beats.clear();  // reset before every parse to prevent stale entries on reuse
+    out.shape_gate_beats.clear();
+    out.split_path_beats.clear();
+    out.onset_marker_beats.clear();
     out.beat_times.clear();
     out.song_id.clear();
     out.title.clear();
@@ -447,14 +450,12 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
             parse_ok = false;
             continue;
         }
-        auto kind_opt = parse_kind(kind_str);
-        if (!kind_opt) {
+        if (!kind_string_is_supported(kind_str)) {
             errors.push_back({entry.beat_index,
                 "Unknown obstacle kind '" + kind_str + "' at beat " + std::to_string(entry.beat_index)});
             parse_ok = false;
             continue;
         }
-        entry.kind = *kind_opt;
 
         if (b.contains("shape")) {
             std::string shape_str;
@@ -470,7 +471,7 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
                 continue;
             }
             entry.shape = *shape_opt;
-        } else if (kind_requires_shape(entry.kind)) {
+        } else if (kind_string_requires_shape(kind_str)) {
             errors.push_back({entry.beat_index,
                 "Missing required shape for obstacle kind '" + kind_str + "' at beat "
                     + std::to_string(entry.beat_index)});
@@ -483,7 +484,7 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
             parse_ok = false;
             continue;
         }
-        if (!b.contains("lane") && kind_requires_lane(entry.kind)) {
+        if (!b.contains("lane") && kind_string_requires_lane(kind_str)) {
             errors.push_back({entry.beat_index,
                 "Missing required lane for obstacle kind '" + kind_str + "' at beat "
                     + std::to_string(entry.beat_index)});
@@ -542,27 +543,42 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
             continue;
         }
 
-        out.beats.push_back(entry);
+        // Per-kind dispatch into the appropriate vector (issue #1202/#1204).
+        // No discriminator enum survives in the data model — the row lives
+        // in exactly one of three per-kind tables.
+        if (kind_str == "shape_gate") {
+            out.shape_gate_beats.push_back(entry);
+        } else if (kind_str == "split_path") {
+            out.split_path_beats.push_back(entry);
+        } else {
+            out.onset_marker_beats.push_back(entry);
+        }
     }
 
     if (!parse_ok) return false;
 
-    // Sort beats by beat_index; for ties, sort by resolved time_sec so
-    // authored timing within the same beat stays schedulable in-order.
-    // Stable sort preserves authored order when keys are identical.
-    std::stable_sort(out.beats.begin(), out.beats.end(),
-                     [](const BeatEntry& a, const BeatEntry& b) {
-                         if (a.beat_index != b.beat_index) {
-                             return a.beat_index < b.beat_index;
-                         }
-                         if (a.time_sec != b.time_sec) {
-                             return a.time_sec < b.time_sec;
-                         }
-                         return false;
-                     });
+    // Sort each per-kind vector by beat_index; for ties, sort by resolved
+    // time_sec so authored timing within the same beat stays schedulable
+    // in-order. Stable sort preserves authored order when keys are identical.
+    auto by_beat = [](const BeatEntry& a, const BeatEntry& b) {
+        if (a.beat_index != b.beat_index) {
+            return a.beat_index < b.beat_index;
+        }
+        if (a.time_sec != b.time_sec) {
+            return a.time_sec < b.time_sec;
+        }
+        return false;
+    };
+    std::stable_sort(out.shape_gate_beats.begin(),   out.shape_gate_beats.end(),   by_beat);
+    std::stable_sort(out.split_path_beats.begin(),   out.split_path_beats.end(),   by_beat);
+    std::stable_sort(out.onset_marker_beats.begin(), out.onset_marker_beats.end(), by_beat);
 
-    if (out.beat_times.empty() && !out.beats.empty()) {
-        const int max_beat = out.beats.back().beat_index;
+    if (out.beat_times.empty()) {
+        int max_beat = -1;
+        if (!out.shape_gate_beats.empty())   max_beat = std::max(max_beat, out.shape_gate_beats.back().beat_index);
+        if (!out.split_path_beats.empty())   max_beat = std::max(max_beat, out.split_path_beats.back().beat_index);
+        if (!out.onset_marker_beats.empty()) max_beat = std::max(max_beat, out.onset_marker_beats.back().beat_index);
+
         if (max_beat >= 0) {
             const auto max_derived_beat = max_derived_beat_for_metadata(out.bpm, out.duration);
             if (!max_derived_beat || max_beat > *max_derived_beat) {
@@ -660,8 +676,11 @@ bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors,
         valid = false;
     }
 
-    // Rule 10: at least 1 beat entry
-    if (map.beats.empty()) {
+    // Rule 10: at least 1 beat entry across all per-kind tables
+    const bool any_beats = !map.shape_gate_beats.empty() ||
+                           !map.split_path_beats.empty() ||
+                           !map.onset_marker_beats.empty();
+    if (!any_beats) {
         errors.push_back({-1, "Beat map must have at least 1 beat entry"});
         valid = false;
     }
@@ -693,6 +712,67 @@ bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors,
         }
     }
 
+    // Per-row rules: walk each per-kind vector once. Cross-kind ordering
+    // rules (Rule 1 — monotonic beat indices, intra-beat resolved-time
+    // monotonicity, time_sec monotonicity) are evaluated by walking a
+    // beat-index merge over the three vectors below.
+    //
+    // Kind-specific rule references:
+    //   has_shape       — true for shape_gate_beats and split_path_beats
+    //   requires_lane   — same set (onset_marker_beats default lane is
+    //                     not validated against [0,2] semantics)
+    auto validate_per_entry = [&](const BeatEntry& entry,
+                                  bool has_shape, bool requires_lane) {
+        // Rule 2: beat index must be within the playable song range
+        if (entry.beat_index < 0) {
+            errors.push_back({entry.beat_index, "Beat index must be non-negative"});
+            valid = false;
+        }
+        if (max_beat && entry.beat_index > *max_beat) {
+            errors.push_back({entry.beat_index, "Beat index exceeds song duration"});
+            valid = false;
+        }
+
+        // Rule 2b: beat_index must reference a loaded timestamp when beat_times are present
+        if (!map.beat_times.empty() &&
+            (entry.beat_index < 0 || static_cast<size_t>(entry.beat_index) >= map.beat_times.size())) {
+            errors.push_back({entry.beat_index, "Beat index is out of range for beat_times array"});
+            valid = false;
+        }
+
+        // Rule 5: lane-bound obstacles must have lane 0-2
+        if (requires_lane && (entry.lane < 0 || entry.lane > 2)) {
+            errors.push_back({entry.beat_index, "Lane must be 0-2"});
+            valid = false;
+        }
+
+        if (entry.has_time_sec) {
+            if (!std::isfinite(entry.time_sec)) {
+                errors.push_back({entry.beat_index, "time_sec must be finite when provided"});
+                valid = false;
+            } else {
+                if (entry.time_sec < 0.0f) {
+                    errors.push_back({entry.beat_index, "time_sec must be >= 0 when provided"});
+                    valid = false;
+                }
+                if (std::isfinite(map.duration) && entry.time_sec > map.duration) {
+                    errors.push_back({entry.beat_index, "time_sec must be <= duration_sec when provided"});
+                    valid = false;
+                }
+            }
+        }
+        (void)has_shape;
+    };
+
+    for (const auto& entry : map.shape_gate_beats)   validate_per_entry(entry, true,  true);
+    for (const auto& entry : map.split_path_beats)   validate_per_entry(entry, true,  true);
+    for (const auto& entry : map.onset_marker_beats) validate_per_entry(entry, false, false);
+
+    // Cross-kind ordering: walk the three sorted vectors in beat-index
+    // merge order so Rule 1 (monotonic), the intra-beat resolved-time
+    // rule, and Rule 6 (different-shape gates) see the same total order
+    // the parser produced.
+    size_t i_sg = 0, i_sp = 0, i_om = 0;
     int prev_beat = -1;
     int prev_shape_beat = -1;
     Shape prev_shape = Shape::Circle;
@@ -702,8 +782,7 @@ bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors,
     bool has_prev_resolved_time_for_beat = false;
     float prev_resolved_time_for_beat = 0.0f;
 
-    for (size_t i = 0; i < map.beats.size(); ++i) {
-        const auto& entry = map.beats[i];
+    auto resolve_time = [&](const BeatEntry& entry) {
         float resolved_time = 0.0f;
         if (timing_metadata_valid) {
             resolved_time = map.offset + static_cast<float>(entry.beat_index) * beat_period;
@@ -715,6 +794,39 @@ bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors,
                    static_cast<size_t>(entry.beat_index) < map.beat_times.size()) {
             resolved_time = map.beat_times[static_cast<size_t>(entry.beat_index)];
         }
+        return resolved_time;
+    };
+
+    // Pick the next-smallest entry by (beat_index, time_sec) across the
+    // three sorted vectors. Each kind tag's vector advances its own cursor.
+    auto step_merge = [&](bool& has_shape_out) -> const BeatEntry* {
+        const BeatEntry* sg = (i_sg < map.shape_gate_beats.size())   ? &map.shape_gate_beats[i_sg]   : nullptr;
+        const BeatEntry* sp = (i_sp < map.split_path_beats.size())   ? &map.split_path_beats[i_sp]   : nullptr;
+        const BeatEntry* om = (i_om < map.onset_marker_beats.size()) ? &map.onset_marker_beats[i_om] : nullptr;
+        const BeatEntry* best = nullptr;
+        size_t* best_cursor = nullptr;
+        has_shape_out = false;
+        auto consider = [&](const BeatEntry* cand, size_t* cursor, bool cand_has_shape) {
+            if (!cand) return;
+            if (!best) { best = cand; best_cursor = cursor; has_shape_out = cand_has_shape; return; }
+            if (cand->beat_index < best->beat_index ||
+                (cand->beat_index == best->beat_index && cand->time_sec < best->time_sec)) {
+                best = cand;
+                best_cursor = cursor;
+                has_shape_out = cand_has_shape;
+            }
+        };
+        consider(sg, &i_sg, true);
+        consider(sp, &i_sp, true);
+        consider(om, &i_om, false);
+        if (best_cursor) (*best_cursor)++;
+        return best;
+    };
+
+    bool entry_has_shape = false;
+    while (const auto* entry_ptr = step_merge(entry_has_shape)) {
+        const auto& entry = *entry_ptr;
+        const float resolved_time = resolve_time(entry);
 
         // Rule 1: beat indices monotonically non-decreasing
         if (entry.beat_index < prev_beat && prev_beat >= 0) {
@@ -736,67 +848,25 @@ bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors,
             has_prev_resolved_time_for_beat = true;
         }
 
-        // Rule 2: beat index must be within the playable song range
-        if (entry.beat_index < 0) {
-            errors.push_back({entry.beat_index, "Beat index must be non-negative"});
-            valid = false;
-        }
-        if (max_beat && entry.beat_index > *max_beat) {
-            errors.push_back({entry.beat_index, "Beat index exceeds song duration"});
-            valid = false;
-        }
-
-        // Rule 2b: beat_index must reference a loaded timestamp when beat_times are present
-        if (!map.beat_times.empty() &&
-            (entry.beat_index < 0 || static_cast<size_t>(entry.beat_index) >= map.beat_times.size())) {
-            errors.push_back({entry.beat_index, "Beat index is out of range for beat_times array"});
-            valid = false;
-        }
-
-        if (!is_supported_beatmap_kind(entry.kind)) {
-            errors.push_back({entry.beat_index, "Unsupported active beatmap obstacle kind"});
-            valid = false;
-        }
-
-        // Rule 5: lane-bound obstacles must have lane 0-2
-        if (kind_requires_lane(entry.kind) && (entry.lane < 0 || entry.lane > 2)) {
-            errors.push_back({entry.beat_index, "Lane must be 0-2"});
-            valid = false;
-        }
-
-        if (entry.has_time_sec) {
-            if (!std::isfinite(entry.time_sec)) {
-                errors.push_back({entry.beat_index, "time_sec must be finite when provided"});
+        if (entry.has_time_sec && std::isfinite(entry.time_sec)) {
+            if (has_prev_authored_time && entry.time_sec < prev_authored_time) {
+                errors.push_back({entry.beat_index,
+                    "time_sec must be non-decreasing across authored beat entries"});
                 valid = false;
-            } else {
-                if (entry.time_sec < 0.0f) {
-                    errors.push_back({entry.beat_index, "time_sec must be >= 0 when provided"});
-                    valid = false;
-                }
-                if (std::isfinite(map.duration) && entry.time_sec > map.duration) {
-                    errors.push_back({entry.beat_index, "time_sec must be <= duration_sec when provided"});
-                    valid = false;
-                }
-                if (has_prev_authored_time && entry.time_sec < prev_authored_time) {
-                    errors.push_back({entry.beat_index,
-                        "time_sec must be non-decreasing across authored beat entries"});
-                    valid = false;
-                }
-                prev_authored_time = entry.time_sec;
-                has_prev_authored_time = true;
             }
+            prev_authored_time = entry.time_sec;
+            has_prev_authored_time = true;
         }
 
         // Rule 6: different-shape gates must be >= min_shape_change_gap beats apart
-        bool has_shape = kind_requires_shape(entry.kind);
-        if (has_shape && prev_had_shape &&
+        if (entry_has_shape && prev_had_shape &&
             entry.shape != prev_shape &&
             (entry.beat_index - prev_shape_beat) < vc.min_shape_change_gap) {
             errors.push_back({entry.beat_index,
                 "Different-shape gates must be >= " + std::to_string(vc.min_shape_change_gap) + " beats apart"});
             valid = false;
         }
-        if (has_shape) {
+        if (entry_has_shape) {
             prev_shape_beat = entry.beat_index;
             prev_shape = entry.shape;
             prev_had_shape = true;
@@ -815,6 +885,8 @@ void init_song_state(SongState& state, const BeatMap& map) {
     state.current_beat = -1;
     state.playing      = false;
     state.finished     = false;
-    state.next_spawn_idx = 0;
+    state.next_shape_gate_idx   = 0;
+    state.next_split_path_idx   = 0;
+    state.next_onset_marker_idx = 0;
     song_state_compute_derived(state);
 }

--- a/app/entities/obstacle_entity.cpp
+++ b/app/entities/obstacle_entity.cpp
@@ -10,75 +10,102 @@
 
 namespace {
 
-bool obstacle_kind_requires_shape(ObstacleKind kind) {
-    return kind == ObstacleKind::ShapeGate || kind == ObstacleKind::SplitPath;
-}
-
-entt::entity spawn_obstacle_base(entt::registry& reg, const ObstacleSpawnParams& params) {
-    if (!obstacle_kind_is_active_runtime_spawnable(params.kind)) {
-        throw std::logic_error("Deprecated obstacle kind is not spawnable at runtime");
-    }
-    if (obstacle_kind_requires_shape(params.kind) && !is_valid_shape(params.shape)) {
-        throw std::logic_error("Invalid obstacle shape");
-    }
-    if (params.kind == ObstacleKind::SplitPath && !lane_utils::is_valid(params.req_lane)) {
-        throw std::logic_error("Invalid obstacle lane");
-    }
-
-    auto e = reg.create();
-    reg.emplace<WorldTransform>(e, WorldTransform{{params.x, params.y}});
-    reg.emplace<TagWorldPass>(e);
-
-    switch (params.kind) {
-        case ObstacleKind::ShapeGate: {
-            reg.emplace<Obstacle>(e, int16_t{constants::PTS_SHAPE_GATE});
-            reg.emplace<RequiredShape>(e, params.shape);
-            reg.emplace<ShapeGateLane>(
-                e, static_cast<int8_t>(lane_utils::nearest_lane_for_x(params.x)));
-            reg.emplace<DrawSize>(e, constants::SCREEN_W_F, 80.0f);
-            reg.emplace<Color>(e, constants::SHAPE_COLORS[shape_index(params.shape)]);
-            break;
-        }
-        case ObstacleKind::SplitPath: {
-            reg.emplace<Obstacle>(e, int16_t{constants::PTS_SPLIT_PATH});
-            reg.emplace<RequiredShape>(e, params.shape);
-            reg.emplace<RequiredLane>(e, params.req_lane);
-            reg.emplace<DrawSize>(e, constants::SCREEN_W_F, 80.0f);
-            reg.emplace<Color>(e, Color{255, 215, 0, 255});
-            break;
-        }
-        case ObstacleKind::OnsetMarker: {
-            reg.emplace<Obstacle>(e, int16_t{0});
-            reg.emplace<OnsetMarkerTag>(e);
-            reg.emplace<NonScorableTag>(e);
-            reg.emplace<DrawSize>(e, constants::SCREEN_W_F, 80.0f);
-            reg.emplace<Color>(e, Color{255, 255, 255, 80});
-            break;
-        }
-    }
-
-    return e;
-}
-
 void finish_obstacle(entt::registry& reg, entt::entity e) {
     spawn_obstacle_meshes(reg, e);
     reg.emplace<ObstacleTag>(e);
 }
 
+entt::entity create_shape_gate(entt::registry& reg, const ShapeGateSpawn& params) {
+    if (!is_valid_shape(params.shape)) {
+        throw std::logic_error("Invalid obstacle shape");
+    }
+    auto e = reg.create();
+    reg.emplace<WorldTransform>(e, WorldTransform{{params.x, params.y}});
+    reg.emplace<TagWorldPass>(e);
+    reg.emplace<ShapeGateTag>(e);
+    reg.emplace<Obstacle>(e, int16_t{constants::PTS_SHAPE_GATE});
+    reg.emplace<RequiredShape>(e, params.shape);
+    reg.emplace<ShapeGateLane>(
+        e, static_cast<int8_t>(lane_utils::nearest_lane_for_x(params.x)));
+    reg.emplace<DrawSize>(e, constants::SCREEN_W_F, 80.0f);
+    reg.emplace<Color>(e, constants::SHAPE_COLORS[shape_index(params.shape)]);
+    return e;
+}
+
+entt::entity create_split_path(entt::registry& reg, const SplitPathSpawn& params) {
+    if (!is_valid_shape(params.shape)) {
+        throw std::logic_error("Invalid obstacle shape");
+    }
+    if (!lane_utils::is_valid(params.req_lane)) {
+        throw std::logic_error("Invalid obstacle lane");
+    }
+    auto e = reg.create();
+    reg.emplace<WorldTransform>(e, WorldTransform{{params.x, params.y}});
+    reg.emplace<TagWorldPass>(e);
+    reg.emplace<SplitPathTag>(e);
+    reg.emplace<Obstacle>(e, int16_t{constants::PTS_SPLIT_PATH});
+    reg.emplace<RequiredShape>(e, params.shape);
+    reg.emplace<RequiredLane>(e, params.req_lane);
+    reg.emplace<DrawSize>(e, constants::SCREEN_W_F, 80.0f);
+    reg.emplace<Color>(e, Color{255, 215, 0, 255});
+    return e;
+}
+
+entt::entity create_onset_marker(entt::registry& reg, const OnsetMarkerSpawn& params) {
+    auto e = reg.create();
+    reg.emplace<WorldTransform>(e, WorldTransform{{params.x, params.y}});
+    reg.emplace<TagWorldPass>(e);
+    reg.emplace<OnsetMarkerTag>(e);
+    reg.emplace<Obstacle>(e, int16_t{0});
+    reg.emplace<NonScorableTag>(e);
+    reg.emplace<DrawSize>(e, constants::SCREEN_W_F, 80.0f);
+    reg.emplace<Color>(e, Color{255, 255, 255, 80});
+    return e;
+}
+
 } // namespace
 
-entt::entity spawn_obstacle(entt::registry& reg, const ObstacleSpawnParams& params) {
-    auto e = spawn_obstacle_base(reg, params);
+entt::entity spawn_shape_gate_obstacle(entt::registry& reg, const ShapeGateSpawn& params) {
+    auto e = create_shape_gate(reg, params);
     reg.emplace<Vector2>(e, Vector2{0.0f, params.speed});
     finish_obstacle(reg, e);
     return e;
 }
 
-entt::entity spawn_rhythm_obstacle(entt::registry& reg, const ObstacleSpawnParams& params,
-                                   const BeatInfo& beat_info) {
-    auto e = spawn_obstacle_base(reg, params);
+entt::entity spawn_split_path_obstacle(entt::registry& reg, const SplitPathSpawn& params) {
+    auto e = create_split_path(reg, params);
+    reg.emplace<Vector2>(e, Vector2{0.0f, params.speed});
+    finish_obstacle(reg, e);
+    return e;
+}
+
+entt::entity spawn_onset_marker_obstacle(entt::registry& reg, const OnsetMarkerSpawn& params) {
+    auto e = create_onset_marker(reg, params);
+    reg.emplace<Vector2>(e, Vector2{0.0f, params.speed});
+    finish_obstacle(reg, e);
+    return e;
+}
+
+entt::entity spawn_shape_gate_rhythm(entt::registry& reg, const ShapeGateSpawn& params,
+                                     const BeatInfo& beat_info) {
+    auto e = create_shape_gate(reg, params);
     reg.emplace<BeatInfo>(e, beat_info);
     finish_obstacle(reg, e);
+    return e;
+}
 
+entt::entity spawn_split_path_rhythm(entt::registry& reg, const SplitPathSpawn& params,
+                                     const BeatInfo& beat_info) {
+    auto e = create_split_path(reg, params);
+    reg.emplace<BeatInfo>(e, beat_info);
+    finish_obstacle(reg, e);
+    return e;
+}
+
+entt::entity spawn_onset_marker_rhythm(entt::registry& reg, const OnsetMarkerSpawn& params,
+                                       const BeatInfo& beat_info) {
+    auto e = create_onset_marker(reg, params);
+    reg.emplace<BeatInfo>(e, beat_info);
+    finish_obstacle(reg, e);
     return e;
 }

--- a/app/entities/obstacle_entity.h
+++ b/app/entities/obstacle_entity.h
@@ -1,28 +1,51 @@
 #pragma once
 
 #include <entt/entt.hpp>
-#include "../components/obstacle.h"
 #include "../components/player.h"  // Shape
 #include "../components/rhythm.h"  // BeatInfo
 
-// Full construction parameters for an obstacle entity.
-struct ObstacleSpawnParams {
-    ObstacleKind kind;
-    float        x        = 0.0f;
-    float        y        = 0.0f;
-    Shape        shape    = Shape::Circle;  // ShapeGate, SplitPath
-    int8_t       req_lane = 0;              // SplitPath
-    float        speed    = 0.0f;
+// Per-kind spawn-parameter rows (issue #1202/#1204). Each former
+// `ObstacleKind` value has its own row schema:
+//   - `ShapeGateSpawn`: shape (gate prompt) + positional lane
+//   - `SplitPathSpawn`: shape + required dodge lane
+//   - `OnsetMarkerSpawn`: position + speed only
+// `req_lane` for ShapeGate is computed at spawn-time from x via
+// `nearest_lane_for_x()` and stored in `ShapeGateLane`. SplitPath uses
+// `req_lane` directly to set `RequiredLane`.
+struct ShapeGateSpawn {
+    float  x      = 0.0f;
+    float  y      = 0.0f;
+    Shape  shape  = Shape::Circle;
+    float  speed  = 0.0f;
 };
 
-// Creates and fully configures an obstacle entity:
-//   ObstacleTag + TagWorldPass + kind-specific components + mesh child entities.
-//   Non-rhythm obstacles get a Vector2 velocity (raw type, see transform.h).
-// Owns the complete component bundle contract for obstacles.
-entt::entity spawn_obstacle(entt::registry& reg, const ObstacleSpawnParams& params);
+struct SplitPathSpawn {
+    float  x        = 0.0f;
+    float  y        = 0.0f;
+    Shape  shape    = Shape::Circle;
+    int8_t req_lane = 0;
+    float  speed    = 0.0f;
+};
 
-// Creates a song-time-authoritative rhythm obstacle:
-//   ObstacleTag + BeatInfo + TagWorldPass + kind-specific components + mesh children.
-// Rhythm obstacles intentionally do not get a velocity Vector2.
-entt::entity spawn_rhythm_obstacle(entt::registry& reg, const ObstacleSpawnParams& params,
-                                   const BeatInfo& beat_info);
+struct OnsetMarkerSpawn {
+    float x     = 0.0f;
+    float y     = 0.0f;
+    float speed = 0.0f;
+};
+
+// Per-kind obstacle spawn entry points. Each emplaces:
+//   ObstacleTag + TagWorldPass + the kind's per-tag table (ShapeGateTag /
+//   SplitPathTag / OnsetMarkerTag) + the per-instance data components
+//   that case carries + mesh children.
+// Non-rhythm variants attach a Vector2 velocity (raw type, see
+// transform.h); rhythm variants attach a `BeatInfo` instead.
+entt::entity spawn_shape_gate_obstacle  (entt::registry& reg, const ShapeGateSpawn& params);
+entt::entity spawn_split_path_obstacle  (entt::registry& reg, const SplitPathSpawn& params);
+entt::entity spawn_onset_marker_obstacle(entt::registry& reg, const OnsetMarkerSpawn& params);
+
+entt::entity spawn_shape_gate_rhythm  (entt::registry& reg, const ShapeGateSpawn& params,
+                                       const BeatInfo& beat_info);
+entt::entity spawn_split_path_rhythm  (entt::registry& reg, const SplitPathSpawn& params,
+                                       const BeatInfo& beat_info);
+entt::entity spawn_onset_marker_rhythm(entt::registry& reg, const OnsetMarkerSpawn& params,
+                                       const BeatInfo& beat_info);

--- a/app/entities/obstacle_render_entity.cpp
+++ b/app/entities/obstacle_render_entity.cpp
@@ -94,52 +94,49 @@ void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical) {
     const auto* wt_ptr = reg.try_get<WorldTransform>(logical);
     auto& col = reg.get<Color>(logical);
     auto& dsz = reg.get<DrawSize>(logical);
-    const ObstacleKind kind = reg.all_of<OnsetMarkerTag>(logical)
-        ? ObstacleKind::OnsetMarker
-        : obstacle_kind_from_components(
-            reg.all_of<RequiredShape>(logical),
-            reg.all_of<RequiredLane>(logical));
 
-    switch (kind) {
-        case ObstacleKind::ShapeGate: {
-            if (!wt_ptr) break;
-            const auto& wt = *wt_ptr;
-            auto* req = reg.try_get<RequiredShape>(logical);
-            uint8_t mesh_index = 0;
-            if (req) {
-                mesh_index = checked_shape_mesh_index(req->shape);
-            }
-            // Shape gates now render as shape-only prompts (no side walls/slabs).
-            if (req)
-                add_shape_child(reg, logical, mesh_index, wt.position.x, 0.0f,
-                                40, col);
-            break;
+    // Per-kind transforms (issue #1202/#1204). Each obstacle entity
+    // carries exactly one kind tag (ShapeGateTag/SplitPathTag/OnsetMarkerTag);
+    // each branch below operates on that tag's filtered view of one row.
+    if (reg.all_of<ShapeGateTag>(logical)) {
+        if (!wt_ptr) return;
+        const auto& wt = *wt_ptr;
+        auto* req = reg.try_get<RequiredShape>(logical);
+        uint8_t mesh_index = 0;
+        if (req) {
+            mesh_index = checked_shape_mesh_index(req->shape);
         }
-        case ObstacleKind::SplitPath: {
-            auto* rlane = reg.try_get<RequiredLane>(logical);
-            int lane_index = 0;
-            if (rlane) {
-                lane_index = checked_lane_index(rlane->lane);
-            }
-            auto* req = reg.try_get<RequiredShape>(logical);
-            uint8_t mesh_index = 0;
-            if (req) {
-                mesh_index = checked_shape_mesh_index(req->shape);
-            }
-            for (int i = 0; i < constants::LANE_COUNT; ++i)
-                if (!rlane || i != lane_index)
-                    add_slab_child(reg, logical, constants::LANE_X[i]-120,
-                                   240.0f, dsz.h, constants::OBSTACLE_3D_HEIGHT, col);
-            if (req && rlane)
-                add_shape_child(reg, logical, mesh_index,
-                                constants::LANE_X[lane_index],
-                                0.0f, 30, {255, 255, 255, 180});
-            break;
+        // Shape gates now render as shape-only prompts (no side walls/slabs).
+        if (req)
+            add_shape_child(reg, logical, mesh_index, wt.position.x, 0.0f,
+                            40, col);
+        return;
+    }
+    if (reg.all_of<SplitPathTag>(logical)) {
+        auto* rlane = reg.try_get<RequiredLane>(logical);
+        int lane_index = 0;
+        if (rlane) {
+            lane_index = checked_lane_index(rlane->lane);
         }
-        case ObstacleKind::OnsetMarker:
-            add_slab_child(reg, logical, 0.0f, dsz.w, dsz.h,
-                           constants::OBSTACLE_3D_HEIGHT, col);
-            break;
+        auto* req = reg.try_get<RequiredShape>(logical);
+        uint8_t mesh_index = 0;
+        if (req) {
+            mesh_index = checked_shape_mesh_index(req->shape);
+        }
+        for (int i = 0; i < constants::LANE_COUNT; ++i)
+            if (!rlane || i != lane_index)
+                add_slab_child(reg, logical, constants::LANE_X[i]-120,
+                               240.0f, dsz.h, constants::OBSTACLE_3D_HEIGHT, col);
+        if (req && rlane)
+            add_shape_child(reg, logical, mesh_index,
+                            constants::LANE_X[lane_index],
+                            0.0f, 30, {255, 255, 255, 180});
+        return;
+    }
+    if (reg.all_of<OnsetMarkerTag>(logical)) {
+        add_slab_child(reg, logical, 0.0f, dsz.w, dsz.h,
+                       constants::OBSTACLE_3D_HEIGHT, col);
+        return;
     }
 }
 

--- a/app/systems/beat_scheduler_system.cpp
+++ b/app/systems/beat_scheduler_system.cpp
@@ -11,6 +11,122 @@
 
 #include <cmath>
 
+namespace {
+
+// Per-kind schedule context shared across the 3 spawn transforms.
+struct ScheduleContext {
+    entt::registry& reg;
+    SongState&      song;
+    const BeatMap&  map;
+    float           audio_offset_sec;
+};
+
+// Resolve the calibrated arrival time for a beat. Mirrors the prior
+// single-loop logic; called once per entry. Returns true if the spawn
+// should proceed; populates `effective_spawn_time`, `start_y`, and
+// `calibrated_arrival_time` for the caller.
+bool resolve_spawn_timing(const ScheduleContext& ctx,
+                          const BeatEntry& entry,
+                          float& calibrated_arrival_time,
+                          float& effective_spawn_time,
+                          float& start_y) {
+    float beat_time = ctx.song.offset + entry.beat_index * ctx.song.beat_period;
+    if (!entry.has_time_sec &&
+        !ctx.map.beat_times.empty() &&
+        entry.beat_index >= 0 &&
+        static_cast<size_t>(entry.beat_index) < ctx.map.beat_times.size()) {
+        beat_time = ctx.map.beat_times[static_cast<size_t>(entry.beat_index)];
+    }
+    if (entry.has_time_sec) {
+        beat_time = entry.time_sec;
+    }
+
+    calibrated_arrival_time = beat_time + ctx.audio_offset_sec;
+    float spawn_time = calibrated_arrival_time - ctx.song.lead_time;
+    if (ctx.song.song_time < spawn_time) return false;
+
+    float overshoot = ctx.song.song_time - spawn_time;
+    start_y = constants::SPAWN_Y + overshoot * ctx.song.scroll_speed;
+    const float max_start_y = constants::PLAYER_Y;
+    effective_spawn_time = spawn_time;
+    if (start_y > max_start_y) {
+        start_y = max_start_y;
+        effective_spawn_time = ctx.song.song_time
+            - (max_start_y - constants::SPAWN_Y) / ctx.song.scroll_speed;
+    }
+    return true;
+}
+
+void warn_invalid_lane_once(int lane) {
+    if (!lane_utils::is_valid(lane)) {
+        TraceLog(LOG_WARNING, "Invalid beatmap lane %d; defaulting to center lane", lane);
+    }
+}
+
+// Per-kind transforms: one while-loop per kind cursor. Replaces the
+// former single switch-on-discriminator loop (issue #1202/#1204).
+
+void schedule_shape_gates(ScheduleContext& ctx) {
+    while (ctx.song.next_shape_gate_idx < ctx.map.shape_gate_beats.size()) {
+        const auto& entry = ctx.map.shape_gate_beats[ctx.song.next_shape_gate_idx];
+        float calibrated_arrival_time = 0.0f;
+        float effective_spawn_time    = 0.0f;
+        float start_y                 = 0.0f;
+        if (!resolve_spawn_timing(ctx, entry, calibrated_arrival_time,
+                                  effective_spawn_time, start_y)) break;
+
+        const int8_t spawn_lane = lane_utils::valid_or_default(entry.lane);
+        const float x_pos = constants::LANE_X[static_cast<int>(spawn_lane)];
+        warn_invalid_lane_once(static_cast<int>(entry.lane));
+
+        const BeatInfo bi{entry.beat_index, calibrated_arrival_time, effective_spawn_time};
+        spawn_shape_gate_rhythm(ctx.reg, {x_pos, start_y, entry.shape,
+                                          ctx.song.scroll_speed}, bi);
+        ctx.song.next_shape_gate_idx++;
+    }
+}
+
+void schedule_split_paths(ScheduleContext& ctx) {
+    while (ctx.song.next_split_path_idx < ctx.map.split_path_beats.size()) {
+        const auto& entry = ctx.map.split_path_beats[ctx.song.next_split_path_idx];
+        float calibrated_arrival_time = 0.0f;
+        float effective_spawn_time    = 0.0f;
+        float start_y                 = 0.0f;
+        if (!resolve_spawn_timing(ctx, entry, calibrated_arrival_time,
+                                  effective_spawn_time, start_y)) break;
+
+        const int8_t spawn_lane = lane_utils::valid_or_default(entry.lane);
+        const float x_pos = constants::LANE_X[static_cast<int>(spawn_lane)];
+        warn_invalid_lane_once(static_cast<int>(entry.lane));
+
+        const BeatInfo bi{entry.beat_index, calibrated_arrival_time, effective_spawn_time};
+        spawn_split_path_rhythm(ctx.reg, {x_pos, start_y, entry.shape,
+                                          spawn_lane, ctx.song.scroll_speed}, bi);
+        ctx.song.next_split_path_idx++;
+    }
+}
+
+void schedule_onset_markers(ScheduleContext& ctx) {
+    while (ctx.song.next_onset_marker_idx < ctx.map.onset_marker_beats.size()) {
+        const auto& entry = ctx.map.onset_marker_beats[ctx.song.next_onset_marker_idx];
+        float calibrated_arrival_time = 0.0f;
+        float effective_spawn_time    = 0.0f;
+        float start_y                 = 0.0f;
+        if (!resolve_spawn_timing(ctx, entry, calibrated_arrival_time,
+                                  effective_spawn_time, start_y)) break;
+
+        const int8_t spawn_lane = lane_utils::valid_or_default(entry.lane);
+        const float x_pos = constants::LANE_X[static_cast<int>(spawn_lane)];
+        warn_invalid_lane_once(static_cast<int>(entry.lane));
+
+        const BeatInfo bi{entry.beat_index, calibrated_arrival_time, effective_spawn_time};
+        spawn_onset_marker_rhythm(ctx.reg, {x_pos, start_y, ctx.song.scroll_speed}, bi);
+        ctx.song.next_onset_marker_idx++;
+    }
+}
+
+} // namespace
+
 void beat_scheduler_system(entt::registry& reg, [[maybe_unused]] float dt) {
     auto* song = reg.ctx().find<SongState>();
     auto* map  = find_beat_map(reg);
@@ -27,71 +143,8 @@ void beat_scheduler_system(entt::registry& reg, [[maybe_unused]] float dt) {
     const auto* settings = find_settings_state(reg);
     const float audio_offset_sec = settings ? settings::audio_offset_seconds(*settings) : 0.0f;
 
-    while (song->next_spawn_idx < map->beats.size()) {
-        const auto& entry = map->beats[song->next_spawn_idx];
-        if (!obstacle_kind_is_active_beatmap_spawnable(entry.kind)) {
-            TraceLog(LOG_WARNING, "Skipping unsupported active beatmap obstacle kind %d",
-                     static_cast<int>(entry.kind));
-            song->next_spawn_idx++;
-            continue;
-        }
-
-        float beat_time = song->offset + entry.beat_index * song->beat_period;
-        if (!entry.has_time_sec &&
-            !map->beat_times.empty() &&
-            entry.beat_index >= 0 &&
-            static_cast<size_t>(entry.beat_index) < map->beat_times.size()) {
-            beat_time = map->beat_times[static_cast<size_t>(entry.beat_index)];
-        }
-        if (entry.has_time_sec) {
-            beat_time = entry.time_sec;
-        }
-        // Beat line is the collision point: calibrated_arrival_time maps to
-        // crossing PLAYER_Y, including player audio calibration.
-        const float calibrated_arrival_time = beat_time + audio_offset_sec;
-        float spawn_time = calibrated_arrival_time - song->lead_time;
-
-        if (song->song_time < spawn_time) break;
-
-        // Compensate for late spawn: if song_time overshot spawn_time,
-        // place the obstacle below SPAWN_Y by the overshoot distance
-        // so it arrives at the player at exactly calibrated_arrival_time.
-        // Clamp the spawn position so a large overshoot cannot place the
-        // obstacle below the beat line, where it may never be scored before
-        // scrolling off-screen.
-        float overshoot = song->song_time - spawn_time;
-        float start_y = constants::SPAWN_Y + overshoot * song->scroll_speed;
-        float max_start_y = constants::PLAYER_Y;
-        float effective_spawn_time = spawn_time;
-        if (start_y > max_start_y) {
-            start_y = max_start_y;
-            // Store an adjusted spawn_time so scroll_system reproduces
-            // the clamped initial position via its song-time formula
-            // (pos.y = SPAWN_Y + (song_time - spawn_time) * scroll_speed),
-            // instead of snapping past the clamp on the first frame.
-            effective_spawn_time = song->song_time
-                - (max_start_y - constants::SPAWN_Y) / song->scroll_speed;
-        }
-
-        // Lane-bound obstacles use a normalized lane so visual position and
-        // lane requirements cannot diverge on invalid beatmap data.
-        const int8_t spawn_lane = lane_utils::valid_or_default(entry.lane);
-        float x_pos = constants::LANE_X[static_cast<int>(spawn_lane)];
-        const int lane = static_cast<int>(entry.lane);
-        if (!lane_utils::is_valid(lane)) {
-            TraceLog(LOG_WARNING, "Invalid beatmap lane %d; defaulting to center lane", lane);
-        }
-
-        const BeatInfo bi{entry.beat_index, calibrated_arrival_time, effective_spawn_time};
-        spawn_rhythm_obstacle(reg, {
-            entry.kind,
-            x_pos,
-            start_y,
-            entry.shape,
-            spawn_lane,
-            song->scroll_speed
-        }, bi);
-
-        song->next_spawn_idx++;
-    }
+    ScheduleContext ctx{reg, *song, *map, audio_offset_sec};
+    schedule_shape_gates(ctx);
+    schedule_split_paths(ctx);
+    schedule_onset_markers(ctx);
 }

--- a/app/systems/play_session.cpp
+++ b/app/systems/play_session.cpp
@@ -35,13 +35,11 @@ bool is_runtime_allowed_validation_error(const BeatMapError& error) {
 }
 
 int count_result_notes(const BeatMap& beatmap) {
-    int total = 0;
-    for (const BeatEntry& beat : beatmap.beats) {
-        if (beat.kind != ObstacleKind::OnsetMarker) {
-            ++total;
-        }
-    }
-    return total;
+    // Per-kind tables (#1202/#1204): result-counted notes are the
+    // scoring-eligible kinds — ShapeGate + SplitPath. OnsetMarker
+    // entries are non-scorable cues and don't contribute.
+    return static_cast<int>(beatmap.shape_gate_beats.size() +
+                            beatmap.split_path_beats.size());
 }
 
 bool load_runtime_beat_map(const char* path,
@@ -146,8 +144,11 @@ void setup_play_session(entt::registry& reg) {
     for (const char* path : paths) {
         load_errors.clear();
         if (load_runtime_beat_map(path, beatmap, load_errors, difficulty_key)) {
+            const size_t total_beats = beatmap.shape_gate_beats.size() +
+                                       beatmap.split_path_beats.size() +
+                                       beatmap.onset_marker_beats.size();
             TraceLog(LOG_INFO, "Loaded beatmap: %s (%zu beats, difficulty=%s)",
-                     path, beatmap.beats.size(), beatmap.difficulty.c_str());
+                     path, total_beats, beatmap.difficulty.c_str());
             loaded = true;
             break;
         }
@@ -182,7 +183,9 @@ void setup_play_session(entt::registry& reg) {
         return;
     }
     runtime_system_scratch_init(reg);
-    runtime_system_scratch_reserve(reg, beatmap.beats.size());
+    runtime_system_scratch_reserve(reg, beatmap.shape_gate_beats.size() +
+                                        beatmap.split_path_beats.size() +
+                                        beatmap.onset_marker_beats.size());
 
     assign_or_emplace_ctx(reg, ScoreState{});
     assign_or_emplace_ctx(reg, ScoreDisplay{});
@@ -209,7 +212,10 @@ void setup_play_session(entt::registry& reg) {
 
     // Init song state
     auto& song = assign_or_emplace_ctx(reg, SongState{});
-    if (!beatmap.beats.empty()) {
+    const bool any_beats = !beatmap.shape_gate_beats.empty() ||
+                           !beatmap.split_path_beats.empty() ||
+                           !beatmap.onset_marker_beats.empty();
+    if (any_beats) {
         init_song_state(song, beatmap);
     } else {
         song.bpm = 120.0f;

--- a/app/systems/session_logger_system.cpp
+++ b/app/systems/session_logger_system.cpp
@@ -95,6 +95,13 @@ void session_log_begin_frame(SessionLog& log) {
     ++log.frame;
 }
 
+std::string_view obstacle_kind_label(const entt::registry& reg, entt::entity entity) {
+    if (reg.all_of<ShapeGateTag>(entity))   return "ShapeGate";
+    if (reg.all_of<SplitPathTag>(entity))   return "SplitPath";
+    if (reg.all_of<OnsetMarkerTag>(entity)) return "OnsetMarker";
+    return "???";
+}
+
 // ── EnTT signal: obstacle spawned ────────────────────────────
 
 void session_log_on_obstacle_spawn(entt::registry& reg, entt::entity entity) {
@@ -116,12 +123,7 @@ void session_log_on_obstacle_spawn(entt::registry& reg, entt::entity entity) {
     if (rlane) lane = rlane->lane;
 
     float arrival = beat ? beat->arrival_time : 0.0f;
-    const ObstacleKind kind = reg.all_of<OnsetMarkerTag>(entity)
-        ? ObstacleKind::OnsetMarker
-        : obstacle_kind_from_components(
-            reg.all_of<RequiredShape>(entity),
-            reg.all_of<RequiredLane>(entity));
-    const std::string_view kind_name = enum_name_or_unknown(kind);
+    const std::string_view kind_name = obstacle_kind_label(reg, entity);
     const std::string_view shape_name = req ? enum_name_or_unknown(req->shape) : std::string_view{"-"};
 
     session_log_write(*log, t, "GAME",
@@ -149,10 +151,7 @@ void session_log_on_scored(entt::registry& reg, entt::entity entity) {
     int beat_num = beat ? beat->beat_index : -1;
     float expected_t = beat ? beat->arrival_time : 0.0f;
     float drift = beat ? (t - beat->arrival_time) : 0.0f;
-    const ObstacleKind kind = obstacle_kind_from_components(
-        reg.all_of<RequiredShape>(entity),
-        reg.all_of<RequiredLane>(entity));
-    const std::string_view kind_name = enum_name_or_unknown(kind);
+    const std::string_view kind_name = obstacle_kind_label(reg, entity);
 
     // Per-tier tag → label. Replaces enum_name(grade->tier) lookup; the tier
     // discriminator is now a per-tier tag on the entity (issue #1202/#1204).

--- a/app/systems/session_logger_system.h
+++ b/app/systems/session_logger_system.h
@@ -17,6 +17,11 @@ std::string_view enum_name_or_unknown(E value) {
     return name.empty() ? std::string_view{"???"} : name;
 }
 
+// Per-tag obstacle-kind label for log lines. Replaces the former
+// `enum_name(ObstacleKind)` lookup with a tag-presence dispatch
+// (issue #1202/#1204). Returns "???" when no kind tag is present.
+std::string_view obstacle_kind_label(const entt::registry& reg, entt::entity entity);
+
 struct SessionLog {
     // Maximum bytes buffered per frame before a flush. Pre-reserved at
     // construction so the hot write path never triggers heap reallocation.

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -296,10 +296,7 @@ void test_player_system(entt::registry& reg, float dt) {
         if (log) {
             auto* beat_info = reg.try_get<BeatInfo>(entity);
             int beat_num = beat_info ? beat_info->beat_index : -1;
-            const ObstacleKind kind = obstacle_kind_from_components(
-                reg.all_of<RequiredShape>(entity),
-                reg.all_of<RequiredLane>(entity));
-            const std::string_view kind_name = enum_name_or_unknown(kind);
+            const std::string_view kind_name = obstacle_kind_label(reg, entity);
             const std::string_view shape_name = enum_name_or_unknown(action.target_shape);
 
             session_log_write(*log, song_time, "PLAYER",

--- a/app/tags/tags.h
+++ b/app/tags/tags.h
@@ -27,6 +27,19 @@ struct ShapeWindowMorphOutTag {};
 // ── Obstacles ────────────────────────────────────────────────
 struct ObstacleTag {};
 
+// ── Obstacle kind (per-tag table; exactly one per obstacle entity) ──
+// Replaces the former ObstacleKind enum (issue #1202/#1204). Each
+// former enum value is its own per-kind table:
+//   - ShapeGateTag / SplitPathTag  → zero-column tag; the per-instance
+//     data (`RequiredShape`, `RequiredLane`, `ShapeGateLane`) lives in
+//     its own component table per the schema-per-kind mechanic in #1204.
+//   - OnsetMarkerTag → zero-column tag (no per-instance data).
+// Spawn helpers in `entities/obstacle_entity.h` emplace exactly one
+// kind tag; renderer / logger / test-player systems dispatch via
+// tag-presence views (no `switch` on a discriminator).
+struct ShapeGateTag {};
+struct SplitPathTag {};
+
 // Runtime cue authored from beatmap onset metadata. It is visible but
 // intentionally non-scorable and non-blocking.
 struct OnsetMarkerTag {};

--- a/tests/test_audio_offset_calibration.cpp
+++ b/tests/test_audio_offset_calibration.cpp
@@ -48,7 +48,7 @@ ScheduleResult schedule_one(int16_t audio_offset_ms,
     song.song_time = song_time_when_scheduling;
 
     auto& map = beat_map(reg);
-    map.beats.push_back({beat_index, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({beat_index, Shape::Circle, 1, 0, false});
 
     beat_scheduler_system(reg, 0.016f);
 
@@ -162,10 +162,10 @@ TEST_CASE("beat_scheduler: audio_offset gates spawn before calibrated spawn time
     auto& song = reg.ctx().get<SongState>();
     song.lead_time = 0.0f;
     song.song_time = 0.1f;
-    song.next_spawn_idx = 0;
+    song.next_shape_gate_idx = 0;
 
     auto& map = beat_map(reg);
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0, false});
 
     beat_scheduler_system(reg, 0.016f);
     CHECK(count_obstacles(reg) == 0);
@@ -197,21 +197,21 @@ TEST_CASE("audio_offset: zero setting matches absent SettingsState",
     auto scheduler_with_zero = make_rhythm_registry();
     auto& zero_schedule_song = scheduler_with_zero.ctx().get<SongState>();
     zero_schedule_song.song_time = 1.0f;
-    zero_schedule_song.next_spawn_idx = 0;
-    beat_map(scheduler_with_zero).beats.push_back(
-        {2, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    zero_schedule_song.next_shape_gate_idx = 0;
+    beat_map(scheduler_with_zero).shape_gate_beats.push_back(
+        {2, Shape::Circle, 1, 0, false});
     beat_scheduler_system(scheduler_with_zero, 0.016f);
 
     auto scheduler_without_settings = make_rhythm_registry();
     destroy_settings_entity(scheduler_without_settings);
     auto& absent_schedule_song = scheduler_without_settings.ctx().get<SongState>();
     absent_schedule_song.song_time = 1.0f;
-    absent_schedule_song.next_spawn_idx = 0;
-    beat_map(scheduler_without_settings).beats.push_back(
-        {2, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    absent_schedule_song.next_shape_gate_idx = 0;
+    beat_map(scheduler_without_settings).shape_gate_beats.push_back(
+        {2, Shape::Circle, 1, 0, false});
     beat_scheduler_system(scheduler_without_settings, 0.016f);
 
-    CHECK(absent_schedule_song.next_spawn_idx == zero_schedule_song.next_spawn_idx);
+    CHECK(absent_schedule_song.next_shape_gate_idx == zero_schedule_song.next_shape_gate_idx);
     CHECK(count_obstacles(scheduler_without_settings) == count_obstacles(scheduler_with_zero));
 }
 
@@ -251,7 +251,7 @@ OffsetGameplayResult run_calibrated_on_arrival_hit(int16_t audio_offset_ms) {
 
     constexpr int kBeatIndex = 4;
     auto& map = beat_map(reg);
-    map.beats.push_back({kBeatIndex, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({kBeatIndex, Shape::Circle, 1, 0, false});
 
     const float beat_time = song.offset + static_cast<float>(kBeatIndex) * song.beat_period;
     const float spawn_time = beat_time - song.lead_time + settings::audio_offset_seconds(settings);

--- a/tests/test_beat_map_parser_unknown_fields.cpp
+++ b/tests/test_beat_map_parser_unknown_fields.cpp
@@ -37,7 +37,9 @@ TEST_CASE("parse: unknown kind does not silently become ShapeGate", "[parse][kin
     bool ok = parse_beat_map(json, map, errors);
     CHECK_FALSE(ok);
     // Beat must not have been silently added with a default kind
-    CHECK(map.beats.empty());
+    CHECK(map.shape_gate_beats.empty());
+    CHECK(map.split_path_beats.empty());
+    CHECK(map.onset_marker_beats.empty());
 }
 
 TEST_CASE("parse: unknown kind at non-zero beat includes correct beat index", "[parse][kind][regression]") {
@@ -87,7 +89,9 @@ TEST_CASE("parse: unknown shape does not silently become Circle", "[parse][shape
 
     bool ok = parse_beat_map(json, map, errors);
     CHECK_FALSE(ok);
-    CHECK(map.beats.empty());
+    CHECK(map.shape_gate_beats.empty());
+    CHECK(map.split_path_beats.empty());
+    CHECK(map.onset_marker_beats.empty());
 }
 
 // ── Valid beatmaps remain error-free ──────────────────────────
@@ -112,7 +116,7 @@ TEST_CASE("parse: all active kinds parse without errors", "[parse][kind][issue87
         })";
         INFO("Testing kind: " << kind);
         CHECK(parse_beat_map(json, map, errors));
-        CHECK(map.beats.size() == 1);
+        CHECK(map.shape_gate_beats.size() + map.split_path_beats.size() + map.onset_marker_beats.size() == 1);
     }
 }
 
@@ -130,7 +134,7 @@ TEST_CASE("parse: all valid shapes parse without errors", "[parse][shape]") {
         })";
         INFO("Testing shape: " << shape);
         CHECK(parse_beat_map(json, map, errors));
-        CHECK(map.beats.size() == 1);
+        CHECK(map.shape_gate_beats.size() + map.split_path_beats.size() + map.onset_marker_beats.size() == 1);
     }
 }
 
@@ -239,7 +243,9 @@ TEST_CASE("parse: missing beat is rejected", "[parse][beat][required][issue757]"
     REQUIRE_FALSE(errors.empty());
     CHECK(errors[0].beat_index == -1);
     CHECK(errors[0].message.find("beat") != std::string::npos);
-    CHECK(map.beats.empty());
+    CHECK(map.shape_gate_beats.empty());
+    CHECK(map.split_path_beats.empty());
+    CHECK(map.onset_marker_beats.empty());
 }
 
 TEST_CASE("parse: missing shape gate lane is rejected", "[parse][lane][required][issue757]") {
@@ -256,7 +262,9 @@ TEST_CASE("parse: missing shape gate lane is rejected", "[parse][lane][required]
     REQUIRE_FALSE(errors.empty());
     CHECK(errors[0].beat_index == 4);
     CHECK(errors[0].message.find("lane") != std::string::npos);
-    CHECK(map.beats.empty());
+    CHECK(map.shape_gate_beats.empty());
+    CHECK(map.split_path_beats.empty());
+    CHECK(map.onset_marker_beats.empty());
 }
 
 TEST_CASE("parse: unshipped obstacle kinds are rejected", "[parse][kind][issue873]") {
@@ -273,7 +281,9 @@ TEST_CASE("parse: unshipped obstacle kinds are rejected", "[parse][kind][issue87
     REQUIRE_FALSE(errors.empty());
     CHECK(errors[0].beat_index == 8);
     CHECK(errors[0].message.find("Unknown obstacle kind") != std::string::npos);
-    CHECK(map.beats.empty());
+    CHECK(map.shape_gate_beats.empty());
+    CHECK(map.split_path_beats.empty());
+    CHECK(map.onset_marker_beats.empty());
 }
 
 TEST_CASE("parse: wrong metadata types report BeatMapError instead of throwing", "[parse][metadata][types][regression]") {

--- a/tests/test_beat_map_validation.cpp
+++ b/tests/test_beat_map_validation.cpp
@@ -35,7 +35,7 @@ TEST_CASE("validate: valid BPM passes", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -48,7 +48,7 @@ TEST_CASE("validate: BPM below 60 fails", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -61,7 +61,7 @@ TEST_CASE("validate: BPM above 300 fails", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -73,7 +73,7 @@ TEST_CASE("validate: BPM at 60 boundary passes", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -85,7 +85,7 @@ TEST_CASE("validate: BPM at 300 boundary passes", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -99,7 +99,7 @@ TEST_CASE("validate: anchored small negative offset passes", "[validate]") {
     map.offset = -0.1f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -112,7 +112,7 @@ TEST_CASE("validate: offset below anchored negative floor fails", "[validate]") 
     map.offset = -0.11f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -124,7 +124,7 @@ TEST_CASE("validate: offset above 5.0 fails", "[validate]") {
     map.offset = 5.1f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -138,7 +138,7 @@ TEST_CASE("validate: lead_beats below 2 fails", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 1;
     map.duration = 60.0f;
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -150,7 +150,7 @@ TEST_CASE("validate: lead_beats above 8 fails", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 9;
     map.duration = 60.0f;
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -164,7 +164,7 @@ TEST_CASE("validate: negative beat index fails", "[validate][issue132]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.beats.push_back({-1, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({-1, Shape::Circle, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -190,8 +190,8 @@ TEST_CASE("validate: duplicate beat indices pass when timing order is non-decrea
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.beats.push_back({4, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
-    map.beats.push_back({4, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -204,8 +204,8 @@ TEST_CASE("validate: non-monotonic beat indices fail", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.beats.push_back({5, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
-    map.beats.push_back({3, ObstacleKind::ShapeGate, Shape::Square, 1, 0});
+    map.shape_gate_beats.push_back({5, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_beats.push_back({3, Shape::Square, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -217,7 +217,7 @@ TEST_CASE("validate: beat index beyond duration fails", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 10.0f;  // max_beat = 10 / 0.5 = 20
-    map.beats.push_back({25, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({25, Shape::Circle, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -231,8 +231,8 @@ TEST_CASE("validate: different shapes >= 3 beats apart passes", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
-    map.beats.push_back({3, ObstacleKind::ShapeGate, Shape::Square, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_beats.push_back({3, Shape::Square, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -244,8 +244,8 @@ TEST_CASE("validate: different shapes < 3 beats apart fails", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
-    map.beats.push_back({2, ObstacleKind::ShapeGate, Shape::Square, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_beats.push_back({2, Shape::Square, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -257,8 +257,8 @@ TEST_CASE("validate: same shapes close together is OK", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
-    map.beats.push_back({1, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_beats.push_back({1, Shape::Circle, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -272,7 +272,7 @@ TEST_CASE("validate: shape_gate invalid lane fails", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 5, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 5, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -284,7 +284,7 @@ TEST_CASE("validate: split_path invalid lane fails", "[validate][issue932]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.beats.push_back({0, ObstacleKind::SplitPath, Shape::Circle, 5, 0});
+    map.split_path_beats.push_back({0, Shape::Circle, 5, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -313,7 +313,7 @@ TEST_CASE("validate: split_path is supported in active beatmaps", "[validate][ki
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.beats.push_back({4, ObstacleKind::SplitPath, Shape::Circle, 2, 0});
+    map.split_path_beats.push_back({4, Shape::Circle, 2, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -349,7 +349,9 @@ TEST_CASE("init_song_state: resets playback state", "[init_song]") {
     state.current_beat = 10;
     state.playing = true;
     state.finished = true;
-    state.next_spawn_idx = 5;
+    state.next_shape_gate_idx = 5;
+    state.next_split_path_idx = 7;
+    state.next_onset_marker_idx = 3;
 
     init_song_state(state, map);
 
@@ -357,7 +359,9 @@ TEST_CASE("init_song_state: resets playback state", "[init_song]") {
     CHECK(state.current_beat == -1);
     CHECK_FALSE(state.playing);
     CHECK_FALSE(state.finished);
-    CHECK(state.next_spawn_idx == 0);
+    CHECK(state.next_shape_gate_idx == 0);
+    CHECK(state.next_split_path_idx == 0);
+    CHECK(state.next_onset_marker_idx == 0);
 }
 
 TEST_CASE("init_song_state: computes derived fields", "[init_song]") {
@@ -528,7 +532,9 @@ TEST_CASE("load_and_validate_beat_map rejects invalid BPM at load time", "[load]
     CHECK_FALSE(load_and_validate_beat_map(file.path.string(), map, errors));
     REQUIRE_FALSE(errors.empty());
     CHECK(errors[0].message.find("BPM") != std::string::npos);
-    CHECK(map.beats.empty());
+    CHECK(map.shape_gate_beats.empty());
+    CHECK(map.split_path_beats.empty());
+    CHECK(map.onset_marker_beats.empty());
 }
 
 TEST_CASE("load_and_validate_beat_map rejects negative beat_index at load time",
@@ -549,7 +555,9 @@ TEST_CASE("load_and_validate_beat_map rejects negative beat_index at load time",
     CHECK_FALSE(load_and_validate_beat_map(file.path.string(), map, errors));
     REQUIRE_FALSE(errors.empty());
     CHECK(errors[0].message.find("Beat index") != std::string::npos);
-    CHECK(map.beats.empty());
+    CHECK(map.shape_gate_beats.empty());
+    CHECK(map.split_path_beats.empty());
+    CHECK(map.onset_marker_beats.empty());
 }
 
 TEST_CASE("load_and_validate_beat_map accepts valid beatmaps at load time",
@@ -569,7 +577,7 @@ TEST_CASE("load_and_validate_beat_map accepts valid beatmaps at load time",
     std::vector<BeatMapError> errors;
     REQUIRE(load_and_validate_beat_map(file.path.string(), map, errors));
     CHECK(errors.empty());
-    REQUIRE(map.beats.size() == 1);
+    REQUIRE(map.shape_gate_beats.size() == 1);
     CHECK(map.song_id == "valid_load");
 }
 
@@ -583,7 +591,7 @@ TEST_CASE("validate_beat_map explicit constants: custom BPM range is respected",
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors, vc));
@@ -601,7 +609,7 @@ TEST_CASE("validate_beat_map explicit constants: BPM within custom range passes"
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors, vc));
@@ -618,8 +626,8 @@ TEST_CASE("validate_beat_map explicit constants: custom shape gap is respected",
     map.lead_beats = 4;
     map.duration = 60.0f;
     // 3 beats apart — passes default rule but must fail the stricter custom rule
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
-    map.beats.push_back({3, ObstacleKind::ShapeGate, Shape::Square, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_beats.push_back({3, Shape::Square, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors, vc));
@@ -643,10 +651,10 @@ TEST_CASE("parse: beat_times and per-obstacle time_sec are loaded", "[parse][bea
     })";
 
     CHECK(parse_beat_map(json, map, errors));
-    REQUIRE(map.beats.size() == 1);
+    REQUIRE(map.shape_gate_beats.size() == 1);
     REQUIRE(map.beat_times.size() == 3);
-    CHECK_THAT(map.beats[0].time_sec, Catch::Matchers::WithinAbs(1.4f, 0.001f));
-    CHECK(map.beats[0].has_time_sec);
+    CHECK_THAT(map.shape_gate_beats[0].time_sec, Catch::Matchers::WithinAbs(1.4f, 0.001f));
+    CHECK(map.shape_gate_beats[0].has_time_sec);
 }
 
 TEST_CASE("parse: non-positive BPM is rejected before deriving beat timing",
@@ -668,7 +676,9 @@ TEST_CASE("parse: non-positive BPM is rejected before deriving beat timing",
     CHECK_FALSE(parse_beat_map(json, map, errors));
     REQUIRE_FALSE(errors.empty());
     CHECK(errors[0].message.find("BPM") != std::string::npos);
-    CHECK(map.beats.empty());
+    CHECK(map.shape_gate_beats.empty());
+    CHECK(map.split_path_beats.empty());
+    CHECK(map.onset_marker_beats.empty());
 }
 
 TEST_CASE("parse: non-positive lead_beats is rejected before runtime timing",
@@ -689,7 +699,9 @@ TEST_CASE("parse: non-positive lead_beats is rejected before runtime timing",
     CHECK_FALSE(parse_beat_map(json, map, errors));
     REQUIRE_FALSE(errors.empty());
     CHECK(errors[0].message.find("lead_beats") != std::string::npos);
-    CHECK(map.beats.empty());
+    CHECK(map.shape_gate_beats.empty());
+    CHECK(map.split_path_beats.empty());
+    CHECK(map.onset_marker_beats.empty());
 }
 
 TEST_CASE("parse: beat without time_sec falls back to beat_times", "[parse][beat_times]") {
@@ -708,9 +720,9 @@ TEST_CASE("parse: beat without time_sec falls back to beat_times", "[parse][beat
     })";
 
     CHECK(parse_beat_map(json, map, errors));
-    REQUIRE(map.beats.size() == 1);
-    CHECK_FALSE(map.beats[0].has_time_sec);
-    CHECK_THAT(map.beats[0].time_sec, Catch::Matchers::WithinAbs(1.4f, 0.001f));
+    REQUIRE(map.shape_gate_beats.size() == 1);
+    CHECK_FALSE(map.shape_gate_beats[0].has_time_sec);
+    CHECK_THAT(map.shape_gate_beats[0].time_sec, Catch::Matchers::WithinAbs(1.4f, 0.001f));
 }
 
 TEST_CASE("parse: beat_times must be finite", "[parse][beat_times][issue995]") {
@@ -775,7 +787,7 @@ TEST_CASE("parse: missing selected difficulty falls back to valid difficulty",
 
     CHECK(parse_beat_map(json, map, errors, "hard"));
     CHECK(map.difficulty == "medium");
-    REQUIRE(map.beats.size() == 1);
+    REQUIRE(map.shape_gate_beats.size() == 1);
     REQUIRE_FALSE(errors.empty());
     CHECK(errors[0].message.find("falling back to 'medium'") != std::string::npos);
 }
@@ -813,7 +825,9 @@ TEST_CASE("parse: malformed selected difficulty fails without fallback",
 
         INFO("difficulty json: " << tc.difficulty_json);
         CHECK_FALSE(parse_beat_map(json, map, errors, "hard"));
-        CHECK(map.beats.empty());
+        CHECK(map.shape_gate_beats.empty());
+        CHECK(map.split_path_beats.empty());
+        CHECK(map.onset_marker_beats.empty());
         REQUIRE_FALSE(errors.empty());
         CHECK(errors[0].message.find(tc.expected_message) != std::string::npos);
     }
@@ -873,10 +887,9 @@ TEST_CASE("parse: split_path loads required shape and lane", "[parse][issue932]"
     })";
 
     CHECK(parse_beat_map(json, map, errors));
-    REQUIRE(map.beats.size() == 1);
-    CHECK(map.beats[0].kind == ObstacleKind::SplitPath);
-    CHECK(map.beats[0].shape == Shape::Triangle);
-    CHECK(map.beats[0].lane == 2);
+    REQUIRE(map.split_path_beats.size() == 1);
+    CHECK(map.split_path_beats[0].shape == Shape::Triangle);
+    CHECK(map.split_path_beats[0].lane == 2);
 }
 
 TEST_CASE("parse: same beat_index entries are ordered by resolved time_sec", "[parse][beat_times][ordering]") {
@@ -897,10 +910,10 @@ TEST_CASE("parse: same beat_index entries are ordered by resolved time_sec", "[p
     })";
 
     REQUIRE(parse_beat_map(json, map, errors));
-    REQUIRE(map.beats.size() == 3);
-    CHECK_THAT(map.beats[0].time_sec, Catch::Matchers::WithinAbs(1.3f, 0.001f));
-    CHECK_THAT(map.beats[1].time_sec, Catch::Matchers::WithinAbs(1.4f, 0.001f));
-    CHECK_THAT(map.beats[2].time_sec, Catch::Matchers::WithinAbs(1.6f, 0.001f));
+    REQUIRE(map.shape_gate_beats.size() == 3);
+    CHECK_THAT(map.shape_gate_beats[0].time_sec, Catch::Matchers::WithinAbs(1.3f, 0.001f));
+    CHECK_THAT(map.shape_gate_beats[1].time_sec, Catch::Matchers::WithinAbs(1.4f, 0.001f));
+    CHECK_THAT(map.shape_gate_beats[2].time_sec, Catch::Matchers::WithinAbs(1.6f, 0.001f));
 }
 
 TEST_CASE("parse: same beat_index entries keep authored order for identical timing", "[parse][beat_times][ordering]") {
@@ -919,9 +932,9 @@ TEST_CASE("parse: same beat_index entries keep authored order for identical timi
     })";
 
     REQUIRE(parse_beat_map(json, map, errors));
-    REQUIRE(map.beats.size() == 2);
-    CHECK(map.beats[0].shape == Shape::Square);
-    CHECK(map.beats[1].shape == Shape::Triangle);
+    REQUIRE(map.shape_gate_beats.size() == 2);
+    CHECK(map.shape_gate_beats[0].shape == Shape::Square);
+    CHECK(map.shape_gate_beats[1].shape == Shape::Triangle);
 }
 
 TEST_CASE("parse: blocked lane arrays are rejected from active beatmaps", "[parse][blocked_mask][issue873]") {
@@ -1036,7 +1049,7 @@ TEST_CASE("validate: unsupported timing range fails before beat range conversion
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = std::numeric_limits<float>::max();
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -1050,8 +1063,8 @@ TEST_CASE("validate: authored time_sec beyond duration fails", "[validate][beat_
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 3.0f;
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0.5f, true});
-    map.beats.push_back({4, ObstacleKind::ShapeGate, Shape::Square, 1, 3.5f, true});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.5f, true});
+    map.shape_gate_beats.push_back({4, Shape::Square, 1, 3.5f, true});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -1065,8 +1078,8 @@ TEST_CASE("validate: authored time_sec must be non-decreasing", "[validate][beat
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 1.2f, true});
-    map.beats.push_back({2, ObstacleKind::ShapeGate, Shape::Circle, 1, 1.1f, true});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 1.2f, true});
+    map.shape_gate_beats.push_back({2, Shape::Circle, 1, 1.1f, true});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -1080,11 +1093,10 @@ TEST_CASE("validate: mixed authored time_sec edge cases are checked", "[validate
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 10.0f;
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0.0f, true});
-    map.beats.push_back({1, ObstacleKind::ShapeGate, Shape::Circle, 1, 0.0f, false});
-    map.beats.push_back({2, ObstacleKind::ShapeGate, Shape::Circle, 1, 1.0f, true});
-    map.beats.push_back({3, ObstacleKind::ShapeGate, Shape::Circle, 1,
-                         std::numeric_limits<float>::quiet_NaN(), true});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, true});
+    map.shape_gate_beats.push_back({1, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_beats.push_back({2, Shape::Circle, 1, 1.0f, true});
+    map.shape_gate_beats.push_back({3, Shape::Circle, 1, std::numeric_limits<float>::quiet_NaN(), true});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -1098,8 +1110,8 @@ TEST_CASE("validate: same beat_index requires non-decreasing resolved time", "[v
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 10.0f;
-    map.beats.push_back({2, ObstacleKind::ShapeGate, Shape::Circle, 1, 1.5f, true});
-    map.beats.push_back({2, ObstacleKind::ShapeGate, Shape::Square, 1, 1.4f, true});
+    map.shape_gate_beats.push_back({2, Shape::Circle, 1, 1.5f, true});
+    map.shape_gate_beats.push_back({2, Shape::Square, 1, 1.4f, true});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -1114,7 +1126,7 @@ TEST_CASE("validate: beat index out of range for beat_times fails", "[validate][
     map.lead_beats = 4;
     map.duration = 60.0f;
     map.beat_times = {0.0f, 0.5f}; // valid indices: 0..1
-    map.beats.push_back({2, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({2, Shape::Circle, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -1129,7 +1141,7 @@ TEST_CASE("validate: beat_times must be finite", "[validate][beat_times][issue99
     map.lead_beats = 4;
     map.duration = 60.0f;
     map.beat_times = {0.0f, std::numeric_limits<float>::infinity()};
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -1144,8 +1156,8 @@ TEST_CASE("validate: beat_times must be non-decreasing", "[validate][beat_times]
     map.lead_beats = 4;
     map.duration = 60.0f;
     map.beat_times = {1.0f, 0.5f};
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
-    map.beats.push_back({1, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_beats.push_back({1, Shape::Circle, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));

--- a/tests/test_beat_scheduler_offset.cpp
+++ b/tests/test_beat_scheduler_offset.cpp
@@ -61,7 +61,7 @@ TEST_CASE("offset_semantics: beat_index=0 arrives at exactly offset", "[beat_sch
     auto& map  = beat_map(reg);
 
     song.offset = 1.5f;
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
 
     advance_to_spawn_all(reg);
 
@@ -76,7 +76,7 @@ TEST_CASE("offset_semantics: beat_index=0 with zero offset arrives at t=0", "[be
     auto& map  = beat_map(reg);
 
     song.offset = 0.0f;
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Square, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Square, 1, 0.0f, false});
 
     advance_to_spawn_all(reg);
 
@@ -96,7 +96,7 @@ TEST_CASE("offset_semantics: beat_index=N arrives at offset + N*period", "[beat_
     song.bpm    = 120.0f;
     song.offset = 0.35f;
     song_state_compute_derived(song);
-    map.beats.push_back({8, ObstacleKind::ShapeGate, Shape::Triangle, 1, 0});
+    map.shape_gate_beats.push_back({8, Shape::Triangle, 1, 0.0f, false});
 
     advance_to_spawn_all(reg);
 
@@ -115,8 +115,8 @@ TEST_CASE("offset_semantics: two beat_indices are exactly period apart", "[beat_
     song.bpm    = 160.0f;
     song.offset = 2.27f;
     song_state_compute_derived(song);
-    map.beats.push_back({10, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
-    map.beats.push_back({11, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({10, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_beats.push_back({11, Shape::Circle, 1, 0.0f, false});
 
     advance_to_spawn_all(reg);
 
@@ -142,7 +142,7 @@ TEST_CASE("offset_semantics: doubling offset shifts arrival by same delta", "[be
         song.bpm    = 120.0f;
         song.offset = offset_val;
         song_state_compute_derived(song);
-        map.beats.push_back({beat_idx, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+        map.shape_gate_beats.push_back({beat_idx, Shape::Circle, 1, 0.0f, false});
         advance_to_spawn_all(reg);
         return single_arrival_time(reg);
     };
@@ -173,7 +173,7 @@ TEST_CASE("offset_semantics: first authored beat_index=N>0 arrives after offset"
 
     // Simulate a typical shipped-beatmap first obstacle (beat_index >= 2)
     const int first_idx = 4;
-    map.beats.push_back({first_idx, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({first_idx, Shape::Circle, 1, 0.0f, false});
 
     advance_to_spawn_all(reg);
 
@@ -203,7 +203,7 @@ TEST_CASE("offset_semantics: offset must not be zero when pipeline sets it from 
     song_state_compute_derived(song);
 
     // First authored obstacle on hard: beat_index = 2
-    map.beats.push_back({2, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({2, Shape::Circle, 1, 0.0f, false});
 
     advance_to_spawn_all(reg);
 
@@ -258,7 +258,7 @@ TEST_CASE("offset_semantics: uniform-beat assumption valid within per-beat toler
     song_state_compute_derived(song);
 
     for (int i = 0; i <= N; i += 10) {
-        map.beats.push_back({i, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+        map.shape_gate_beats.push_back({i, Shape::Circle, 1, 0.0f, false});
     }
 
     advance_to_spawn_all(reg);
@@ -284,7 +284,7 @@ TEST_CASE("offset_semantics: halving BPM doubles all collision intervals", "[bea
         song.bpm    = bpm;
         song.offset = 0.0f;
         song_state_compute_derived(song);
-        map.beats.push_back({beat_idx, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+        map.shape_gate_beats.push_back({beat_idx, Shape::Circle, 1, 0.0f, false});
         advance_to_spawn_all(reg);
         return single_arrival_time(reg);
     };

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -12,7 +12,7 @@ TEST_CASE("beat_scheduler: no spawn when not Playing", "[beat_scheduler]") {
     reg.ctx().get<GameState>().phase = GamePhase::Title;
 
     auto& map = beat_map(reg);
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
 
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 10.0f;
@@ -40,7 +40,7 @@ TEST_CASE("beat_scheduler: no spawn when song not playing", "[beat_scheduler]") 
     reg.ctx().get<SongState>().playing = false;
 
     auto& map = beat_map(reg);
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
 
     beat_scheduler_system(reg, 0.016f);
 
@@ -67,14 +67,15 @@ TEST_CASE("beat_scheduler: spawns ShapeGate when time passes spawn_time", "[beat
     auto& map = beat_map(reg);
 
     // Add a beat at index 0
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
 
     // The spawn_time = offset + beat_index * beat_period - lead_time
     // For beat 0: spawn_time = 0 + 0 * 0.5 - 2.0 = -2.0
     // So any song_time >= -2.0 should trigger spawn
     song.song_time = 0.0f;
-    song.next_spawn_idx = 0;
-
+    song.next_shape_gate_idx = 0;
+    song.next_split_path_idx = 0;
+    song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
     int count = 0;
@@ -97,10 +98,11 @@ TEST_CASE("beat_scheduler: defaults invalid ShapeGate lane to center lane", "[be
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 9, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 9, 0.0f, false});
     song.song_time = 0.0f;
-    song.next_spawn_idx = 0;
-
+    song.next_shape_gate_idx = 0;
+    song.next_split_path_idx = 0;
+    song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
     auto view = reg.view<ObstacleTag, WorldTransform, ShapeGateLane>();
@@ -118,11 +120,12 @@ TEST_CASE("beat_scheduler: does not spawn before spawn_time", "[beat_scheduler]"
     auto& map = beat_map(reg);
 
     // Beat at index 20 — spawn_time = 0 + 20 * 0.5 - 2.0 = 8.0
-    map.beats.push_back({20, ObstacleKind::ShapeGate, Shape::Square, 1, 0});
+    map.shape_gate_beats.push_back({20, Shape::Square, 1, 0.0f, false});
 
     song.song_time = 5.0f;  // Before spawn_time of 8.0
-    song.next_spawn_idx = 0;
-
+    song.next_shape_gate_idx = 0;
+    song.next_split_path_idx = 0;
+    song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
     int count = 0;
@@ -130,18 +133,21 @@ TEST_CASE("beat_scheduler: does not spawn before spawn_time", "[beat_scheduler]"
     CHECK(count == 0);
 }
 
-TEST_CASE("beat_scheduler: increments next_spawn_idx after spawn", "[beat_scheduler]") {
+TEST_CASE("beat_scheduler: increments per-kind cursor after spawn", "[beat_scheduler]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
     song.song_time = 10.0f;
-    song.next_spawn_idx = 0;
-
+    song.next_shape_gate_idx = 0;
+    song.next_split_path_idx = 0;
+    song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
-    CHECK(song.next_spawn_idx == 1);
+    CHECK(song.next_shape_gate_idx == 1);
+    CHECK(song.next_split_path_idx == 0);
+    CHECK(song.next_onset_marker_idx == 0);
 }
 
 TEST_CASE("beat_scheduler: uses beat_times array for arrival time when present",
@@ -154,10 +160,12 @@ TEST_CASE("beat_scheduler: uses beat_times array for arrival time when present",
     song.bpm = 120.0f;
     song_state_compute_derived(song);
     map.beat_times = {0.3f, 0.85f, 1.47f};
-    map.beats.push_back({2, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({2, Shape::Circle, 1, 0.0f, false});
 
     song.song_time = 0.0f;
-    song.next_spawn_idx = 0;
+    song.next_shape_gate_idx = 0;
+    song.next_split_path_idx = 0;
+    song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
     auto view = reg.view<ObstacleTag, BeatInfo>();
@@ -181,15 +189,16 @@ TEST_CASE("beat_scheduler: uses BeatEntry time_sec for arrival time when authore
 
     BeatEntry authored_entry;
     authored_entry.beat_index = 2;
-    authored_entry.kind = ObstacleKind::ShapeGate;
     authored_entry.shape = Shape::Circle;
     authored_entry.lane = 1;
     authored_entry.time_sec = 1.33f;
     authored_entry.has_time_sec = true;
-    map.beats.push_back(authored_entry);
+    map.shape_gate_beats.push_back(authored_entry);
 
     song.song_time = 0.0f;
-    song.next_spawn_idx = 0;
+    song.next_shape_gate_idx = 0;
+    song.next_split_path_idx = 0;
+    song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
     auto view = reg.view<ObstacleTag, BeatInfo>();
@@ -211,10 +220,12 @@ TEST_CASE("beat_scheduler: falls back to beat_times when BeatEntry time_sec is a
     song.bpm = 120.0f;
     song_state_compute_derived(song);
     map.beat_times = {0.3f, 0.85f, 1.47f};
-    map.beats.push_back({2, ObstacleKind::ShapeGate, Shape::Circle, 1, 99.0f, false});
+    map.shape_gate_beats.push_back({2, Shape::Circle, 1, 99.0f, false});
 
     song.song_time = 30.0f;
-    song.next_spawn_idx = 0;
+    song.next_shape_gate_idx = 0;
+    song.next_split_path_idx = 0;
+    song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
     auto view = reg.view<ObstacleTag, BeatInfo>();
@@ -250,7 +261,9 @@ TEST_CASE("beat_scheduler: same beat_index honors authored time_sec ordering",
     // Spawn window reached for 1.3s arrival (spawn at -0.7), but not yet for
     // 1.7s arrival (spawn at -0.3).
     song.song_time = -0.5f;
-    song.next_spawn_idx = 0;
+    song.next_shape_gate_idx = 0;
+    song.next_split_path_idx = 0;
+    song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
     auto view = reg.view<ObstacleTag, BeatInfo, RequiredShape>();
@@ -267,20 +280,23 @@ TEST_CASE("beat_scheduler: spawns multiple beats when time is past all", "[beat_
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
-    map.beats.push_back({2, ObstacleKind::ShapeGate, Shape::Square, 1, 0});
-    map.beats.push_back({4, ObstacleKind::OnsetMarker, Shape::Circle, 1, 0});
-    map.beats.push_back({6, ObstacleKind::ShapeGate, Shape::Triangle, 2, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_beats.push_back({2, Shape::Square, 1, 0.0f, false});
+    map.onset_marker_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_beats.push_back({6, Shape::Triangle, 2, 0.0f, false});
 
     song.song_time = 30.0f;  // Well past all spawn times
-    song.next_spawn_idx = 0;
-
+    song.next_shape_gate_idx = 0;
+    song.next_split_path_idx = 0;
+    song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
     int count = 0;
     for (auto e : reg.view<ObstacleTag>()) { ++count; (void)e; }
     CHECK(count == 4);
-    CHECK(song.next_spawn_idx == 4);
+    CHECK(song.next_shape_gate_idx == 3);
+    CHECK(song.next_onset_marker_idx == 1);
+    CHECK(song.next_split_path_idx == 0);
 }
 
 // ── beat_scheduler: obstacle types ───────────────────────────
@@ -294,10 +310,11 @@ TEST_CASE("beat_scheduler: spawns OnsetMarker as visible non-scorable cue",
     auto& energy = reg.ctx().get<EnergyState>();
     auto& results = reg.ctx().get<SongResults>();
 
-    map.beats.push_back({0, ObstacleKind::OnsetMarker, Shape::Circle, 1, 0});
+    map.onset_marker_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
     song.song_time = 10.0f;
-    song.next_spawn_idx = 0;
-
+    song.next_shape_gate_idx = 0;
+    song.next_split_path_idx = 0;
+    song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
     auto view = reg.view<ObstacleTag, OnsetMarkerTag, NonScorableTag, Obstacle,
@@ -339,7 +356,7 @@ TEST_CASE("beat_scheduler: spawns OnsetMarker as visible non-scorable cue",
     CHECK(score.chain_count == chain_before);
     CHECK(energy.energy == energy_before);
     CHECK(results.miss_count == misses_before);
-    CHECK(song.next_spawn_idx == 1);
+    CHECK(song.next_onset_marker_idx == 1);
 }
 
 TEST_CASE("beat_scheduler: spawns SplitPath in authored lane", "[beat_scheduler][issue932]") {
@@ -347,10 +364,11 @@ TEST_CASE("beat_scheduler: spawns SplitPath in authored lane", "[beat_scheduler]
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.beats.push_back({0, ObstacleKind::SplitPath, Shape::Triangle, 2, 0});
+    map.split_path_beats.push_back({0, Shape::Triangle, 2, 0.0f, false});
     song.song_time = 10.0f;
-    song.next_spawn_idx = 0;
-
+    song.next_shape_gate_idx = 0;
+    song.next_split_path_idx = 0;
+    song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
     auto view = reg.view<ObstacleTag, WorldTransform, RequiredShape, RequiredLane>();
@@ -361,7 +379,7 @@ TEST_CASE("beat_scheduler: spawns SplitPath in authored lane", "[beat_scheduler]
         CHECK(shape.shape == Shape::Triangle);
         CHECK(lane.lane == 2);
     }
-    CHECK(song.next_spawn_idx == 1);
+    CHECK(song.next_split_path_idx == 1);
 }
 
 TEST_CASE("beat_scheduler: defaults invalid SplitPath lane to center lane", "[beat_scheduler][issue1046]") {
@@ -369,10 +387,11 @@ TEST_CASE("beat_scheduler: defaults invalid SplitPath lane to center lane", "[be
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.beats.push_back({0, ObstacleKind::SplitPath, Shape::Square, 9, 0});
+    map.split_path_beats.push_back({0, Shape::Square, 9, 0.0f, false});
     song.song_time = 10.0f;
-    song.next_spawn_idx = 0;
-
+    song.next_shape_gate_idx = 0;
+    song.next_split_path_idx = 0;
+    song.next_onset_marker_idx = 0;
     CHECK_NOTHROW(beat_scheduler_system(reg, 0.016f));
 
     auto view = reg.view<ObstacleTag, WorldTransform, RequiredShape, RequiredLane, ObstacleChildren>();
@@ -388,7 +407,7 @@ TEST_CASE("beat_scheduler: defaults invalid SplitPath lane to center lane", "[be
             CHECK(reg.all_of<MeshChild>(children.children[i]));
         }
     }
-    CHECK(song.next_spawn_idx == 1);
+    CHECK(song.next_split_path_idx == 1);
 }
 
 TEST_CASE("beat_scheduler: spawns all queued beats from BeatMap entries", "[beat_scheduler]") {
@@ -396,12 +415,13 @@ TEST_CASE("beat_scheduler: spawns all queued beats from BeatMap entries", "[beat
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Square, 1, 0});
-    map.beats.push_back({0, ObstacleKind::OnsetMarker, Shape::Circle, 1, 0});
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Triangle, 2, 0});
+    map.shape_gate_beats.push_back({0, Shape::Square, 1, 0.0f, false});
+    map.onset_marker_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_beats.push_back({0, Shape::Triangle, 2, 0.0f, false});
     song.song_time = 10.0f;
-    song.next_spawn_idx = 0;
-
+    song.next_shape_gate_idx = 0;
+    song.next_split_path_idx = 0;
+    song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
     auto obstacle_view = reg.view<ObstacleTag, Obstacle>();
@@ -414,7 +434,9 @@ TEST_CASE("beat_scheduler: spawns all queued beats from BeatMap entries", "[beat
     }
     CHECK(obstacle_count == 3);
     CHECK(shape_gate_count == 2);
-    CHECK(song.next_spawn_idx == 3);
+    CHECK(song.next_shape_gate_idx == 2);
+    CHECK(song.next_onset_marker_idx == 1);
+    CHECK(song.next_split_path_idx == 0);
 }
 
 TEST_CASE("beat_scheduler: all spawned obstacles have BeatInfo", "[beat_scheduler]") {
@@ -422,10 +444,11 @@ TEST_CASE("beat_scheduler: all spawned obstacles have BeatInfo", "[beat_schedule
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.beats.push_back({4, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
     song.song_time = 30.0f;
-    song.next_spawn_idx = 0;
-
+    song.next_shape_gate_idx = 0;
+    song.next_split_path_idx = 0;
+    song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
     auto view = reg.view<ObstacleTag, BeatInfo>();
@@ -443,10 +466,11 @@ TEST_CASE("beat_scheduler: obstacles spawn with overshoot compensation", "[beat_
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
     song.song_time = 10.0f;
-    song.next_spawn_idx = 0;
-
+    song.next_shape_gate_idx = 0;
+    song.next_split_path_idx = 0;
+    song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
     // Obstacle should spawn below SPAWN_Y to compensate for late spawn.
@@ -462,10 +486,11 @@ TEST_CASE("beat_scheduler: rhythm obstacles omit Vector2", "[beat_scheduler]") {
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
     song.song_time = 10.0f;
-    song.next_spawn_idx = 0;
-
+    song.next_shape_gate_idx = 0;
+    song.next_split_path_idx = 0;
+    song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
     auto view = reg.view<ObstacleTag, BeatInfo>();
@@ -483,10 +508,11 @@ TEST_CASE("beat_scheduler: ShapeGate Circle has blue color", "[beat_scheduler]")
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
     song.song_time = 10.0f;
-    song.next_spawn_idx = 0;
-
+    song.next_shape_gate_idx = 0;
+    song.next_split_path_idx = 0;
+    song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
     auto view = reg.view<ObstacleTag, Color>();
@@ -502,10 +528,11 @@ TEST_CASE("beat_scheduler: ShapeGate Square has red color", "[beat_scheduler]") 
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Square, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Square, 1, 0.0f, false});
     song.song_time = 10.0f;
-    song.next_spawn_idx = 0;
-
+    song.next_shape_gate_idx = 0;
+    song.next_split_path_idx = 0;
+    song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
     auto view = reg.view<ObstacleTag, Color>();
@@ -521,10 +548,11 @@ TEST_CASE("beat_scheduler: ShapeGate Triangle has green color", "[beat_scheduler
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Triangle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Triangle, 1, 0.0f, false});
     song.song_time = 10.0f;
-    song.next_spawn_idx = 0;
-
+    song.next_shape_gate_idx = 0;
+    song.next_split_path_idx = 0;
+    song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
     auto view = reg.view<ObstacleTag, Color>();
@@ -540,10 +568,11 @@ TEST_CASE("beat_scheduler: ShapeGate Hexagon has hexagon color", "[beat_schedule
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Hexagon, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Hexagon, 1, 0.0f, false});
     song.song_time = 10.0f;
-    song.next_spawn_idx = 0;
-
+    song.next_shape_gate_idx = 0;
+    song.next_split_path_idx = 0;
+    song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
     auto view = reg.view<ObstacleTag, Color>();
@@ -566,11 +595,12 @@ TEST_CASE("beat_scheduler: clamped late-spawn stores adjusted spawn_time in Beat
     auto& map = beat_map(reg);
 
     // Use beat 0 whose spawn_time is deeply in the past
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
     // Set song_time so the overshoot pushes start_y well past PLAYER_Y
     song.song_time = 100.0f;
-    song.next_spawn_idx = 0;
-
+    song.next_shape_gate_idx = 0;
+    song.next_split_path_idx = 0;
+    song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
     float max_start_y = constants::PLAYER_Y;
@@ -596,26 +626,33 @@ TEST_CASE("beat_scheduler: invalid scroll_speed skips late-spawn division", "[be
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.beats.push_back({0, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
     song.song_time = 100.0f;
     song.scroll_speed = 0.0f;
-    song.next_spawn_idx = 0;
-
+    song.next_shape_gate_idx = 0;
+    song.next_split_path_idx = 0;
+    song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
-    CHECK(song.next_spawn_idx == 0);
+    CHECK(song.next_shape_gate_idx == 0);
+    CHECK(song.next_split_path_idx == 0);
+    CHECK(song.next_onset_marker_idx == 0);
     CHECK(reg.view<ObstacleTag>().begin() == reg.view<ObstacleTag>().end());
     CHECK(reg.view<ObstacleTag, BeatInfo>().begin() == reg.view<ObstacleTag, BeatInfo>().end());
 
     song.scroll_speed = -1.0f;
     beat_scheduler_system(reg, 0.016f);
 
-    CHECK(song.next_spawn_idx == 0);
+    CHECK(song.next_shape_gate_idx == 0);
+    CHECK(song.next_split_path_idx == 0);
+    CHECK(song.next_onset_marker_idx == 0);
     CHECK(reg.view<ObstacleTag>().begin() == reg.view<ObstacleTag>().end());
 
     song.scroll_speed = std::numeric_limits<float>::quiet_NaN();
     beat_scheduler_system(reg, 0.016f);
 
-    CHECK(song.next_spawn_idx == 0);
+    CHECK(song.next_shape_gate_idx == 0);
+    CHECK(song.next_split_path_idx == 0);
+    CHECK(song.next_onset_marker_idx == 0);
     CHECK(reg.view<ObstacleTag>().begin() == reg.view<ObstacleTag>().end());
 }

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -279,8 +279,8 @@ TEST_CASE("ecs: make_split_path creates proper entity", "[ecs]") {
     CHECK(reg.all_of<Obstacle>(obs));
     CHECK(reg.all_of<RequiredShape>(obs));
     CHECK(reg.all_of<RequiredLane>(obs));
-    CHECK(obstacle_kind_from_components(reg.all_of<RequiredShape>(obs),
-                                        reg.all_of<RequiredLane>(obs)) == ObstacleKind::SplitPath);
+    CHECK(reg.all_of<SplitPathTag>(obs));
+    CHECK(!reg.all_of<ShapeGateTag>(obs));
     CHECK(reg.get<RequiredShape>(obs).shape == Shape::Triangle);
     CHECK(reg.get<RequiredLane>(obs).lane == 2);
 }
@@ -361,7 +361,7 @@ TEST_CASE("ecs: obstacle mesh lifecycle explicit cleanup is idempotent",
           "[ecs][obstacle][lifecycle]") {
     entt::registry reg;
 
-    auto parent = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f, Shape::Circle});
+    auto parent = spawn_shape_gate_obstacle(reg, {360.0f, -120.0f, Shape::Circle});
     REQUIRE(mesh_child_count(reg) > 0);
 
     destroy_obstacle_with_children(reg, parent);

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -4,6 +4,7 @@
 #include "components/transform.h"
 #include "components/player.h"
 #include "components/obstacle.h"
+#include "tags/tags.h"
 #include "systems/input.h"
 #include "systems/input_events.h"
 #include "components/game_state.h"
@@ -259,6 +260,7 @@ inline entt::entity make_shape_gate(entt::registry& reg, Shape shape, float y) {
     const auto& song = reg.ctx().get<SongState>();
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
+    reg.emplace<ShapeGateTag>(obs);
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], y}});
     reg.emplace<Vector2>(obs, Vector2{0.0f, song.scroll_speed});
     reg.emplace<Obstacle>(obs, int16_t{constants::PTS_SHAPE_GATE});
@@ -275,6 +277,7 @@ inline entt::entity make_split_path(entt::registry& reg, Shape shape, int8_t lan
     const auto& song = reg.ctx().get<SongState>();
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
+    reg.emplace<SplitPathTag>(obs);
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], y}});
     reg.emplace<Vector2>(obs, Vector2{0.0f, song.scroll_speed});
     reg.emplace<Obstacle>(obs, int16_t{constants::PTS_SPLIT_PATH});

--- a/tests/test_helpers_and_functions.cpp
+++ b/tests/test_helpers_and_functions.cpp
@@ -144,11 +144,10 @@ TEST_CASE("ToString: Shape covers all shapes", "[ToString]") {
     CHECK(magic_enum::enum_name(Shape::Hexagon)  == "Hexagon");
 }
 
-TEST_CASE("ToString: ObstacleKind covers all kinds", "[ToString]") {
-    CHECK(magic_enum::enum_name(ObstacleKind::ShapeGate) == "ShapeGate");
-    CHECK(magic_enum::enum_name(ObstacleKind::SplitPath) == "SplitPath");
-    CHECK(magic_enum::enum_name(ObstacleKind::OnsetMarker) == "OnsetMarker");
-}
+// ObstacleKind enum was eradicated in issue #1202/#1204 (per Fabian's
+// existential processing); each former value is now a zero-column tag
+// (ShapeGateTag/SplitPathTag/OnsetMarkerTag) and the magic_enum
+// reflection check no longer applies.
 
 // TimingTier enum was eradicated in issue #1202/#1204 (per Fabian's existential
 // processing); each former value is now a zero-column tag in app/tags/tags.h

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -39,13 +39,8 @@ struct TempBeatMapFile {
 };
 
 int count_result_notes(const BeatMap& beatmap) {
-    int total = 0;
-    for (const BeatEntry& beat : beatmap.beats) {
-        if (beat.kind != ObstacleKind::OnsetMarker) {
-            ++total;
-        }
-    }
-    return total;
+    return static_cast<int>(beatmap.shape_gate_beats.size() +
+                            beatmap.split_path_beats.size());
 }
 
 int count_mesh_children(entt::registry& reg) {
@@ -97,7 +92,7 @@ TEST_CASE("Play session: invalid level-select indices fall back before content l
 TEST_CASE("Play session: restart clears obstacle mesh children without stale listener state",
           "[play_session][issue957]") {
     auto reg = make_registry();
-    auto obstacle = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f, Shape::Circle});
+    auto obstacle = spawn_shape_gate_obstacle(reg, {360.0f, -120.0f, Shape::Circle});
     REQUIRE(reg.all_of<ObstacleChildren>(obstacle));
     const auto children = reg.get<ObstacleChildren>(obstacle);
     REQUIRE(children.count > 0);
@@ -110,7 +105,7 @@ TEST_CASE("Play session: restart clears obstacle mesh children without stale lis
     CHECK_FALSE(reg.valid(first_child));
     CHECK(count_mesh_children(reg) == 0);
 
-    auto next_obstacle = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f, Shape::Square});
+    auto next_obstacle = spawn_shape_gate_obstacle(reg, {360.0f, -120.0f, Shape::Square});
     REQUIRE(count_mesh_children(reg) > 0);
 
     destroy_obstacle_with_children(reg, next_obstacle);
@@ -136,7 +131,12 @@ TEST_CASE("Play session: missing selected beatmap returns to level select withou
 
     CHECK(gs.phase == GamePhase::LevelSelect);
     CHECK_FALSE(lss.confirmed);
-    CHECK(beat_map(reg).beats.empty());
+    {
+        const auto& bm = beat_map(reg);
+        CHECK(bm.shape_gate_beats.empty());
+        CHECK(bm.split_path_beats.empty());
+        CHECK(bm.onset_marker_beats.empty());
+    }
     CHECK(reg.view<PlayerTag>().empty());
     CHECK(reg.ctx().find<ScoreState>() == nullptr);
     CHECK(session.key_hash == 0);
@@ -200,9 +200,11 @@ TEST_CASE("Play session: SongResults total_notes excludes onset marker metadata"
             setup_play_session(reg);
 
             const auto& beatmap = beat_map(reg);
-            REQUIRE_FALSE(beatmap.beats.empty());
-            saw_onset_marker = saw_onset_marker || (count_result_notes(beatmap)
-                != static_cast<int>(beatmap.beats.size()));
+            const size_t total_beats = beatmap.shape_gate_beats.size() +
+                                       beatmap.split_path_beats.size() +
+                                       beatmap.onset_marker_beats.size();
+            REQUIRE(total_beats > 0);
+            saw_onset_marker = saw_onset_marker || !beatmap.onset_marker_beats.empty();
 
             CAPTURE(content_config::LEVELS[level].title);
             CAPTURE(content_config::DIFFICULTY_KEYS[difficulty]);

--- a/tests/test_obstacle_archetypes.cpp
+++ b/tests/test_obstacle_archetypes.cpp
@@ -2,6 +2,7 @@
 #include "test_helpers.h"
 #include "entities/obstacle_entity.h"
 #include "entities/obstacle_render_entity.h"
+#include "tags/tags.h"
 
 #include <stdexcept>
 
@@ -49,7 +50,7 @@ void check_no_mesh_children(entt::registry& reg, entt::entity parent) {
 
 TEST_CASE("entity: ShapeGate Circle - correct components and color", "[archetype]") {
     entt::registry reg;
-    auto e = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f, Shape::Circle});
+    auto e = spawn_shape_gate_obstacle(reg, {360.0f, -120.0f, Shape::Circle});
 
     REQUIRE(reg.all_of<ObstacleTag, Vector2, WorldTransform, Obstacle, RequiredShape, ShapeGateLane, DrawSize, Color>(e));
     CHECK(!reg.all_of<uint8_t>(e));
@@ -71,7 +72,7 @@ TEST_CASE("entity: ObstacleTag is emplaced after obstacle metadata", "[archetype
     reg.on_construct<ObstacleTag>().connect<&probe_obstacle_tag_construct>();
     BeatInfo beat_info{7, 1.5f, 0.25f};
 
-    spawn_rhythm_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f, Shape::Circle}, beat_info);
+    spawn_shape_gate_rhythm(reg, {360.0f, -120.0f, Shape::Circle}, beat_info);
 
     CHECK(probe.saw_obstacle);
     CHECK(probe.saw_beat_info);
@@ -79,7 +80,7 @@ TEST_CASE("entity: ObstacleTag is emplaced after obstacle metadata", "[archetype
 
 TEST_CASE("entity: obstacle roots and mesh children declare world render pass", "[archetype][render]") {
     entt::registry reg;
-    auto e = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f, Shape::Circle});
+    auto e = spawn_shape_gate_obstacle(reg, {360.0f, -120.0f, Shape::Circle});
 
     CHECK(reg.all_of<TagWorldPass>(e));
     REQUIRE(reg.all_of<ObstacleChildren>(e));
@@ -112,6 +113,7 @@ TEST_CASE("entity: obstacle mesh overflow does not create orphan MeshChild", "[a
         children.children[children.count++] = child;
     }
     reg.emplace<ObstacleTag>(parent);
+    reg.emplace<ShapeGateTag>(parent);
 
     CHECK(count_mesh_children(reg) == ObstacleChildren::MAX);
     CHECK_THROWS_AS(spawn_obstacle_meshes(reg, parent), std::logic_error);
@@ -125,7 +127,7 @@ TEST_CASE("entity: obstacle mesh overflow does not create orphan MeshChild", "[a
 
 TEST_CASE("entity: obstacle mesh lifetime helper cleans factory children", "[archetype][render][cleanup]") {
     entt::registry reg;
-    auto parent = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f, Shape::Circle});
+    auto parent = spawn_shape_gate_obstacle(reg, {360.0f, -120.0f, Shape::Circle});
 
     REQUIRE(count_mesh_children(reg) > 0);
 
@@ -139,6 +141,7 @@ TEST_CASE("entity: direct mesh factory cleanup does not depend on ObstacleTag or
     auto parent = make_mesh_factory_obstacle(reg);
     reg.emplace<RequiredShape>(parent, Shape::Circle);
     reg.emplace<ObstacleTag>(parent);
+    reg.emplace<ShapeGateTag>(parent);
 
     spawn_obstacle_meshes(reg, parent);
     REQUIRE(count_mesh_children(reg) > 0);
@@ -155,6 +158,7 @@ TEST_CASE("entity: mesh factory rejects invalid RequiredShape before children", 
         entt::registry reg;
         auto parent = make_mesh_factory_obstacle(reg);
         reg.emplace<RequiredShape>(parent, invalid_shape);
+        reg.emplace<ShapeGateTag>(parent);
 
         CHECK_THROWS_AS(spawn_obstacle_meshes(reg, parent), std::logic_error);
         check_no_mesh_children(reg, parent);
@@ -165,6 +169,7 @@ TEST_CASE("entity: mesh factory rejects invalid RequiredShape before children", 
         auto parent = make_mesh_factory_obstacle(reg);
         reg.emplace<RequiredShape>(parent, invalid_shape);
         reg.emplace<RequiredLane>(parent, int8_t{1});
+        reg.emplace<SplitPathTag>(parent);
 
         CHECK_THROWS_AS(spawn_obstacle_meshes(reg, parent), std::logic_error);
         check_no_mesh_children(reg, parent);
@@ -177,6 +182,7 @@ TEST_CASE("entity: mesh factory rejects invalid RequiredLane before children", "
         auto parent = make_mesh_factory_obstacle(reg);
         reg.emplace<RequiredShape>(parent, Shape::Square);
         reg.emplace<RequiredLane>(parent, int8_t{-1});
+        reg.emplace<SplitPathTag>(parent);
 
         CHECK_THROWS_AS(spawn_obstacle_meshes(reg, parent), std::logic_error);
         check_no_mesh_children(reg, parent);
@@ -187,6 +193,7 @@ TEST_CASE("entity: mesh factory rejects invalid RequiredLane before children", "
         auto parent = make_mesh_factory_obstacle(reg);
         reg.emplace<RequiredShape>(parent, Shape::Square);
         reg.emplace<RequiredLane>(parent, int8_t{3});
+        reg.emplace<SplitPathTag>(parent);
 
         CHECK_THROWS_AS(spawn_obstacle_meshes(reg, parent), std::logic_error);
         check_no_mesh_children(reg, parent);
@@ -198,7 +205,7 @@ TEST_CASE("entity: spawn_obstacle rejects invalid ShapeGate shape before indexin
     entt::registry reg;
     const Shape invalid_shape = static_cast<Shape>(255);
 
-    CHECK_THROWS_AS(spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f, invalid_shape}),
+    CHECK_THROWS_AS(spawn_shape_gate_obstacle(reg, {360.0f, -120.0f, invalid_shape}),
                     std::logic_error);
     CHECK(count_mesh_children(reg) == 0);
 }
@@ -207,8 +214,8 @@ TEST_CASE("entity: spawn_obstacle rejects invalid SplitPath lane before creating
           "[archetype][validation][issue1046]") {
     entt::registry reg;
 
-    CHECK_THROWS_AS(spawn_obstacle(reg, {ObstacleKind::SplitPath, 360.0f, -120.0f,
-                                         Shape::Square, int8_t{3}}),
+    CHECK_THROWS_AS(spawn_split_path_obstacle(reg, {360.0f, -120.0f,
+                                                    Shape::Square, int8_t{3}}),
                     std::logic_error);
     CHECK(reg.view<ObstacleTag>().begin() == reg.view<ObstacleTag>().end());
     CHECK(reg.view<WorldTransform>().begin() == reg.view<WorldTransform>().end());
@@ -217,7 +224,7 @@ TEST_CASE("entity: spawn_obstacle rejects invalid SplitPath lane before creating
 
 TEST_CASE("entity: ShapeGate Square - red color", "[archetype]") {
     entt::registry reg;
-    auto e = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 60.0f, -120.0f, Shape::Square});
+    auto e = spawn_shape_gate_obstacle(reg, {60.0f, -120.0f, Shape::Square});
 
     auto& c = reg.get<Color>(e);
     CHECK(c.r == 255); CHECK(c.g == 100); CHECK(c.b == 100);
@@ -225,7 +232,7 @@ TEST_CASE("entity: ShapeGate Square - red color", "[archetype]") {
 
 TEST_CASE("entity: ShapeGate Triangle - green color", "[archetype]") {
     entt::registry reg;
-    auto e = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 60.0f, -120.0f, Shape::Triangle});
+    auto e = spawn_shape_gate_obstacle(reg, {60.0f, -120.0f, Shape::Triangle});
 
     auto& c = reg.get<Color>(e);
     CHECK(c.r == 100); CHECK(c.g == 255); CHECK(c.b == 100);
@@ -233,8 +240,8 @@ TEST_CASE("entity: ShapeGate Triangle - green color", "[archetype]") {
 
 TEST_CASE("entity: SplitPath - RequiredShape and RequiredLane", "[archetype]") {
     entt::registry reg;
-    auto e = spawn_obstacle(reg, {ObstacleKind::SplitPath, 360.0f, -120.0f,
-                                   Shape::Square, int8_t{2}});
+    auto e = spawn_split_path_obstacle(reg, {360.0f, -120.0f,
+                                              Shape::Square, int8_t{2}});
 
     REQUIRE(reg.all_of<ObstacleTag, Vector2, WorldTransform, Obstacle, RequiredShape, RequiredLane, DrawSize, Color>(e));
     CHECK(!reg.all_of<uint8_t>(e));
@@ -247,7 +254,7 @@ TEST_CASE("entity: SplitPath - RequiredShape and RequiredLane", "[archetype]") {
 
 TEST_CASE("entity: ShapeGate position x/y propagated from input", "[archetype]") {
     entt::registry reg;
-    auto e = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 123.5f, 456.7f});
+    auto e = spawn_shape_gate_obstacle(reg, {123.5f, 456.7f});
 
     auto& transform = reg.get<WorldTransform>(e);
     CHECK(transform.position.x == 123.5f);
@@ -257,7 +264,7 @@ TEST_CASE("entity: ShapeGate position x/y propagated from input", "[archetype]")
 TEST_CASE("entity: BeatInfo emplaced when provided", "[archetype]") {
     entt::registry reg;
     const BeatInfo bi{5, 1.5f, 1.0f};
-    auto e = spawn_rhythm_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f}, bi);
+    auto e = spawn_shape_gate_rhythm(reg, {360.0f, -120.0f}, bi);
 
     REQUIRE(reg.all_of<BeatInfo>(e));
     CHECK_FALSE(reg.all_of<Vector2>(e));
@@ -268,7 +275,7 @@ TEST_CASE("entity: BeatInfo emplaced when provided", "[archetype]") {
 
 TEST_CASE("entity: no BeatInfo when not provided", "[archetype]") {
     entt::registry reg;
-    auto e = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f});
+    auto e = spawn_shape_gate_obstacle(reg, {360.0f, -120.0f});
 
     CHECK_FALSE(reg.all_of<BeatInfo>(e));
     CHECK(reg.all_of<Vector2>(e));

--- a/tests/test_perspective.cpp
+++ b/tests/test_perspective.cpp
@@ -141,7 +141,7 @@ TEST_CASE("game_camera_system drops mesh children for destroyed logical obstacle
     entt::registry reg;
     reg.ctx().emplace<ShapeMeshConfig>();
     reg.ctx().emplace<FloorParams>();
-    auto parent = spawn_obstacle(reg, {ObstacleKind::ShapeGate, 360.0f, -120.0f, Shape::Circle});
+    auto parent = spawn_shape_gate_obstacle(reg, {360.0f, -120.0f, Shape::Circle});
     REQUIRE(reg.all_of<ObstacleChildren>(parent));
     const auto children = reg.get<ObstacleChildren>(parent);
     REQUIRE(children.count > 0);

--- a/tests/test_pr43_regression.cpp
+++ b/tests/test_pr43_regression.cpp
@@ -87,8 +87,7 @@ TEST_CASE("MeshChild: depth field stores DrawSize.h (scroll-axis) for OnsetMarke
     using Catch::Matchers::WithinAbs;
 
     auto reg = make_registry();
-    auto obs = spawn_obstacle(reg, {ObstacleKind::OnsetMarker, constants::LANE_X[1], 500.0f,
-                                    Shape::Circle, int8_t{1}, 100.0f});
+    auto obs = spawn_onset_marker_obstacle(reg, {constants::LANE_X[1], 500.0f, 100.0f});
 
     const float expected_depth  = reg.get<DrawSize>(obs).h;
     const float expected_height = constants::OBSTACLE_3D_HEIGHT;
@@ -112,8 +111,7 @@ TEST_CASE("MeshChild: depth/height fields are distinct values (non-trivially int
     // constants are different so the slab_matrix arg-swap produces a visible
     // change and our field-contract test is meaningful.
     auto reg = make_registry();
-    auto obs = spawn_obstacle(reg, {ObstacleKind::OnsetMarker, constants::LANE_X[1], 500.0f,
-                                    Shape::Circle, int8_t{1}, 100.0f});
+    auto obs = spawn_onset_marker_obstacle(reg, {constants::LANE_X[1], 500.0f, 100.0f});
 
     const float dsz_h = reg.get<DrawSize>(obs).h;
     // DrawSize.h for an onset-marker (80) must differ from OBSTACLE_3D_HEIGHT (20).

--- a/tests/test_rhythm_system.cpp
+++ b/tests/test_rhythm_system.cpp
@@ -30,12 +30,11 @@ TEST_CASE("beatmap: parse minimal valid JSON", "[rhythm][beatmap]") {
     CHECK(map.bpm == 120.0f);
     CHECK(map.offset == 0.2f);
     CHECK(map.lead_beats == 4);
-    CHECK(map.beats.size() == 2);
-    CHECK(map.beats[0].beat_index == 4);
-    CHECK(map.beats[0].kind == ObstacleKind::ShapeGate);
-    CHECK(map.beats[0].shape == Shape::Circle);
-    CHECK(map.beats[1].beat_index == 8);
-    CHECK(map.beats[1].shape == Shape::Triangle);
+    CHECK(map.shape_gate_beats.size() == 2);
+    CHECK(map.shape_gate_beats[0].beat_index == 4);
+    CHECK(map.shape_gate_beats[0].shape == Shape::Circle);
+    CHECK(map.shape_gate_beats[1].beat_index == 8);
+    CHECK(map.shape_gate_beats[1].shape == Shape::Triangle);
 }
 
 TEST_CASE("beatmap: parse active obstacle kinds", "[rhythm][beatmap][issue873]") {
@@ -50,9 +49,10 @@ TEST_CASE("beatmap: parse active obstacle kinds", "[rhythm][beatmap][issue873]")
     })";
 
     REQUIRE(parse_beat_map(json, map, errors));
-    REQUIRE(map.beats.size() == 2);
-    CHECK(map.beats[0].kind == ObstacleKind::ShapeGate);
-    CHECK(map.beats[1].kind == ObstacleKind::OnsetMarker);
+    REQUIRE(map.shape_gate_beats.size() == 1);
+    REQUIRE(map.onset_marker_beats.size() == 1);
+    CHECK(map.shape_gate_beats[0].beat_index == 4);
+    CHECK(map.onset_marker_beats[0].beat_index == 8);
 }
 
 TEST_CASE("beatmap: tempo_changes in JSON are ignored", "[rhythm][beatmap]") {
@@ -70,7 +70,7 @@ TEST_CASE("beatmap: tempo_changes in JSON are ignored", "[rhythm][beatmap]") {
 
     REQUIRE(parse_beat_map(json, map, errors));
     CHECK(map.bpm == 120.0f);
-    CHECK(map.beats.size() == 1);
+    CHECK(map.shape_gate_beats.size() == 1);
 }
 
 TEST_CASE("beatmap: invalid JSON returns error", "[rhythm][beatmap]") {
@@ -93,9 +93,10 @@ TEST_CASE("beatmap: beats sorted by beat_index", "[rhythm][beatmap]") {
     })";
 
     REQUIRE(parse_beat_map(json, map, errors));
-    CHECK(map.beats[0].beat_index == 4);
-    CHECK(map.beats[1].beat_index == 8);
-    CHECK(map.beats[2].beat_index == 12);
+    REQUIRE(map.shape_gate_beats.size() == 3);
+    CHECK(map.shape_gate_beats[0].beat_index == 4);
+    CHECK(map.shape_gate_beats[1].beat_index == 8);
+    CHECK(map.shape_gate_beats[2].beat_index == 12);
 }
 
 // Beat Map Validation
@@ -103,7 +104,7 @@ TEST_CASE("beatmap: beats sorted by beat_index", "[rhythm][beatmap]") {
 TEST_CASE("beatmap: validate BPM range", "[rhythm][beatmap]") {
     BeatMap map;
     map.bpm = 50.0f; map.offset = 0.0f; map.lead_beats = 4; map.duration = 60.0f;
-    map.beats.push_back({4, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
 
@@ -117,7 +118,7 @@ TEST_CASE("beatmap: validate BPM range", "[rhythm][beatmap]") {
 TEST_CASE("beatmap: validate offset range", "[rhythm][beatmap]") {
     BeatMap map;
     map.bpm = 120.0f; map.offset = -1.0f; map.lead_beats = 4; map.duration = 60.0f;
-    map.beats.push_back({4, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
 }
@@ -125,7 +126,7 @@ TEST_CASE("beatmap: validate offset range", "[rhythm][beatmap]") {
 TEST_CASE("beatmap: validate lead_beats range", "[rhythm][beatmap]") {
     BeatMap map;
     map.bpm = 120.0f; map.offset = 0.0f; map.lead_beats = 1; map.duration = 60.0f;
-    map.beats.push_back({4, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
 }
@@ -140,8 +141,8 @@ TEST_CASE("beatmap: validate empty beats rejected", "[rhythm][beatmap]") {
 TEST_CASE("beatmap: validate different-shape gates min spacing", "[rhythm][beatmap]") {
     BeatMap map;
     map.bpm = 120.0f; map.offset = 0.0f; map.lead_beats = 4; map.duration = 60.0f;
-    map.beats.push_back({4, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
-    map.beats.push_back({5, ObstacleKind::ShapeGate, Shape::Triangle, 1, 0});
+    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_beats.push_back({5, Shape::Triangle, 1, 0.0f, false});
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
 }
@@ -149,8 +150,8 @@ TEST_CASE("beatmap: validate different-shape gates min spacing", "[rhythm][beatm
 TEST_CASE("beatmap: same-shape gates can be adjacent", "[rhythm][beatmap]") {
     BeatMap map;
     map.bpm = 120.0f; map.offset = 0.0f; map.lead_beats = 4; map.duration = 60.0f;
-    map.beats.push_back({4, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
-    map.beats.push_back({5, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_beats.push_back({5, Shape::Circle, 1, 0.0f, false});
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
 }
@@ -158,7 +159,7 @@ TEST_CASE("beatmap: same-shape gates can be adjacent", "[rhythm][beatmap]") {
 TEST_CASE("beatmap: validate beat index beyond duration", "[rhythm][beatmap]") {
     BeatMap map;
     map.bpm = 120.0f; map.offset = 0.0f; map.lead_beats = 4; map.duration = 10.0f;
-    map.beats.push_back({100, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({100, Shape::Circle, 1, 0.0f, false});
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
 }
@@ -246,7 +247,7 @@ TEST_CASE("beat_scheduler: spawns obstacle at spawn_time", "[rhythm][scheduler]"
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
-    map.beats.push_back({4, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
     song.playing = true;
     // Advance past spawn_time
     song.song_time = 0.1f;
@@ -258,7 +259,7 @@ TEST_CASE("beat_scheduler: obstacle has correct BeatInfo", "[rhythm][scheduler]"
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
-    map.beats.push_back({8, ObstacleKind::ShapeGate, Shape::Triangle, 1, 0});
+    map.shape_gate_beats.push_back({8, Shape::Triangle, 1, 0.0f, false});
     song.playing = true; song.song_time = 2.5f;
     beat_scheduler_system(reg, 0.016f);
     auto obs_view = reg.view<ObstacleTag, BeatInfo>();
@@ -274,7 +275,7 @@ TEST_CASE("beat_scheduler: does not spawn before spawn_time", "[rhythm][schedule
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
-    map.beats.push_back({20, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({20, Shape::Circle, 1, 0.0f, false});
     song.playing = true; song.song_time = 0.5f;
     beat_scheduler_system(reg, 0.016f);
     CHECK(reg.view<ObstacleTag>().size() == 0);
@@ -284,8 +285,8 @@ TEST_CASE("beat_scheduler: spawns multiple when time catches up", "[rhythm][sche
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
-    map.beats.push_back({4, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
-    map.beats.push_back({8, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_beats.push_back({8, Shape::Circle, 1, 0.0f, false});
     song.playing = true; song.song_time = 3.0f;
     beat_scheduler_system(reg, 0.016f);
     CHECK(reg.view<ObstacleTag>().size() == 2);
@@ -295,7 +296,7 @@ TEST_CASE("beat_scheduler: rhythm obstacles use BeatInfo without Vector2", "[rhy
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
-    map.beats.push_back({4, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
     song.playing = true; song.song_time = 0.1f;
     beat_scheduler_system(reg, 0.016f);
     auto obs_view = reg.view<ObstacleTag, BeatInfo>();
@@ -885,7 +886,7 @@ TEST_CASE("integration: obstacle arrives on-beat within 1 frame", "[rhythm][inte
     make_rhythm_player(reg);
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
-    map.beats.push_back({4, ObstacleKind::ShapeGate, Shape::Circle, 1, 0});
+    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
     song.playing = true; song.song_time = 0.1f;
     constexpr float dt = 1.0f / 60.0f;
     bool obstacle_at_player = false;

--- a/tests/test_shipped_beatmap_difficulty_ramp.cpp
+++ b/tests/test_shipped_beatmap_difficulty_ramp.cpp
@@ -47,10 +47,6 @@ static std::vector<std::string> find_shipped_beatmaps() {
 }
 
 
-static bool is_easy_allowed_kind(ObstacleKind k) {
-    return k == ObstacleKind::ShapeGate || k == ObstacleKind::OnsetMarker;
-}
-
 // ── Guard: content directory must be reachable ────────────────────────────
 
 TEST_CASE("difficulty ramp: content directory is reachable from test CWD",
@@ -75,15 +71,15 @@ TEST_CASE("difficulty ramp: easy contains only shape_gate obstacles or onset mar
         std::vector<BeatMapError> errors;
         if (!load_beat_map(path, map, errors, "easy")) continue;
 
-        for (const auto& beat : map.beats) {
-            const auto k = beat.kind;
-            if (!is_easy_allowed_kind(k)) {
-                FAIL_CHECK("easy shape_gate_only: " << path
-                           << " contains unsupported easy obstacle kind="
-                           << static_cast<int>(k)
-                           << " (easy required obstacles must be shape_gate-only per #125; "
-                              "onset_marker is non-blocking metadata per #642)");
-            }
+        // Per #1202/#1204: kind is identified by which per-kind vector the
+        // entry lives in. Easy permits only shape_gate and onset_marker; any
+        // entry in split_path_beats is a violation.
+        for (const auto& beat : map.split_path_beats) {
+            FAIL_CHECK("easy shape_gate_only: " << path
+                       << " contains unsupported easy obstacle (split_path) at beat "
+                       << beat.beat_index
+                       << " (easy required obstacles must be shape_gate-only per #125; "
+                          "onset_marker is non-blocking metadata per #642)");
         }
     }
 }
@@ -107,9 +103,7 @@ TEST_CASE("difficulty ramp: shape-gate count increases with difficulty",
                            << " difficulty=" << diffs[i]);
                 continue;
             }
-            for (const auto& beat : map.beats) {
-                if (beat.kind == ObstacleKind::ShapeGate) ++counts[i];
-            }
+            counts[i] = static_cast<int>(map.shape_gate_beats.size());
         }
 
         if (counts[0] == 0 || counts[1] == 0 || counts[2] == 0) {

--- a/tests/test_shipped_beatmap_first_collision.cpp
+++ b/tests/test_shipped_beatmap_first_collision.cpp
@@ -58,14 +58,23 @@ TEST_CASE("first collision: every shipped difficulty has a valid first beat",
             BeatMap map;
             std::vector<BeatMapError> load_errors;
             if (!load_beat_map(path, map, load_errors, diff)) continue;
-            if (map.beats.empty()) continue;
 
-            // Find the smallest beat_index — entries are non-decreasing but
-            // we don't rely on it.
-            int first_beat = map.beats.front().beat_index;
-            for (const auto& b : map.beats) {
-                if (b.beat_index < first_beat) first_beat = b.beat_index;
-            }
+            // Per #1202/#1204 the chart is split into 3 per-kind vectors.
+            // Walk all of them to find the smallest authored beat_index.
+            bool any = false;
+            int first_beat = 0;
+            auto consider = [&](const std::vector<BeatEntry>& v) {
+                for (const auto& b : v) {
+                    if (!any || b.beat_index < first_beat) {
+                        first_beat = b.beat_index;
+                        any = true;
+                    }
+                }
+            };
+            consider(map.shape_gate_beats);
+            consider(map.split_path_beats);
+            consider(map.onset_marker_beats);
+            if (!any) continue;
 
             if (first_beat < 0) {
                 FAIL_CHECK("first-collision integrity violation: " << path

--- a/tests/test_shipped_beatmap_gap_one_readability.cpp
+++ b/tests/test_shipped_beatmap_gap_one_readability.cpp
@@ -43,18 +43,35 @@ TEST_CASE("gap=1 readability: adjacent authored beats remain shape gates",
     const auto beatmaps = find_shipped_beatmaps();
     REQUIRE_FALSE(beatmaps.empty());
 
+    // Required (non-OnsetMarker) entries with their kind tag, merged across
+    // shape_gate_beats and split_path_beats by beat_index (sorted independently
+    // by parser). Per #1202/#1204, kind is identified by which vector the row
+    // came from rather than a discriminator field.
+    enum class RequiredKind { ShapeGate, SplitPath };
+    struct RequiredEntry {
+        RequiredKind kind;
+        int beat_index;
+    };
+
     for (const auto& path : beatmaps) {
         for (const char* difficulty : kDifficulties) {
             BeatMap map;
             std::vector<BeatMapError> errors;
             if (!load_beat_map(path, map, errors, difficulty)) continue;
 
-            std::vector<BeatEntry> required_beats;
-            for (const auto& beat : map.beats) {
-                if (beat.kind != ObstacleKind::OnsetMarker) {
-                    required_beats.push_back(beat);
-                }
+            std::vector<RequiredEntry> required_beats;
+            required_beats.reserve(map.shape_gate_beats.size() +
+                                   map.split_path_beats.size());
+            for (const auto& b : map.shape_gate_beats) {
+                required_beats.push_back({RequiredKind::ShapeGate, b.beat_index});
             }
+            for (const auto& b : map.split_path_beats) {
+                required_beats.push_back({RequiredKind::SplitPath, b.beat_index});
+            }
+            std::stable_sort(required_beats.begin(), required_beats.end(),
+                             [](const RequiredEntry& a, const RequiredEntry& b) {
+                                 return a.beat_index < b.beat_index;
+                             });
             if (required_beats.size() <= 1) continue;
 
             for (size_t index = 1; index < required_beats.size(); ++index) {
@@ -63,7 +80,7 @@ TEST_CASE("gap=1 readability: adjacent authored beats remain shape gates",
                 const int gap = right.beat_index - left.beat_index;
 
                 if (gap != 1) continue;
-                if (left.kind != ObstacleKind::ShapeGate || right.kind != ObstacleKind::ShapeGate) {
+                if (left.kind != RequiredKind::ShapeGate || right.kind != RequiredKind::ShapeGate) {
                     FAIL_CHECK(path << " [" << difficulty
                                << "] gap=1 contains non-shape-gate obstacle at beat "
                                << left.beat_index);

--- a/tests/test_shipped_beatmap_max_gap.cpp
+++ b/tests/test_shipped_beatmap_max_gap.cpp
@@ -61,35 +61,53 @@ TEST_CASE("shipped beatmaps: authored beats are strictly increasing",
             // only on hard I/O / JSON failures.
             if (!load_beat_map(path, map, load_errors, diff)) continue;
 
-            if (map.beats.empty()) {
-                FAIL_CHECK("beat order integrity: " << path << " [" << diff << "] has no authored beats");
-                continue;
-            }
-
             // Issue #396 — subdivision-aware snap can place two distinct
             // obstacles at the same beat_index (e.g. downbeat + eighth or
             // cross-layer onsets within 50ms).  Strict beat-index uniqueness
             // is intentionally no longer required; obstacles must instead
             // stay strictly ordered in onset time and never go backwards in
             // beat index.
-            for (size_t i = 1; i < map.beats.size(); ++i) {
-                if (map.beats[i].beat_index < map.beats[i - 1].beat_index) {
+            //
+            // Per #1202/#1204 the chart is normalized: each former
+            // `ObstacleKind` lives in its own vector. To check the cross-kind
+            // ordering invariant we merge the three vectors into one flat
+            // sorted view (by beat_index, then time_sec).
+            std::vector<BeatEntry> merged;
+            merged.reserve(map.shape_gate_beats.size() +
+                           map.split_path_beats.size() +
+                           map.onset_marker_beats.size());
+            merged.insert(merged.end(), map.shape_gate_beats.begin(),   map.shape_gate_beats.end());
+            merged.insert(merged.end(), map.split_path_beats.begin(),   map.split_path_beats.end());
+            merged.insert(merged.end(), map.onset_marker_beats.begin(), map.onset_marker_beats.end());
+            std::stable_sort(merged.begin(), merged.end(),
+                             [](const BeatEntry& a, const BeatEntry& b) {
+                                 if (a.beat_index != b.beat_index) return a.beat_index < b.beat_index;
+                                 return a.time_sec < b.time_sec;
+                             });
+
+            if (merged.empty()) {
+                FAIL_CHECK("beat order integrity: " << path << " [" << diff << "] has no authored beats");
+                continue;
+            }
+
+            for (size_t i = 1; i < merged.size(); ++i) {
+                if (merged[i].beat_index < merged[i - 1].beat_index) {
                     FAIL_CHECK("beat order integrity: " << path
                                << " [" << diff << "] has decreasing beat index pair "
-                               << map.beats[i - 1].beat_index << " -> " << map.beats[i].beat_index);
+                               << merged[i - 1].beat_index << " -> " << merged[i].beat_index);
                 }
                 // Same-beat ties are allowed: cross-layer onsets within the
                 // 50 ms protected window remain distinct events anchored to a
                 // shared beat/subdivision.  We only flag a regression if a
                 // later beat has both equal beat_index AND strictly smaller
                 // time_sec (out-of-order within the same beat).
-                if (map.beats[i].beat_index > map.beats[i - 1].beat_index &&
-                    map.beats[i].time_sec < map.beats[i - 1].time_sec) {
+                if (merged[i].beat_index > merged[i - 1].beat_index &&
+                    merged[i].time_sec < merged[i - 1].time_sec) {
                     FAIL_CHECK("beat order integrity: " << path
                                << " [" << diff << "] has decreasing time_sec across beats "
-                               << map.beats[i - 1].beat_index << " (" << map.beats[i - 1].time_sec
-                               << ") -> " << map.beats[i].beat_index << " ("
-                               << map.beats[i].time_sec << ")");
+                               << merged[i - 1].beat_index << " (" << merged[i - 1].time_sec
+                               << ") -> " << merged[i].beat_index << " ("
+                               << merged[i].time_sec << ")");
                 }
             }
         }

--- a/tests/test_shipped_beatmap_medium_balance.cpp
+++ b/tests/test_shipped_beatmap_medium_balance.cpp
@@ -54,10 +54,10 @@ TEST_CASE("medium balance: shipped beatmaps keep motif lane mapping",
         std::vector<BeatMapError> errors;
         if (!load_beat_map(path, map, errors, "medium")) continue;
 
+        // Per #1202/#1204: shape-gate entries live in their own per-kind vector.
         int total_shape_gates = 0;
 
-        for (const auto& beat : map.beats) {
-            if (beat.kind != ObstacleKind::ShapeGate) continue;
+        for (const auto& beat : map.shape_gate_beats) {
             ++total_shape_gates;
             const int expected_lane = expected_lane_for_shape(beat.shape);
             if (expected_lane < 0) {


### PR DESCRIPTION
Closes part of #1202 (per-value table for ObstacleKind). Implements the mechanic described in #1204.

## What

Eradicates the `enum class ObstacleKind` discriminator. Each former value now has its own table:

| Former value | ECS tag | Per-row data on entity | Chart-data vector |
|---|---|---|---|
| `ShapeGate` | `ShapeGateTag` | `RequiredShape`, `ShapeGateLane` | `BeatMap::shape_gate_beats` |
| `SplitPath` | `SplitPathTag` | `RequiredShape`, `RequiredLane` | `BeatMap::split_path_beats` |
| `OnsetMarker` | `OnsetMarkerTag` (existing) | (none) | `BeatMap::onset_marker_beats` |

Tags carry zero columns (degenerate per-value table); data components carry the per-row columns each case carries. The chart is normalized: each former enum value gets its own vector at the `BeatMap` level. The kind is identified by **which vector** a beat row lives in.

## Switches eliminated

- `entities/obstacle_render_entity.cpp` — `switch(kind)` → three tag-presence transforms
- `systems/beat_scheduler_system.cpp` — single while-loop → three per-kind transforms with independent cursors (`next_shape_gate_idx`, `next_split_path_idx`, `next_onset_marker_idx`)
- `systems/session_logger_system.cpp` / `systems/test_player_system.cpp` — `enum_name(ObstacleKind)` → `obstacle_kind_label(reg, e)` helper that dispatches on tag presence
- `systems/play_session.cpp` — `count_result_notes` switches to `shape_gate_beats.size() + split_path_beats.size()`
- `entities/beat_map.cpp` — parser dispatches by JSON kind-string into the appropriate vector; validator merges the three vectors by beat-index for cross-kind rules and walks individual vectors for kind-specific rules

## Spawn API

Six per-kind entry points replace the two single-dispatch ones:

\`\`\`cpp
spawn_shape_gate_obstacle  (reg, ShapeGateSpawn);
spawn_split_path_obstacle  (reg, SplitPathSpawn);
spawn_onset_marker_obstacle(reg, OnsetMarkerSpawn);
spawn_shape_gate_rhythm  (reg, ShapeGateSpawn,  BeatInfo);
spawn_split_path_rhythm  (reg, SplitPathSpawn,  BeatInfo);
spawn_onset_marker_rhythm(reg, OnsetMarkerSpawn, BeatInfo);
\`\`\`

Each row schema carries exactly the columns its case needs (no \`req_lane\` on \`ShapeGateSpawn\`; no \`shape\` on \`OnsetMarkerSpawn\`).

## Tests

17 test files updated to use per-kind vectors, the new spawn API, and per-kind cursors. The \`magic_enum(ObstacleKind)\` reflection test is removed (the enum no longer exists). Test helpers \`make_shape_gate\` / \`make_split_path\` now emplace the matching per-kind tag.

## Verification

- ✅ Unity build clean (\`-Wall -Wextra -Werror\`)
- ✅ Non-unity build clean
- ✅ All 876 cases / 2923 assertions pass
- ✅ No \`ObstacleKind\` references in code (only docs/comments referencing the migration history)
- ✅ No \`switch (kind)\` / \`if (kind == ObstacleKind::*)\` in \`app/\`
- ✅ One tag per spawned obstacle

Refs #1202, #1204