### PR TITLE
Migrate InputSource enum to per-source ctx tags (refs #1202, #1204)

### DIFF
--- a/app/.allowed-enums.txt
+++ b/app/.allowed-enums.txt
@@ -45,6 +45,5 @@ FontSize           # UI layout label
 # Adding a row here would be drift; eradicate instead.
 Shape                 # #1202: per-shape tags; player identity, 4 cases
 GamePhase             # #1202: per-phase tag/struct mix; blocked on game_state.h split
-InputSource           # #1202 re-triage: 3-state mutex in InputState ctx singleton
 GameplayHudShapeSlot  # #1202 re-triage: switch in app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
 GameplayHudRingCue    # #1202 re-triage: switch in app/ui/screen_controllers/gameplay_hud_screen_controller.cpp

--- a/app/systems/input.h
+++ b/app/systems/input.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <cstdint>
-
 // ── Raw input state (internal to input_system) ──────────────────────────────
 // Tracks touch/mouse hardware state. Downstream systems should read
 // semantic events, not this struct — except for quit_requested.
@@ -14,7 +12,16 @@
 // (issue #1194) — this is per-frame ctx-singleton hardware-capture state,
 // not entity-owned component data.
 
-enum class InputSource : uint8_t { None, Mouse, Touch };
+// Per-source ctx tags replacing the former `InputSource` enum
+// (issues #1202 / #1204). The former 3-state mutex
+// (`None`/`Mouse`/`Touch`) on `InputState::active_source` becomes:
+//   • presence of `InputSourceMouse` ctx table  ⇔ Mouse owns the gesture
+//   • presence of `InputSourceTouch` ctx table  ⇔ Touch owns the gesture
+//   • absence of both                            ⇔ None
+// The mutex (at most one tag present) is enforced by the input_system
+// helpers `set_input_source_mouse / _touch` and `clear_input_source`.
+struct InputSourceMouse {};
+struct InputSourceTouch {};
 
 struct TouchSlot {
     static constexpr int InvalidId = -1;
@@ -35,7 +42,6 @@ struct InputState {
     float end_x    = 0.0f, end_y   = 0.0f;
     float duration = 0.0f;
 
-    InputSource active_source = InputSource::None;
     bool  touch_down     = false;
     bool  touch_up       = false;
     bool  click          = false;

--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -36,7 +36,8 @@ struct WebInputPolicy {
     //  • A USB/Bluetooth mouse plugged into a touch-capable device is
     //    not silently ignored for the rest of the session.
     // Per-frame routing between mouse and touch is handled by the
-    // active_source guard inside input_system.
+    // InputSourceMouse / InputSourceTouch ctx-tag mutex inside
+    // input_system (issues #1202 / #1204).
     bool touch_capable = false;
 };
 
@@ -139,6 +140,37 @@ void release_touch_slot(TouchSlot& slot,
     slot = TouchSlot{};
 }
 
+// ── Input-source ctx-tag mutex helpers (issues #1202 / #1204) ──────────────
+// The former InputSource enum tracked which input device "owns" the
+// current gesture as a 3-state mutex on InputState. Per Fabian's
+// existential-processing canon, each former value is now its own ctx
+// table (InputSourceMouse / InputSourceTouch); absence of both = the
+// former `None`. These helpers maintain the mutex invariant so callers
+// don't have to duplicate the erase-the-other pattern.
+
+void set_input_source_mouse(entt::registry& reg) {
+    reg.ctx().insert_or_assign(InputSourceMouse{});
+    if (reg.ctx().find<InputSourceTouch>()) {
+        reg.ctx().erase<InputSourceTouch>();
+    }
+}
+
+void set_input_source_touch(entt::registry& reg) {
+    reg.ctx().insert_or_assign(InputSourceTouch{});
+    if (reg.ctx().find<InputSourceMouse>()) {
+        reg.ctx().erase<InputSourceMouse>();
+    }
+}
+
+void clear_input_source(entt::registry& reg) {
+    if (reg.ctx().find<InputSourceMouse>()) {
+        reg.ctx().erase<InputSourceMouse>();
+    }
+    if (reg.ctx().find<InputSourceTouch>()) {
+        reg.ctx().erase<InputSourceTouch>();
+    }
+}
+
 } // namespace
 
 void input_system_init(entt::registry& reg) {
@@ -168,12 +200,12 @@ void input_system_clear_pointer_state(entt::registry& reg) {
         input->click = false;
         input->button_touch_up = false;
         input->touching = false;
-        input->active_source = InputSource::None;
         input->duration = 0.0f;
         for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
             input->touch_slots[i] = TouchSlot{};
         }
     }
+    clear_input_source(reg);
     if (auto* priv = reg.ctx().find<InputSystemPrivate>()) {
         priv->suppress_mouse_release = false;
     }
@@ -196,8 +228,9 @@ void input_system(entt::registry& reg, float raw_dt) {
 #if defined(PLATFORM_WEB) && defined(__EMSCRIPTEN__)
     const auto& web_policy = reg.ctx().get<WebInputPolicy>();
     // Mouse is always allowed on web. Touch is allowed whenever the
-    // browser reports a touch surface. The active_source guard below
-    // prevents a single gesture from being routed through both paths.
+    // browser reports a touch surface. The InputSourceMouse /
+    // InputSourceTouch ctx-tag mutex below prevents a single gesture
+    // from being routed through both paths.
     const bool allow_mouse_input = true;
     const bool allow_touch_input = web_policy.touch_capable;
 #else
@@ -213,22 +246,32 @@ void input_system(entt::registry& reg, float raw_dt) {
         priv.suppress_mouse_release = false;
     }
 
+    // Read live each call — the mouse and touch blocks below mutate the
+    // mutex (set_input_source_mouse / _touch / clear_input_source) so a
+    // cached snapshot would race against the very same frame's writes.
+    const auto touch_owns_gesture = [&]() {
+        return reg.ctx().find<InputSourceTouch>() != nullptr;
+    };
+    const auto mouse_owns_gesture = [&]() {
+        return reg.ctx().find<InputSourceMouse>() != nullptr;
+    };
+
     // ── Mouse (desktop) — click-only semantics ─
     if (allow_mouse_input &&
-        input.active_source != InputSource::Touch &&
+        !touch_owns_gesture() &&
         !priv.suppress_mouse_release &&
         touch_point_count == 0 &&
         IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
-        input.active_source = InputSource::Mouse;
+        set_input_source_mouse(reg);
         priv.suppress_mouse_release = false;
     }
     if (allow_mouse_input &&
-        input.active_source != InputSource::Touch &&
+        !touch_owns_gesture() &&
         mouse_released) {
         const bool suppress_this_release = priv.suppress_mouse_release;
         input.click      = !suppress_this_release;
         input.touching   = false;
-        input.active_source = InputSource::None;
+        clear_input_source(reg);
         priv.suppress_mouse_release = false;
         const Vector2 mouse_pos = GetMousePosition();
         const Vector2 pos = screen_to_virtual({mouse_pos.x, mouse_pos.y}, st);
@@ -239,7 +282,7 @@ void input_system(entt::registry& reg, float raw_dt) {
 
     // ── Touch (mobile / web) — up to one swipe-zone and one button-zone contact ─
     if (allow_touch_input &&
-        input.active_source != InputSource::Mouse &&
+        !mouse_owns_gesture() &&
         touch_point_count > 0) {
         const float zone_y = constants::SCREEN_H_F * constants::SWIPE_ZONE_SPLIT;
         Direction latest_swipe_dir = Direction::Up;
@@ -310,7 +353,7 @@ void input_system(entt::registry& reg, float raw_dt) {
             }
         }
         if (input.touching) {
-            input.active_source = InputSource::Touch;
+            set_input_source_touch(reg);
         }
         input.duration = 0.0f;
         for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
@@ -319,15 +362,15 @@ void input_system(entt::registry& reg, float raw_dt) {
             }
         }
     } else if (allow_touch_input &&
-               input.active_source != InputSource::Mouse &&
-               input.touching && input.active_source == InputSource::Touch) {
+               !mouse_owns_gesture() &&
+               input.touching && touch_owns_gesture()) {
         Direction latest_swipe_dir = Direction::Up;
         bool has_latest_swipe = false;
         bool had_swipe_zone_release = false;
         input.touch_up  = true;
         input.touching  = false;
         priv.suppress_mouse_release = true;
-        input.active_source = InputSource::None;
+        clear_input_source(reg);
         for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
             auto& slot = input.touch_slots[i];
             if (!slot.active) {
@@ -396,7 +439,7 @@ void input_system(entt::registry& reg, float raw_dt) {
         priv.was_focused = focused;
     }
 
-    if (input.active_source != InputSource::Mouse &&
+    if (!mouse_owns_gesture() &&
         !input.touching &&
         !input.touch_up) {
         Direction gesture_dir = Direction::Up;

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -392,7 +392,14 @@ struct EnergyState {
 /// events below instead, except for `quit_requested`. Per-frame edge flags
 /// (`touch_down`, `touch_up`, `click`, `button_touch_up`) are recomputed each
 /// pass through `input_system`; there is no separate `clear_events()` step.
-enum class InputSource : uint8_t { None, Mouse, Touch };
+
+/// Input-source mutex (issues #1202 / #1204): the former `enum InputSource`
+/// became per-source ctx tables. Presence of `InputSourceMouse` ⇔ Mouse
+/// owns the current gesture; presence of `InputSourceTouch` ⇔ Touch owns
+/// it; absence of both ⇔ None. The mutex (at most one tag present) is
+/// maintained by input_system helpers.
+struct InputSourceMouse {};
+struct InputSourceTouch {};
 
 struct TouchSlot {
     static constexpr int InvalidId = -1;
@@ -413,7 +420,6 @@ struct InputState {
     float end_x   = 0.0f, end_y   = 0.0f;
     float duration = 0.0f;
 
-    InputSource active_source = InputSource::None;
     bool  touch_down            = false;  // pressed this frame
     bool  touch_up              = false;  // released this frame
     bool  click                 = false;  // tap classification this frame
@@ -1608,7 +1614,7 @@ app/
 │   └── song_state.h             ← SongState
 │
 ├── systems/                     ← all system free functions
-│   ├── input.h                  ← InputState, TouchSlot, InputSource (singleton hardware-capture state)
+│   ├── input.h                  ← InputState, TouchSlot, InputSourceMouse, InputSourceTouch (singleton hardware-capture state)
 │   ├── all_systems.h            ← convenience #include for all systems
 │   ├── input_system.cpp         ← raylib polling → semantic dispatcher events
 │   ├── game_state_system.cpp    ← phase transitions

--- a/design-docs/feature-specs.md
+++ b/design-docs/feature-specs.md
@@ -103,8 +103,16 @@ inputs resolve deterministically.
 ### ECS Components (C++ structs)
 
 ```cpp
-// ── Input source identification ──
-enum class InputSource : uint8_t { None, Mouse, Touch };
+// ── Input source ctx-tag mutex (former enum InputSource) ──
+// Per-source ctx tables replace the former 3-state enum on
+// InputState::active_source (issues #1202 / #1204):
+//   • presence of InputSourceMouse ⇔ Mouse owns the gesture
+//   • presence of InputSourceTouch ⇔ Touch owns the gesture
+//   • absence of both              ⇔ None
+// The mutex is maintained by input_system helpers
+// (set_input_source_mouse / _touch, clear_input_source).
+struct InputSourceMouse {};
+struct InputSourceTouch {};
 
 // ── Per-touch tracking slot (multi-touch support) ──
 struct TouchSlot {
@@ -130,7 +138,6 @@ struct InputState {
     float end_x    = 0.0f, end_y   = 0.0f;  // position on touch_up
     float duration = 0.0f;                  // seconds held
 
-    InputSource active_source = InputSource::None;
     bool  touch_down     = false;           // just pressed this frame
     bool  touch_up       = false;           // just released this frame
     bool  click          = false;           // tap recognised this frame

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -266,7 +266,7 @@ TEST_CASE("game_state: transition clears in-flight pointer capture", "[gamestate
     input.touch_down = true;
     input.touch_up = false;
     input.touching = true;
-    input.active_source = InputSource::Mouse;
+    reg.ctx().insert_or_assign(InputSourceMouse{});
     priv.suppress_mouse_release = true;
     input.duration = 0.25f;
 
@@ -278,7 +278,8 @@ TEST_CASE("game_state: transition clears in-flight pointer capture", "[gamestate
     CHECK_FALSE(input.touch_down);
     CHECK_FALSE(input.touch_up);
     CHECK_FALSE(input.touching);
-    CHECK(input.active_source == InputSource::None);
+    CHECK_FALSE(reg.ctx().contains<InputSourceMouse>());
+    CHECK_FALSE(reg.ctx().contains<InputSourceTouch>());
     CHECK_FALSE(priv.suppress_mouse_release);
     CHECK(input.duration == 0.0f);
 }

--- a/tests/test_web_input_policy.cpp
+++ b/tests/test_web_input_policy.cpp
@@ -14,8 +14,9 @@
 // We can't drive emscripten's EM_ASM_INT from the native test runner, but we
 // CAN assert on the non-web invariant that input_system_init runs cleanly
 // and that input_system continues to honor both sources concurrently with
-// active_source acting as the per-gesture arbiter (covered by the existing
-// pipeline tests for swipe/keyboard routing).
+// the InputSourceMouse / InputSourceTouch ctx-tag mutex acting as the
+// per-gesture arbiter (covered by the existing pipeline tests for
+// swipe/keyboard routing).
 
 #include <catch2/catch_test_macros.hpp>
 


### PR DESCRIPTION
## Summary

Eradicates `enum class InputSource : uint8_t { None, Mouse, Touch }` — the input-device mutex on the `InputState` ctx singleton — per Fabian's existential-processing canon (issues #1202 / #1204). Each former value becomes its own zero-column ctx table; absence of both tags is the former `None`.

| Former value         | New ctx table          |
|----------------------|------------------------|
| `InputSource::Mouse` | `struct InputSourceMouse{}` |
| `InputSource::Touch` | `struct InputSourceTouch{}` |
| `InputSource::None`  | absence of both             |

Mirrors the precedent set by #1247 (EndScreenChoice → per-choice ctx tags).

## Mechanic

- The 3-state field `InputState::active_source` is deleted. The mutex invariant (at most one tag present) is now maintained by three helpers in the input_system anonymous namespace: `set_input_source_mouse`, `set_input_source_touch`, `clear_input_source`.
- Read sites use live ctx lookups (lambdas `touch_owns_gesture()` / `mouse_owns_gesture()`) so the original same-frame ordering (mouse block runs first, touch block sees its writes) is preserved.
- `input_system_clear_pointer_state()` calls `clear_input_source(reg)` so phase transitions still drop in-flight pointer capture.

## Enum count

`tools/check_enum_allowlist.py`: **14 → 13** allowlisted enums. The `InputSource` row in `app/.allowed-enums.txt` is deleted. Remaining pending eradication: `Shape`, `GamePhase`, `GameplayHudShapeSlot`, `GameplayHudRingCue`.

## Tests

- `tests/test_game_state_extended.cpp` — 'game_state: transition clears in-flight pointer capture' updated to emplace `InputSourceMouse` via ctx and assert both tags absent after the transition. One additional CHECK assertion is added (mouse-tag-absent + touch-tag-absent replaces the single enum-equality check).
- `tests/test_web_input_policy.cpp` — comment-only update referencing the new ctx-tag mutex.

## Docs

- `design-docs/architecture.md` § 2.7 (Input singletons) and the directory tree updated.
- `design-docs/feature-specs.md` input component snippet updated.

## Validation

- `cmake --build build` (unity) ✅ zero warnings.
- `cmake --build build-no-unity` (non-unity) ✅ zero warnings.
- `./build/shapeshifter_tests` → 2924 assertions / 876 cases ✅.
- `./build-no-unity/shapeshifter_tests` → 2924 assertions / 876 cases ✅.
- `python3 tools/check_enum_allowlist.py` → 13 enums, all allowlisted ✅.

Refs #1202, #1204.