### PR TITLE
refactor(ui): eradicate GameplayHudRingCue enum via return-data struct (#1202, #1204)

### DIFF
--- a/app/.allowed-enums.txt
+++ b/app/.allowed-enums.txt
@@ -46,4 +46,3 @@ FontSize           # UI layout label
 Shape                 # #1202: per-shape tags; player identity, 4 cases
 GamePhase             # #1202: per-phase tag/struct mix; blocked on game_state.h split
 GameplayHudShapeSlot  # #1202 re-triage: switch in app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
-GameplayHudRingCue    # #1202 re-triage: switch in app/ui/screen_controllers/gameplay_hud_screen_controller.cpp

--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
@@ -61,9 +61,6 @@ struct GameplayHudVisualStyle {
     Color active_icon;
     Color inactive_icon;
     float approach_ring_max_radius_scale;
-    Color ring_perfect;
-    Color ring_near;
-    Color ring_far;
     Color lane_divider_color;
 };
 
@@ -75,27 +72,10 @@ constexpr GameplayHudVisualStyle kGameplayHudVisualStyle{
     {200, 230, 255, 255},
     {100, 100, 120, 200},
     2.0f,
-    {100, 255, 100, 255},
-    {180, 255, 100, 255},
-    {120, 120, 180, 255},
     {40, 40, 60, 200},
 };
 
 constexpr float kLaneDividerOffsetFromShapeRow = 20.0f;
-
-Color ring_color_for_cue(GameplayHudRingCue cue, const GameplayHudVisualStyle& style) {
-    switch (cue) {
-        case GameplayHudRingCue::Perfect:
-            return style.ring_perfect;
-        case GameplayHudRingCue::Near:
-            return style.ring_near;
-        case GameplayHudRingCue::Far:
-            return style.ring_far;
-        case GameplayHudRingCue::Hidden:
-            break;
-    }
-    return style.ring_far;
-}
 
 struct ApproachRingEnvelope {
     float radius = 0.0f;
@@ -203,18 +183,17 @@ void render_shape_buttons(const entt::registry& reg,
                                                perfect_dist,
                                                good_dist,
                                                ring_appear_dist);
-        if (cue == GameplayHudRingCue::Hidden) continue;
+        if (!cue.visible) continue;
         float ratio = gameplay_hud_ring_ratio(nearest_dist[shape_index], perfect_dist, ring_appear_dist);
 
         const auto envelope = approach_ring_envelope(ratio, btn_radius,
                                                      max_ring_radius, reduce_motion);
         if (envelope.alpha_scale <= 0.0f) continue;
 
-        Color base = ring_color_for_cue(cue, style);
-        Color ring_color = Fade(base, (200.0f / 255.0f) * envelope.alpha_scale);
+        Color ring_color = Fade(cue.color, (200.0f / 255.0f) * envelope.alpha_scale);
         DrawCircleLinesV({button.cx, button.cy}, envelope.radius, ring_color);
         DrawCircleLinesV({button.cx, button.cy}, envelope.radius - 1.0f,
-            {base.r, base.g, base.b, static_cast<unsigned char>(ring_color.a / 2)});
+            {cue.color.r, cue.color.g, cue.color.b, static_cast<unsigned char>(ring_color.a / 2)});
     }
 }
 
@@ -330,9 +309,10 @@ GameplayHudRingCue gameplay_hud_ring_cue(float nearest_dist,
                                          float perfect_dist,
                                          float good_dist,
                                          float ring_appear_dist) {
-    if (nearest_dist <= 0.0f || nearest_dist >= ring_appear_dist) return GameplayHudRingCue::Hidden;
-    if (nearest_dist <= perfect_dist) return GameplayHudRingCue::Perfect;
-    return (nearest_dist <= good_dist) ? GameplayHudRingCue::Near : GameplayHudRingCue::Far;
+    if (nearest_dist <= 0.0f || nearest_dist >= ring_appear_dist) return {};
+    if (nearest_dist <= perfect_dist) return {true, kGameplayHudRingPerfectColor};
+    if (nearest_dist <= good_dist)    return {true, kGameplayHudRingNearColor};
+    return {true, kGameplayHudRingFarColor};
 }
 
 void init_gameplay_hud_screen_ui() {

--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.h
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.h
@@ -11,12 +11,31 @@ enum class GameplayHudShapeSlot {
     Triangle = 2
 };
 
-enum class GameplayHudRingCue {
-    Hidden,
-    Far,
-    Near,
-    Perfect
+// Approach-ring proximity readout (issue #1202 / #1204): the former
+// `GameplayHudRingCue` discriminator switched on `Hidden/Far/Near/Perfect`,
+// then re-switched to look up a draw color. Per Fabian's existential
+// processing chapter the function now returns the data the renderer needs
+// directly — visibility plus the ring color — instead of a label.
+//
+//   `visible == false`     → the ring is not drawn (former Hidden value).
+//   `visible == true`      → ring is drawn with `color`. Far/Near/Perfect
+//                            are encoded only by which `kGameplayHudRing*`
+//                            constant `color` matches.
+struct GameplayHudRingCue {
+    bool  visible = false;
+    Color color   = {0, 0, 0, 0};
+
+    friend constexpr bool operator==(const GameplayHudRingCue& a,
+                                     const GameplayHudRingCue& b) {
+        return a.visible == b.visible
+            && a.color.r == b.color.r && a.color.g == b.color.g
+            && a.color.b == b.color.b && a.color.a == b.color.a;
+    }
 };
+
+inline constexpr Color kGameplayHudRingPerfectColor{100, 255, 100, 255};
+inline constexpr Color kGameplayHudRingNearColor   {180, 255, 100, 255};
+inline constexpr Color kGameplayHudRingFarColor    {120, 120, 180, 255};
 
 float gameplay_hud_perfect_distance(const SongState* song_state);
 float gameplay_hud_good_distance(const SongState* song_state);

--- a/tests/test_input_pipeline_behavior.cpp
+++ b/tests/test_input_pipeline_behavior.cpp
@@ -411,10 +411,13 @@ TEST_CASE("pipeline: gameplay HUD proximity ring progresses through far near per
     CHECK(appear_dist > 59.99f);
     CHECK(appear_dist < 60.01f);
 
-    CHECK(gameplay_hud_ring_cue(900.0f, perfect_dist, good_dist, appear_dist) == GameplayHudRingCue::Hidden);
-    CHECK(gameplay_hud_ring_cue(50.0f, perfect_dist, good_dist, appear_dist) == GameplayHudRingCue::Far);
-    CHECK(gameplay_hud_ring_cue(good_dist, perfect_dist, good_dist, appear_dist) == GameplayHudRingCue::Near);
-    CHECK(gameplay_hud_ring_cue(perfect_dist, perfect_dist, good_dist, appear_dist) == GameplayHudRingCue::Perfect);
+    CHECK_FALSE(gameplay_hud_ring_cue(900.0f, perfect_dist, good_dist, appear_dist).visible);
+    CHECK(gameplay_hud_ring_cue(50.0f, perfect_dist, good_dist, appear_dist)
+          == GameplayHudRingCue{true, kGameplayHudRingFarColor});
+    CHECK(gameplay_hud_ring_cue(good_dist, perfect_dist, good_dist, appear_dist)
+          == GameplayHudRingCue{true, kGameplayHudRingNearColor});
+    CHECK(gameplay_hud_ring_cue(perfect_dist, perfect_dist, good_dist, appear_dist)
+          == GameplayHudRingCue{true, kGameplayHudRingPerfectColor});
 }
 
 TEST_CASE("pipeline: gameplay HUD raygui shape presses ignored outside Playing",


### PR DESCRIPTION
## Summary

Migrates `GameplayHudRingCue` (4-value control-flow enum: `Hidden / Far / Near / Perfect`) to a return-data struct, per the existential-processing mechanic in #1202 / #1204.

Before, every renderer call did **two switches** on the discriminator: `ring_color_for_cue` mapped the value to a draw color, and `if (cue == Hidden) continue` early-outed. The enum existed only to be switched on. Per Fabian, the correct transform is to **return the data the renderer needs directly** instead of returning a label.

## Mechanic

```cpp
// Before
enum class GameplayHudRingCue { Hidden, Far, Near, Perfect };
GameplayHudRingCue gameplay_hud_ring_cue(float nearest, ...);

// After (no enum, no switch)
struct GameplayHudRingCue {
    bool  visible = false;
    Color color   = {0, 0, 0, 0};
};
GameplayHudRingCue gameplay_hud_ring_cue(float nearest, ...);
```

The three ring colors (perfect / near / far) are now published in the header as `constexpr Color` constants. Tests assert on `{visible, color}` instead of enum equality. The renderer goes from `Color base = ring_color_for_cue(cue, style);` to `Color base = cue.color;`.

## Changes

- **Header**: enum → `struct { bool visible; Color color; }`; add public `kGameplayHudRing{Perfect,Near,Far}Color` constants.
- **Implementation**: delete `ring_color_for_cue` switch; `gameplay_hud_ring_cue()` now returns colored data directly; remove dead `ring_perfect / ring_near / ring_far` fields from `GameplayHudVisualStyle` (nothing else read them).
- **Tests**: `tests/test_input_pipeline_behavior.cpp` updated to compare against `GameplayHudRingCue{visible, color}` literals.
- **Allowlist**: `app/.allowed-enums.txt` loses the `GameplayHudRingCue` line — `check_enum_allowlist.py` now reports 12 enums (was 13).

## Acceptance (#1204 per-PR checklist)

- [x] Enum declaration deleted.
- [x] No `switch` on the former enum remains in `app/`.
- [x] No `if (x.kind == Foo::Bar)` branches remain.
- [x] The branching code is replaced with direct data return.
- [x] `app/.allowed-enums.txt` updated (line removed, not just commented).
- [x] Local Clang build is warning-free under `-Wall -Wextra -Werror`.
- [x] All 876 Catch2 test cases / 2924 assertions pass — identical to baseline.
- [x] No semantic changes — proximity ring still renders with the same colors at the same distance thresholds.

## Cyclomatic ratchet

- **Deleted switches:** 1 (`ring_color_for_cue`, 4 cases including default fall-through).
- **Deleted enum-equality branches:** 1 (`if (cue == Hidden) continue`).
- **Net cyclomatic complexity change:** -5 branches.

Refs #1202 #1204