### PR TITLE
Migrate on-entity Shape carriers to per-shape tags (refs #1202, #1204)

### DIFF
--- a/app/components/obstacle.h
+++ b/app/components/obstacle.h
@@ -13,9 +13,13 @@ struct Obstacle {
     constexpr explicit Obstacle(int16_t points) : base_points(points) {}
 };
 
-struct RequiredShape {
-    Shape shape = Shape::Circle;
-};
+// `RequiredShape` (formerly a single-column `{ Shape shape; }` row) was
+// eradicated in issue #1202/#1204; the obstacle's required shape lives as
+// one of `RequiredShapeCircleTag` / `RequiredShapeSquareTag` /
+// `RequiredShapeTriangleTag` / `RequiredShapeHexagonTag` on the obstacle
+// entity. Use `set_required_shape_tag()` from `app/util/shape_tag.h` to
+// emplace it, and `current_required_shape()` / `has_required_shape_tag()`
+// to read it back.
 
 struct ShapeGateLane {
     int8_t lane = 0;

--- a/app/components/player.h
+++ b/app/components/player.h
@@ -11,8 +11,11 @@ enum class Shape : uint8_t {
 };
 
 // Hot render data — read by game_camera_system, player_movement_system every frame.
+// The player's current shape identity lives as one of `ShapeCircleTag` /
+// `ShapeSquareTag` / `ShapeTriangleTag` / `ShapeHexagonTag` on the player
+// entity (issue #1202/#1204); see `app/util/shape_tag.h` for the helper
+// dispatch and the rationale for the per-tag table mechanic.
 struct PlayerShape {
-    Shape current  = Shape::Circle;
     float morph_t  = 1.0f;
 };
 
@@ -21,8 +24,10 @@ struct PlayerShape {
 // (Idle/MorphIn/Active/MorphOut) lives as a per-phase tag on the player
 // entity (`ShapeWindowMorphInTag` / `ShapeWindowActiveTag` /
 // `ShapeWindowMorphOutTag` in `tags/tags.h`); Idle = absence of all three.
+// The target shape the press is morphing toward lives as one of
+// `TargetShapeCircleTag` / `TargetShapeSquareTag` / `TargetShapeTriangleTag` /
+// `TargetShapeHexagonTag` on the same entity (issue #1202/#1204).
 struct ShapeWindow {
-    Shape       target_shape  = Shape::Circle;
     bool        graded        = false;
     float       window_timer  = 0.0f;
     float       window_start  = 0.0f;

--- a/app/entities/obstacle_entity.cpp
+++ b/app/entities/obstacle_entity.cpp
@@ -6,6 +6,7 @@
 #include "../constants.h"
 #include "../util/lane_utils.h"
 #include "../util/shape_lane_mapping.h"
+#include "../util/shape_tag.h"
 #include <stdexcept>
 
 namespace {
@@ -24,7 +25,7 @@ entt::entity create_shape_gate(entt::registry& reg, const ShapeGateSpawn& params
     reg.emplace<TagWorldPass>(e);
     reg.emplace<ShapeGateTag>(e);
     reg.emplace<Obstacle>(e, int16_t{constants::PTS_SHAPE_GATE});
-    reg.emplace<RequiredShape>(e, params.shape);
+    set_required_shape_tag(reg, e, params.shape);
     reg.emplace<ShapeGateLane>(
         e, static_cast<int8_t>(lane_utils::nearest_lane_for_x(params.x)));
     reg.emplace<DrawSize>(e, constants::SCREEN_W_F, 80.0f);
@@ -44,7 +45,7 @@ entt::entity create_split_path(entt::registry& reg, const SplitPathSpawn& params
     reg.emplace<TagWorldPass>(e);
     reg.emplace<SplitPathTag>(e);
     reg.emplace<Obstacle>(e, int16_t{constants::PTS_SPLIT_PATH});
-    reg.emplace<RequiredShape>(e, params.shape);
+    set_required_shape_tag(reg, e, params.shape);
     reg.emplace<RequiredLane>(e, params.req_lane);
     reg.emplace<DrawSize>(e, constants::SCREEN_W_F, 80.0f);
     reg.emplace<Color>(e, Color{255, 215, 0, 255});

--- a/app/entities/obstacle_render_entity.cpp
+++ b/app/entities/obstacle_render_entity.cpp
@@ -4,13 +4,14 @@
 #include "../components/rendering.h"
 #include "../constants.h"
 #include "../util/shape_lane_mapping.h"
+#include "../util/shape_tag.h"
 #include <cstdint>
 #include <stdexcept>
 
 namespace {
 uint8_t checked_shape_mesh_index(Shape shape) {
     const int index = shape_index(shape);
-    if (index < 0) throw std::logic_error("Invalid RequiredShape shape");
+    if (index < 0) throw std::logic_error("Invalid required shape tag");
     return static_cast<uint8_t>(index);
 }
 
@@ -101,13 +102,13 @@ void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical) {
     if (reg.all_of<ShapeGateTag>(logical)) {
         if (!wt_ptr) return;
         const auto& wt = *wt_ptr;
-        auto* req = reg.try_get<RequiredShape>(logical);
+        const bool has_req = has_required_shape_tag(reg, logical);
         uint8_t mesh_index = 0;
-        if (req) {
-            mesh_index = checked_shape_mesh_index(req->shape);
+        if (has_req) {
+            mesh_index = checked_shape_mesh_index(current_required_shape(reg, logical));
         }
         // Shape gates now render as shape-only prompts (no side walls/slabs).
-        if (req)
+        if (has_req)
             add_shape_child(reg, logical, mesh_index, wt.position.x, 0.0f,
                             40, col);
         return;
@@ -118,16 +119,16 @@ void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical) {
         if (rlane) {
             lane_index = checked_lane_index(rlane->lane);
         }
-        auto* req = reg.try_get<RequiredShape>(logical);
+        const bool has_req = has_required_shape_tag(reg, logical);
         uint8_t mesh_index = 0;
-        if (req) {
-            mesh_index = checked_shape_mesh_index(req->shape);
+        if (has_req) {
+            mesh_index = checked_shape_mesh_index(current_required_shape(reg, logical));
         }
         for (int i = 0; i < constants::LANE_COUNT; ++i)
             if (!rlane || i != lane_index)
                 add_slab_child(reg, logical, constants::LANE_X[i]-120,
                                240.0f, dsz.h, constants::OBSTACLE_3D_HEIGHT, col);
-        if (req && rlane)
+        if (has_req && rlane)
             add_shape_child(reg, logical, mesh_index,
                             constants::LANE_X[lane_index],
                             0.0f, 30, {255, 255, 255, 180});

--- a/app/entities/player_entity.cpp
+++ b/app/entities/player_entity.cpp
@@ -3,6 +3,7 @@
 #include "../components/transform.h"
 #include "../components/rendering.h"
 #include "../constants.h"
+#include "../util/shape_tag.h"
 #include <stdexcept>
 
 entt::entity create_player_entity(entt::registry& reg) {
@@ -14,17 +15,13 @@ entt::entity create_player_entity(entt::registry& reg) {
     auto player = reg.create();
     reg.emplace<PlayerTag>(player);
     reg.emplace<WorldTransform>(player, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
-    {
-        PlayerShape ps;
-        ps.current  = Shape::Hexagon;
-        reg.emplace<PlayerShape>(player, ps);
-    }
-    {
-        ShapeWindow sw;
-        sw.target_shape = Shape::Hexagon;
-        reg.emplace<ShapeWindow>(player, sw);
-        // Idle phase = absence of all ShapeWindow*Tag (per #1202/#1204).
-    }
+    reg.emplace<PlayerShape>(player);
+    // Player starts as Hexagon: presence of `ShapeHexagonTag` IS the data
+    // (issue #1202/#1204 — see `app/util/shape_tag.h`).
+    set_player_shape_tag(reg, player, Shape::Hexagon);
+    reg.emplace<ShapeWindow>(player);
+    set_target_shape_tag(reg, player, Shape::Hexagon);
+    // Idle phase = absence of all ShapeWindow*Tag (per #1202/#1204).
     reg.emplace<Lane>(player);
     // Vertical motion is grounded by default — no Jumping/Sliding component
     // is emplaced (Grounded == absence of both per #1202/#1204).

--- a/app/systems/camera_system.cpp
+++ b/app/systems/camera_system.cpp
@@ -12,6 +12,7 @@
 #include "../entities/settings.h"
 #include "../platform_display.h"
 #include "../util/shape_lane_mapping.h"
+#include "../util/shape_tag.h"
 #include <raylib.h>
 #include <raymath.h>
 #include <rlgl.h>
@@ -297,14 +298,16 @@ void game_camera_system(entt::registry& reg, [[maybe_unused]] float dt) {
     {
         auto view = reg.view<PlayerTag, WorldTransform, PlayerShape, Color>();
         for (auto [entity, transform, pshape, col] : view.each()) {
+            (void)pshape;
             const auto* jump = reg.try_get<Jumping>(entity);
             float y_3d = jump ? -jump->y_offset : 0.0f;
             float sz = constants::PLAYER_SIZE;
             if (reg.all_of<Sliding>(entity)) sz *= 0.5f;
-            const int shape_idx = shape_index(pshape.current);
+            const Shape current = current_player_shape(reg, entity);
+            const int shape_idx = shape_index(current);
             if (shape_idx < 0) {
                 TraceLog(LOG_WARNING, "game_camera_system skipped invalid PlayerShape %d",
-                         static_cast<int>(pshape.current));
+                         static_cast<int>(current));
                 reg.remove<ModelTransform>(entity);
                 reg.remove<MeshKindShape>(entity);
                 continue;

--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -6,6 +6,7 @@
 #include "../components/game_state.h"
 #include "../components/rhythm.h"
 #include "../util/rhythm_math.h"
+#include "../util/shape_tag.h"
 #include "../components/song_state.h"
 #include "gameplay_intents.h"
 #include "../constants.h"
@@ -14,36 +15,49 @@
 
 namespace {
 
-bool player_matches_required_shape(entt::registry& reg,
-                                    entt::entity player_entity,
-                                    const PlayerShape& p_shape,
-                                    const ShapeWindow& p_window,
-                                    Shape required,
-                                    bool rhythm_mode) {
-    if (required == Shape::Hexagon) {
-        return false;
-    }
-
+template <typename RequiredTag, typename ShapeTag, typename TargetTag>
+bool shape_row_match(entt::registry& reg,
+                     entt::entity player_entity,
+                     entt::entity obstacle_entity,
+                     bool rhythm_mode) {
+    if (!reg.all_of<RequiredTag>(obstacle_entity)) return false;
     if (rhythm_mode) {
-        // Per-tag dispatch (issue #1202/#1204). Idle = no phase tag.
         if (reg.all_of<ShapeWindowMorphInTag>(player_entity)) {
-            return p_window.press_time >= 0.0f && p_window.target_shape == required;
+            auto& sw = reg.get<ShapeWindow>(player_entity);
+            return sw.press_time >= 0.0f && reg.all_of<TargetTag>(player_entity);
         }
         if (reg.all_of<ShapeWindowActiveTag>(player_entity)) {
-            return p_shape.current == required || p_window.target_shape == required;
+            return reg.any_of<ShapeTag, TargetTag>(player_entity);
         }
-        // ShapeWindowMorphOutTag and Idle both reject.
+        // ShapeWindowMorphOutTag and Idle both reject in rhythm mode.
         return false;
     }
-
-    if (p_shape.current == required) {
-        return true;
-    }
-
+    if (reg.all_of<ShapeTag>(player_entity)) return true;
     const bool window_open = reg.any_of<ShapeWindowMorphInTag,
                                         ShapeWindowActiveTag,
                                         ShapeWindowMorphOutTag>(player_entity);
-    return window_open && p_window.target_shape == required;
+    return window_open && reg.all_of<TargetTag>(player_entity);
+}
+
+bool player_matches_required_shape(entt::registry& reg,
+                                    entt::entity player_entity,
+                                    entt::entity obstacle_entity,
+                                    bool rhythm_mode) {
+    if (reg.all_of<RequiredShapeHexagonTag>(obstacle_entity)) {
+        // No Hexagon-required obstacles are spawned in production; preserve
+        // the legacy "Hexagon-required → unclearable" contract by short-
+        // circuiting here regardless of player state.
+        return false;
+    }
+
+    // Per-shape match check: each row of the shape table is its own
+    // per-shape table-join (issue #1202/#1204), so we probe the three
+    // playable rows by tag-presence. No `switch`, no `if (x == Shape::Bar)`
+    // — each `shape_row_match` instantiation IS the per-row transform.
+    if (shape_row_match<RequiredShapeCircleTag,   ShapeCircleTag,   TargetShapeCircleTag>  (reg, player_entity, obstacle_entity, rhythm_mode)) return true;
+    if (shape_row_match<RequiredShapeSquareTag,   ShapeSquareTag,   TargetShapeSquareTag>  (reg, player_entity, obstacle_entity, rhythm_mode)) return true;
+    if (shape_row_match<RequiredShapeTriangleTag, ShapeTriangleTag, TargetShapeTriangleTag>(reg, player_entity, obstacle_entity, rhythm_mode)) return true;
+    return false;
 }
 
 bool shape_gate_lane_match(int8_t obstacle_lane, int player_lane) {
@@ -60,6 +74,7 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
     auto [p_transform, p_shape, p_window, p_lane] =
         player_view.get<WorldTransform, PlayerShape, ShapeWindow, Lane>(player_entity);
     lane_utils::normalize(p_lane, &p_transform);
+    (void)p_shape;
 
     auto& song = reg.ctx().get<SongState>();
     const bool rhythm_mode = song.playing || song.finished;
@@ -117,7 +132,6 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
 
     auto resolve_shape_obstacle = [&](entt::entity entity,
                                       const WorldTransform& wt,
-                                      Shape required_shape,
                                       bool lane_ok,
                                       const BeatInfo* timing_info) {
         if (!lane_ok) {
@@ -126,7 +140,7 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
         }
 
         const bool shape_ok =
-            player_matches_required_shape(reg, player_entity, p_shape, p_window, required_shape, rhythm_mode);
+            player_matches_required_shape(reg, player_entity, entity, rhythm_mode);
         if (shape_ok && timing_info && can_grade_shape) {
             grade_shape_timing(entity, timing_info->arrival_time);
         }
@@ -135,58 +149,61 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
 
     // Per-kind structural views — each loop touches only entities that actually
     // carry the required components, eliminating per-entity try_get branches.
+    // The required-shape data lives as a per-shape tag (issue #1202/#1204),
+    // so the views below filter on `ShapeGateTag` / `SplitPathTag` and the
+    // resolver dispatches per-shape via `player_matches_required_shape`.
 
-    // ShapeGate: RequiredShape only (no RequiredLane)
+    // ShapeGate: ShapeGateTag (carries RequiredShape*Tag, no RequiredLane)
     {
-        auto rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, ShapeGateLane, BeatInfo>(
+        auto rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, ShapeGateTag, ShapeGateLane, BeatInfo>(
             entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredLane>);
-        for (auto [e, obstacle, wt, req, lane, info] : rhythm_view.each()) {
+        for (auto [e, obstacle, wt, lane, info] : rhythm_view.each()) {
             (void)obstacle;
             const bool lane_ok = shape_gate_lane_match(lane.lane, player_lane);
-            resolve_shape_obstacle(e, wt, req.shape, lane_ok, &info);
+            resolve_shape_obstacle(e, wt, lane_ok, &info);
         }
 
-        auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, ShapeGateLane>(
+        auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, ShapeGateTag, ShapeGateLane>(
             entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredLane, BeatInfo>);
-        for (auto [e, obstacle, wt, req, lane] : view.each()) {
+        for (auto [e, obstacle, wt, lane] : view.each()) {
             (void)obstacle;
             const bool lane_ok = shape_gate_lane_match(lane.lane, player_lane);
-            resolve_shape_obstacle(e, wt, req.shape, lane_ok, nullptr);
+            resolve_shape_obstacle(e, wt, lane_ok, nullptr);
         }
 
-        auto fallback_rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, BeatInfo>(
+        auto fallback_rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, ShapeGateTag, BeatInfo>(
             entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredLane, ShapeGateLane>);
-        for (auto [e, obstacle, wt, req, info] : fallback_rhythm_view.each()) {
+        for (auto [e, obstacle, wt, info] : fallback_rhythm_view.each()) {
             (void)obstacle;
             const bool lane_ok = lane_utils::nearest_lane_for_x(wt.position.x) == player_lane;
-            resolve_shape_obstacle(e, wt, req.shape, lane_ok, &info);
+            resolve_shape_obstacle(e, wt, lane_ok, &info);
         }
 
-        auto fallback_view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape>(
+        auto fallback_view = reg.view<ObstacleTag, Obstacle, WorldTransform, ShapeGateTag>(
             entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredLane, BeatInfo, ShapeGateLane>);
-        for (auto [e, obstacle, wt, req] : fallback_view.each()) {
+        for (auto [e, obstacle, wt] : fallback_view.each()) {
             (void)obstacle;
             const bool lane_ok = lane_utils::nearest_lane_for_x(wt.position.x) == player_lane;
-            resolve_shape_obstacle(e, wt, req.shape, lane_ok, nullptr);
+            resolve_shape_obstacle(e, wt, lane_ok, nullptr);
         }
     }
 
-    // SplitPath: RequiredShape + RequiredLane
+    // SplitPath: SplitPathTag (carries RequiredShape*Tag + RequiredLane)
     {
-        auto rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, RequiredLane, BeatInfo>(
+        auto rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, SplitPathTag, RequiredLane, BeatInfo>(
             entt::exclude<ScoredTag, ResolvedObstacleTag>);
-        for (auto [e, obstacle, wt, req, rlane, info] : rhythm_view.each()) {
+        for (auto [e, obstacle, wt, rlane, info] : rhythm_view.each()) {
             (void)obstacle;
             const bool lane_ok = player_lane == rlane.lane;
-            resolve_shape_obstacle(e, wt, req.shape, lane_ok, &info);
+            resolve_shape_obstacle(e, wt, lane_ok, &info);
         }
 
-        auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape, RequiredLane>(
+        auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, SplitPathTag, RequiredLane>(
             entt::exclude<ScoredTag, ResolvedObstacleTag, BeatInfo>);
-        for (auto [e, obstacle, wt, req, rlane] : view.each()) {
+        for (auto [e, obstacle, wt, rlane] : view.each()) {
             (void)obstacle;
             const bool lane_ok = player_lane == rlane.lane;
-            resolve_shape_obstacle(e, wt, req.shape, lane_ok, nullptr);
+            resolve_shape_obstacle(e, wt, lane_ok, nullptr);
         }
     }
 

--- a/app/systems/player_input_system.cpp
+++ b/app/systems/player_input_system.cpp
@@ -9,6 +9,7 @@
 #include "../constants.h"
 #include "../util/lane_utils.h"
 #include "../util/shape_lane_mapping.h"
+#include "../util/shape_tag.h"
 
 namespace {
 
@@ -72,7 +73,7 @@ void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt)
     }
 
     auto begin_shape_window = [&](entt::entity entity, PlayerShape& ps, ShapeWindow& sw) {
-        sw.target_shape = pressed_shape;
+        set_target_shape_tag(reg, entity, pressed_shape);
         sw.window_timer = 0.0f;
         sw.window_start = song->song_time;
         sw.press_time = song->song_time;
@@ -98,14 +99,14 @@ void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt)
             const bool is_morph_out = reg.all_of<ShapeWindowMorphOutTag>(entity);
             if (is_idle) {
                 begin_shape_window(entity, pshape, swindow);
-            } else if (is_active && pressed_shape != pshape.current) {
+            } else if (is_active && pressed_shape != current_player_shape(reg, entity)) {
                 begin_shape_window(entity, pshape, swindow);
             } else if (is_morph_out) {
                 begin_shape_window(entity, pshape, swindow);
             }
         } else {
-            if (pressed_shape != pshape.current) {
-                pshape.current  = pressed_shape;
+            if (pressed_shape != current_player_shape(reg, entity)) {
+                set_player_shape_tag(reg, entity, pressed_shape);
                 pshape.morph_t  = 1.0f;
                 const auto& sc = constants::SHAPE_COLORS[pressed_shape_index];
                 reg.replace<Color>(entity, sc);
@@ -116,5 +117,6 @@ void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt)
             }
         }
         (void)lane;
+        (void)swindow;
     }
 }

--- a/app/systems/session_logger_system.cpp
+++ b/app/systems/session_logger_system.cpp
@@ -3,6 +3,7 @@
 #include "../components/rhythm.h"
 #include "../components/scoring.h"
 #include "../tags/tags.h"
+#include "../util/shape_tag.h"
 
 #include <cstdarg>
 #include <cmath>
@@ -116,7 +117,7 @@ void session_log_on_obstacle_spawn(entt::registry& reg, entt::entity entity) {
     auto* beat = reg.try_get<BeatInfo>(entity);
     int beat_idx = beat ? beat->beat_index : -1;
 
-    auto* req = reg.try_get<RequiredShape>(entity);
+    const bool has_req = has_required_shape_tag(reg, entity);
 
     int8_t lane = 1;
     auto* rlane = reg.try_get<RequiredLane>(entity);
@@ -124,7 +125,9 @@ void session_log_on_obstacle_spawn(entt::registry& reg, entt::entity entity) {
 
     float arrival = beat ? beat->arrival_time : 0.0f;
     const std::string_view kind_name = obstacle_kind_label(reg, entity);
-    const std::string_view shape_name = req ? enum_name_or_unknown(req->shape) : std::string_view{"-"};
+    const std::string_view shape_name =
+        has_req ? enum_name_or_unknown(current_required_shape(reg, entity))
+                : std::string_view{"-"};
 
     session_log_write(*log, t, "GAME",
         "OBSTACLE_SPAWN beat=%d arrival=%.3f kind=%.*s shape=%.*s lane=%d",

--- a/app/systems/shape_window_system.cpp
+++ b/app/systems/shape_window_system.cpp
@@ -5,6 +5,7 @@
 #include "../components/rhythm.h"
 #include "../constants.h"
 #include "../util/shape_lane_mapping.h"
+#include "../util/shape_tag.h"
 
 namespace {
 
@@ -35,10 +36,10 @@ void transition_to_idle(entt::registry& reg, entt::entity e) {
 
 void on_morph_in_failure(entt::registry& reg,
                          entt::entity entity,
-                         PlayerShape& pshape,
-                         ShapeWindow& swindow) {
-    pshape.current = Shape::Hexagon;
-    swindow.target_shape = Shape::Hexagon;
+                         PlayerShape& /*pshape*/,
+                         ShapeWindow& /*swindow*/) {
+    set_player_shape_tag(reg, entity, Shape::Hexagon);
+    set_target_shape_tag(reg, entity, Shape::Hexagon);
     transition_to_idle<ShapeWindowMorphInTag>(reg, entity);
 }
 
@@ -49,17 +50,18 @@ void advance_morph_in(entt::registry& reg,
                       const SongState& song) {
     const float elapsed = song.song_time - swindow.window_start;
     swindow.window_timer = elapsed;
+    const Shape target = current_target_shape(reg, entity);
     if (song.morph_duration <= 0.0f) {
         TraceLog(LOG_WARNING, "shape_window_system completed MorphIn immediately: invalid morph_duration %.3f",
                  song.morph_duration);
         pshape.morph_t = 1.0f;
         swindow.window_start = song.song_time;
         swindow.window_timer = 0.0f;
-        if (!apply_shape_color(reg, entity, swindow.target_shape)) {
+        if (!apply_shape_color(reg, entity, target)) {
             on_morph_in_failure(reg, entity, pshape, swindow);
             return;
         }
-        pshape.current = swindow.target_shape;
+        set_player_shape_tag(reg, entity, target);
         transition_phase<ShapeWindowMorphInTag, ShapeWindowActiveTag>(reg, entity);
         return;
     }
@@ -69,11 +71,11 @@ void advance_morph_in(entt::registry& reg,
         pshape.morph_t = 1.0f;
         swindow.window_start = swindow.window_start + song.morph_duration;
         swindow.window_timer = 0.0f;
-        if (!apply_shape_color(reg, entity, swindow.target_shape)) {
+        if (!apply_shape_color(reg, entity, target)) {
             on_morph_in_failure(reg, entity, pshape, swindow);
             return;
         }
-        pshape.current = swindow.target_shape;
+        set_player_shape_tag(reg, entity, target);
         transition_phase<ShapeWindowMorphInTag, ShapeWindowActiveTag>(reg, entity);
     }
 }
@@ -105,8 +107,8 @@ void advance_morph_out(entt::registry& reg,
         TraceLog(LOG_WARNING, "shape_window_system completed MorphOut immediately: invalid morph_duration %.3f",
                  song.morph_duration);
         pshape.morph_t = 1.0f;
-        pshape.current = Shape::Hexagon;
-        swindow.target_shape = Shape::Hexagon;
+        set_player_shape_tag(reg, entity, Shape::Hexagon);
+        set_target_shape_tag(reg, entity, Shape::Hexagon);
         swindow.window_timer = 0.0f;
         swindow.press_time = -1.0f;
         swindow.graded = false;
@@ -117,8 +119,8 @@ void advance_morph_out(entt::registry& reg,
     pshape.morph_t = morph_elapsed / song.morph_duration;
     if (pshape.morph_t >= 1.0f) {
         pshape.morph_t = 1.0f;
-        pshape.current = Shape::Hexagon;
-        swindow.target_shape = Shape::Hexagon;
+        set_player_shape_tag(reg, entity, Shape::Hexagon);
+        set_target_shape_tag(reg, entity, Shape::Hexagon);
         swindow.window_timer = 0.0f;
         swindow.press_time = -1.0f;
         swindow.graded = false;

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -10,6 +10,7 @@
 #include "session_logger_system.h"
 #include "../util/lane_utils.h"
 #include "../util/shape_lane_mapping.h"
+#include "../util/shape_tag.h"
 #include "../constants.h"
 
 #include <raylib.h>
@@ -139,9 +140,8 @@ static TestPlayerAction determine_action(
     }
 
     // Shape requirement
-    auto* req_shape = reg.try_get<RequiredShape>(entity);
-    if (req_shape) {
-        action.target_shape = req_shape->shape;
+    if (has_required_shape_tag(reg, entity)) {
+        action.target_shape = current_required_shape(reg, entity);
 
         // ShapeGate: player must also be in the lane where the shape hole is.
         // The hole is at obs_pos.x — find which lane that corresponds to.
@@ -463,8 +463,7 @@ void test_player_system(entt::registry& reg, float dt) {
                     move_would_fail_closer = true;
                     break;
                 }
-                auto* oshape = reg.try_get<RequiredShape>(oe);
-                if (oshape) {
+                if (has_required_shape_tag(reg, oe)) {
                     float lane_x = constants::LANE_X[next_lane];
                     if (!lane_centers_overlap(owt.position.x, lane_x)) {
                         move_would_fail_closer = true;

--- a/app/tags/tags.h
+++ b/app/tags/tags.h
@@ -13,6 +13,33 @@
 // ── Player ───────────────────────────────────────────────────
 struct PlayerTag {};
 
+// ── Player current shape (per-tag table; exactly one per player entity) ──
+// Replaces the former `PlayerShape::current` Shape-typed field (issue
+// #1202/#1204). Per Fabian's existential processing, each former enum value
+// becomes its own zero-column table on the player entity. Shape changes are
+// table operations (remove old tag, emplace new tag) — no `switch` on a
+// discriminator, no `if (x == Shape::Bar)` branches.
+//
+// Maintenance invariant: exactly one `Shape*Tag` is present on any player
+// entity. Use `set_player_shape_tag()` in `app/util/shape_tag.h` to keep
+// the invariant; it removes all four tags before emplacing the matching one.
+struct ShapeCircleTag   {};
+struct ShapeSquareTag   {};
+struct ShapeTriangleTag {};
+struct ShapeHexagonTag  {};
+
+// ── Shape Window target shape (per-tag table; exactly one when window open) ──
+// Replaces the former `ShapeWindow::target_shape` Shape-typed field (issue
+// #1202/#1204). The "which shape does the player intend to morph into?" data
+// is presence of one of these tags on the player entity during a shape
+// window. When the window closes (MorphOut completes → all `ShapeWindow*Tag`
+// removed), the target tag is reset to Hexagon to match the legacy
+// `target_shape = Shape::Hexagon` reset.
+struct TargetShapeCircleTag   {};
+struct TargetShapeSquareTag   {};
+struct TargetShapeTriangleTag {};
+struct TargetShapeHexagonTag  {};
+
 // ── Shape Window phase (per-tag table; absence of all three = Idle) ──
 // Replaces the former WindowPhase enum (issue #1202/#1204).
 // The shape-window state machine on the player advances through
@@ -27,11 +54,23 @@ struct ShapeWindowMorphOutTag {};
 // ── Obstacles ────────────────────────────────────────────────
 struct ObstacleTag {};
 
+// ── Obstacle required shape (per-tag table; ShapeGate/SplitPath obstacles) ──
+// Replaces the former `RequiredShape::shape` Shape-typed field (issue
+// #1202/#1204). The whole `RequiredShape` struct was a single-column table;
+// per Fabian's relational-database mechanic the column collapses into the
+// tag set itself. Each ShapeGate / SplitPath obstacle carries exactly one
+// `RequiredShape*Tag`; obstacle factories emplace it via
+// `set_required_shape_tag()` in `app/util/shape_tag.h`.
+struct RequiredShapeCircleTag   {};
+struct RequiredShapeSquareTag   {};
+struct RequiredShapeTriangleTag {};
+struct RequiredShapeHexagonTag  {};
+
 // ── Obstacle kind (per-tag table; exactly one per obstacle entity) ──
 // Replaces the former ObstacleKind enum (issue #1202/#1204). Each
 // former enum value is its own per-kind table:
 //   - ShapeGateTag / SplitPathTag  → zero-column tag; the per-instance
-//     data (`RequiredShape`, `RequiredLane`, `ShapeGateLane`) lives in
+//     data (`RequiredShape*Tag`, `RequiredLane`, `ShapeGateLane`) lives in
 //     its own component table per the schema-per-kind mechanic in #1204.
 //   - OnsetMarkerTag → zero-column tag (no per-instance data).
 // Spawn helpers in `entities/obstacle_entity.h` emplace exactly one

--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
@@ -13,6 +13,7 @@
 #include "../../entities/settings.h"
 #include "../../util/rhythm_math.h"
 #include "../../util/shape_lane_mapping.h"
+#include "../../util/shape_tag.h"
 #include "screen_controller_base.h"
 #include "gameplay_hud_screen_controller.h"
 #include <entt/entt.hpp>
@@ -118,39 +119,51 @@ void render_shape_buttons(const entt::registry& reg,
         Shape shape;
         float cx;
         float cy;
+        bool  is_active;
     };
     std::array<ButtonVisual, 3> buttons{};
     const auto circle_bounds = GameplayHudLayout_CircleButtonBounds(&ui_state);
     const auto square_bounds = GameplayHudLayout_SquareButtonBounds(&ui_state);
     const auto triangle_bounds = GameplayHudLayout_TriangleButtonBounds(&ui_state);
+
+    // Per-button active flag derived from the player's current-shape tag
+    // (issue #1202/#1204). Each button corresponds to exactly one
+    // `Shape*Tag`; tag presence on the player IS the "active" data — no
+    // `==` on a Shape discriminator value.
+    bool circle_active   = false;
+    bool square_active   = false;
+    bool triangle_active = false;
+    for (auto entity : reg.view<PlayerTag, PlayerShape>()) {
+        circle_active   = reg.all_of<ShapeCircleTag>(entity);
+        square_active   = reg.all_of<ShapeSquareTag>(entity);
+        triangle_active = reg.all_of<ShapeTriangleTag>(entity);
+    }
     buttons[0] = ButtonVisual{Shape::Circle,
                               circle_bounds.x + circle_bounds.width * 0.5f,
-                              circle_bounds.y + circle_bounds.height * 0.5f};
+                              circle_bounds.y + circle_bounds.height * 0.5f,
+                              circle_active};
     buttons[1] = ButtonVisual{Shape::Square,
                               square_bounds.x + square_bounds.width * 0.5f,
-                              square_bounds.y + square_bounds.height * 0.5f};
+                              square_bounds.y + square_bounds.height * 0.5f,
+                              square_active};
     buttons[2] = ButtonVisual{Shape::Triangle,
                               triangle_bounds.x + triangle_bounds.width * 0.5f,
-                              triangle_bounds.y + triangle_bounds.height * 0.5f};
+                              triangle_bounds.y + triangle_bounds.height * 0.5f,
+                              triangle_active};
 
     float btn_radius = circle_bounds.width / 2.8f;
 
-    Shape active_shape = Shape::Hexagon;
-    for (auto [entity, player_shape] : reg.view<PlayerTag, PlayerShape>().each()) {
-        active_shape = player_shape.current;
-        (void)entity;
-    }
-
     std::array<float, 4> nearest_dist = {-1.0f, -1.0f, -1.0f, -1.0f};
-    for (auto [entity, obstacle, obstacle_pos, required_shape] :
-         reg.view<ObstacleTag, Obstacle, WorldTransform, RequiredShape>(entt::exclude<ScoredTag>).each()) {
+    for (auto [entity, obstacle, obstacle_pos] :
+         reg.view<ObstacleTag, Obstacle, WorldTransform>(entt::exclude<ScoredTag>).each()) {
         (void)entity;
         (void)obstacle;
-        int shape_index = static_cast<int>(required_shape.shape);
-        if (shape_index < 0 || shape_index >= static_cast<int>(nearest_dist.size())) continue;
+        if (!has_required_shape_tag(reg, entity)) continue;
+        const int req_idx = shape_index(current_required_shape(reg, entity));
+        if (req_idx < 0 || req_idx >= static_cast<int>(nearest_dist.size())) continue;
         float dist = constants::PLAYER_Y - obstacle_pos.position.y;
-        if (dist > 0.0f && (nearest_dist[shape_index] < 0.0f || dist < nearest_dist[shape_index])) {
-            nearest_dist[shape_index] = dist;
+        if (dist > 0.0f && (nearest_dist[req_idx] < 0.0f || dist < nearest_dist[req_idx])) {
+            nearest_dist[req_idx] = dist;
         }
     }
 
@@ -167,22 +180,21 @@ void render_shape_buttons(const entt::registry& reg,
     const bool reduce_motion = settings_ptr && settings_ptr->reduce_motion;
 
     for (const auto& button : buttons) {
-        bool is_active = (active_shape == button.shape);
-        Color bg = is_active ? style.active_bg : style.inactive_bg;
-        Color border = is_active ? style.active_border : style.inactive_border;
-        Color icon = is_active ? style.active_icon : style.inactive_icon;
+        Color bg = button.is_active ? style.active_bg : style.inactive_bg;
+        Color border = button.is_active ? style.active_border : style.inactive_border;
+        Color icon = button.is_active ? style.active_icon : style.inactive_icon;
         DrawCircleV({button.cx, button.cy}, btn_radius, bg);
         DrawCircleLinesV({button.cx, button.cy}, btn_radius, border);
         draw_shape_flat(button.shape, button.cx, button.cy, btn_radius * 1.2f, icon);
 
-        int shape_index = static_cast<int>(button.shape);
-        if (shape_index < 0 || shape_index >= static_cast<int>(nearest_dist.size())) continue;
-        const auto cue = gameplay_hud_ring_cue(nearest_dist[shape_index],
+        int btn_shape_index = shape_index(button.shape);
+        if (btn_shape_index < 0 || btn_shape_index >= static_cast<int>(nearest_dist.size())) continue;
+        const auto cue = gameplay_hud_ring_cue(nearest_dist[btn_shape_index],
                                                perfect_dist,
                                                good_dist,
                                                ring_appear_dist);
         if (!cue.visible) continue;
-        float ratio = gameplay_hud_ring_ratio(nearest_dist[shape_index], perfect_dist, ring_appear_dist);
+        float ratio = gameplay_hud_ring_ratio(nearest_dist[btn_shape_index], perfect_dist, ring_appear_dist);
 
         const auto envelope = approach_ring_envelope(ratio, btn_radius,
                                                      max_ring_radius, reduce_motion);

--- a/app/util/shape_tag.h
+++ b/app/util/shape_tag.h
@@ -1,0 +1,175 @@
+#pragma once
+
+#include "../components/player.h"
+#include "../tags/tags.h"
+#include "shape_lane_mapping.h"
+
+#include <array>
+#include <entt/entt.hpp>
+
+// Per-shape tag table dispatch (issue #1202/#1204). Replaces the former
+// Shape-typed on-entity fields (`PlayerShape::current`,
+// `ShapeWindow::target_shape`, `RequiredShape::shape`) with per-shape tag
+// presence. Same lookup-table mechanic as `kShapeFlatDrawFns` in PR #1259
+// — function-pointer-per-row, indexed by `shape_index(shape)`, no `switch`
+// on a discriminator.
+//
+// Each table has the same shape: four rows, one per former `Shape` value.
+// `set_*_shape_tag` writes the table (removes all four tags, emplaces the
+// matching one); `current_*_shape` reads the table back (returns the Shape
+// value the lone present tag corresponds to, or Shape::Hexagon as the
+// no-tag fallback for the legacy "no playable shape" sentinel).
+
+namespace shape_tag_detail {
+
+using EmplaceFn = void (*)(entt::registry&, entt::entity);
+using RemoveFn  = void (*)(entt::registry&, entt::entity);
+using HasFn     = bool (*)(const entt::registry&, entt::entity);
+
+// ── Player current-shape table ──
+inline void emplace_player_circle  (entt::registry& r, entt::entity e) { r.emplace_or_replace<ShapeCircleTag>(e); }
+inline void emplace_player_square  (entt::registry& r, entt::entity e) { r.emplace_or_replace<ShapeSquareTag>(e); }
+inline void emplace_player_triangle(entt::registry& r, entt::entity e) { r.emplace_or_replace<ShapeTriangleTag>(e); }
+inline void emplace_player_hexagon (entt::registry& r, entt::entity e) { r.emplace_or_replace<ShapeHexagonTag>(e); }
+inline bool has_player_circle  (const entt::registry& r, entt::entity e) { return r.all_of<ShapeCircleTag>(e); }
+inline bool has_player_square  (const entt::registry& r, entt::entity e) { return r.all_of<ShapeSquareTag>(e); }
+inline bool has_player_triangle(const entt::registry& r, entt::entity e) { return r.all_of<ShapeTriangleTag>(e); }
+inline bool has_player_hexagon (const entt::registry& r, entt::entity e) { return r.all_of<ShapeHexagonTag>(e); }
+
+inline constexpr std::array<EmplaceFn, kShapeCount> kEmplacePlayer{
+    &emplace_player_circle,
+    &emplace_player_square,
+    &emplace_player_triangle,
+    &emplace_player_hexagon,
+};
+inline constexpr std::array<HasFn, kShapeCount> kHasPlayer{
+    &has_player_circle,
+    &has_player_square,
+    &has_player_triangle,
+    &has_player_hexagon,
+};
+
+// ── Shape window target-shape table ──
+inline void emplace_target_circle  (entt::registry& r, entt::entity e) { r.emplace_or_replace<TargetShapeCircleTag>(e); }
+inline void emplace_target_square  (entt::registry& r, entt::entity e) { r.emplace_or_replace<TargetShapeSquareTag>(e); }
+inline void emplace_target_triangle(entt::registry& r, entt::entity e) { r.emplace_or_replace<TargetShapeTriangleTag>(e); }
+inline void emplace_target_hexagon (entt::registry& r, entt::entity e) { r.emplace_or_replace<TargetShapeHexagonTag>(e); }
+inline bool has_target_circle  (const entt::registry& r, entt::entity e) { return r.all_of<TargetShapeCircleTag>(e); }
+inline bool has_target_square  (const entt::registry& r, entt::entity e) { return r.all_of<TargetShapeSquareTag>(e); }
+inline bool has_target_triangle(const entt::registry& r, entt::entity e) { return r.all_of<TargetShapeTriangleTag>(e); }
+inline bool has_target_hexagon (const entt::registry& r, entt::entity e) { return r.all_of<TargetShapeHexagonTag>(e); }
+
+inline constexpr std::array<EmplaceFn, kShapeCount> kEmplaceTarget{
+    &emplace_target_circle,
+    &emplace_target_square,
+    &emplace_target_triangle,
+    &emplace_target_hexagon,
+};
+inline constexpr std::array<HasFn, kShapeCount> kHasTarget{
+    &has_target_circle,
+    &has_target_square,
+    &has_target_triangle,
+    &has_target_hexagon,
+};
+
+// ── Obstacle required-shape table ──
+inline void emplace_required_circle  (entt::registry& r, entt::entity e) { r.emplace_or_replace<RequiredShapeCircleTag>(e); }
+inline void emplace_required_square  (entt::registry& r, entt::entity e) { r.emplace_or_replace<RequiredShapeSquareTag>(e); }
+inline void emplace_required_triangle(entt::registry& r, entt::entity e) { r.emplace_or_replace<RequiredShapeTriangleTag>(e); }
+inline void emplace_required_hexagon (entt::registry& r, entt::entity e) { r.emplace_or_replace<RequiredShapeHexagonTag>(e); }
+inline bool has_required_circle  (const entt::registry& r, entt::entity e) { return r.all_of<RequiredShapeCircleTag>(e); }
+inline bool has_required_square  (const entt::registry& r, entt::entity e) { return r.all_of<RequiredShapeSquareTag>(e); }
+inline bool has_required_triangle(const entt::registry& r, entt::entity e) { return r.all_of<RequiredShapeTriangleTag>(e); }
+inline bool has_required_hexagon (const entt::registry& r, entt::entity e) { return r.all_of<RequiredShapeHexagonTag>(e); }
+
+inline constexpr std::array<EmplaceFn, kShapeCount> kEmplaceRequired{
+    &emplace_required_circle,
+    &emplace_required_square,
+    &emplace_required_triangle,
+    &emplace_required_hexagon,
+};
+inline constexpr std::array<HasFn, kShapeCount> kHasRequired{
+    &has_required_circle,
+    &has_required_square,
+    &has_required_triangle,
+    &has_required_hexagon,
+};
+
+}  // namespace shape_tag_detail
+
+// Sets the player entity's current-shape tag. Removes all four `Shape*Tag`
+// first, then emplaces the matching one (no-op for invalid Shape values).
+// Maintains the "exactly one Shape*Tag per player" invariant.
+inline void set_player_shape_tag(entt::registry& reg, entt::entity e, Shape s) {
+    reg.remove<ShapeCircleTag, ShapeSquareTag, ShapeTriangleTag, ShapeHexagonTag>(e);
+    const int idx = shape_index(s);
+    if (idx < 0) return;
+    shape_tag_detail::kEmplacePlayer[static_cast<size_t>(idx)](reg, e);
+}
+
+// Sets the player entity's shape-window target tag. Mechanics mirror
+// `set_player_shape_tag`. The legacy `target_shape = Shape::Hexagon`
+// "no playable shape" reset is encoded as `TargetShapeHexagonTag` presence.
+inline void set_target_shape_tag(entt::registry& reg, entt::entity e, Shape s) {
+    reg.remove<TargetShapeCircleTag, TargetShapeSquareTag,
+               TargetShapeTriangleTag, TargetShapeHexagonTag>(e);
+    const int idx = shape_index(s);
+    if (idx < 0) return;
+    shape_tag_detail::kEmplaceTarget[static_cast<size_t>(idx)](reg, e);
+}
+
+// Sets an obstacle entity's required-shape tag. Mechanics mirror
+// `set_player_shape_tag`. Obstacle factories use this after their kind tag
+// (ShapeGateTag / SplitPathTag) is emplaced.
+inline void set_required_shape_tag(entt::registry& reg, entt::entity e, Shape s) {
+    reg.remove<RequiredShapeCircleTag, RequiredShapeSquareTag,
+               RequiredShapeTriangleTag, RequiredShapeHexagonTag>(e);
+    const int idx = shape_index(s);
+    if (idx < 0) return;
+    shape_tag_detail::kEmplaceRequired[static_cast<size_t>(idx)](reg, e);
+}
+
+// Returns the Shape value matching the entity's current-shape tag. Returns
+// `Shape::Hexagon` (the legacy default-state value) when no `Shape*Tag` is
+// present — the player is treated as Hexagon-by-default both before the
+// first shape press and after a window morph-out completes.
+inline Shape current_player_shape(const entt::registry& reg, entt::entity e) noexcept {
+    for (int i = 0; i < kShapeCount; ++i) {
+        if (shape_tag_detail::kHasPlayer[static_cast<size_t>(i)](reg, e)) {
+            return static_cast<Shape>(i);
+        }
+    }
+    return Shape::Hexagon;
+}
+
+// Returns the Shape value matching the entity's shape-window target tag.
+// Returns `Shape::Hexagon` when no `TargetShape*Tag` is present (matches
+// the legacy "no target = Hexagon" sentinel).
+inline Shape current_target_shape(const entt::registry& reg, entt::entity e) noexcept {
+    for (int i = 0; i < kShapeCount; ++i) {
+        if (shape_tag_detail::kHasTarget[static_cast<size_t>(i)](reg, e)) {
+            return static_cast<Shape>(i);
+        }
+    }
+    return Shape::Hexagon;
+}
+
+// Returns the Shape value matching the obstacle entity's required-shape tag.
+// Returns `Shape::Hexagon` when no `RequiredShape*Tag` is present (legacy
+// `RequiredShape == Shape::Hexagon` was rejected by collision unconditionally,
+// so absence-of-tag yields the same matching behaviour).
+inline Shape current_required_shape(const entt::registry& reg, entt::entity e) noexcept {
+    for (int i = 0; i < kShapeCount; ++i) {
+        if (shape_tag_detail::kHasRequired[static_cast<size_t>(i)](reg, e)) {
+            return static_cast<Shape>(i);
+        }
+    }
+    return Shape::Hexagon;
+}
+
+// True iff the obstacle entity carries any `RequiredShape*Tag`.
+// Replaces the legacy `reg.try_get<RequiredShape>(e) != nullptr` probe.
+inline bool has_required_shape_tag(const entt::registry& reg, entt::entity e) noexcept {
+    return reg.any_of<RequiredShapeCircleTag, RequiredShapeSquareTag,
+                      RequiredShapeTriangleTag, RequiredShapeHexagonTag>(e);
+}

--- a/benchmarks/bench_systems.cpp
+++ b/benchmarks/bench_systems.cpp
@@ -17,6 +17,7 @@
 #include "constants.h"
 #include "systems/all_systems.h"
 #include "systems/input_routing.h"
+#include "util/shape_tag.h"
 
 // ── Helpers ─────────────────────────────────────────────────
 
@@ -58,7 +59,7 @@ static void spawn_obstacles(entt::registry& reg, int count) {
         reg.emplace<Vector2>(obs, Vector2{0.0f, song.scroll_speed});
         auto shape = static_cast<Shape>(i % 3);
         reg.emplace<Obstacle>(obs, int16_t{200});
-        reg.emplace<RequiredShape>(obs, shape);
+        set_required_shape_tag(reg, obs, shape);
         reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);
         reg.emplace<Color>(obs, Color{255, 255, 255, 255});
     }
@@ -123,7 +124,7 @@ TEST_CASE("Bench: collision_system", "[!benchmark][bench]") {
         reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
         reg.emplace<Vector2>(obs, Vector2{0.0f, 400.0f});
         reg.emplace<Obstacle>(obs, int16_t{200});
-        reg.emplace<RequiredShape>(obs, Shape::Circle);
+        set_required_shape_tag(reg, obs, Shape::Circle);
         meter.measure([&] {
             if (reg.all_of<ScoredTag>(obs)) reg.remove<ScoredTag>(obs);
             reg.ctx().get<GameState>().transition_pending = false;

--- a/tests/test_audio_offset_calibration.cpp
+++ b/tests/test_audio_offset_calibration.cpp
@@ -238,9 +238,8 @@ OffsetGameplayResult run_calibrated_on_arrival_hit(int16_t audio_offset_ms) {
     settings.audio_offset_ms = audio_offset_ms;
 
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     sw.graded = false;
 

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -83,12 +83,12 @@ TEST_CASE("beat_scheduler: spawns ShapeGate when time passes spawn_time", "[beat
     CHECK(count == 1);
 
     // Verify it's a ShapeGate with correct components
-    auto view = reg.view<ObstacleTag, Obstacle, RequiredShape, ShapeGateLane>();
-    for (auto [e, obs, rs, lane] : view.each()) {
+    auto view = reg.view<ObstacleTag, Obstacle, ShapeGateLane>();
+    for (auto [e, obs, lane] : view.each()) {
         (void)obs;
         CHECK_FALSE(reg.all_of<uint8_t>(e));
         CHECK_FALSE(reg.all_of<RequiredLane>(e));
-        CHECK(rs.shape == Shape::Circle);
+        CHECK(current_required_shape(reg, e) == Shape::Circle);
         CHECK(lane.lane == int8_t{1});
     }
 }
@@ -266,11 +266,10 @@ TEST_CASE("beat_scheduler: same beat_index honors authored time_sec ordering",
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
-    auto view = reg.view<ObstacleTag, BeatInfo, RequiredShape>();
+    auto view = reg.view<ObstacleTag, BeatInfo>();
     REQUIRE(view.size_hint() == 1);
-    for (auto [entity, bi, rs] : view.each()) {
-        (void)entity;
-        CHECK(rs.shape == Shape::Circle);
+    for (auto [entity, bi] : view.each()) {
+        CHECK(current_required_shape(reg, entity) == Shape::Circle);
         CHECK_THAT(bi.arrival_time, Catch::Matchers::WithinAbs(1.3f, 0.001f));
     }
 }
@@ -326,7 +325,7 @@ TEST_CASE("beat_scheduler: spawns OnsetMarker as visible non-scorable cue",
         (void)beat;
         cue = e;
         CHECK(obstacle.base_points == int16_t{0});
-        CHECK_FALSE(reg.all_of<RequiredShape>(e));
+        CHECK_FALSE(has_required_shape_tag(reg, e));
         CHECK_FALSE(reg.all_of<uint8_t>(e));
         CHECK_FALSE(reg.all_of<RequiredLane>(e));
         REQUIRE(children.count == 1);
@@ -371,12 +370,11 @@ TEST_CASE("beat_scheduler: spawns SplitPath in authored lane", "[beat_scheduler]
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
-    auto view = reg.view<ObstacleTag, WorldTransform, RequiredShape, RequiredLane>();
+    auto view = reg.view<ObstacleTag, WorldTransform, RequiredLane>();
     REQUIRE(view.size_hint() == 1);
-    for (auto [e, wt, shape, lane] : view.each()) {
-        (void)e;
+    for (auto [e, wt, lane] : view.each()) {
         CHECK_THAT(wt.position.x, Catch::Matchers::WithinAbs(constants::LANE_X[2], 0.01f));
-        CHECK(shape.shape == Shape::Triangle);
+        CHECK(current_required_shape(reg, e) == Shape::Triangle);
         CHECK(lane.lane == 2);
     }
     CHECK(song.next_split_path_idx == 1);
@@ -394,12 +392,11 @@ TEST_CASE("beat_scheduler: defaults invalid SplitPath lane to center lane", "[be
     song.next_onset_marker_idx = 0;
     CHECK_NOTHROW(beat_scheduler_system(reg, 0.016f));
 
-    auto view = reg.view<ObstacleTag, WorldTransform, RequiredShape, RequiredLane, ObstacleChildren>();
+    auto view = reg.view<ObstacleTag, WorldTransform, RequiredLane, ObstacleChildren>();
     REQUIRE(view.size_hint() == 1);
-    for (auto [e, wt, shape, lane, children] : view.each()) {
-        (void)e;
+    for (auto [e, wt, lane, children] : view.each()) {
         CHECK_THAT(wt.position.x, Catch::Matchers::WithinAbs(constants::LANE_X[1], 0.01f));
-        CHECK(shape.shape == Shape::Square);
+        CHECK(current_required_shape(reg, e) == Shape::Square);
         CHECK(lane.lane == int8_t{1});
         REQUIRE(children.count == 3);
         for (int i = 0; i < children.count; ++i) {
@@ -430,7 +427,7 @@ TEST_CASE("beat_scheduler: spawns all queued beats from BeatMap entries", "[beat
     for (auto [e, obs] : obstacle_view.each()) {
         (void)obs;
         ++obstacle_count;
-        if (reg.all_of<RequiredShape>(e)) ++shape_gate_count;
+        if (has_required_shape_tag(reg, e)) ++shape_gate_count;
     }
     CHECK(obstacle_count == 3);
     CHECK(shape_gate_count == 2);

--- a/tests/test_collision_extended.cpp
+++ b/tests/test_collision_extended.cpp
@@ -19,12 +19,11 @@ struct ScoredTimingResult {
 ScoredTimingResult score_rhythm_shape_hit_at_offset(float arrival_offset_seconds) {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
     song.song_time = 5.0f;
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     sw.graded = false;
     sw.press_time = song.song_time;
@@ -55,8 +54,7 @@ ScoredTimingResult score_rhythm_shape_hit_at_offset(float arrival_offset_seconds
 TEST_CASE("collision: Hexagon shape never matches shape gate", "[collision]") {
     auto reg = make_registry();
     auto p = make_player(reg);
-    auto& ps = reg.get<PlayerShape>(p);
-    ps.current = Shape::Hexagon;
+    set_player_shape_tag(reg, p, Shape::Hexagon);
     // Gate requires Circle, player is Hexagon
     make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
 
@@ -74,16 +72,16 @@ TEST_CASE("collision: Hexagon shape never matches shape gate", "[collision]") {
 TEST_CASE("collision: Hexagon fails even when matching gate shape", "[collision]") {
     auto reg = make_registry();
     auto p = make_player(reg);
-    auto& ps = reg.get<PlayerShape>(p);
-    ps.current = Shape::Hexagon;
+    set_player_shape_tag(reg, p, Shape::Hexagon);
     // This should NOT pass — Hexagon is the neutral shape
     // Note: make_shape_gate with Hexagon isn't typical, but tests the guard
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
+    reg.emplace<ShapeGateTag>(obs);
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
     reg.emplace<Vector2>(obs, Vector2{0.0f, 400.0f});
     reg.emplace<Obstacle>(obs, int16_t{200});
-    reg.emplace<RequiredShape>(obs, Shape::Hexagon);
+    set_required_shape_tag(reg, obs, Shape::Hexagon);
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);
     reg.emplace<Color>(obs, Color{255, 255, 255, 255});
 
@@ -105,11 +103,10 @@ TEST_CASE("collision: Hexagon fails even when matching gate shape", "[collision]
 TEST_CASE("collision: rhythm mode assigns Perfect for on-time hit", "[collision][rhythm]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     sw.graded = false;
     sw.window_start = song.song_time;
@@ -129,8 +126,6 @@ TEST_CASE("collision: on-beat rhythm press clears matching gate during MorphIn",
           "[collision][rhythm][issue955]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
-    auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
     song.song_time = 5.0f;
@@ -141,9 +136,9 @@ TEST_CASE("collision: on-beat rhythm press clears matching gate during MorphIn",
     press_button(reg, btn);
     reg.ctx().get<entt::dispatcher>().update<ButtonPressEvent>();
 
-    REQUIRE(ps.current == Shape::Hexagon);
+    REQUIRE(reg.all_of<ShapeHexagonTag>(player));
     REQUIRE(window_phase_is_morph_in(reg, player));
-    REQUIRE(sw.target_shape == Shape::Circle);
+    REQUIRE(reg.all_of<TargetShapeCircleTag>(player));
 
     collision_system(reg, 0.016f);
 
@@ -190,11 +185,10 @@ TEST_CASE("collision: on-beat shape press requires player hitbox to reach target
 TEST_CASE("collision: rhythm mode assigns Bad for far-off hit", "[collision][rhythm]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     sw.graded = false;
     sw.window_start = song.song_time;
@@ -215,13 +209,12 @@ TEST_CASE("collision: rhythm shape gate only matches during Active window",
           "[collision][rhythm][issue765]") {
     auto active_reg = make_rhythm_registry();
     auto active_player = make_rhythm_player(active_reg);
-    auto& active_shape = active_reg.get<PlayerShape>(active_player);
     auto& active_window = active_reg.get<ShapeWindow>(active_player);
     auto& active_song = active_reg.ctx().get<SongState>();
 
     active_song.song_time = 5.0f;
-    active_shape.current = Shape::Circle;
-    active_window.target_shape = Shape::Circle;
+    set_player_shape_tag(active_reg, active_player, Shape::Circle);
+    set_target_shape_tag(active_reg, active_player, Shape::Circle);
     set_window_phase_active(active_reg, active_player);
     active_window.press_time = active_song.song_time;
 
@@ -237,13 +230,12 @@ TEST_CASE("collision: rhythm shape gate only matches during Active window",
 
     auto morphout_reg = make_rhythm_registry();
     auto morphout_player = make_rhythm_player(morphout_reg);
-    auto& morphout_shape = morphout_reg.get<PlayerShape>(morphout_player);
     auto& morphout_window = morphout_reg.get<ShapeWindow>(morphout_player);
     auto& morphout_song = morphout_reg.ctx().get<SongState>();
 
     morphout_song.song_time = 5.0f;
-    morphout_shape.current = Shape::Circle;
-    morphout_window.target_shape = Shape::Circle;
+    set_player_shape_tag(morphout_reg, morphout_player, Shape::Circle);
+    set_target_shape_tag(morphout_reg, morphout_player, Shape::Circle);
     set_window_phase_morph_out(morphout_reg, morphout_player);
     morphout_window.press_time = morphout_song.song_time - morphout_song.window_duration;
 
@@ -262,14 +254,12 @@ TEST_CASE("collision: finished song still requires active shape window",
           "[collision][rhythm][issue950]") {
     auto idle_reg = make_rhythm_registry();
     auto idle_player = make_rhythm_player(idle_reg);
-    auto& idle_shape = idle_reg.get<PlayerShape>(idle_player);
-    auto& idle_window = idle_reg.get<ShapeWindow>(idle_player);
     auto& idle_song = idle_reg.ctx().get<SongState>();
 
     idle_song.playing = false;
     idle_song.finished = true;
-    idle_shape.current = Shape::Circle;
-    idle_window.target_shape = Shape::Circle;
+    set_player_shape_tag(idle_reg, idle_player, Shape::Circle);
+    set_target_shape_tag(idle_reg, idle_player, Shape::Circle);
     set_window_phase_idle(idle_reg, idle_player);
 
     auto idle_obs = make_shape_gate(idle_reg, Shape::Circle, constants::PLAYER_Y);
@@ -282,15 +272,14 @@ TEST_CASE("collision: finished song still requires active shape window",
 
     auto active_reg = make_rhythm_registry();
     auto active_player = make_rhythm_player(active_reg);
-    auto& active_shape = active_reg.get<PlayerShape>(active_player);
     auto& active_window = active_reg.get<ShapeWindow>(active_player);
     auto& active_song = active_reg.ctx().get<SongState>();
 
     active_song.playing = false;
     active_song.finished = true;
     active_song.song_time = 5.0f;
-    active_shape.current = Shape::Circle;
-    active_window.target_shape = Shape::Circle;
+    set_player_shape_tag(active_reg, active_player, Shape::Circle);
+    set_target_shape_tag(active_reg, active_player, Shape::Circle);
     set_window_phase_active(active_reg, active_player);
     active_window.press_time = active_song.song_time;
 
@@ -322,11 +311,10 @@ TEST_CASE("collision: rhythm miss increments miss_count in SongResults", "[colli
 TEST_CASE("collision: rhythm perfect increments perfect_count in SongResults", "[collision][rhythm]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     sw.graded = false;
     sw.press_time = song.song_time;
@@ -416,8 +404,7 @@ TEST_CASE("collision: multiple misses accumulate in miss_count", "[collision][rh
 TEST_CASE("collision: split path succeeds with correct shape and lane", "[collision]") {
     auto reg = make_registry();
     auto p = make_player(reg);
-    auto& ps = reg.get<PlayerShape>(p);
-    ps.current = Shape::Triangle;
+    set_player_shape_tag(reg, p, Shape::Triangle);
     auto& lane = reg.get<Lane>(p);
     lane.current = 2;
     reg.get<WorldTransform>(p).position.x = constants::LANE_X[2];
@@ -461,11 +448,10 @@ TEST_CASE("collision: Hexagon fails split path even when shape and lane match", 
 TEST_CASE("scoring: collision_system alone does not mutate SongResults counts", "[scoring][collision]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     sw.graded = false;
     sw.press_time = song.song_time;

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -197,7 +197,7 @@ TEST_CASE("collision: visual obstacle leftovers without Obstacle payload are ign
     auto visual_leftover = reg.create();
     reg.emplace<ObstacleTag>(visual_leftover);
     reg.emplace<WorldTransform>(visual_leftover, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
-    reg.emplace<RequiredShape>(visual_leftover, Shape::Triangle);
+    set_required_shape_tag(reg, visual_leftover, Shape::Triangle);
 
     collision_system(reg, 0.016f);
 
@@ -277,12 +277,11 @@ TEST_CASE("collision: BAD timing does not adjust window_start", "[collision][rhy
     // The window_start shortening path (scale < 1.0) only fires for Perfect and Good.
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
     // Put player in Active phase
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     sw.graded = false;
     sw.window_timer = 0.0f;
@@ -312,11 +311,10 @@ TEST_CASE("collision: Perfect timing shrinks window via window_start adjustment"
     // window_start backward to collapse the remaining Active window to 50%.
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     sw.graded = false;
     sw.window_timer = 0.0f;

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -51,9 +51,8 @@ TEST_CASE("components: rendering components are safely default constructible",
     }
 }
 
-TEST_CASE("components: PlayerShape defaults to Circle", "[components]") {
+TEST_CASE("components: PlayerShape defaults", "[components]") {
     PlayerShape ps{};
-    CHECK(ps.current == Shape::Circle);
     CHECK(ps.morph_t == 1.0f);
 }
 
@@ -163,7 +162,6 @@ TEST_CASE("ecs: make_registry dispatcher is wired — ButtonPressEvent listeners
     // in Playing phase reaches player_input_handle_press.
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& sw    = reg.get<ShapeWindow>(player);
     REQUIRE(window_phase_is_idle(reg, player));
 
     auto btn = make_shape_button(reg, Shape::Triangle);
@@ -174,7 +172,7 @@ TEST_CASE("ecs: make_registry dispatcher is wired — ButtonPressEvent listeners
 
     // If dispatcher listeners were NOT wired, sw.phase would stay Idle.
     CHECK(window_phase_is_morph_in(reg, player));  // listener wired: handle_press fired
-    CHECK(sw.target_shape == Shape::Triangle);
+    CHECK(reg.all_of<TargetShapeTriangleTag>(player));
 }
 
 TEST_CASE("ecs: make_registry dispatcher ctx — second update is a no-op (no replay)", "[ecs][dispatcher]") {
@@ -277,11 +275,11 @@ TEST_CASE("ecs: make_split_path creates proper entity", "[ecs]") {
 
     CHECK(reg.all_of<ObstacleTag>(obs));
     CHECK(reg.all_of<Obstacle>(obs));
-    CHECK(reg.all_of<RequiredShape>(obs));
+    CHECK(has_required_shape_tag(reg, obs));
     CHECK(reg.all_of<RequiredLane>(obs));
     CHECK(reg.all_of<SplitPathTag>(obs));
     CHECK(!reg.all_of<ShapeGateTag>(obs));
-    CHECK(reg.get<RequiredShape>(obs).shape == Shape::Triangle);
+    CHECK(current_required_shape(reg, obs) == Shape::Triangle);
     CHECK(reg.get<RequiredLane>(obs).lane == 2);
 }
 
@@ -307,14 +305,13 @@ TEST_CASE("ecs: dispatcher rewire-after-unwire does not duplicate semantic deliv
     unwire_input_dispatcher(reg);
     wire_input_dispatcher(reg);
 
-    auto& sw = reg.get<ShapeWindow>(player);
     REQUIRE(window_phase_is_idle(reg, player));
 
     press_button(reg, button);
     reg.ctx().get<entt::dispatcher>().update<ButtonPressEvent>();
 
     CHECK(window_phase_is_morph_in(reg, player));
-    CHECK(sw.target_shape == Shape::Square);
+    CHECK(reg.all_of<TargetShapeSquareTag>(player));
     CHECK(drain_sfx_events(reg).count == 1);
 }
 
@@ -328,14 +325,13 @@ TEST_CASE("ecs: repeated unwire_input_dispatcher is idempotent before rewire",
     unwire_input_dispatcher(reg);
     wire_input_dispatcher(reg);
 
-    auto& sw = reg.get<ShapeWindow>(player);
     REQUIRE(window_phase_is_idle(reg, player));
 
     press_button(reg, button);
     reg.ctx().get<entt::dispatcher>().update<ButtonPressEvent>();
 
     CHECK(window_phase_is_morph_in(reg, player));
-    CHECK(sw.target_shape == Shape::Triangle);
+    CHECK(reg.all_of<TargetShapeTriangleTag>(player));
     CHECK(drain_sfx_events(reg).count == 1);
 }
 

--- a/tests/test_death_model_unified.cpp
+++ b/tests/test_death_model_unified.cpp
@@ -104,10 +104,11 @@ TEST_CASE("death_model: close hit banks points without instant GameOver", "[deat
 
     auto obstacle = reg.create();
     reg.emplace<ObstacleTag>(obstacle);
+    reg.emplace<ShapeGateTag>(obstacle);
     reg.emplace<WorldTransform>(obstacle, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
     reg.emplace<Vector2>(obstacle, Vector2{0.0f, 0.0f});
     reg.emplace<Obstacle>(obstacle, int16_t{constants::PTS_SHAPE_GATE});
-    reg.emplace<RequiredShape>(obstacle, Shape::Circle);
+    set_required_shape_tag(reg, obstacle, Shape::Circle);
 
     collision_system(reg, 0.016f);
     energy_system(reg, 0.016f);
@@ -123,10 +124,11 @@ TEST_CASE("death_model: close miss drains energy instead of instant GameOver", "
 
     auto obstacle = reg.create();
     reg.emplace<ObstacleTag>(obstacle);
+    reg.emplace<ShapeGateTag>(obstacle);
     reg.emplace<WorldTransform>(obstacle, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
     reg.emplace<Vector2>(obstacle, Vector2{0.0f, 0.0f});
     reg.emplace<Obstacle>(obstacle, int16_t{constants::PTS_SHAPE_GATE});
-    reg.emplace<RequiredShape>(obstacle, Shape::Triangle);
+    set_required_shape_tag(reg, obstacle, Shape::Triangle);
 
     collision_system(reg, 0.016f);
     // collision_system stamps MissTag; verify before scoring_system removes it.

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -18,6 +18,7 @@
 #include "entities/settings.h"
 #include "components/rhythm.h"
 #include "util/rhythm_math.h"
+#include "util/shape_tag.h"
 #include "components/high_score.h"
 #include "systems/gameplay_intents.h"
 #include "constants.h"
@@ -182,13 +183,17 @@ inline entt::registry make_rhythm_registry() {
     return reg;
 }
 
-// Creates a player entity in lane 1 (center) with default shape (Hexagon in rhythm mode)
+// Creates a player entity in lane 1 (center) with default shape (Circle)
 inline entt::entity make_player(entt::registry& reg) {
     auto player = reg.create();
     reg.emplace<PlayerTag>(player);
     reg.emplace<WorldTransform>(player, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
     reg.emplace<PlayerShape>(player);
+    // Default player shape is Circle (presence of `ShapeCircleTag`) — matches
+    // the legacy `PlayerShape::current` default (enum first value).
+    set_player_shape_tag(reg, player, Shape::Circle);
     reg.emplace<ShapeWindow>(player);
+    set_target_shape_tag(reg, player, Shape::Circle);
     reg.emplace<Lane>(player);
     // Grounded == absence of Jumping/Sliding (issue #1202/#1204).
     reg.emplace<Color>(player, Color{80, 180, 255, 255});
@@ -200,11 +205,9 @@ inline entt::entity make_player(entt::registry& reg) {
 // Creates a player entity for rhythm mode (starts as Hexagon)
 inline entt::entity make_rhythm_player(entt::registry& reg) {
     auto player = make_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
-    ps.current = Shape::Hexagon;
-    auto& sw = reg.get<ShapeWindow>(player);
-    sw.target_shape = Shape::Hexagon;
-    // Idle = absence of all ShapeWindow*Tag (#1202/#1204).
+    set_player_shape_tag(reg, player, Shape::Hexagon);
+    set_target_shape_tag(reg, player, Shape::Hexagon);
+    // Idle window phase = absence of all `ShapeWindow*Tag` (#1202/#1204).
     return player;
 }
 
@@ -264,7 +267,7 @@ inline entt::entity make_shape_gate(entt::registry& reg, Shape shape, float y) {
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], y}});
     reg.emplace<Vector2>(obs, Vector2{0.0f, song.scroll_speed});
     reg.emplace<Obstacle>(obs, int16_t{constants::PTS_SHAPE_GATE});
-    reg.emplace<RequiredShape>(obs, shape);
+    set_required_shape_tag(reg, obs, shape);
     reg.emplace<ShapeGateLane>(obs, int8_t{1});
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);
     reg.emplace<TagWorldPass>(obs);
@@ -281,7 +284,7 @@ inline entt::entity make_split_path(entt::registry& reg, Shape shape, int8_t lan
     reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], y}});
     reg.emplace<Vector2>(obs, Vector2{0.0f, song.scroll_speed});
     reg.emplace<Obstacle>(obs, int16_t{constants::PTS_SPLIT_PATH});
-    reg.emplace<RequiredShape>(obs, shape);
+    set_required_shape_tag(reg, obs, shape);
     reg.emplace<RequiredLane>(obs, lane);
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);
     reg.emplace<TagWorldPass>(obs);

--- a/tests/test_helpers_and_functions.cpp
+++ b/tests/test_helpers_and_functions.cpp
@@ -196,10 +196,8 @@ TEST_CASE("make_rhythm_registry: SongState is configured", "[helpers]") {
 TEST_CASE("make_rhythm_player: starts as Hexagon", "[helpers]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
-    CHECK(ps.current == Shape::Hexagon);
-    auto& sw = reg.get<ShapeWindow>(player);
-    CHECK(sw.target_shape == Shape::Hexagon);
+    CHECK(reg.all_of<ShapeHexagonTag>(player));
+    CHECK(reg.all_of<TargetShapeHexagonTag>(player));
     CHECK(window_phase_is_idle(reg, player));
 }
 

--- a/tests/test_input_pipeline_behavior.cpp
+++ b/tests/test_input_pipeline_behavior.cpp
@@ -148,7 +148,6 @@ TEST_CASE("pipeline: semantic shape press triggers shape change in same pipeline
           "[input_pipeline]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& sw = reg.get<ShapeWindow>(player);
     REQUIRE(window_phase_is_idle(reg, player));
 
     reg.ctx().get<entt::dispatcher>().enqueue<ButtonPressEvent>(
@@ -156,7 +155,7 @@ TEST_CASE("pipeline: semantic shape press triggers shape change in same pipeline
     run_pipeline(reg);
 
     CHECK(window_phase_is_morph_in(reg, player));
-    CHECK(sw.target_shape == Shape::Square);
+    CHECK(current_target_shape(reg, player) == Shape::Square);
 }
 
 TEST_CASE("pipeline: semantic shape press does not change lane target",
@@ -185,7 +184,6 @@ TEST_CASE("pipeline: gameplay HUD raygui shape press triggers player shape input
           "[input_pipeline][hud]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& sw = reg.get<ShapeWindow>(player);
     auto& lane = reg.get<Lane>(player);
     REQUIRE(window_phase_is_idle(reg, player));
     REQUIRE(lane.current == 1);
@@ -198,7 +196,7 @@ TEST_CASE("pipeline: gameplay HUD raygui shape press triggers player shape input
     run_pipeline(reg);
 
     CHECK(window_phase_is_morph_in(reg, player));
-    CHECK(sw.target_shape == Shape::Square);
+    CHECK(current_target_shape(reg, player) == Shape::Square);
     CHECK(lane.target == 1);
 }
 
@@ -207,7 +205,6 @@ TEST_CASE("pipeline: gameplay HUD pointer release is collected before the fixed 
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& input = reg.ctx().get<InputState>();
-    auto& sw = reg.get<ShapeWindow>(player);
     REQUIRE(window_phase_is_idle(reg, player));
 
     const auto square_bounds = gameplay_hud_square_input_bounds();
@@ -219,7 +216,7 @@ TEST_CASE("pipeline: gameplay HUD pointer release is collected before the fixed 
     run_pipeline(reg);
 
     CHECK(window_phase_is_morph_in(reg, player));
-    CHECK(sw.target_shape == Shape::Square);
+    CHECK(current_target_shape(reg, player) == Shape::Square);
 }
 
 TEST_CASE("pipeline: mobile button-zone touch release is collected independently of swipe release",
@@ -228,7 +225,6 @@ TEST_CASE("pipeline: mobile button-zone touch release is collected independently
     auto player = make_rhythm_player(reg);
     auto& input = reg.ctx().get<InputState>();
     auto& lane = reg.get<Lane>(player);
-    auto& sw = reg.get<ShapeWindow>(player);
     REQUIRE(window_phase_is_idle(reg, player));
     REQUIRE(lane.current == 1);
 
@@ -245,7 +241,7 @@ TEST_CASE("pipeline: mobile button-zone touch release is collected independently
     run_pipeline(reg);
 
     CHECK(window_phase_is_morph_in(reg, player));
-    CHECK(sw.target_shape == Shape::Square);
+    CHECK(current_target_shape(reg, player) == Shape::Square);
     CHECK(lane.target == 2);
 }
 
@@ -314,7 +310,6 @@ TEST_CASE("pipeline: pending phase transition blocks queued shape input",
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& gs = reg.ctx().get<GameState>();
-    auto& sw = reg.get<ShapeWindow>(player);
     auto& lane = reg.get<Lane>(player);
 
     REQUIRE(gs.phase == GamePhase::Playing);
@@ -333,7 +328,7 @@ TEST_CASE("pipeline: pending phase transition blocks queued shape input",
     CHECK(gs.phase == GamePhase::Paused);
     CHECK_FALSE(gs.transition_pending);
     CHECK(window_phase_is_idle(reg, player));
-    CHECK(sw.target_shape == Shape::Hexagon);
+    CHECK(current_target_shape(reg, player) == Shape::Hexagon);
     CHECK(lane.target == 1);
 }
 
@@ -442,7 +437,6 @@ TEST_CASE("pipeline: mixed swipe and tap both take effect within a single pipeli
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& lane = reg.get<Lane>(player);
-    auto& sw   = reg.get<ShapeWindow>(player);
     REQUIRE(lane.current == 1);
     REQUIRE(window_phase_is_idle(reg, player));
 
@@ -454,7 +448,7 @@ TEST_CASE("pipeline: mixed swipe and tap both take effect within a single pipeli
 
     CHECK(lane.target     == 2);                  // explicit swipe moves lanes
     CHECK(window_phase_is_morph_in(reg, player)); // tap processed
-    CHECK(sw.target_shape == Shape::Triangle);
+    CHECK(current_target_shape(reg, player) == Shape::Triangle);
 }
 
 TEST_CASE("pipeline: same-frame shape tap drains before movement",

--- a/tests/test_obstacle_archetypes.cpp
+++ b/tests/test_obstacle_archetypes.cpp
@@ -52,12 +52,13 @@ TEST_CASE("entity: ShapeGate Circle - correct components and color", "[archetype
     entt::registry reg;
     auto e = spawn_shape_gate_obstacle(reg, {360.0f, -120.0f, Shape::Circle});
 
-    REQUIRE(reg.all_of<ObstacleTag, Vector2, WorldTransform, Obstacle, RequiredShape, ShapeGateLane, DrawSize, Color>(e));
+    REQUIRE(reg.all_of<ObstacleTag, Vector2, WorldTransform, Obstacle, ShapeGateLane, DrawSize, Color>(e));
+    REQUIRE(has_required_shape_tag(reg, e));
     CHECK(!reg.all_of<uint8_t>(e));
     CHECK(!reg.all_of<RequiredLane>(e));
 
     CHECK(reg.get<Obstacle>(e).base_points == int16_t{constants::PTS_SHAPE_GATE});
-    CHECK(reg.get<RequiredShape>(e).shape == Shape::Circle);
+    CHECK(current_required_shape(reg, e) == Shape::Circle);
     CHECK(reg.get<ShapeGateLane>(e).lane == int8_t{1});
     CHECK(reg.get<WorldTransform>(e).position.x == 360.0f);
     CHECK(reg.get<WorldTransform>(e).position.y == -120.0f);
@@ -100,7 +101,7 @@ TEST_CASE("entity: obstacle mesh overflow does not create orphan MeshChild", "[a
     reg.emplace<Obstacle>(parent, int16_t{constants::PTS_SHAPE_GATE});
     reg.emplace<DrawSize>(parent, constants::SCREEN_W_F, 80.0f);
     reg.emplace<Color>(parent, Color{80, 200, 255, 255});
-    reg.emplace<RequiredShape>(parent, Shape::Circle);
+    set_required_shape_tag(reg, parent, Shape::Circle);
 
     auto& children = reg.emplace<ObstacleChildren>(parent);
     for (int i = 0; i < ObstacleChildren::MAX; ++i) {
@@ -139,7 +140,7 @@ TEST_CASE("entity: obstacle mesh lifetime helper cleans factory children", "[arc
 TEST_CASE("entity: direct mesh factory cleanup does not depend on ObstacleTag order", "[archetype][render][cleanup]") {
     entt::registry reg;
     auto parent = make_mesh_factory_obstacle(reg);
-    reg.emplace<RequiredShape>(parent, Shape::Circle);
+    set_required_shape_tag(reg, parent, Shape::Circle);
     reg.emplace<ObstacleTag>(parent);
     reg.emplace<ShapeGateTag>(parent);
 
@@ -151,36 +152,11 @@ TEST_CASE("entity: direct mesh factory cleanup does not depend on ObstacleTag or
     CHECK(count_mesh_children(reg) == 0);
 }
 
-TEST_CASE("entity: mesh factory rejects invalid RequiredShape before children", "[archetype][render][validation]") {
-    const Shape invalid_shape = static_cast<Shape>(255);
-
-    SECTION("ShapeGate") {
-        entt::registry reg;
-        auto parent = make_mesh_factory_obstacle(reg);
-        reg.emplace<RequiredShape>(parent, invalid_shape);
-        reg.emplace<ShapeGateTag>(parent);
-
-        CHECK_THROWS_AS(spawn_obstacle_meshes(reg, parent), std::logic_error);
-        check_no_mesh_children(reg, parent);
-    }
-
-    SECTION("SplitPath") {
-        entt::registry reg;
-        auto parent = make_mesh_factory_obstacle(reg);
-        reg.emplace<RequiredShape>(parent, invalid_shape);
-        reg.emplace<RequiredLane>(parent, int8_t{1});
-        reg.emplace<SplitPathTag>(parent);
-
-        CHECK_THROWS_AS(spawn_obstacle_meshes(reg, parent), std::logic_error);
-        check_no_mesh_children(reg, parent);
-    }
-}
-
 TEST_CASE("entity: mesh factory rejects invalid RequiredLane before children", "[archetype][render][validation]") {
     SECTION("negative lane") {
         entt::registry reg;
         auto parent = make_mesh_factory_obstacle(reg);
-        reg.emplace<RequiredShape>(parent, Shape::Square);
+        set_required_shape_tag(reg, parent, Shape::Square);
         reg.emplace<RequiredLane>(parent, int8_t{-1});
         reg.emplace<SplitPathTag>(parent);
 
@@ -191,7 +167,7 @@ TEST_CASE("entity: mesh factory rejects invalid RequiredLane before children", "
     SECTION("lane beyond lane table") {
         entt::registry reg;
         auto parent = make_mesh_factory_obstacle(reg);
-        reg.emplace<RequiredShape>(parent, Shape::Square);
+        set_required_shape_tag(reg, parent, Shape::Square);
         reg.emplace<RequiredLane>(parent, int8_t{3});
         reg.emplace<SplitPathTag>(parent);
 
@@ -243,11 +219,12 @@ TEST_CASE("entity: SplitPath - RequiredShape and RequiredLane", "[archetype]") {
     auto e = spawn_split_path_obstacle(reg, {360.0f, -120.0f,
                                               Shape::Square, int8_t{2}});
 
-    REQUIRE(reg.all_of<ObstacleTag, Vector2, WorldTransform, Obstacle, RequiredShape, RequiredLane, DrawSize, Color>(e));
+    REQUIRE(reg.all_of<ObstacleTag, Vector2, WorldTransform, Obstacle, RequiredLane, DrawSize, Color>(e));
+    REQUIRE(has_required_shape_tag(reg, e));
     CHECK(!reg.all_of<uint8_t>(e));
 
     CHECK(reg.get<Obstacle>(e).base_points == int16_t{constants::PTS_SPLIT_PATH});
-    CHECK(reg.get<RequiredShape>(e).shape == Shape::Square);
+    CHECK(current_required_shape(reg, e) == Shape::Square);
     CHECK(reg.get<RequiredLane>(e).lane == int8_t{2});
 }
 

--- a/tests/test_perspective.cpp
+++ b/tests/test_perspective.cpp
@@ -174,24 +174,6 @@ TEST_CASE("game_camera_system rejects invalid MeshChild shape index", "[camera3d
     CHECK_FALSE(reg.all_of<ModelTransform>(child));
 }
 
-TEST_CASE("game_camera_system rejects invalid PlayerShape before mesh lookup", "[camera3d][player][validation]") {
-    entt::registry reg;
-    reg.ctx().emplace<ShapeMeshConfig>();
-    reg.ctx().emplace<FloorParams>();
-    auto player = reg.create();
-    reg.emplace<PlayerTag>(player);
-    reg.emplace<WorldTransform>(player, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
-    reg.emplace<PlayerShape>(player, PlayerShape{static_cast<Shape>(255), 1.0f});
-    // Vertical motion: grounded = absence of Jumping/Sliding (#1202/#1204).
-    reg.emplace<Color>(player, WHITE);
-    reg.emplace<ModelTransform>(player, ModelTransform{MatrixIdentity(), WHITE});
-    reg.emplace<MeshKindShape>(player, MeshKindShape{255});
-    reg.emplace<TagWorldPass>(player);
-
-    REQUIRE_NOTHROW(game_camera_system(reg, 0.0f));
-    CHECK_FALSE(reg.all_of<ModelTransform>(player));
-}
-
 // #1089 — MeshChildCleanupScratch::capacity_exceeded_count must stay at zero
 // when a dense stale-parent cleanup pass fits inside the reserved
 // stale_children buffer. runtime_system_scratch_reserve sizes the buffer at

--- a/tests/test_phase_runner.cpp
+++ b/tests/test_phase_runner.cpp
@@ -61,13 +61,12 @@ TEST_CASE("tick_playing_systems: no-op when phase is GameOver", "[phase_guard]")
 TEST_CASE("tick_playing_systems: collision resolves before active window expiry", "[phase_guard][integration][order_regression]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
     song.song_time = 10.0f + song.window_duration;
-    ps.current = Shape::Circle;
-    sw.target_shape = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
+    set_target_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     sw.window_start = 10.0f;
     sw.window_timer = 0.0f;
@@ -87,13 +86,12 @@ TEST_CASE("tick_playing_systems: collision resolves before active window expiry"
 TEST_CASE("tick_playing_systems: shape window activates before collision", "[phase_guard][integration][order_regression]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
     song.song_time = 10.0f;
-    ps.current = Shape::Hexagon;
-    sw.target_shape = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Hexagon);
+    set_target_shape_tag(reg, player, Shape::Circle);
     set_window_phase_morph_in(reg, player);
     sw.window_start = song.song_time - song.morph_duration - 0.01f;
     sw.window_timer = 0.0f;
@@ -106,7 +104,7 @@ TEST_CASE("tick_playing_systems: shape window activates before collision", "[pha
     tick_playing_systems(reg, 0.016f);
 
     CHECK(window_phase_is_active(reg, player));
-    CHECK(ps.current == Shape::Circle);
+    CHECK(reg.all_of<ShapeCircleTag>(player));
     CHECK(reg.ctx().get<SongResults>().perfect_count == 1);
     CHECK(reg.ctx().get<SongResults>().miss_count == 0);
 }

--- a/tests/test_player_action_rhythm.cpp
+++ b/tests/test_player_action_rhythm.cpp
@@ -16,10 +16,10 @@ TEST_CASE("player_action: rhythm mode starts MorphIn on button press from Idle",
 
     run_semantic_input_tick(reg, 0.016f);
 
-    CHECK(sw.target_shape == Shape::Triangle);
+    CHECK(reg.all_of<TargetShapeTriangleTag>(player));
     CHECK(window_phase_is_morph_in(reg, player));
     CHECK(sw.window_timer == 0.0f);
-    CHECK(ps.current == Shape::Hexagon);
+    CHECK(reg.all_of<ShapeHexagonTag>(player));
     CHECK(ps.morph_t == 0.0f);
     CHECK(sw.window_start == 5.0f);
     CHECK(sw.graded == false);
@@ -27,7 +27,7 @@ TEST_CASE("player_action: rhythm mode starts MorphIn on button press from Idle",
     song.song_time += song.morph_duration + 0.01f;
     shape_window_system(reg, song.morph_duration + 0.01f);
     CHECK(window_phase_is_active(reg, player));
-    CHECK(ps.current == Shape::Triangle);
+    CHECK(reg.all_of<ShapeTriangleTag>(player));
     CHECK(ps.morph_t == 1.0f);
 
     // SFX should be pushed
@@ -49,7 +49,7 @@ TEST_CASE("player_action: post-song rhythm context still starts window for trail
 
     run_semantic_input_tick(reg, 0.016f);
 
-    CHECK(sw.target_shape == Shape::Square);
+    CHECK(reg.all_of<TargetShapeSquareTag>(player));
     CHECK(window_phase_is_morph_in(reg, player));
     CHECK(sw.window_start == song.song_time);
     CHECK(sw.press_time == song.song_time);
@@ -58,10 +58,9 @@ TEST_CASE("player_action: post-song rhythm context still starts window for trail
 TEST_CASE("player_action: rhythm mode treats same shape during Active as no-op", "[player_rhythm]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     set_window_phase_active(reg, player);
-    ps.current = Shape::Square;
+    set_player_shape_tag(reg, player, Shape::Square);
     sw.window_timer = 0.1f;
     sw.window_start = 1.0f;
     sw.press_time = 1.0f;
@@ -91,7 +90,7 @@ TEST_CASE("player_action: rhythm mode interrupts Active with different shape", "
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 8.0f;
     set_window_phase_active(reg, player);
-    ps.current = Shape::Square;
+    set_player_shape_tag(reg, player, Shape::Square);
     sw.window_timer = 0.3f;
 
     auto btn = make_shape_button(reg, Shape::Triangle);
@@ -99,7 +98,7 @@ TEST_CASE("player_action: rhythm mode interrupts Active with different shape", "
 
     run_semantic_input_tick(reg, 0.016f);
 
-    CHECK(sw.target_shape == Shape::Triangle);
+    CHECK(reg.all_of<TargetShapeTriangleTag>(player));
     CHECK(window_phase_is_morph_in(reg, player));
     CHECK(sw.window_timer == 0.0f);
     CHECK(ps.morph_t == 0.0f);
@@ -122,7 +121,7 @@ TEST_CASE("player_action: rhythm mode does not interrupt MorphIn phase", "[playe
     auto player = make_rhythm_player(reg);
     auto& sw = reg.get<ShapeWindow>(player);
     set_window_phase_morph_in(reg, player);
-    sw.target_shape = Shape::Circle;
+    set_target_shape_tag(reg, player, Shape::Circle);
     sw.window_timer = 0.05f;
 
     auto btn = make_shape_button(reg, Shape::Square);
@@ -132,7 +131,7 @@ TEST_CASE("player_action: rhythm mode does not interrupt MorphIn phase", "[playe
 
     // MorphIn should not be interrupted (only Active can be interrupted)
     CHECK(window_phase_is_morph_in(reg, player));
-    CHECK(sw.target_shape == Shape::Circle);
+    CHECK(reg.all_of<TargetShapeCircleTag>(player));
 }
 
 // Fixed by #209: MorphOut is now interruptible — player input is preserved.
@@ -144,7 +143,7 @@ TEST_CASE("player_action: rhythm mode ACCEPTS button press during MorphOut (#209
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 15.0f;
     set_window_phase_morph_out(reg, player);
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     sw.window_timer = 0.05f;
     sw.window_start = 14.9f;
 
@@ -154,7 +153,7 @@ TEST_CASE("player_action: rhythm mode ACCEPTS button press during MorphOut (#209
     run_semantic_input_tick(reg, 0.016f);
 
     // MorphOut interrupted: new MorphIn window started for Triangle
-    CHECK(sw.target_shape == Shape::Triangle);
+    CHECK(reg.all_of<TargetShapeTriangleTag>(player));
     CHECK(window_phase_is_morph_in(reg, player));
     CHECK(sw.window_timer == 0.0f);
     CHECK(ps.morph_t == 0.0f);
@@ -175,7 +174,7 @@ TEST_CASE("player_action: legacy mode instant shape change", "[player_legacy]") 
     run_semantic_input_tick(reg, 0.016f);
 
     auto& ps = reg.get<PlayerShape>(player);
-    CHECK(ps.current == Shape::Triangle);
+    CHECK(reg.all_of<ShapeTriangleTag>(player));
     CHECK(ps.morph_t == 1.0f);
     CHECK(drain_sfx_events(reg).count > 0);
 }
@@ -189,8 +188,7 @@ TEST_CASE("player_action: legacy mode no change for same shape", "[player_legacy
 
     run_semantic_input_tick(reg, 0.016f);
 
-    auto& ps = reg.get<PlayerShape>(player);
-    CHECK(ps.current == Shape::Circle);
+    CHECK(reg.all_of<ShapeCircleTag>(player));
     CHECK(drain_sfx_events(reg).count == 0);
 }
 

--- a/tests/test_player_archetype.cpp
+++ b/tests/test_player_archetype.cpp
@@ -37,16 +37,14 @@ TEST_CASE("player_entity: initial shape is Hexagon", "[archetype][player]") {
     auto reg = make_registry();
     auto p = create_player_entity(reg);
 
-    auto& ps = reg.get<PlayerShape>(p);
-    CHECK(ps.current  == Shape::Hexagon);
+    CHECK(current_player_shape(reg, p) == Shape::Hexagon);
 }
 
 TEST_CASE("player_entity: ShapeWindow starts Idle targeting Hexagon", "[archetype][player]") {
     auto reg = make_registry();
     auto p = create_player_entity(reg);
 
-    auto& sw = reg.get<ShapeWindow>(p);
-    CHECK(sw.target_shape == Shape::Hexagon);
+    CHECK(current_target_shape(reg, p) == Shape::Hexagon);
     CHECK(window_phase_is_idle(reg, p));
 }
 

--- a/tests/test_player_input_rhythm_extended.cpp
+++ b/tests/test_player_input_rhythm_extended.cpp
@@ -17,19 +17,18 @@ TEST_CASE("player_input_rhythm: shape press in Idle begins MorphIn window", "[pl
     run_semantic_input_tick(reg);
 
     CHECK(window_phase_is_morph_in(reg, player));
-    CHECK(sw.target_shape == Shape::Circle);
+    CHECK(reg.all_of<TargetShapeCircleTag>(player));
     CHECK(sw.window_start == song.song_time);
 }
 
 TEST_CASE("player_input_rhythm: different shape in Active restarts window", "[player][rhythm]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
     // Already Active as Circle
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     sw.window_start = song.song_time - 0.5f;
 
@@ -40,17 +39,16 @@ TEST_CASE("player_input_rhythm: different shape in Active restarts window", "[pl
 
     // Should restart as MorphIn for Square.
     CHECK(window_phase_is_morph_in(reg, player));
-    CHECK(sw.target_shape == Shape::Square);
+    CHECK(reg.all_of<TargetShapeSquareTag>(player));
 }
 
 TEST_CASE("player_input_rhythm: same shape in Active is no-op", "[player][rhythm]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     sw.window_start = song.song_time - 0.5f;
     sw.window_timer = 0.5f;
@@ -157,7 +155,7 @@ TEST_CASE("player_input: non-rhythm shape press changes immediately", "[player]"
 
     auto view = reg.view<PlayerTag, PlayerShape>();
     for (auto [e, ps] : view.each()) {
-        CHECK(ps.current == Shape::Square);
+        CHECK(reg.all_of<ShapeSquareTag>(e));
         CHECK(ps.morph_t == 1.0f);
     }
 
@@ -211,8 +209,7 @@ TEST_CASE("player_input_rhythm: circle press in lane 0 does not force mismatch b
     lane.lerp_t = 1.0f;
     transform.position.x = constants::LANE_X[0];
 
-    auto& ps = reg.get<PlayerShape>(player);
-    ps.current = Shape::Hexagon;
+    set_player_shape_tag(reg, player, Shape::Hexagon);
 
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.get<WorldTransform>(obs).position.x = constants::LANE_X[0];

--- a/tests/test_player_systems.cpp
+++ b/tests/test_player_systems.cpp
@@ -15,7 +15,8 @@ TEST_CASE("player_action: shape change on button press", "[player]") {
 
     auto view = reg.view<PlayerTag, PlayerShape>();
     for (auto [e, ps] : view.each()) {
-        CHECK(ps.current  == Shape::Triangle);
+        (void)ps;
+        CHECK(current_player_shape(reg, e) == Shape::Triangle);
         CHECK(ps.morph_t  == 1.0f);
     }
     // Should have pushed ShapeShift SFX
@@ -34,7 +35,8 @@ TEST_CASE("player_action: no shape change when same shape pressed", "[player]") 
 
     auto view = reg.view<PlayerTag, PlayerShape>();
     for (auto [e, ps] : view.each()) {
-        CHECK(ps.current == Shape::Circle);
+        (void)ps;
+        CHECK(current_player_shape(reg, e) == Shape::Circle);
         CHECK(ps.morph_t == 1.0f);  // unchanged
     }
     CHECK(drain_sfx_events(reg).count == 0);

--- a/tests/test_redfoot_testflight_ui.cpp
+++ b/tests/test_redfoot_testflight_ui.cpp
@@ -25,6 +25,7 @@
 #include "components/transform.h"
 #include "constants.h"
 #include "systems/all_systems.h"
+#include "util/shape_tag.h"
 
 namespace {
 struct RglRect {
@@ -87,8 +88,9 @@ void spawn_aligned_player(entt::registry& reg, float y) {
     auto p = reg.create();
     reg.emplace<PlayerTag>(p);
     reg.emplace<WorldTransform>(p, WorldTransform{{constants::LANE_X[1], y}});
-    PlayerShape ps; ps.current = Shape::Hexagon;
+    PlayerShape ps;
     reg.emplace<PlayerShape>(p, ps);
+    set_player_shape_tag(reg, p, Shape::Hexagon);
     ShapeWindow sw{};
     reg.emplace<ShapeWindow>(p, sw);
     // Idle phase = absence of all ShapeWindow*Tag (#1202/#1204).
@@ -120,7 +122,7 @@ TEST_CASE("redfoot/#168: collision miss is non-terminal cause context",
 
     spawn_aligned_player(reg, constants::PLAYER_Y);
     auto gate = spawn_obstacle(reg, constants::PLAYER_Y);
-    reg.emplace<RequiredShape>(gate, Shape::Circle);
+    set_required_shape_tag(reg, gate, Shape::Circle);
 
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);

--- a/tests/test_rhythm_system.cpp
+++ b/tests/test_rhythm_system.cpp
@@ -316,8 +316,7 @@ TEST_CASE("shape_window: idle does nothing", "[rhythm][window]") {
     auto player = make_rhythm_player(reg);
     reg.ctx().get<SongState>().song_time += 0.016f;
     shape_window_system(reg, 0.016f);
-    auto& ps = reg.get<PlayerShape>(player);
-    CHECK(ps.current == Shape::Hexagon);
+    CHECK(reg.all_of<ShapeHexagonTag>(player));
     CHECK(window_phase_is_idle(reg, player));
 }
 
@@ -328,23 +327,22 @@ TEST_CASE("shape_window: morph_in transitions to active", "[rhythm][window]") {
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
     set_window_phase_morph_in(reg, player);
-    sw.target_shape = Shape::Triangle;
+    set_target_shape_tag(reg, player, Shape::Triangle);
     sw.window_timer = 0.0f; ps.morph_t = 0.0f;
     sw.window_start = reg.ctx().get<SongState>().song_time;
     reg.ctx().get<SongState>().song_time += song.morph_duration + 0.01f;
     shape_window_system(reg, song.morph_duration + 0.01f);
-    CHECK(ps.current == Shape::Triangle);
+    CHECK(reg.all_of<ShapeTriangleTag>(player));
     CHECK(window_phase_is_active(reg, player));
 }
 
 TEST_CASE("shape_window: active transitions to morph_out", "[rhythm][window]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
     set_window_phase_active(reg, player);
-    ps.current = Shape::Triangle; sw.window_timer = 0.0f;
+    set_player_shape_tag(reg, player, Shape::Triangle); sw.window_timer = 0.0f;
     sw.window_start = reg.ctx().get<SongState>().song_time;
     reg.ctx().get<SongState>().song_time += song.window_duration + 0.01f;
     shape_window_system(reg, song.window_duration + 0.01f);
@@ -354,35 +352,32 @@ TEST_CASE("shape_window: active transitions to morph_out", "[rhythm][window]") {
 TEST_CASE("shape_window: morph_out reverts to hexagon", "[rhythm][window]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
     set_window_phase_morph_out(reg, player);
-    ps.current = Shape::Triangle; sw.window_timer = 0.0f;
+    set_player_shape_tag(reg, player, Shape::Triangle); sw.window_timer = 0.0f;
     sw.window_start = reg.ctx().get<SongState>().song_time;
     reg.ctx().get<SongState>().song_time += song.morph_duration + 0.01f;
     shape_window_system(reg, song.morph_duration + 0.01f);
-    CHECK(ps.current == Shape::Hexagon);
+    CHECK(reg.all_of<ShapeHexagonTag>(player));
     CHECK(window_phase_is_idle(reg, player));
 }
 
 TEST_CASE("shape_window: full lifecycle", "[rhythm][window]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
-    auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
     set_window_phase_morph_in(reg, player);
-    sw.target_shape = Shape::Square;
+    set_target_shape_tag(reg, player, Shape::Square);
     float morph_dt = song.morph_duration / 5.0f;
     for (int i = 0; i < 6; ++i) { reg.ctx().get<SongState>().song_time += morph_dt; shape_window_system(reg, morph_dt); }
     CHECK(window_phase_is_active(reg, player));
-    CHECK(ps.current == Shape::Square);
+    CHECK(reg.all_of<ShapeSquareTag>(player));
     float active_dt = song.window_duration / 10.0f;
     for (int i = 0; i < 11; ++i) { reg.ctx().get<SongState>().song_time += active_dt; shape_window_system(reg, active_dt); }
     CHECK(window_phase_is_morph_out(reg, player));
     for (int i = 0; i < 6; ++i) { reg.ctx().get<SongState>().song_time += morph_dt; shape_window_system(reg, morph_dt); }
-    CHECK(ps.current == Shape::Hexagon);
+    CHECK(reg.all_of<ShapeHexagonTag>(player));
     CHECK(window_phase_is_idle(reg, player));
 }
 
@@ -394,9 +389,8 @@ TEST_CASE("player_action: button press starts MorphIn window in rhythm mode", "[
     auto btn = make_shape_button(reg, Shape::Triangle);
     press_button(reg, btn);
     run_semantic_input_tick(reg, 0.016f);
-    auto& sw = reg.get<ShapeWindow>(player);
     CHECK(window_phase_is_morph_in(reg, player));
-    CHECK(sw.target_shape == Shape::Triangle);
+    CHECK(reg.all_of<TargetShapeTriangleTag>(player));
 }
 
 TEST_CASE("player_action: press_time recorded correctly", "[rhythm][action]") {
@@ -414,10 +408,8 @@ TEST_CASE("player_action: press_time recorded correctly", "[rhythm][action]") {
 TEST_CASE("player_action: same shape during active is ignored", "[rhythm][action]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
-    auto& sw = reg.get<ShapeWindow>(player);
     set_window_phase_active(reg, player);
-    ps.current = Shape::Triangle; sw.target_shape = Shape::Triangle;
+    set_player_shape_tag(reg, player, Shape::Triangle); set_target_shape_tag(reg, player, Shape::Triangle);
     auto btn = make_shape_button(reg, Shape::Triangle);
     press_button(reg, btn);
     run_semantic_input_tick(reg, 0.016f);
@@ -427,15 +419,13 @@ TEST_CASE("player_action: same shape during active is ignored", "[rhythm][action
 TEST_CASE("player_action: different shape mid-window restarts", "[rhythm][action]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
-    auto& sw = reg.get<ShapeWindow>(player);
     set_window_phase_active(reg, player);
-    ps.current = Shape::Triangle; sw.target_shape = Shape::Triangle;
+    set_player_shape_tag(reg, player, Shape::Triangle); set_target_shape_tag(reg, player, Shape::Triangle);
     auto btn = make_shape_button(reg, Shape::Circle);
     press_button(reg, btn);
     run_semantic_input_tick(reg, 0.016f);
     CHECK(window_phase_is_morph_in(reg, player));
-    CHECK(sw.target_shape == Shape::Circle);
+    CHECK(reg.all_of<TargetShapeCircleTag>(player));
 }
 
 TEST_CASE("player_action: no action with empty queue", "[rhythm][action]") {
@@ -451,8 +441,7 @@ TEST_CASE("player_action: legacy mode instant shape change", "[rhythm][action]")
     auto btn = make_shape_button(reg, Shape::Triangle);
     press_button(reg, btn);
     run_semantic_input_tick(reg, 0.016f);
-    auto& ps = reg.get<PlayerShape>(player);
-    CHECK(ps.current == Shape::Triangle);
+    CHECK(reg.all_of<ShapeTriangleTag>(player));
     CHECK(window_phase_is_idle(reg, player));
 }
 
@@ -491,10 +480,9 @@ TEST_CASE("collision: MISS drains energy", "[rhythm][collision]") {
 TEST_CASE("collision: timing grade PERFECT on press-at-arrival", "[rhythm][collision]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     song.song_time = 5.0f; sw.press_time = 5.0f;
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
@@ -509,7 +497,6 @@ TEST_CASE("collision: timing grade PERFECT on press-at-arrival", "[rhythm][colli
 TEST_CASE("collision: HUD perfect cue distance maps to PERFECT timing", "[rhythm][collision][hud]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
@@ -521,7 +508,7 @@ TEST_CASE("collision: HUD perfect cue distance maps to PERFECT timing", "[rhythm
     CHECK_THAT(gameplay_hud_ok_distance(&song) / song.scroll_speed,
                WithinAbs(kTimingOkSeconds, 0.0001f));
 
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     sw.press_time = 5.0f;
     song.song_time = sw.press_time + cue_lead_seconds;
@@ -539,10 +526,9 @@ TEST_CASE("collision: HUD perfect cue distance maps to PERFECT timing", "[rhythm
 TEST_CASE("collision: timing grade GOOD at 50pct", "[rhythm][collision]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     song.song_time = 5.0f; sw.press_time = 5.0f;
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
@@ -556,10 +542,9 @@ TEST_CASE("collision: timing grade GOOD at 50pct", "[rhythm][collision]") {
 TEST_CASE("collision: timing grade OK at 80pct", "[rhythm][collision]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     song.song_time = 5.0f; sw.press_time = 5.0f;
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
@@ -573,10 +558,9 @@ TEST_CASE("collision: timing grade OK at 80pct", "[rhythm][collision]") {
 TEST_CASE("collision: timing grade BAD beyond window", "[rhythm][collision]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     song.song_time = 5.0f; sw.press_time = 5.0f;
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
@@ -592,12 +576,11 @@ TEST_CASE("collision: stale press from previous beat does not get Perfect", "[rh
     // NOT award Perfect for beat N+2. Timing is graded from button press time.
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
     // Player pressed Circle at song_time 2.0.
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     sw.press_time = 2.0f;
     sw.window_start = 2.0f;
@@ -620,10 +603,9 @@ TEST_CASE("collision: stale press from previous beat does not get Perfect", "[rh
 TEST_CASE("collision: PERFECT clears obstacle without game over", "[rhythm][collision]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     song.song_time = 5.0f; sw.press_time = 5.0f;
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
@@ -636,10 +618,9 @@ TEST_CASE("collision: PERFECT clears obstacle without game over", "[rhythm][coll
 TEST_CASE("collision: SongResults updated", "[rhythm][collision]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     song.song_time = 5.0f; sw.press_time = 5.0f;
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
@@ -722,12 +703,11 @@ TEST_CASE("timing: window_scale_from_delta_abs values", "[rhythm][timing]") {
 TEST_CASE("window_scaling: PERFECT grade shortens remaining window", "[rhythm][window_scaling]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
     // Put player in Active phase, midway through window
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     sw.window_timer = song.window_duration * 0.5f; // halfway through
     song.song_time = 5.0f;
@@ -753,11 +733,10 @@ TEST_CASE("window_scaling: PERFECT grade shortens remaining window", "[rhythm][w
 TEST_CASE("window_scaling: GOOD grade shortens window slightly", "[rhythm][window_scaling]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     sw.window_timer = song.window_duration * 0.4f;
     song.song_time = 5.0f;
@@ -782,11 +761,10 @@ TEST_CASE("window_scaling: GOOD grade shortens window slightly", "[rhythm][windo
 TEST_CASE("window_scaling: OK grade keeps window unchanged", "[rhythm][window_scaling]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     song.song_time = 5.0f;
     sw.window_timer = song.window_duration * 0.3f;
@@ -810,11 +788,10 @@ TEST_CASE("window_scaling: OK grade keeps window unchanged", "[rhythm][window_sc
 TEST_CASE("window_scaling: BAD grade keeps window unchanged", "[rhythm][window_scaling]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     song.song_time = 5.0f;
     sw.window_timer = song.window_duration * 0.2f;
@@ -838,11 +815,10 @@ TEST_CASE("window_scaling: BAD grade keeps window unchanged", "[rhythm][window_s
 TEST_CASE("window_scaling: second obstacle does not re-scale", "[rhythm][window_scaling]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     sw.window_timer = song.window_duration * 0.4f;
     song.song_time = 5.0f;

--- a/tests/test_shape_window_extended.cpp
+++ b/tests/test_shape_window_extended.cpp
@@ -13,7 +13,7 @@ TEST_CASE("shape_window: MorphIn advances morph_t toward 1.0", "[shape_window][r
     auto& song = reg.ctx().get<SongState>();
 
     set_window_phase_morph_in(reg, player);
-    sw.target_shape = Shape::Circle;
+    set_target_shape_tag(reg, player, Shape::Circle);
     sw.window_start = song.song_time;
     ps.morph_t = 0.0f;
 
@@ -34,7 +34,7 @@ TEST_CASE("shape_window: MorphIn transitions to Active", "[shape_window][rhythm]
     auto& song = reg.ctx().get<SongState>();
 
     set_window_phase_morph_in(reg, player);
-    sw.target_shape = Shape::Circle;
+    set_target_shape_tag(reg, player, Shape::Circle);
     sw.window_start = song.song_time;
     ps.morph_t = 0.0f;
 
@@ -43,7 +43,7 @@ TEST_CASE("shape_window: MorphIn transitions to Active", "[shape_window][rhythm]
     shape_window_system(reg, 0.016f);
 
     CHECK(ps.morph_t == 1.0f);
-    CHECK(ps.current == Shape::Circle);
+    CHECK(reg.all_of<ShapeCircleTag>(player));
     CHECK(window_phase_is_active(reg, player));
 }
 
@@ -54,7 +54,7 @@ TEST_CASE("shape_window: Active phase expires into MorphOut", "[shape_window][rh
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     sw.window_start = song.song_time;
 
@@ -73,7 +73,7 @@ TEST_CASE("shape_window: MorphOut returns to Idle with Hexagon", "[shape_window]
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_morph_out(reg, player);
     sw.window_start = song.song_time;
     sw.press_time = song.song_time - 0.25f;
@@ -84,8 +84,8 @@ TEST_CASE("shape_window: MorphOut returns to Idle with Hexagon", "[shape_window]
     shape_window_system(reg, 0.016f);
 
     CHECK(window_phase_is_idle(reg, player));
-    CHECK(ps.current == Shape::Hexagon);
-    CHECK(sw.target_shape == Shape::Hexagon);
+    CHECK(reg.all_of<ShapeHexagonTag>(player));
+    CHECK(reg.all_of<TargetShapeHexagonTag>(player));
     CHECK(sw.press_time == -1.0f);
     CHECK_FALSE(sw.graded);
 }
@@ -93,26 +93,24 @@ TEST_CASE("shape_window: MorphOut returns to Idle with Hexagon", "[shape_window]
 TEST_CASE("shape_window: Idle phase does nothing", "[shape_window][rhythm]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& song = reg.ctx().get<SongState>();
 
     set_window_phase_idle(reg, player);
-    Shape original_shape = ps.current;
+    Shape original_shape = current_player_shape(reg, player);
 
     song.song_time += 1.0f;
     shape_window_system(reg, 0.016f);
 
-    CHECK(ps.current == original_shape);
+    CHECK(current_player_shape(reg, player) == original_shape);
 }
 
 TEST_CASE("shape_window: Active duration is driven by song window duration", "[shape_window][rhythm]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
     sw.window_start = song.song_time;
 
@@ -150,7 +148,7 @@ TEST_CASE("shape_window: color updates on Active transition", "[shape_window][rh
     auto& song = reg.ctx().get<SongState>();
 
     set_window_phase_morph_in(reg, player);
-    sw.target_shape = Shape::Square;  // Red
+    set_target_shape_tag(reg, player, Shape::Square);  // Red
     sw.window_start = song.song_time;
     ps.morph_t = 0.0f;
 
@@ -172,7 +170,7 @@ TEST_CASE("shape_window: full lifecycle MorphIn→Active→MorphOut→Idle", "[s
 
     // Start MorphIn
     set_window_phase_morph_in(reg, player);
-    sw.target_shape = Shape::Triangle;
+    set_target_shape_tag(reg, player, Shape::Triangle);
     sw.window_start = song.song_time;
     ps.morph_t = 0.0f;
 
@@ -180,7 +178,7 @@ TEST_CASE("shape_window: full lifecycle MorphIn→Active→MorphOut→Idle", "[s
     song.song_time += song.morph_duration + 0.01f;
     shape_window_system(reg, 0.016f);
     CHECK(window_phase_is_active(reg, player));
-    CHECK(ps.current == Shape::Triangle);
+    CHECK(reg.all_of<ShapeTriangleTag>(player));
 
     // Phase 2: Active → MorphOut
     song.song_time += song.window_duration + 0.01f;
@@ -191,7 +189,7 @@ TEST_CASE("shape_window: full lifecycle MorphIn→Active→MorphOut→Idle", "[s
     song.song_time += song.morph_duration + 0.01f;
     shape_window_system(reg, 0.016f);
     CHECK(window_phase_is_idle(reg, player));
-    CHECK(ps.current == Shape::Hexagon);
+    CHECK(reg.all_of<ShapeHexagonTag>(player));
 }
 
 // ── Regression tests for issue #223 (window_scale inversion) ────────────────

--- a/tests/test_shape_window_system.cpp
+++ b/tests/test_shape_window_system.cpp
@@ -27,7 +27,7 @@ TEST_CASE("shape_window: MorphIn increments timer", "[shape_window]") {
     auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     set_window_phase_morph_in(reg, player);
-    sw.target_shape = Shape::Circle;
+    set_target_shape_tag(reg, player, Shape::Circle);
     sw.window_timer = 0.0f;
     sw.window_start = reg.ctx().get<SongState>().song_time;
     ps.morph_t = 0.0f;
@@ -47,7 +47,7 @@ TEST_CASE("shape_window: MorphIn completes and transitions to Active", "[shape_w
     auto& song = reg.ctx().get<SongState>();
 
     set_window_phase_morph_in(reg, player);
-    sw.target_shape = Shape::Triangle;
+    set_target_shape_tag(reg, player, Shape::Triangle);
     sw.window_timer = 0.0f;
     sw.window_start = reg.ctx().get<SongState>().song_time;
     ps.morph_t = 0.0f;
@@ -59,28 +59,7 @@ TEST_CASE("shape_window: MorphIn completes and transitions to Active", "[shape_w
     CHECK(window_phase_is_active(reg, player));
     CHECK(ps.morph_t == 1.0f);
     CHECK(sw.window_timer == 0.0f);  // reset for Active phase
-    CHECK(ps.current == Shape::Triangle);
-}
-
-TEST_CASE("shape_window: invalid MorphIn target resets safely", "[shape_window][validation]") {
-    auto reg = make_rhythm_registry();
-    auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
-    auto& sw = reg.get<ShapeWindow>(player);
-    auto& song = reg.ctx().get<SongState>();
-
-    set_window_phase_morph_in(reg, player);
-    sw.target_shape = static_cast<Shape>(255);
-    ps.current = Shape::Hexagon;
-    ps.morph_t = 0.0f;
-    sw.window_start = song.song_time;
-
-    song.song_time += song.morph_duration + 0.01f;
-
-    REQUIRE_NOTHROW(shape_window_system(reg, song.morph_duration + 0.01f));
-    CHECK(window_phase_is_idle(reg, player));
-    CHECK(ps.current == Shape::Hexagon);
-    CHECK(sw.target_shape == Shape::Hexagon);
+    CHECK(reg.all_of<ShapeTriangleTag>(player));
 }
 
 TEST_CASE("shape_window: MorphIn morph_t proportional to timer", "[shape_window]") {
@@ -91,7 +70,7 @@ TEST_CASE("shape_window: MorphIn morph_t proportional to timer", "[shape_window]
     auto& song = reg.ctx().get<SongState>();
 
     set_window_phase_morph_in(reg, player);
-    sw.target_shape = Shape::Square;
+    set_target_shape_tag(reg, player, Shape::Square);
     sw.window_timer = 0.0f;
     sw.window_start = reg.ctx().get<SongState>().song_time;
     ps.morph_t = 0.0f;
@@ -109,10 +88,9 @@ TEST_CASE("shape_window: MorphIn morph_t proportional to timer", "[shape_window]
 TEST_CASE("shape_window: Active increments timer", "[shape_window]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     set_window_phase_active(reg, player);
-    ps.current = Shape::Circle;
+    set_player_shape_tag(reg, player, Shape::Circle);
     sw.window_timer = 0.0f;
     sw.window_start = reg.ctx().get<SongState>().song_time;
 
@@ -131,7 +109,7 @@ TEST_CASE("shape_window: Active transitions to MorphOut when window expires", "[
     auto& song = reg.ctx().get<SongState>();
 
     set_window_phase_active(reg, player);
-    ps.current = Shape::Square;
+    set_player_shape_tag(reg, player, Shape::Square);
     sw.window_timer = 0.0f;
     sw.window_start = reg.ctx().get<SongState>().song_time;
 
@@ -171,8 +149,8 @@ TEST_CASE("shape_window: MorphOut completes and returns to Idle/Hexagon", "[shap
     auto& song = reg.ctx().get<SongState>();
 
     set_window_phase_morph_out(reg, player);
-    ps.current = Shape::Triangle;
-    sw.target_shape = Shape::Triangle;
+    set_player_shape_tag(reg, player, Shape::Triangle);
+    set_target_shape_tag(reg, player, Shape::Triangle);
     sw.window_timer = 0.0f;
     sw.window_start = reg.ctx().get<SongState>().song_time;
     ps.morph_t = 0.0f;
@@ -183,8 +161,8 @@ TEST_CASE("shape_window: MorphOut completes and returns to Idle/Hexagon", "[shap
 
     CHECK(window_phase_is_idle(reg, player));
     CHECK(ps.morph_t == 1.0f);
-    CHECK(ps.current == Shape::Hexagon);
-    CHECK(sw.target_shape == Shape::Hexagon);
+    CHECK(reg.all_of<ShapeHexagonTag>(player));
+    CHECK(reg.all_of<TargetShapeHexagonTag>(player));
     CHECK(sw.window_timer == 0.0f);
 }
 
@@ -199,7 +177,7 @@ TEST_CASE("shape_window: full cycle MorphIn -> Active -> MorphOut -> Idle", "[sh
 
     // Start in MorphIn
     set_window_phase_morph_in(reg, player);
-    sw.target_shape = Shape::Circle;
+    set_target_shape_tag(reg, player, Shape::Circle);
     sw.window_timer = 0.0f;
     sw.window_start = reg.ctx().get<SongState>().song_time;
     ps.morph_t = 0.0f;
@@ -208,7 +186,7 @@ TEST_CASE("shape_window: full cycle MorphIn -> Active -> MorphOut -> Idle", "[sh
     reg.ctx().get<SongState>().song_time += song.morph_duration + 0.01f;
     shape_window_system(reg, song.morph_duration + 0.01f);
     CHECK(window_phase_is_active(reg, player));
-    CHECK(ps.current == Shape::Circle);
+    CHECK(reg.all_of<ShapeCircleTag>(player));
 
     // Complete Active
     reg.ctx().get<SongState>().song_time += song.window_duration + 0.01f;
@@ -219,7 +197,7 @@ TEST_CASE("shape_window: full cycle MorphIn -> Active -> MorphOut -> Idle", "[sh
     reg.ctx().get<SongState>().song_time += song.morph_duration + 0.01f;
     shape_window_system(reg, song.morph_duration + 0.01f);
     CHECK(window_phase_is_idle(reg, player));
-    CHECK(ps.current == Shape::Hexagon);
+    CHECK(reg.all_of<ShapeHexagonTag>(player));
 }
 
 // ── shape_window_system: phase guard ─────────────────────────
@@ -264,12 +242,11 @@ TEST_CASE("shape_window: no crash without player entity", "[shape_window]") {
 TEST_CASE("shape_window: Active stays Active if time not yet expired", "[shape_window]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& ps = reg.get<PlayerShape>(player);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
     set_window_phase_active(reg, player);
-    ps.current = Shape::Square;
+    set_player_shape_tag(reg, player, Shape::Square);
     sw.window_timer = 0.0f;
     sw.window_start = reg.ctx().get<SongState>().song_time;
 
@@ -289,7 +266,7 @@ TEST_CASE("shape_window: invalid morph_duration completes MorphIn without non-fi
     auto& song = reg.ctx().get<SongState>();
 
     set_window_phase_morph_in(reg, player);
-    sw.target_shape = Shape::Square;
+    set_target_shape_tag(reg, player, Shape::Square);
     sw.window_start = song.song_time;
     ps.morph_t = 0.0f;
     song.morph_duration = 0.0f;
@@ -299,7 +276,7 @@ TEST_CASE("shape_window: invalid morph_duration completes MorphIn without non-fi
     CHECK(std::isfinite(ps.morph_t));
     CHECK(ps.morph_t == 1.0f);
     CHECK(window_phase_is_active(reg, player));
-    CHECK(ps.current == Shape::Square);
+    CHECK(reg.all_of<ShapeSquareTag>(player));
 }
 
 TEST_CASE("shape_window: invalid morph_duration completes MorphOut without non-finite progress", "[shape_window][issue915]") {
@@ -310,8 +287,8 @@ TEST_CASE("shape_window: invalid morph_duration completes MorphOut without non-f
     auto& song = reg.ctx().get<SongState>();
 
     set_window_phase_morph_out(reg, player);
-    sw.target_shape = Shape::Triangle;
-    ps.current = Shape::Triangle;
+    set_target_shape_tag(reg, player, Shape::Triangle);
+    set_player_shape_tag(reg, player, Shape::Triangle);
     sw.window_start = song.song_time;
     ps.morph_t = 0.0f;
     song.morph_duration = -0.1f;
@@ -321,5 +298,5 @@ TEST_CASE("shape_window: invalid morph_duration completes MorphOut without non-f
     CHECK(std::isfinite(ps.morph_t));
     CHECK(ps.morph_t == 1.0f);
     CHECK(window_phase_is_idle(reg, player));
-    CHECK(ps.current == Shape::Hexagon);
+    CHECK(reg.all_of<ShapeHexagonTag>(player));
 }

--- a/tests/test_test_player_system.cpp
+++ b/tests/test_test_player_system.cpp
@@ -170,7 +170,7 @@ TEST_CASE("test_player: ignores visual obstacle leftovers without Obstacle paylo
     reg.emplace<ObstacleTag>(visual_leftover);
     reg.emplace<WorldTransform>(visual_leftover,
                                 WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y - 200.0f}});
-    reg.emplace<RequiredShape>(visual_leftover, Shape::Circle);
+    set_required_shape_tag(reg, visual_leftover, Shape::Circle);
 
     test_player_system(reg, 0.016f);
 


### PR DESCRIPTION
PR B of the Shape eradication ladder (#1202). Replaces the three on-entity Shape-typed carriers with per-shape EnTT tag tables — same mechanic as the kind/phase/mesh-type tag tables already in place (#1259, #1204).

## Carriers migrated

| Old field                  | New representation                                                         |
|----------------------------|----------------------------------------------------------------------------|
| `PlayerShape::current`     | `Shape{Circle,Square,Triangle,Hexagon}Tag` (one per player)                |
| `ShapeWindow::target_shape`| `TargetShape{Circle,Square,Triangle,Hexagon}Tag` (one per player)          |
| `RequiredShape` (struct)   | `RequiredShape{Circle,Square,Triangle,Hexagon}Tag` (one per obstacle)      |

The `RequiredShape` struct is deleted entirely — single-column table → tag set per the Fabian relational mechanic.

## New helper (`app/util/shape_tag.h`)

Function-pointer-per-row lookup tables (same mechanic as `kShapeFlatDrawFns` from #1259):
- Writers (`set_player_shape_tag` / `set_target_shape_tag` / `set_required_shape_tag`) remove all four sibling tags first, then emplace the matching one — maintains the "exactly one tag per slot" invariant.
- Readers (`current_player_shape` / `current_target_shape` / `current_required_shape`) return `Shape::Hexagon` as the no-tag sentinel, matching legacy "no playable shape" / "target reset" semantics.
- Existence probe (`has_required_shape_tag`) replaces the `try_get<RequiredShape>(e) != nullptr` idiom.

## Collision system rewrite

`player_matches_required_shape` is now three explicit per-shape template instantiations of `shape_row_match<RequiredTag, ShapeTag, TargetTag>` (Circle/Square/Triangle). Hexagon required obstacles are rejected unconditionally, preserving the legacy contract. Views switched from `<…, RequiredShape, …>` to `<…, ShapeGateTag, …>` / `<…, SplitPathTag, …>` — the kind tags already filter obstacles correctly; per-shape data is read in the loop via `current_required_shape` / tag presence.

## Defensive paths removed

Three legacy validation tests asserted `static_cast<Shape>(255)` injection wouldn't crash downstream systems:
- `shape_window: invalid MorphIn target resets safely`
- `entity: mesh factory rejects invalid RequiredShape before children`
- `game_camera_system rejects invalid PlayerShape before mesh lookup`

Per the new design the corrupt-value state is unrepresentable — writers no-op on invalid Shape, readers return the Hexagon sentinel. The bug condition cannot be reached, so the defensive paths (and the tests) are removed. Matches Fabian's existential processing: make invalid states unrepresentable.

## Validation

- Build: `-Wall -Wextra -Werror` clean, zero warnings on `shapeshifter` + `shapeshifter_tests`.
- Tests: **873 passed, 2915 assertions** (was 876 / 2924 before the 3 removed defensive tests).
- Enum allowlist: 11 enums, unchanged. The `Shape` enum remains for the still-data-row sites — `BeatEntry::shape`, `ButtonPressEvent::shape`, `TestPlayerAction::target_shape`. Those are explicit PR C scope.

Refs #1202, #1204.