### PR TITLE
Eradicate Shape switch dispatch via per-shape lookup tables (refs #1202, #1204)

### DIFF
--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -9,9 +9,11 @@
 #include "../components/scoring.h"
 #include "session_logger_system.h"
 #include "../util/lane_utils.h"
+#include "../util/shape_lane_mapping.h"
 #include "../constants.h"
 
 #include <raylib.h>
+#include <array>
 #include <cmath>
 #include <random>
 #include <string_view>
@@ -30,13 +32,21 @@ static bool lane_centers_overlap(float lhs_x, float rhs_x) {
     return CheckCollisionRecs(lane_overlap_rect(lhs_x), lane_overlap_rect(rhs_x));
 }
 
+// Per-shape key-name lookup (issue #1202/#1204). The former
+// `switch (s)` is replaced by a constexpr string column indexed by
+// `shape_index(s)`; Hexagon's slot doubles as the invalid-shape fallback
+// since the player never directly presses a Hexagon key.
+static constexpr std::array<const char*, kShapeCount> kShapeKeyNames{
+    "key_1(Circle)",
+    "key_2(Square)",
+    "key_3(Triangle)",
+    "key_?(?)",
+};
+
 static const char* shape_key_name(Shape s) {
-    switch (s) {
-        case Shape::Circle:   return "key_1(Circle)";
-        case Shape::Square:   return "key_2(Square)";
-        case Shape::Triangle: return "key_3(Triangle)";
-        default:              return "key_?(?)";
-    }
+    const int idx = shape_index(s);
+    if (idx < 0 || idx >= kShapeCount) return "key_?(?)";
+    return kShapeKeyNames[static_cast<size_t>(idx)];
 }
 
 static bool test_player_shape_done(const TestPlayerAction& action) {

--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
@@ -12,6 +12,7 @@
 #include "../../constants.h"
 #include "../../entities/settings.h"
 #include "../../util/rhythm_math.h"
+#include "../../util/shape_lane_mapping.h"
 #include "screen_controller_base.h"
 #include "gameplay_hud_screen_controller.h"
 #include <entt/entt.hpp>
@@ -29,28 +30,37 @@ using GameplayHudController = RGuiScreenController<GameplayHudLayoutState,
                                                     &GameplayHudLayout_Init,
                                                     &GameplayHudLayout_Render>;
 
+// Per-shape flat draw functions (issue #1202/#1204). Each former
+// `switch (shape)` case becomes its own row in a fn-ptr column indexed by
+// `shape_index(shape)`; the dispatcher reads the column directly rather than
+// branching on the discriminator. Same mechanic as ProceduralWave PR #1254.
+void draw_circle_flat(float cx, float cy, float size, Color color) {
+    DrawCircleV({cx, cy}, size / 2.0f, color);
+}
+void draw_square_flat(float cx, float cy, float size, Color color) {
+    const float half = size / 2.0f;
+    DrawRectangleRec({cx - half, cy - half, size, size}, color);
+}
+void draw_triangle_flat(float cx, float cy, float size, Color color) {
+    const float half = size / 2.0f;
+    DrawTriangle({cx, cy - half}, {cx - half, cy + half}, {cx + half, cy + half}, color);
+}
+void draw_hexagon_flat(float cx, float cy, float size, Color color) {
+    DrawPoly({cx, cy}, 6, size * 0.6f, -90.0f, color);
+}
+
+using ShapeFlatDrawFn = void (*)(float, float, float, Color);
+constexpr std::array<ShapeFlatDrawFn, kShapeCount> kShapeFlatDrawFns{
+    &draw_circle_flat,
+    &draw_square_flat,
+    &draw_triangle_flat,
+    &draw_hexagon_flat,
+};
+
 void draw_shape_flat(Shape shape, float cx, float cy, float size, Color color) {
-    switch (shape) {
-        case Shape::Circle: {
-            DrawCircleV({cx, cy}, size / 2.0f, color);
-            break;
-        }
-        case Shape::Square: {
-            float half = size / 2.0f;
-            DrawRectangleRec({cx - half, cy - half, size, size}, color);
-            break;
-        }
-        case Shape::Triangle: {
-            float half = size / 2.0f;
-            DrawTriangle({cx, cy - half}, {cx - half, cy + half}, {cx + half, cy + half}, color);
-            break;
-        }
-        case Shape::Hexagon: {
-            float radius = size * 0.6f;
-            DrawPoly({cx, cy}, 6, radius, -90.0f, color);
-            break;
-        }
-    }
+    const int idx = shape_index(shape);
+    if (idx < 0) return;
+    kShapeFlatDrawFns[static_cast<size_t>(idx)](cx, cy, size, color);
 }
 
 struct GameplayHudVisualStyle {

--- a/app/util/shape_lane_mapping.h
+++ b/app/util/shape_lane_mapping.h
@@ -6,14 +6,15 @@
 
 inline constexpr int kShapeCount = 4;
 
+// Shape is a 4-value ordinal label: the enumerator IS the index. Per Fabian's
+// existential processing (issue #1202/#1204), the former 4-case discriminator
+// switch was a hidden lookup table; we replace it with the direct ordinal
+// dispatch the switch was hand-rolling. The bounds check rejects ill-formed
+// casts (tests construct `static_cast<Shape>(255)` to probe error paths) so
+// the contract is identical to the pre-migration switch.
 inline constexpr int shape_index(Shape shape) noexcept {
-    switch (shape) {
-        case Shape::Circle:   return 0;
-        case Shape::Square:   return 1;
-        case Shape::Triangle: return 2;
-        case Shape::Hexagon:  return 3;
-    }
-    return -1;
+    const auto raw = static_cast<uint8_t>(shape);
+    return (raw < static_cast<uint8_t>(kShapeCount)) ? static_cast<int>(raw) : -1;
 }
 
 inline constexpr bool is_valid_shape(Shape shape) noexcept {

--- a/tests/test_shipped_beatmap_medium_balance.cpp
+++ b/tests/test_shipped_beatmap_medium_balance.cpp
@@ -6,8 +6,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include "entities/beat_map.h"
 #include "components/obstacle.h"
+#include "util/shape_lane_mapping.h"
 
 #include <algorithm>
+#include <array>
 #include <filesystem>
 #include <string>
 #include <vector>
@@ -28,14 +30,20 @@ static std::vector<std::string> find_shipped_beatmaps() {
     return paths;
 }
 
+// Per-shape motif lane column (issue #1202/#1204). The former
+// `switch (shape)` is replaced by a constexpr int column indexed by
+// `shape_index(shape)`; Hexagon's slot is -1 (no motif lane).
+static constexpr std::array<int, kShapeCount> kMotifLaneForShape{
+    0,   // Circle
+    1,   // Square
+    2,   // Triangle
+    -1,  // Hexagon — not lane-mapped
+};
+
 static int expected_lane_for_shape(Shape shape) {
-    switch (shape) {
-        case Shape::Circle: return 0;
-        case Shape::Square: return 1;
-        case Shape::Triangle: return 2;
-        case Shape::Hexagon: return -1;
-    }
-    return -1;
+    const int idx = shape_index(shape);
+    if (idx < 0 || idx >= kShapeCount) return -1;
+    return kMotifLaneForShape[static_cast<size_t>(idx)];
 }
 
 TEST_CASE("medium balance: content directory is reachable",


### PR DESCRIPTION
Per Fabian's existential-processing canon (Principle 1: no `switch` on discriminator), the three remaining `switch (Shape)` sites are replaced with per-shape column lookups indexed by `shape_index(shape)`. Same mechanic as ProceduralWave PR #1254 (function-pointer-per-row for constexpr data tables).

### Per-shape schema (Fabian's relational mechanic)

Following the `#1204` table-aware (not blanket-tag) doctrine:

| Former switch site | Per-row column |
|---|---|
| `shape_index` in `util/shape_lane_mapping.h` | direct ordinal — the enumerator IS the index |
| `draw_shape_flat` in `gameplay_hud_screen_controller.cpp` | constexpr fn-ptr table (`kShapeFlatDrawFns[kShapeCount]`) |
| `shape_key_name` in `test_player_system.cpp` | constexpr string table (`kShapeKeyNames[kShapeCount]`) |

A fourth lookup in `tests/test_shipped_beatmap_medium_balance.cpp`'s `expected_lane_for_shape` helper (a parallel motif-lane column with Hexagon = -1) is also collapsed to a constexpr int table for consistency with the in-app mechanic.

### Multi-PR split rationale

Scope check: `Shape::` appears at **502 sites** across `app/` + `tests/` — significantly larger than recent enum migrations (`ObstacleKind` #1253 was 31 files / 912+/624- lines; `TimingTier` #1252 was 24 files / 825+/478-). A single-PR full eradication would be too risky and unreviewable.

This PR is the first of a planned split for `Shape`:

1. **This PR (PR A — ships now):** eradicate the `switch (Shape)` dispatch sites via lookup tables. No enum changes; no entity-shape semantics change. Pure Principle 1 progress.
2. **PR B (follow-up):** migrate the on-entity carriers — `PlayerShape::current`, `ShapeWindow::target_shape`, `RequiredShape::shape`, `Obstacle::shape` (in `ShapeGateSpawn`/`SplitPathSpawn`) — to per-shape tags (`ShapeCircleTag`/`ShapeSquareTag`/`ShapeTriangleTag`/`ShapeHexagonTag`). Eradicates the `== Shape::Hexagon` sentinel comparisons (Principle 1: no `if (x.kind == Foo::Bar)`).
3. **PR C (follow-up):** migrate data-row carriers — `BeatEntry::shape`, `ButtonPressEvent::shape`, `TestPlayerAction::target_shape` — to per-shape vectors / per-shape event types. Deletes the `Shape` enum and removes the line from `app/.allowed-enums.txt`.

A cycle comment on #1202 documents this split.

### Acceptance progress for #1202 `Shape`

- [x] No `switch` on `Shape` exists anywhere in `app/` or `tests/` (only `switch (slot)` in `keyboard_shape_mapping.h` remains, with `case KeyboardShapeSlot::*` arms returning `Shape` values — switch is on `KeyboardShapeSlot`, a Keep enum).
- [ ] No `if (x.kind == Foo::Bar)` style branches remain on Shape. *(deferred to PR B)*
- [ ] The enum declaration is deleted. *(deferred to PR C)*
- [ ] One tag struct per former enum value lives in `app/tags/tags.h`. *(deferred to PR B)*

### Validation

- 876 Catch2 tests / 2924 assertions pass under unity + non-unity Clang `-Wall -Wextra -Werror`.
- `python3 tools/check_enum_allowlist.py` → `ok: 11 enum(s) in app/, all allowlisted` (unchanged — `Shape` row still pending eradication).
- `grep -rEn '(switch|case)\s.*Shape::' app/ tests/` → only the `KeyboardShapeSlot`→`Shape` mapping in `keyboard_shape_mapping.h` (not a Shape discriminator).

Refs #1202 #1204.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>