### PR TITLE
Eradicate GameplayHudShapeSlot enum via per-shape named accessors (refs #1202, #1204)

### DIFF
--- a/app/.allowed-enums.txt
+++ b/app/.allowed-enums.txt
@@ -45,4 +45,3 @@ FontSize           # UI layout label
 # Adding a row here would be drift; eradicate instead.
 Shape                 # #1202: per-shape tags; player identity, 4 cases
 GamePhase             # #1202: per-phase tag/struct mix; blocked on game_state.h split
-GameplayHudShapeSlot  # #1202 re-triage: switch in app/ui/screen_controllers/gameplay_hud_screen_controller.cpp

--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
@@ -101,18 +101,6 @@ ApproachRingEnvelope approach_ring_envelope(float ratio,
     return out;
 }
 
-Rectangle shape_slot_bounds(const GameplayHudLayoutState& state, GameplayHudShapeSlot slot) {
-    switch (slot) {
-        case GameplayHudShapeSlot::Circle:
-            return GameplayHudLayout_CircleButtonBounds(&state);
-        case GameplayHudShapeSlot::Square:
-            return GameplayHudLayout_SquareButtonBounds(&state);
-        case GameplayHudShapeSlot::Triangle:
-            return GameplayHudLayout_TriangleButtonBounds(&state);
-    }
-    return GameplayHudLayout_CircleButtonBounds(&state);
-}
-
 void render_shape_buttons(const entt::registry& reg,
                           const GameplayHudVisualStyle& style,
                           const GameplayHudLayoutState& ui_state) {
@@ -122,9 +110,9 @@ void render_shape_buttons(const entt::registry& reg,
         float cy;
     };
     std::array<ButtonVisual, 3> buttons{};
-    const auto circle_bounds = shape_slot_bounds(ui_state, GameplayHudShapeSlot::Circle);
-    const auto square_bounds = shape_slot_bounds(ui_state, GameplayHudShapeSlot::Square);
-    const auto triangle_bounds = shape_slot_bounds(ui_state, GameplayHudShapeSlot::Triangle);
+    const auto circle_bounds = GameplayHudLayout_CircleButtonBounds(&ui_state);
+    const auto square_bounds = GameplayHudLayout_SquareButtonBounds(&ui_state);
+    const auto triangle_bounds = GameplayHudLayout_TriangleButtonBounds(&ui_state);
     buttons[0] = ButtonVisual{Shape::Circle,
                               circle_bounds.x + circle_bounds.width * 0.5f,
                               circle_bounds.y + circle_bounds.height * 0.5f};
@@ -319,9 +307,19 @@ void init_gameplay_hud_screen_ui() {
     // Controller state is registry-owned and initialized lazily in render.
 }
 
-Rectangle gameplay_hud_shape_input_bounds(GameplayHudShapeSlot slot) {
+Rectangle gameplay_hud_circle_input_bounds() {
     static const GameplayHudLayoutState geometry_state = GameplayHudLayout_Init();
-    return shape_slot_bounds(geometry_state, slot);
+    return GameplayHudLayout_CircleButtonBounds(&geometry_state);
+}
+
+Rectangle gameplay_hud_square_input_bounds() {
+    static const GameplayHudLayoutState geometry_state = GameplayHudLayout_Init();
+    return GameplayHudLayout_SquareButtonBounds(&geometry_state);
+}
+
+Rectangle gameplay_hud_triangle_input_bounds() {
+    static const GameplayHudLayoutState geometry_state = GameplayHudLayout_Init();
+    return GameplayHudLayout_TriangleButtonBounds(&geometry_state);
 }
 
 void gameplay_hud_process_button_input(entt::registry& reg) {
@@ -442,7 +440,7 @@ void render_gameplay_hud_screen_ui(entt::registry& reg) {
     GuiLabel(Rectangle{ 10, 740, 90, 30 }, "ENERGY");
     GuiSetAlpha(1.0f);
 
-    const Rectangle circle_bounds = shape_slot_bounds(state, GameplayHudShapeSlot::Circle);
+    const Rectangle circle_bounds = GameplayHudLayout_CircleButtonBounds(&state);
     const float lane_divider_y = circle_bounds.y - kLaneDividerOffsetFromShapeRow;
     DrawLineV({0.0f, lane_divider_y},
               {constants::SCREEN_W_F, lane_divider_y},

--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.h
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.h
@@ -5,12 +5,6 @@
 
 #include "../../components/song_state.h"
 
-enum class GameplayHudShapeSlot {
-    Circle = 0,
-    Square = 1,
-    Triangle = 2
-};
-
 // Approach-ring proximity readout (issue #1202 / #1204): the former
 // `GameplayHudRingCue` discriminator switched on `Hidden/Far/Near/Perfect`,
 // then re-switched to look up a draw color. Per Fabian's existential
@@ -48,7 +42,14 @@ GameplayHudRingCue gameplay_hud_ring_cue(float nearest_dist,
 void init_gameplay_hud_screen_ui();
 void gameplay_hud_process_button_input(entt::registry& reg);
 void render_gameplay_hud_screen_ui(entt::registry& reg);
-Rectangle gameplay_hud_shape_input_bounds(GameplayHudShapeSlot slot);
+// Per-shape input bounds for the gameplay HUD. The former
+// `gameplay_hud_shape_input_bounds(GameplayHudShapeSlot)` switched on a
+// 3-value discriminator to pick one of these getters; per Fabian's
+// existential processing (issues #1202 / #1204) each shape is its own
+// named accessor — the type IS the choice, no runtime branch.
+Rectangle gameplay_hud_circle_input_bounds();
+Rectangle gameplay_hud_square_input_bounds();
+Rectangle gameplay_hud_triangle_input_bounds();
 void gameplay_hud_apply_button_presses(entt::registry& reg,
                                         bool pause_pressed,
                                         bool circle_pressed,

--- a/tests/test_input_pipeline_behavior.cpp
+++ b/tests/test_input_pipeline_behavior.cpp
@@ -210,7 +210,7 @@ TEST_CASE("pipeline: gameplay HUD pointer release is collected before the fixed 
     auto& sw = reg.get<ShapeWindow>(player);
     REQUIRE(window_phase_is_idle(reg, player));
 
-    const auto square_bounds = gameplay_hud_shape_input_bounds(GameplayHudShapeSlot::Square);
+    const auto square_bounds = gameplay_hud_square_input_bounds();
     input.click = true;
     input.end_x = square_bounds.x + square_bounds.width * 0.5f;
     input.end_y = square_bounds.y + square_bounds.height * 0.5f;
@@ -232,7 +232,7 @@ TEST_CASE("pipeline: mobile button-zone touch release is collected independently
     REQUIRE(window_phase_is_idle(reg, player));
     REQUIRE(lane.current == 1);
 
-    const auto square_bounds = gameplay_hud_shape_input_bounds(GameplayHudShapeSlot::Square);
+    const auto square_bounds = gameplay_hud_square_input_bounds();
     input.touch_up = true;
     input.end_x = constants::SCREEN_W_F * 0.5f;
     input.end_y = constants::SCREEN_H_F * 0.25f;
@@ -259,7 +259,7 @@ TEST_CASE("pipeline: swipe-zone touch release over shape HUD does not press shap
     REQUIRE(lane.current == 1);
     lane.target = lane.current;
 
-    const auto square_bounds = gameplay_hud_shape_input_bounds(GameplayHudShapeSlot::Square);
+    const auto square_bounds = gameplay_hud_square_input_bounds();
     input.touch_up = true;
     input.button_touch_up = false;
     input.end_x = square_bounds.x + square_bounds.width * 0.5f;
@@ -365,7 +365,7 @@ TEST_CASE("pipeline: pending phase transition blocks queued go input",
 
 TEST_CASE("pipeline: gameplay HUD shape tap uses slot rectangle bounds",
           "[input_pipeline][hud]") {
-    const auto circle_input_bounds = gameplay_hud_shape_input_bounds(GameplayHudShapeSlot::Circle);
+    const auto circle_input_bounds = gameplay_hud_circle_input_bounds();
     const Vector2 tap_center = {200.0f, 1190.0f};
     const Vector2 tap_plus_49 = {200.0f, 1239.0f};
     const Vector2 tap_plus_51 = {200.0f, 1241.0f};
@@ -377,9 +377,9 @@ TEST_CASE("pipeline: gameplay HUD shape tap uses slot rectangle bounds",
 
 TEST_CASE("pipeline: gameplay HUD shape geometry matches gameplay.rgl slots",
           "[input_pipeline][hud]") {
-    const auto circle_bounds = gameplay_hud_shape_input_bounds(GameplayHudShapeSlot::Circle);
-    const auto square_bounds = gameplay_hud_shape_input_bounds(GameplayHudShapeSlot::Square);
-    const auto triangle_bounds = gameplay_hud_shape_input_bounds(GameplayHudShapeSlot::Triangle);
+    const auto circle_bounds = gameplay_hud_circle_input_bounds();
+    const auto square_bounds = gameplay_hud_square_input_bounds();
+    const auto triangle_bounds = gameplay_hud_triangle_input_bounds();
 
     CHECK(circle_bounds.x == 130.0f);
     CHECK(square_bounds.x == 290.0f);


### PR DESCRIPTION
Continues the enum-eradication line tracked by #1202 / #1204. After PRs
#1257 (GameplayHudRingCue), #1256 (InputSource), #1254 (ProceduralWave),
#1253 (ObstacleKind), #1252 (TimingTier), #1245 (DeathCause), #1244 (MeshType),
#1243 (WindowPhase), #1242 (Layer), this PR retires the next pending row
in `app/.allowed-enums.txt`.

## Per-value schema decision (Fabian Principle 1 — no switch on discriminator)

`GameplayHudShapeSlot { Circle, Square, Triangle }` was a 3-value
discriminator driving exactly one switch in
`app/ui/screen_controllers/gameplay_hud_screen_controller.cpp`:

```cpp
Rectangle shape_slot_bounds(const GameplayHudLayoutState& state, GameplayHudShapeSlot slot) {
    switch (slot) {
        case GameplayHudShapeSlot::Circle:   return GameplayHudLayout_CircleButtonBounds(&state);
        case GameplayHudShapeSlot::Square:   return GameplayHudLayout_SquareButtonBounds(&state);
        case GameplayHudShapeSlot::Triangle: return GameplayHudLayout_TriangleButtonBounds(&state);
    }
    return GameplayHudLayout_CircleButtonBounds(&state);  // never-reached fallback
}
```

Every existing call site at every level — `render_shape_buttons`, the
public bounds-accessor consumed by `gameplay_hud_process_button_input`
and tests — already knows at compile time which of the three shapes it
wants. The discriminator value was being looked up only so the switch
could pick the matching generated-layout accessor. That is the textbook
Fabian case: **the type IS the choice; push the choice into the function name.**

| Former value | Per-value data | Target |
| --- | --- | --- |
| `GameplayHudShapeSlot::Circle`   | none | `gameplay_hud_circle_input_bounds()`   → `GameplayHudLayout_CircleButtonBounds()` |
| `GameplayHudShapeSlot::Square`   | none | `gameplay_hud_square_input_bounds()`   → `GameplayHudLayout_SquareButtonBounds()` |
| `GameplayHudShapeSlot::Triangle` | none | `gameplay_hud_triangle_input_bounds()` → `GameplayHudLayout_TriangleButtonBounds()` |

Per-value column count = 0 (no data carried beyond identity), so each
former value is a zero-column relation — best expressed as a named free
function rather than a tag, since the bounds are pure layout-geometry
queries with no entity to attach to.

## Changes

- `app/ui/screen_controllers/gameplay_hud_screen_controller.h` — delete
  `enum class GameplayHudShapeSlot`; replace the single-parameter
  `gameplay_hud_shape_input_bounds(GameplayHudShapeSlot)` declaration
  with three shape-specific declarations and a comment block recording
  the migration (same convention as PR #1257).
- `app/ui/screen_controllers/gameplay_hud_screen_controller.cpp` —
  delete the private `shape_slot_bounds()` switch; inline its three
  generated-layout calls at the two remaining call sites
  (`render_shape_buttons`, the lane-divider computation in
  `render_gameplay_hud_screen_ui`); replace the public accessor with
  three trivial named functions, each holding its own `static const`
  geometry cache (preserving the lazy-init behaviour of the prior code).
- `tests/test_input_pipeline_behavior.cpp` — update all six call sites
  to the new per-shape accessors (`gameplay_hud_circle_input_bounds()`,
  `gameplay_hud_square_input_bounds()`, `gameplay_hud_triangle_input_bounds()`).
- `app/.allowed-enums.txt` — delete the `GameplayHudShapeSlot` row.
  Enum count in `app/` is now **11** (was 12; 9 Keep + 2 Pending —
  `Shape`, `GamePhase`).

## Verification

- `cmake --build build` — zero warnings under `-Wall -Wextra -Werror`.
- `./build/shapeshifter_tests` — **all-pass, 2924 assertions in 876 test cases**
  (matches baseline before the migration).
- `python3 tools/check_enum_allowlist.py` — `ok: 11 enum(s) in app/, all allowlisted`.
- `grep -rn "GameplayHudShapeSlot\|gameplay_hud_shape_input_bounds\|shape_slot_bounds" app/ tests/`
  returns only the comment-block reference in the new `.h` documenting
  the former API for future readers (no live code).

## Remaining pending eradications (per `app/.allowed-enums.txt`)

| Enum | Status |
| --- | --- |
| `Shape`     | pending — player-identity, 4 cases (Circle/Square/Triangle/Hexagon) |
| `GamePhase` | pending — **blocked** on the `game_state.h` SPLIT in #1194 |

`GamePhase` is gated by the god-struct split tracked in #1194; `Shape` is the
next standalone candidate after this PR lands.

Refs #1202, #1204.
