### PR TITLE
Add check-enum-allowlist CI guard against new enums (refs #1204, #1202)

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -96,7 +96,7 @@ jobs:
           mkdir -p build/ci
           ctest --test-dir build -N \
             | sed -nE 's/^ *Test *#[0-9]+: (.*)$/\1/p' \
-            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|validate_required_cross_lane_jump_time|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
+            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|validate_required_cross_lane_jump_time|check_shape_change_gap|check_enum_allowlist|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
             | sort -u > build/ci/ctest-nonbench-catch.txt
           ./build/shapeshifter_tests --list-tests "~[bench]" --verbosity quiet \
             | sort -u > build/ci/catch-nonbench.txt
@@ -104,7 +104,7 @@ jobs:
           ./build/shapeshifter_tests "~[bench]"
           xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24" \
             ctest --test-dir build --output-on-failure -R "^startup_shutdown_smoke$"
-          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|validate_required_cross_lane_jump_time|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
+          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|validate_required_cross_lane_jump_time|check_shape_change_gap|check_enum_allowlist|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
 
       - name: Upload artifact
         if: success()

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -98,14 +98,14 @@ jobs:
           mkdir -p build/ci
           ctest --test-dir build -N \
             | sed -nE 's/^ *Test *#[0-9]+: (.*)$/\1/p' \
-            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|validate_required_cross_lane_jump_time|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
+            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|validate_required_cross_lane_jump_time|check_shape_change_gap|check_enum_allowlist|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
             | sort -u > build/ci/ctest-nonbench-catch.txt
           ./build/shapeshifter_tests --list-tests "~[bench]" --verbosity quiet \
             | sort -u > build/ci/catch-nonbench.txt
           diff -u build/ci/ctest-nonbench-catch.txt build/ci/catch-nonbench.txt
           ./build/shapeshifter_tests "~[bench]"
           ctest --test-dir build --output-on-failure -R "^startup_shutdown_smoke$"
-          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|validate_required_cross_lane_jump_time|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
+          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|validate_required_cross_lane_jump_time|check_shape_change_gap|check_enum_allowlist|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
 
       - name: Upload artifact
         if: success()

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -91,7 +91,7 @@ jobs:
           mkdir -p build/ci
           ctest --test-dir build -N \
             | sed -nE 's/^ *Test *#[0-9]+: (.*)$/\1/p' \
-            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|validate_required_cross_lane_jump_time|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
+            | grep -Ev '^Bench:|^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|validate_required_cross_lane_jump_time|check_shape_change_gap|check_enum_allowlist|beatmap_editor_node_tests|service_worker_cache_policy_node_tests|startup_shutdown_smoke)$' \
             | tr -d '\r' \
             | sort -u > build/ci/ctest-nonbench-catch.txt
           ./build/shapeshifter_tests.exe --list-tests "~[bench]" --verbosity quiet \
@@ -100,7 +100,7 @@ jobs:
           diff -u build/ci/ctest-nonbench-catch.txt build/ci/catch-nonbench.txt
           ./build/shapeshifter_tests.exe "~[bench]"
           ctest --test-dir build --output-on-failure -R "^startup_shutdown_smoke$"
-          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|validate_required_cross_lane_jump_time|check_shape_change_gap|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
+          ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|validate_required_cross_lane_jump_time|check_shape_change_gap|check_enum_allowlist|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
         shell: bash
 
       - name: Upload artifact

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -631,6 +631,11 @@ if(NOT EMSCRIPTEN AND NOT SHAPESHIFTER_IOS)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/check_shape_change_gap.py
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     )
+    add_test(
+        NAME check_enum_allowlist
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/check_enum_allowlist.py
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    )
     find_program(NODE_EXECUTABLE node)
     if(NODE_EXECUTABLE)
         file(GLOB _beatmap_editor_node_test_files CONFIGURE_DEPENDS

--- a/app/.allowed-enums.txt
+++ b/app/.allowed-enums.txt
@@ -1,0 +1,50 @@
+# Enum allowlist for app/ (issue #1204).
+#
+# Per Fabian's Existential Processing chapter (DoD), enums that drive
+# `switch` statements or virtual dispatch must be eradicated and replaced
+# with per-case component tables (real structs) or empty tags. Enums
+# survive in this codebase only as:
+#
+#   - input event labels / keybindings  (Direction, MenuActionKind,
+#                                        ButtonPressKind, KeyboardShapeSlot)
+#   - playback IDs                      (HapticEvent, ImpactStyle, SFX)
+#   - finite return codes               (Status)
+#   - UI layout labels                  (FontSize)
+#
+# See .squad/decisions.md § "DoD source-text grounding (Fabian) Principle 1"
+# and the per-enum schema table in issue #1204.
+#
+# How to add an enum:
+#   - Add the bare name on its own line (inline `#` comment for the reason).
+#   - Justify with one of the Keep categories above, or open a discussion
+#     issue first if it does not fit any of them.
+#
+# How to remove an enum:
+#   - When a migration lands and the enum declaration is deleted, also
+#     delete its line here. `check_enum_allowlist.py` rejects stale entries
+#     symmetrically with unlisted ones, so the file stays accurate.
+#
+# Mechanism: tools/check_enum_allowlist.py greps
+# `^\s*enum(\s+class)?\s+<Name>\b` across app/*.{h,hpp,cpp,cc,cxx} and
+# fails CI on any name not present in this file.
+
+# --- Keep set: label / lookup / return code (Fabian "enums that make sense")
+Direction          # input event label
+MenuActionKind     # input event label
+ButtonPressKind    # input event label
+KeyboardShapeSlot  # keybinding lookup key
+HapticEvent        # playback ID
+ImpactStyle        # playback ID
+SFX                # playback ID
+Status             # persistence return code (Fabian "collision response" exemplar)
+FontSize           # UI layout label
+
+# --- Pending eradication per #1202 / #1204 (set must shrink, never grow) ----
+# Each row below is a control-flow enum awaiting migration to per-case tags
+# or component tables. Removing a row here = the migration landed.
+# Adding a row here would be drift; eradicate instead.
+Shape                 # #1202: per-shape tags; player identity, 4 cases
+GamePhase             # #1202: per-phase tag/struct mix; blocked on game_state.h split
+InputSource           # #1202 re-triage: 3-state mutex in InputState ctx singleton
+GameplayHudShapeSlot  # #1202 re-triage: switch in app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
+GameplayHudRingCue    # #1202 re-triage: switch in app/ui/screen_controllers/gameplay_hud_screen_controller.cpp

--- a/tools/check_enum_allowlist.py
+++ b/tools/check_enum_allowlist.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+check_enum_allowlist.py
+=======================
+Drift guard for issue #1204: prevent new control-flow enums from sneaking
+into ``app/``. Every ``enum`` / ``enum class`` declared under ``app/`` must
+appear in ``app/.allowed-enums.txt``.
+
+The allowlist file may contain blank lines and ``#`` comments (full-line or
+inline). Each remaining non-empty token is a single enum name.
+
+Failure modes (any of these is a non-zero exit):
+
+  * **unlisted** — an enum exists in ``app/`` but is not allowlisted. Either
+    eradicate it (per #1202 / #1204 mechanic) or add it with a justification.
+  * **stale**    — an allowlist entry no longer matches any enum in ``app/``.
+    Delete the stale line; the migration already landed.
+
+Per Fabian's *Existential Processing* (DoD), enums survive in this codebase
+only as labels / lookup keys / finite return codes — anything that drives
+``switch`` or virtual dispatch must be modeled as per-case component tables.
+See ``.squad/decisions.md`` § *DoD source-text grounding (Fabian) Principle 1*.
+
+Exits 0 on success, 1 on failure.
+
+Usage::
+
+    python3 tools/check_enum_allowlist.py
+    python3 tools/check_enum_allowlist.py --app-dir app \\
+                                          --allowlist app/.allowed-enums.txt
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+DEFAULT_APP = REPO / "app"
+DEFAULT_ALLOWLIST = REPO / "app" / ".allowed-enums.txt"
+
+CXX_SUFFIXES = (".h", ".hpp", ".cpp", ".cc", ".cxx")
+
+ENUM_RE = re.compile(r"^\s*enum(?:\s+class)?\s+(\w+)\b")
+
+
+def find_enums(app_dir: Path, repo_root: Path | None = None) -> dict[str, list[str]]:
+    """Return ``{enum_name: ["relpath:line", ...]}`` for every ``enum`` /
+    ``enum class`` declaration found in C/C++ source under *app_dir*.
+
+    Matching is line-anchored: an enum line must have ``enum`` (optionally
+    ``enum class``) as its first non-whitespace token, so commented-out or
+    string-literal occurrences of the keyword are ignored.
+
+    Paths are reported relative to *repo_root* (default: parent of *app_dir*)
+    so the error message survives being copy-pasted out of CI logs.
+    """
+    repo_root = repo_root if repo_root is not None else app_dir.parent
+    out: dict[str, list[str]] = {}
+    for path in sorted(app_dir.rglob("*")):
+        if path.suffix not in CXX_SUFFIXES or not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        try:
+            rel = path.relative_to(repo_root).as_posix()
+        except ValueError:
+            rel = path.as_posix()
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            m = ENUM_RE.match(line)
+            if not m:
+                continue
+            out.setdefault(m.group(1), []).append(f"{rel}:{lineno}")
+    return out
+
+
+def load_allowlist(path: Path) -> set[str]:
+    """Parse the allowlist file. Each non-empty, non-comment line is an
+    enum name (inline ``# comment`` is also stripped).
+    """
+    if not path.exists():
+        return set()
+    names: set[str] = set()
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        token = raw.split("#", 1)[0].strip()
+        if not token:
+            continue
+        names.add(token)
+    return names
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Fail if any enum in app/ is missing from app/.allowed-enums.txt (issue #1204)."
+    )
+    parser.add_argument("--app-dir", type=Path, default=DEFAULT_APP,
+                        help="Root of game source (default: %(default)s)")
+    parser.add_argument("--allowlist", type=Path, default=DEFAULT_ALLOWLIST,
+                        help="Path to allowlist file (default: %(default)s)")
+    args = parser.parse_args(argv)
+
+    if not args.app_dir.is_dir():
+        print(f"error: app dir not found: {args.app_dir}", file=sys.stderr)
+        return 2
+
+    found = find_enums(args.app_dir)
+    allowed = load_allowlist(args.allowlist)
+
+    unlisted = sorted(set(found) - allowed)
+    stale = sorted(allowed - set(found))
+
+    if not unlisted and not stale:
+        print(f"ok: {len(found)} enum(s) in {args.app_dir.name}/, all allowlisted")
+        return 0
+
+    print("error: enum allowlist drift detected (issue #1204)")
+    print(f"  allowlist: {args.allowlist}")
+    if unlisted:
+        print()
+        print("  enums declared in app/ but NOT in the allowlist:")
+        for name in unlisted:
+            sites = ", ".join(found[name])
+            print(f"    - {name}  ({sites})")
+        print()
+        print("  Action: either")
+        print("    (a) eradicate the enum via the #1202 / #1204 mechanic")
+        print("        (per-case tags or component tables), or")
+        print(f"    (b) add the enum name to {args.allowlist.name} with a")
+        print("        one-line justification (lookup key / label / keybinding /")
+        print("        finite return code per Fabian's Keep examples).")
+    if stale:
+        print()
+        print("  allowlisted enums no longer present in app/ (delete the line):")
+        for name in stale:
+            print(f"    - {name}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_check_enum_allowlist.py
+++ b/tools/test_check_enum_allowlist.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/check_enum_allowlist.py (issue #1204)."""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import check_enum_allowlist as mod  # noqa: E402
+
+
+def _write_tree(root: Path, files: dict[str, str]) -> None:
+    for rel, body in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+
+
+class TestFindEnums(unittest.TestCase):
+    def test_finds_enum_class_with_underlying_type(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _write_tree(root, {"app/a.h": "enum class Foo : uint8_t { A, B };"})
+            self.assertIn("Foo", mod.find_enums(root / "app", root))
+
+    def test_finds_plain_unscoped_enum(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _write_tree(root, {"app/a.h": "enum Bar { A, B };"})
+            self.assertIn("Bar", mod.find_enums(root / "app", root))
+
+    def test_ignores_non_cxx_files(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _write_tree(root, {
+                "app/a.txt": "enum class Ignored1 {};",
+                "app/b.md":  "enum class Ignored2 {};",
+                "app/c.py":  "enum class Ignored3 {};",
+            })
+            self.assertEqual(mod.find_enums(root / "app", root), {})
+
+    def test_records_relative_file_line_sites(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _write_tree(root, {"app/sub/a.h": "\n\nenum class Foo : int { A };\n"})
+            found = mod.find_enums(root / "app", root)
+            self.assertEqual(found["Foo"], ["app/sub/a.h:3"])
+
+    def test_finds_multiple_enums_in_one_file(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _write_tree(root, {
+                "app/a.h": (
+                    "enum class A : uint8_t { X };\n"
+                    "enum class B : uint8_t { Y };\n"
+                ),
+            })
+            found = mod.find_enums(root / "app", root)
+            self.assertEqual(set(found), {"A", "B"})
+
+    def test_does_not_match_enum_in_comment_only_line(self) -> None:
+        # The regex anchors on leading whitespace + `enum` keyword. Any line
+        # whose first non-whitespace token is `enum` matches; everything else
+        # (including comments and string literals) does not.
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _write_tree(root, {
+                "app/a.h": '// enum class Hidden {};\nconst char* s = "enum class Also {};";\n',
+            })
+            self.assertEqual(mod.find_enums(root / "app", root), {})
+
+
+class TestLoadAllowlist(unittest.TestCase):
+    def test_strips_full_line_and_inline_comments(self) -> None:
+        with TemporaryDirectory() as td:
+            p = Path(td) / "list.txt"
+            p.write_text(
+                "# full-line comment\n"
+                "\n"
+                "Foo  # inline reason\n"
+                "Bar\n"
+                "   Baz   \n"
+                "\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(mod.load_allowlist(p), {"Foo", "Bar", "Baz"})
+
+    def test_missing_file_returns_empty_set(self) -> None:
+        self.assertEqual(mod.load_allowlist(Path("/no/such/file.txt")), set())
+
+
+class TestEndToEnd(unittest.TestCase):
+    def _run(self, files: dict[str, str], allowlist: str) -> int:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _write_tree(root, files)
+            (root / "app").mkdir(exist_ok=True)
+            (root / "app" / ".allowed-enums.txt").write_text(allowlist, encoding="utf-8")
+            return mod.main([
+                "--app-dir", str(root / "app"),
+                "--allowlist", str(root / "app" / ".allowed-enums.txt"),
+            ])
+
+    def test_exits_zero_when_aligned(self) -> None:
+        rc = self._run({"app/a.h": "enum class Foo {};"}, "Foo\n")
+        self.assertEqual(rc, 0)
+
+    def test_exits_zero_with_no_enums_and_empty_allowlist(self) -> None:
+        rc = self._run({"app/a.h": "// nothing here\n"}, "# empty\n")
+        self.assertEqual(rc, 0)
+
+    def test_exits_nonzero_on_unlisted_enum(self) -> None:
+        rc = self._run({"app/a.h": "enum class Sneaky {};"}, "# nothing here\n")
+        self.assertEqual(rc, 1)
+
+    def test_exits_nonzero_on_stale_allowlist_entry(self) -> None:
+        rc = self._run({"app/a.h": "// no enums\n"}, "Stale\n")
+        self.assertEqual(rc, 1)
+
+    def test_reports_both_unlisted_and_stale_in_one_run(self) -> None:
+        rc = self._run({"app/a.h": "enum class New {};"}, "Old\n")
+        self.assertEqual(rc, 1)
+
+    def test_exits_two_when_app_dir_missing(self) -> None:
+        with TemporaryDirectory() as td:
+            allow = Path(td) / "a.txt"
+            allow.write_text("", encoding="utf-8")
+            rc = mod.main([
+                "--app-dir", str(Path(td) / "does_not_exist"),
+                "--allowlist", str(allow),
+            ])
+            self.assertEqual(rc, 2)
+
+
+class TestRepoBaseline(unittest.TestCase):
+    """The shipped allowlist must stay in sync with the live tree — this
+    guards against accidentally landing a PR that desyncs them locally."""
+
+    def test_repo_allowlist_matches_repo_enums(self) -> None:
+        rc = mod.main([])  # uses repo defaults
+        self.assertEqual(rc, 0, "tools/check_enum_allowlist.py reports drift "
+                                "against the shipped app/.allowed-enums.txt")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the missing prevention half of #1204.

## Why

Half the value of the #1202 / #1204 migration train is the per-PR
eradication work; the other half is preventing future regression. The
latest comment on #1202 explicitly notes the allowlist guard "still needs
to land separately." This PR lands it.

Per Fabian (DoD, *Existential Processing* — "Don't use enums quite as
much"), enums that drive `switch` or virtual dispatch should be modeled
as per-case component tables; enums survive only as labels / lookup keys /
finite return codes. The allowlist makes that policy enforceable in CI.

## What

1. **`tools/check_enum_allowlist.py`** — line-anchored grep for `enum` /
   `enum class` declarations across `app/*.{h,hpp,cpp,cc,cxx}`. Compares
   against `app/.allowed-enums.txt`. Fails on either direction of drift:
   - **unlisted**: enum exists in code but not in allowlist
   - **stale**: allowlist entry no longer matches any code enum

   Both modes print clear next-step messages with `file:line` citations.

2. **`app/.allowed-enums.txt`** — seeds with the 14 current enums:
   - **9 Keep set** (per Fabian's "enums that make sense" examples):
     `Direction`, `MenuActionKind`, `ButtonPressKind`, `KeyboardShapeSlot`,
     `HapticEvent`, `ImpactStyle`, `SFX`, `Status`, `FontSize`
   - **5 Pending eradication** (per #1202 / #1204): `Shape`, `GamePhase`,
     `InputSource`, `GameplayHudShapeSlot`, `GameplayHudRingCue` —
     each migration PR deletes its line. **The set must shrink, never grow.**

3. **`tools/test_check_enum_allowlist.py`** — 15 unit tests covering
   regex variants, allowlist parsing, both failure modes, and a
   repo-baseline test that re-runs the live validator (so a desync
   between the shipped allowlist and the live tree fails the existing
   `python_tool_tests` ctest entry).

4. **`CMakeLists.txt`** — registers a `check_enum_allowlist` ctest entry
   next to `check_shape_change_gap`.

5. **`.github/workflows/ci-{linux,macos,windows}.yml`** — adds
   `check_enum_allowlist` to both:
   - the catch-tests exclude regex (so the ctest/catch parity diff
     still matches the catch list exactly)
   - the python-validator allowlist regex (so the new test runs in
     the same explicit batch as the other native validators).

## Verification

| check | result |
|---|---|
| `python3 tools/check_enum_allowlist.py` | `ok: 14 enum(s) in app/, all allowlisted` |
| `python3 -m unittest discover -s tools -p 'test_*.py'` | 214 tests pass (15 new) |
| `ctest -R '^check_enum_allowlist$'` | Passed |
| python-validator ctest batch | 12/12 pass |
| `shapeshifter_tests '~[bench]'` | 876 cases / 2923 assertions pass |
| Catch/ctest parity diff | identical (872 lines each) |
| Failure path: remove `FontSize` from allowlist | reports `FontSize (app/components/text.h:7)` with action steps |

## Follow-ups

This PR locks in the current state but does not migrate any enum. The
five Pending eradication entries are still queued per #1202's migration
order. The next ECS-refactor PR (Shape eradication has been called
"next" with the largest blast radius) will delete its line from
`app/.allowed-enums.txt` as part of the eradication; the same guard
will then ensure no new enums sneak back in.

Refs #1204, #1202.
