### PR TITLE
Eradicate ButtonPressEvent via per-shape press events + MenuPressEvent (refs #1202, #1204)

### DIFF
--- a/app/.allowed-enums.txt
+++ b/app/.allowed-enums.txt
@@ -6,7 +6,7 @@
 # survive in this codebase only as:
 #
 #   - input event labels / keybindings  (Direction, MenuActionKind,
-#                                        ButtonPressKind, KeyboardShapeSlot)
+#                                        KeyboardShapeSlot)
 #   - playback IDs                      (HapticEvent, ImpactStyle, SFX)
 #   - finite return codes               (Status)
 #   - UI layout labels                  (FontSize)
@@ -31,7 +31,6 @@
 # --- Keep set: label / lookup / return code (Fabian "enums that make sense")
 Direction          # input event label
 MenuActionKind     # input event label
-ButtonPressKind    # input event label
 KeyboardShapeSlot  # keybinding lookup key
 HapticEvent        # playback ID
 ImpactStyle        # playback ID

--- a/app/systems/game_state_routing.cpp
+++ b/app/systems/game_state_routing.cpp
@@ -8,7 +8,7 @@
 #include "../constants.h"
 
 namespace {
-bool game_state_handle_end_screen_press(entt::registry& reg, const ButtonPressEvent& evt) {
+bool game_state_handle_end_screen_press(entt::registry& reg, const MenuPressEvent& evt) {
     auto& gs = reg.ctx().get<GameState>();
     if (gs.phase != GamePhase::GameOver && gs.phase != GamePhase::SongComplete) {
         return false;
@@ -22,8 +22,8 @@ bool game_state_handle_end_screen_press(entt::registry& reg, const ButtonPressEv
     }
 
     const MenuActionKind action =
-        (evt.menu_action == MenuActionKind::Confirm) ? MenuActionKind::Restart
-                                                      : evt.menu_action;
+        (evt.action == MenuActionKind::Confirm) ? MenuActionKind::Restart
+                                                : evt.action;
 
     if (auto* disp = reg.ctx().find<entt::dispatcher>()) {
         disp->enqueue<PlayHapticEvent>({action == MenuActionKind::Restart
@@ -51,19 +51,18 @@ void game_state_handle_go(entt::registry& reg, const GoEvent& /*evt*/) {
     gs.next_phase = GamePhase::Playing;
 }
 
-void game_state_handle_press(entt::registry& reg, const ButtonPressEvent& evt) {
-    if (evt.kind != ButtonPressKind::Menu) return;  // ignore shape-button events
+void game_state_handle_press_menu(entt::registry& reg, const MenuPressEvent& evt) {
     auto& gs = reg.ctx().get<GameState>();
 
     if (gs.phase == GamePhase::Title) {
         if (auto* disp = reg.ctx().find<entt::dispatcher>()) {
             disp->enqueue<PlayHapticEvent>({HapticEvent::UIButtonTap});
         }
-        if (evt.menu_action == MenuActionKind::Exit) {
+        if (evt.action == MenuActionKind::Exit) {
 #ifndef PLATFORM_WEB
             reg.ctx().get<InputState>().quit_requested = true;
 #endif
-        } else if (evt.menu_action == MenuActionKind::Confirm) {
+        } else if (evt.action == MenuActionKind::Confirm) {
             gs.transition_pending = true;
             gs.next_phase = GamePhase::LevelSelect;
         }
@@ -76,7 +75,7 @@ void game_state_handle_press(entt::registry& reg, const ButtonPressEvent& evt) {
 
     if (gs.phase == GamePhase::Tutorial) {
         if (gs.phase_timer <= constants::UI_ENTRY_DEBOUNCE) return;
-        if (evt.menu_action != MenuActionKind::Confirm) return;
+        if (evt.action != MenuActionKind::Confirm) return;
         if (auto* settings_state = find_settings_state(reg)) {
             settings::mark_ftue_complete(*settings_state);
             if (auto* persistence = find_settings_persistence(reg)) {

--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -71,7 +71,9 @@ void game_state_system(entt::registry& reg, float dt) {
 
     // ── Primary event drain ───────────────────────────────────────────────────
     // game_state_system runs first in tick_fixed_systems (game_loop.cpp) and
-    // owns the authoritative drain for GoEvent and ButtonPressEvent.
+    // owns the authoritative drain for GoEvent and all press event queues
+    // (per-shape ShapePress* + MenuPressEvent — see input_events.h for the
+    // per-event-type split, issue #1202/#1204).
     // Calling update<T>() here fires every registered listener in registration
     // order: game_state → level_select → player_input
     // (see wire_input_dispatcher in systems/input_dispatcher.cpp).
@@ -81,13 +83,16 @@ void game_state_system(entt::registry& reg, float dt) {
     // drain before movement so same-frame mobile tap+swipe combo obstacles
     // resolve deterministically.
     //
-    // ⚠ Do NOT call disp.clear<GoEvent/ButtonPressEvent>() before this point
-    //   within a frame.  Those pre-tick systems enqueue same-frame events that
-    //   must reach player_input_handle_go / player_input_handle_press through
-    //   this update() call.  clear() would silently drop them before delivery.
+    // ⚠ Do NOT call disp.clear<>() on any of these queues before this point
+    //   within a frame.  Pre-tick systems enqueue same-frame events that
+    //   must reach player_input listeners through this update() call.
+    //   clear() would silently drop them before delivery.
     //
     auto& disp = reg.ctx().get<entt::dispatcher>();
-    disp.update<ButtonPressEvent>();
+    disp.update<ShapePressCircleEvent>();
+    disp.update<ShapePressSquareEvent>();
+    disp.update<ShapePressTriangleEvent>();
+    disp.update<MenuPressEvent>();
     disp.update<GoEvent>();
 
     if (gs.transition_pending) {

--- a/app/systems/input_dispatcher.cpp
+++ b/app/systems/input_dispatcher.cpp
@@ -8,24 +8,33 @@ namespace {
 struct InputDispatcherConnections {
     entt::dispatcher* owner = nullptr;
     entt::scoped_connection go_game_state;
-    entt::scoped_connection press_game_state;
+    entt::scoped_connection menu_press_game_state;
     entt::scoped_connection go_level_select;
-    entt::scoped_connection press_level_select;
+    entt::scoped_connection menu_press_level_select;
     entt::scoped_connection go_player_input;
-    entt::scoped_connection press_player_input;
+    entt::scoped_connection shape_press_circle_player_input;
+    entt::scoped_connection shape_press_square_player_input;
+    entt::scoped_connection shape_press_triangle_player_input;
 };
 
 void warm_dispatcher_event_queues(entt::dispatcher& disp) {
     // Move first vector allocation out of the first gameplay input frame.
     disp.enqueue<GoEvent>(GoEvent{});
-    disp.enqueue<ButtonPressEvent>(ButtonPressEvent{});
+    disp.enqueue<ShapePressCircleEvent>(ShapePressCircleEvent{});
+    disp.enqueue<ShapePressSquareEvent>(ShapePressSquareEvent{});
+    disp.enqueue<ShapePressTriangleEvent>(ShapePressTriangleEvent{});
+    disp.enqueue<MenuPressEvent>(MenuPressEvent{});
     disp.clear<GoEvent>();
-    disp.clear<ButtonPressEvent>();
+    disp.clear<ShapePressCircleEvent>();
+    disp.clear<ShapePressSquareEvent>();
+    disp.clear<ShapePressTriangleEvent>();
+    disp.clear<MenuPressEvent>();
 }
 }
 
-// game_state_system owns the fixed-step GoEvent/ButtonPressEvent drain.
-// EnTT sinks are last-connected first; connect in reverse semantic order.
+// game_state_system owns the fixed-step drain of GoEvent and the per-shape
+// + menu press event queues. EnTT sinks are last-connected first; connect in
+// reverse semantic order (player_input → level_select → game_state).
 void wire_input_dispatcher(entt::registry& reg) {
     auto* disp = reg.ctx().find<entt::dispatcher>();
     if (!disp) {
@@ -43,18 +52,24 @@ void wire_input_dispatcher(entt::registry& reg) {
     state->owner = disp;
 
     // Fixed-step semantic order: game_state, level_select, player_input.
+    // Shape presses route only to player_input (no menu listeners care about
+    // them). Menu presses route to both game_state and level_select.
     state->go_player_input = entt::scoped_connection{
         disp->sink<GoEvent>().connect<&player_input_handle_go>(reg)};
-    state->press_player_input = entt::scoped_connection{
-        disp->sink<ButtonPressEvent>().connect<&player_input_handle_press>(reg)};
+    state->shape_press_circle_player_input = entt::scoped_connection{
+        disp->sink<ShapePressCircleEvent>().connect<&player_input_handle_press_circle>(reg)};
+    state->shape_press_square_player_input = entt::scoped_connection{
+        disp->sink<ShapePressSquareEvent>().connect<&player_input_handle_press_square>(reg)};
+    state->shape_press_triangle_player_input = entt::scoped_connection{
+        disp->sink<ShapePressTriangleEvent>().connect<&player_input_handle_press_triangle>(reg)};
     state->go_level_select = entt::scoped_connection{
         disp->sink<GoEvent>().connect<&level_select_handle_go>(reg)};
-    state->press_level_select = entt::scoped_connection{
-        disp->sink<ButtonPressEvent>().connect<&level_select_handle_press>(reg)};
+    state->menu_press_level_select = entt::scoped_connection{
+        disp->sink<MenuPressEvent>().connect<&level_select_handle_press_menu>(reg)};
     state->go_game_state = entt::scoped_connection{
         disp->sink<GoEvent>().connect<&game_state_handle_go>(reg)};
-    state->press_game_state = entt::scoped_connection{
-        disp->sink<ButtonPressEvent>().connect<&game_state_handle_press>(reg)};
+    state->menu_press_game_state = entt::scoped_connection{
+        disp->sink<MenuPressEvent>().connect<&game_state_handle_press_menu>(reg)};
 
     warm_dispatcher_event_queues(*disp);
 }

--- a/app/systems/input_events.h
+++ b/app/systems/input_events.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "../components/player.h"  // Shape
 #include <cstdint>
 
 // ── Directions ──────────────────────────────────────────────────────────────
@@ -20,23 +19,30 @@ enum class MenuActionKind : uint8_t {
     SelectDiff    = 6,
 };
 
-// ── Semantic Events (produced by HUD controllers, test player, or keyboard) ────────
+// ── Semantic Press Events (produced by HUD controllers, test player, or keyboard) ──
 //
-// ButtonPressEvent carries semantic value data encoded at source (#273).
-// Consumers act on kind/shape/menu_action — never on a live entity handle,
-// which would be a lifetime hazard if the button entity were destroyed between
-// event production and consumption.
+// Per Fabian's existential processing (issues #1202/#1204), the former
+// `ButtonPressKind` discriminator and the union-like `ButtonPressEvent::shape`
+// column were eradicated. Each former (kind × shape) combination is now its
+// own event type. Listeners subscribe to the specific event they handle, so
+// there is no `switch (kind)` and no `if (evt.kind == Foo::Bar)` at any
+// consumer call site.
+//
+// Shape presses are zero-column tag-events: "which shape?" is identity-
+// encoded in the event type itself, no payload, no runtime discriminator.
+// Menu presses keep the two semantic columns (action + index); per-action
+// dispatch lives in the menu consumers, still keyed on the `MenuActionKind`
+// label (allowlisted as a Keep enum: input event label).
+//
+// Producers never store an entity handle in any event — that was the
+// pre-#273 lifetime hazard and stays out of the new design.
+struct ShapePressCircleEvent   {};
+struct ShapePressSquareEvent   {};
+struct ShapePressTriangleEvent {};
 
-enum class ButtonPressKind : uint8_t {
-    Shape,  // shape button pressed — use .shape
-    Menu,   // menu button pressed  — use .menu_action / .menu_index
-};
-
-struct ButtonPressEvent {
-    ButtonPressKind kind        = ButtonPressKind::Shape;
-    Shape           shape       = Shape::Circle;           // valid when kind == Shape
-    MenuActionKind  menu_action = MenuActionKind::Confirm; // valid when kind == Menu
-    uint8_t         menu_index  = 0;                       // valid when kind == Menu
+struct MenuPressEvent {
+    MenuActionKind action = MenuActionKind::Confirm;
+    uint8_t        index  = 0;
 };
 
 struct GoEvent {

--- a/app/systems/input_routing.h
+++ b/app/systems/input_routing.h
@@ -2,14 +2,22 @@
 
 #include <entt/entt.hpp>
 
-struct ButtonPressEvent;
 struct GoEvent;
+struct MenuPressEvent;
+struct ShapePressCircleEvent;
+struct ShapePressSquareEvent;
+struct ShapePressTriangleEvent;
 
 // Semantic listeners: events -> game/player state.
+// Per issue #1202/#1204, the press-event handler tree is identity-encoded
+// in the event type — no `switch (kind)` at consumers; the type IS the choice.
 void game_state_handle_go(entt::registry& reg, const GoEvent& evt);
-void game_state_handle_press(entt::registry& reg, const ButtonPressEvent& evt);
+void game_state_handle_press_menu(entt::registry& reg, const MenuPressEvent& evt);
+
 void player_input_handle_go(entt::registry& reg, const GoEvent& evt);
-void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt);
+void player_input_handle_press_circle  (entt::registry& reg, const ShapePressCircleEvent&   evt);
+void player_input_handle_press_square  (entt::registry& reg, const ShapePressSquareEvent&   evt);
+void player_input_handle_press_triangle(entt::registry& reg, const ShapePressTriangleEvent& evt);
 
 // Dispatcher wiring for input and semantic event listeners.
 void wire_input_dispatcher(entt::registry& reg);

--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -2,7 +2,6 @@
 #include "camera_system.h"
 #include "input_system_private.h"
 #include "web_input_policy.h"
-#include "../util/keyboard_shape_mapping.h"
 #include "input.h"
 #include "input_events.h"
 #include "../components/player.h"
@@ -400,29 +399,20 @@ void input_system(entt::registry& reg, float raw_dt) {
     if (IsKeyPressed(KEY_A) || IsKeyPressed(KEY_LEFT))  { disp.enqueue<GoEvent>({Direction::Left}); }
     if (IsKeyPressed(KEY_D) || IsKeyPressed(KEY_RIGHT)) { disp.enqueue<GoEvent>({Direction::Right}); }
 
-    // Keyboard shape-button presses: encode semantic payload directly — no
-    // entity lookup needed (#273).
+    // Keyboard shape-button presses: each key emits its own zero-column
+    // event type directly (#1202/#1204 — no discriminator field, identity
+    // is the event type). Z/X/C left-center-right ordering preserved.
     if (IsKeyPressed(KEY_ONE) || IsKeyPressed(KEY_Z)) {
-        disp.enqueue<ButtonPressEvent>({ButtonPressKind::Shape,
-                                        shape_for_keyboard_slot(KeyboardShapeSlot::Left),
-                                        MenuActionKind::Confirm,
-                                        0});
+        disp.enqueue<ShapePressCircleEvent>({});
     }
     if (IsKeyPressed(KEY_TWO) || IsKeyPressed(KEY_X)) {
-        disp.enqueue<ButtonPressEvent>({ButtonPressKind::Shape,
-                                        shape_for_keyboard_slot(KeyboardShapeSlot::Center),
-                                        MenuActionKind::Confirm,
-                                        0});
+        disp.enqueue<ShapePressSquareEvent>({});
     }
     if (IsKeyPressed(KEY_THREE) || IsKeyPressed(KEY_C)) {
-        disp.enqueue<ButtonPressEvent>({ButtonPressKind::Shape,
-                                        shape_for_keyboard_slot(KeyboardShapeSlot::Right),
-                                        MenuActionKind::Confirm,
-                                        0});
+        disp.enqueue<ShapePressTriangleEvent>({});
     }
     if (IsKeyPressed(KEY_ENTER) || IsKeyPressed(KEY_SPACE)) {
-        disp.enqueue<ButtonPressEvent>({ButtonPressKind::Menu, Shape::Circle,
-                                       MenuActionKind::Confirm, 0});
+        disp.enqueue<MenuPressEvent>({MenuActionKind::Confirm, 0});
     }
 #endif
 

--- a/app/systems/player_input_system.cpp
+++ b/app/systems/player_input_system.cpp
@@ -58,19 +58,15 @@ void player_input_handle_go(entt::registry& reg, const GoEvent& evt) {
     }
 }
 
-void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt) {
-    if (evt.kind != ButtonPressKind::Shape) return;  // ignore menu-button events
+namespace {
+
+void player_input_handle_shape_press_impl(entt::registry& reg, Shape pressed_shape) {
     if (!gameplay_input_enabled(reg)) return;
     auto* song = reg.ctx().find<SongState>();
     const bool rhythm_mode = (song != nullptr && (song->playing || song->finished));
 
-    auto pressed_shape = evt.shape;
     const int pressed_shape_index = shape_index(pressed_shape);
-    if (pressed_shape_index < 0) {
-        TraceLog(LOG_WARNING, "player_input_system ignored invalid shape %d",
-                 static_cast<int>(pressed_shape));
-        return;
-    }
+    if (pressed_shape_index < 0) return;  // unreachable: callers pass Circle/Square/Triangle
 
     auto begin_shape_window = [&](entt::entity entity, PlayerShape& ps, ShapeWindow& sw) {
         set_target_shape_tag(reg, entity, pressed_shape);
@@ -119,4 +115,18 @@ void player_input_handle_press(entt::registry& reg, const ButtonPressEvent& evt)
         (void)lane;
         (void)swindow;
     }
+}
+
+}  // namespace
+
+void player_input_handle_press_circle(entt::registry& reg, const ShapePressCircleEvent&) {
+    player_input_handle_shape_press_impl(reg, Shape::Circle);
+}
+
+void player_input_handle_press_square(entt::registry& reg, const ShapePressSquareEvent&) {
+    player_input_handle_shape_press_impl(reg, Shape::Square);
+}
+
+void player_input_handle_press_triangle(entt::registry& reg, const ShapePressTriangleEvent&) {
+    player_input_handle_shape_press_impl(reg, Shape::Triangle);
 }

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -50,6 +50,33 @@ static const char* shape_key_name(Shape s) {
     return kShapeKeyNames[static_cast<size_t>(idx)];
 }
 
+// Per-shape press-event enqueue table (issue #1202/#1204). Each row is the
+// function-pointer producer for the matching ShapePress*Event; the table is
+// indexed by `shape_index(shape)`. The Hexagon slot is a no-op — test player
+// callers gate via `test_player_needs_shape()` which never returns true for
+// Hexagon, so the slot is unreachable; it exists only to keep the table
+// dense (matches `kShapeFlatDrawFns` / `kEmplacePlayer` precedent).
+namespace {
+using ShapePressEnqueueFn = void (*)(entt::dispatcher&);
+inline void enqueue_press_circle  (entt::dispatcher& d) { d.enqueue<ShapePressCircleEvent>({});   }
+inline void enqueue_press_square  (entt::dispatcher& d) { d.enqueue<ShapePressSquareEvent>({});   }
+inline void enqueue_press_triangle(entt::dispatcher& d) { d.enqueue<ShapePressTriangleEvent>({}); }
+inline void enqueue_press_noop    (entt::dispatcher&  ) {}
+
+inline constexpr std::array<ShapePressEnqueueFn, kShapeCount> kEnqueueShapePress{
+    &enqueue_press_circle,
+    &enqueue_press_square,
+    &enqueue_press_triangle,
+    &enqueue_press_noop,
+};
+
+inline void enqueue_shape_press(entt::dispatcher& disp, Shape s) {
+    const int idx = shape_index(s);
+    if (idx < 0) return;
+    kEnqueueShapePress[static_cast<size_t>(idx)](disp);
+}
+}  // namespace
+
 static bool test_player_shape_done(const TestPlayerAction& action) {
     return action.shape_done;
 }
@@ -187,8 +214,7 @@ void test_player_system(entt::registry& reg, float dt) {
                                   gs.phase == GamePhase::SongComplete)
                                  ? MenuActionKind::Restart
                                  : MenuActionKind::Confirm;
-            disp.enqueue<ButtonPressEvent>({ButtonPressKind::Menu, Shape::Circle,
-                                           target_action, 0});
+            disp.enqueue<MenuPressEvent>({target_action, 0});
             if (log) {
                 const char* phase_name =
                     (gs.phase == GamePhase::Title) ? "Title" :
@@ -215,15 +241,13 @@ void test_player_system(entt::registry& reg, float dt) {
     }
 
     if (gs.phase == GamePhase::Paused) {
-        disp.enqueue<ButtonPressEvent>({ButtonPressKind::Menu, Shape::Circle,
-                                       MenuActionKind::Confirm, 0});
+        disp.enqueue<MenuPressEvent>({MenuActionKind::Confirm, 0});
         return;
     }
 
     // Auto-confirm on LevelSelect (level/difficulty already set in main.cpp)
     if (gs.phase == GamePhase::LevelSelect && gs.phase_timer > constants::UI_ENTRY_DEBOUNCE) {
-        disp.enqueue<ButtonPressEvent>({ButtonPressKind::Menu, Shape::Circle,
-                                       MenuActionKind::Confirm, 0});
+        disp.enqueue<MenuPressEvent>({MenuActionKind::Confirm, 0});
         return;
     }
 
@@ -395,8 +419,7 @@ void test_player_system(entt::registry& reg, float dt) {
                                     song->song_time < action.shape_not_before_time);
         bool waiting_on_lane = test_player_needs_lane(action);
         if (test_player_needs_shape(action) && !waiting_on_lane && !too_early_for_shape) {
-            disp.enqueue<ButtonPressEvent>({ButtonPressKind::Shape, action.target_shape,
-                                           MenuActionKind::Confirm, 0});
+            enqueue_shape_press(disp, action.target_shape);
             test_player_mark_shape_done(action);
             key_injected = true;
 

--- a/app/ui/level_select_controller.cpp
+++ b/app/ui/level_select_controller.cpp
@@ -19,26 +19,25 @@ void level_select_handle_go(entt::registry& reg, const GoEvent& evt) {
     }
 }
 
-void level_select_handle_press(entt::registry& reg, const ButtonPressEvent& evt) {
+void level_select_handle_press_menu(entt::registry& reg, const MenuPressEvent& evt) {
     auto& gs = reg.ctx().get<GameState>();
     if (gs.phase != GamePhase::LevelSelect) return;
     if (gs.phase_timer < 0.05f) return;
-    if (evt.kind != ButtonPressKind::Menu) return;
 
     auto& lss = reg.ctx().get<LevelSelectState>();
 
-    switch (evt.menu_action) {
+    switch (evt.action) {
         case MenuActionKind::Confirm:
             lss.confirmed = true;
             break;
         case MenuActionKind::SelectLevel:
-            if (content_config::is_valid_level_index(evt.menu_index)) {
-                lss.selected_level = evt.menu_index;
+            if (content_config::is_valid_level_index(evt.index)) {
+                lss.selected_level = evt.index;
             }
             break;
         case MenuActionKind::SelectDiff:
-            if (content_config::is_valid_difficulty_index(evt.menu_index)) {
-                lss.selected_difficulty = evt.menu_index;
+            if (content_config::is_valid_difficulty_index(evt.index)) {
+                lss.selected_difficulty = evt.index;
             }
             break;
         default: break;

--- a/app/ui/level_select_controller.h
+++ b/app/ui/level_select_controller.h
@@ -2,8 +2,8 @@
 
 #include <entt/entt.hpp>
 
-struct ButtonPressEvent;
 struct GoEvent;
+struct MenuPressEvent;
 
 void level_select_handle_go(entt::registry& reg, const GoEvent& evt);
-void level_select_handle_press(entt::registry& reg, const ButtonPressEvent& evt);
+void level_select_handle_press_menu(entt::registry& reg, const MenuPressEvent& evt);

--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
@@ -390,16 +390,13 @@ void gameplay_hud_apply_button_presses(entt::registry& reg,
 
     auto& disp = reg.ctx().get<entt::dispatcher>();
     if (circle_pressed) {
-        disp.enqueue<ButtonPressEvent>(
-            {ButtonPressKind::Shape, Shape::Circle, MenuActionKind::Confirm, 0});
+        disp.enqueue<ShapePressCircleEvent>({});
     }
     if (square_pressed) {
-        disp.enqueue<ButtonPressEvent>(
-            {ButtonPressKind::Shape, Shape::Square, MenuActionKind::Confirm, 0});
+        disp.enqueue<ShapePressSquareEvent>({});
     }
     if (triangle_pressed) {
-        disp.enqueue<ButtonPressEvent>(
-            {ButtonPressKind::Shape, Shape::Triangle, MenuActionKind::Confirm, 0});
+        disp.enqueue<ShapePressTriangleEvent>({});
     }
 
     if (pause_pressed) {

--- a/benchmarks/bench_systems.cpp
+++ b/benchmarks/bench_systems.cpp
@@ -171,7 +171,7 @@ TEST_CASE("Bench: player_input + movement", "[!benchmark][bench]") {
         make_bench_player(reg);
 
         meter.measure([&] {
-            player_input_handle_press(reg, ButtonPressEvent{ButtonPressKind::Shape, Shape::Triangle});
+            player_input_handle_press_triangle(reg, ShapePressTriangleEvent{});
             player_input_handle_go(reg, GoEvent{Direction::Right});
             player_movement_system(reg, DT);
         });

--- a/tests/test_collision_extended.cpp
+++ b/tests/test_collision_extended.cpp
@@ -134,7 +134,7 @@ TEST_CASE("collision: on-beat rhythm press clears matching gate during MorphIn",
 
     auto btn = make_shape_button(reg, Shape::Circle);
     press_button(reg, btn);
-    reg.ctx().get<entt::dispatcher>().update<ButtonPressEvent>();
+    update_press_events(reg);
 
     REQUIRE(reg.all_of<ShapeHexagonTag>(player));
     REQUIRE(window_phase_is_morph_in(reg, player));
@@ -166,7 +166,7 @@ TEST_CASE("collision: on-beat shape press requires player hitbox to reach target
 
     auto btn = make_shape_button(reg, Shape::Circle);
     press_button(reg, btn);
-    reg.ctx().get<entt::dispatcher>().update<ButtonPressEvent>();
+    update_press_events(reg);
     song.song_time += song.morph_duration + 0.001f;
     shape_window_system(reg, song.morph_duration + 0.001f);
 

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -157,18 +157,17 @@ TEST_CASE("ecs: make_registry dispatcher is wired — GoEvent listeners register
     CHECK(lane.target == 2);   // listener wired: player_input_handle_go fired
 }
 
-TEST_CASE("ecs: make_registry dispatcher is wired — ButtonPressEvent listeners registered", "[ecs][dispatcher]") {
-    // Verifies ButtonPressEvent sink is wired: a press event on a valid button
-    // in Playing phase reaches player_input_handle_press.
+TEST_CASE("ecs: make_registry dispatcher is wired — ShapePress*Event listeners registered", "[ecs][dispatcher]") {
+    // Verifies the per-shape press sinks are wired: a press event on a valid
+    // button in Playing phase reaches player_input_handle_press_triangle.
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     REQUIRE(window_phase_is_idle(reg, player));
 
     auto btn = make_shape_button(reg, Shape::Triangle);
 
-    auto& disp = reg.ctx().get<entt::dispatcher>();
     press_button(reg, btn);
-    disp.update<ButtonPressEvent>();
+    update_press_events(reg);
 
     // If dispatcher listeners were NOT wired, sw.phase would stay Idle.
     CHECK(window_phase_is_morph_in(reg, player));  // listener wired: handle_press fired
@@ -178,7 +177,7 @@ TEST_CASE("ecs: make_registry dispatcher is wired — ButtonPressEvent listeners
 TEST_CASE("ecs: make_registry dispatcher ctx — second update is a no-op (no replay)", "[ecs][dispatcher]") {
     // Contract: after an authoritative drain, a subsequent update<T>() with no
     // new enqueues must not re-deliver the previously drained event.
-    // Applies to both GoEvent and ButtonPressEvent pools.
+    // Applies to both GoEvent and the per-shape ShapePress*Event pools.
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& lane  = reg.get<Lane>(player);
@@ -200,7 +199,7 @@ TEST_CASE("ecs: wire_input_dispatcher is idempotent", "[ecs][dispatcher]") {
 
     wire_input_dispatcher(reg);
     press_button(reg, btn);
-    reg.ctx().get<entt::dispatcher>().update<ButtonPressEvent>();
+    update_press_events(reg);
 
     CHECK(window_phase_is_morph_in(reg, player));
     CHECK(drain_sfx_events(reg).count == 1);
@@ -308,7 +307,7 @@ TEST_CASE("ecs: dispatcher rewire-after-unwire does not duplicate semantic deliv
     REQUIRE(window_phase_is_idle(reg, player));
 
     press_button(reg, button);
-    reg.ctx().get<entt::dispatcher>().update<ButtonPressEvent>();
+    update_press_events(reg);
 
     CHECK(window_phase_is_morph_in(reg, player));
     CHECK(reg.all_of<TargetShapeSquareTag>(player));
@@ -328,7 +327,7 @@ TEST_CASE("ecs: repeated unwire_input_dispatcher is idempotent before rewire",
     REQUIRE(window_phase_is_idle(reg, player));
 
     press_button(reg, button);
-    reg.ctx().get<entt::dispatcher>().update<ButtonPressEvent>();
+    update_press_events(reg);
 
     CHECK(window_phase_is_morph_in(reg, player));
     CHECK(reg.all_of<TargetShapeTriangleTag>(player));

--- a/tests/test_entt_dispatcher_contract.cpp
+++ b/tests/test_entt_dispatcher_contract.cpp
@@ -1,7 +1,7 @@
 // tests/test_entt_dispatcher_contract.cpp
 //
 // Verifies entt::dispatcher semantics relied on by the semantic input pipeline
-// (GoEvent/ButtonPressEvent only).
+// (GoEvent + per-shape ShapePress*Event + MenuPressEvent only).
 
 #include <catch2/catch_test_macros.hpp>
 #include <entt/entt.hpp>
@@ -21,7 +21,7 @@ struct GoCounter {
 
 struct PressCounter {
     int count{0};
-    void on_press(const ButtonPressEvent&) { ++count; }
+    void on_press(const ShapePressCircleEvent&) { ++count; }
 };
 
 struct OrderedListener {
@@ -151,24 +151,24 @@ TEST_CASE("dispatcher: same-type enqueue inside listener is delivered next updat
     CHECK(counter.last == Direction::Left);
 }
 
-TEST_CASE("dispatcher: trigger ButtonPressEvent reaches listener immediately",
+TEST_CASE("dispatcher: trigger ShapePressEvent reaches listener immediately",
           "[entt_dispatcher]") {
     entt::dispatcher dispatcher;
     PressCounter counter;
-    dispatcher.sink<ButtonPressEvent>().connect<&PressCounter::on_press>(counter);
+    dispatcher.sink<ShapePressCircleEvent>().connect<&PressCounter::on_press>(counter);
 
-    dispatcher.trigger(ButtonPressEvent{ButtonPressKind::Shape, Shape::Circle});
+    dispatcher.trigger(ShapePressCircleEvent{});
 
     CHECK(counter.count == 1);
 }
 
-TEST_CASE("dispatcher: enqueue ButtonPressEvent without update delivers nothing",
+TEST_CASE("dispatcher: enqueue ShapePressEvent without update delivers nothing",
           "[entt_dispatcher]") {
     entt::dispatcher dispatcher;
     PressCounter counter;
-    dispatcher.sink<ButtonPressEvent>().connect<&PressCounter::on_press>(counter);
+    dispatcher.sink<ShapePressCircleEvent>().connect<&PressCounter::on_press>(counter);
 
-    dispatcher.enqueue(ButtonPressEvent{ButtonPressKind::Shape, Shape::Circle});
+    dispatcher.enqueue(ShapePressCircleEvent{});
 
     CHECK(counter.count == 0);
 }
@@ -179,7 +179,10 @@ TEST_CASE("wire_input_dispatcher prewarms semantic event queues without pending 
     auto& dispatcher = reg.ctx().get<entt::dispatcher>();
 
     CHECK(dispatcher.size<GoEvent>() == 0);
-    CHECK(dispatcher.size<ButtonPressEvent>() == 0);
+    CHECK(dispatcher.size<ShapePressCircleEvent>()   == 0);
+    CHECK(dispatcher.size<ShapePressSquareEvent>()   == 0);
+    CHECK(dispatcher.size<ShapePressTriangleEvent>() == 0);
+    CHECK(dispatcher.size<MenuPressEvent>()          == 0);
 }
 
 TEST_CASE("runtime scratch queues are explicit registry context state",

--- a/tests/test_event_queue.cpp
+++ b/tests/test_event_queue.cpp
@@ -37,43 +37,50 @@ TEST_CASE("dispatcher: GoEvent enqueue/update flows to listeners", "[events]") {
     CHECK(cap.buf[1].dir == Direction::Up);
 }
 
-// ── ButtonPressEvent semantic payload tests (#273) ────────────────────────
+// ── Per-shape press event tests (#1202/#1204) ─────────────────────────────
 
-TEST_CASE("dispatcher: ButtonPressEvent semantic payload enqueue/update", "[events]") {
+TEST_CASE("dispatcher: ShapePress*Event enqueue/update", "[events]") {
     entt::registry reg;
     reg.ctx().emplace<entt::dispatcher>();
 
     auto& disp = reg.ctx().get<entt::dispatcher>();
     PressCapture cap;
-    disp.sink<ButtonPressEvent>().connect<&PressCapture::capture>(cap);
+    disp.sink<ShapePressCircleEvent>().connect<&PressCapture::on_circle>(cap);
+    disp.sink<ShapePressSquareEvent>().connect<&PressCapture::on_square>(cap);
+    disp.sink<ShapePressTriangleEvent>().connect<&PressCapture::on_triangle>(cap);
+    disp.sink<MenuPressEvent>().connect<&PressCapture::on_menu>(cap);
 
-    disp.enqueue<ButtonPressEvent>({ButtonPressKind::Shape, Shape::Square,
-                                   MenuActionKind::Confirm, 0});
-    disp.enqueue<ButtonPressEvent>({ButtonPressKind::Menu, Shape::Circle,
-                                   MenuActionKind::Restart, 0});
-    disp.update<ButtonPressEvent>();
-    disp.sink<ButtonPressEvent>().disconnect<&PressCapture::capture>(cap);
+    disp.enqueue<ShapePressSquareEvent>({});
+    disp.enqueue<MenuPressEvent>({MenuActionKind::Restart, 0});
+    disp.update<ShapePressCircleEvent>();
+    disp.update<ShapePressSquareEvent>();
+    disp.update<ShapePressTriangleEvent>();
+    disp.update<MenuPressEvent>();
+    disp.sink<ShapePressCircleEvent>().disconnect<&PressCapture::on_circle>(cap);
+    disp.sink<ShapePressSquareEvent>().disconnect<&PressCapture::on_square>(cap);
+    disp.sink<ShapePressTriangleEvent>().disconnect<&PressCapture::on_triangle>(cap);
+    disp.sink<MenuPressEvent>().disconnect<&PressCapture::on_menu>(cap);
 
-    REQUIRE(cap.count == 2);
-    CHECK(cap.buf[0].kind  == ButtonPressKind::Shape);
-    CHECK(cap.buf[0].shape == Shape::Square);
-    CHECK(cap.buf[1].kind        == ButtonPressKind::Menu);
-    CHECK(cap.buf[1].menu_action == MenuActionKind::Restart);
+    REQUIRE(cap.shape_count() == 1);
+    CHECK(cap.square == 1);
+    CHECK(cap.circle == 0);
+    CHECK(cap.triangle == 0);
+    REQUIRE(cap.menu_count == 1);
+    CHECK(cap.menu_buf[0].action == MenuActionKind::Restart);
 }
 
-TEST_CASE("dispatcher: ButtonPressEvent stale-entity safety — no entity field", "[events]") {
-    // #273: ButtonPressEvent no longer stores an entity handle.  Verify the
-    // struct has no entity field and carries semantic data instead.
+TEST_CASE("dispatcher: press events are pure value types — no entity field", "[events]") {
+    // Per #1202/#1204 (and the legacy #273 contract), no press event stores
+    // an entity handle. Constructing an event remains valid regardless of
+    // any entity lifecycle.
     entt::registry reg;
     auto btn_entity = reg.create();
     reg.destroy(btn_entity);  // entity is now invalid / recycled
 
-    // Construct a ButtonPressEvent with semantic payload — previously this
-    // would have stored the (now stale) entity handle.
-    ButtonPressEvent evt{ButtonPressKind::Shape, Shape::Triangle,
-                         MenuActionKind::Confirm, 0};
-    // The event remains fully valid regardless of entity lifecycle.
-    CHECK(evt.kind  == ButtonPressKind::Shape);
-    CHECK(evt.shape == Shape::Triangle);
+    ShapePressTriangleEvent shape_evt{};
+    MenuPressEvent menu_evt{MenuActionKind::Confirm, 3};
+    (void)shape_evt;
+    CHECK(menu_evt.action == MenuActionKind::Confirm);
+    CHECK(menu_evt.index  == 3);
     (void)btn_entity;
 }

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -365,8 +365,8 @@ TEST_CASE("tutorial: menu confirm marks FTUE complete and requests gameplay",
     persistence.path.clear();
     persistence.dirty = false;
 
-    reg.ctx().get<entt::dispatcher>().enqueue<ButtonPressEvent>({
-        ButtonPressKind::Menu, Shape::Circle, MenuActionKind::Confirm, 0});
+    reg.ctx().get<entt::dispatcher>().enqueue<MenuPressEvent>({
+        MenuActionKind::Confirm, 0});
     game_state_system(reg, 0.016f);
 
     const auto& saved_settings = settings_state(reg);

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -64,9 +64,21 @@ struct GoCapture {
 };
 
 struct PressCapture {
-    ButtonPressEvent buf[8] = {};
-    int              count  = 0;
-    void capture(const ButtonPressEvent& e) { if (count < 8) buf[count++] = e; }
+    int circle = 0;
+    int square = 0;
+    int triangle = 0;
+    MenuPressEvent menu_buf[8] = {};
+    int menu_count = 0;
+
+    int shape_count() const { return circle + square + triangle; }
+    int count() const { return shape_count() + menu_count; }
+
+    void on_circle  (const ShapePressCircleEvent&)   { ++circle;   }
+    void on_square  (const ShapePressSquareEvent&)   { ++square;   }
+    void on_triangle(const ShapePressTriangleEvent&) { ++triangle; }
+    void on_menu(const MenuPressEvent& e) {
+        if (menu_count < 8) menu_buf[menu_count++] = e;
+    }
 };
 
 struct SfxCapture {
@@ -93,10 +105,30 @@ inline GoCapture drain_go_events(entt::registry& reg) {
 inline PressCapture drain_press_events(entt::registry& reg) {
     PressCapture cap;
     auto& disp = reg.ctx().get<entt::dispatcher>();
-    disp.sink<ButtonPressEvent>().connect<&PressCapture::capture>(cap);
-    disp.update<ButtonPressEvent>();
-    disp.sink<ButtonPressEvent>().disconnect<&PressCapture::capture>(cap);
+    disp.sink<ShapePressCircleEvent>().connect<&PressCapture::on_circle>(cap);
+    disp.sink<ShapePressSquareEvent>().connect<&PressCapture::on_square>(cap);
+    disp.sink<ShapePressTriangleEvent>().connect<&PressCapture::on_triangle>(cap);
+    disp.sink<MenuPressEvent>().connect<&PressCapture::on_menu>(cap);
+    disp.update<ShapePressCircleEvent>();
+    disp.update<ShapePressSquareEvent>();
+    disp.update<ShapePressTriangleEvent>();
+    disp.update<MenuPressEvent>();
+    disp.sink<ShapePressCircleEvent>().disconnect<&PressCapture::on_circle>(cap);
+    disp.sink<ShapePressSquareEvent>().disconnect<&PressCapture::on_square>(cap);
+    disp.sink<ShapePressTriangleEvent>().disconnect<&PressCapture::on_triangle>(cap);
+    disp.sink<MenuPressEvent>().disconnect<&PressCapture::on_menu>(cap);
     return cap;
+}
+
+// Drains all press-event queues (per-shape ShapePress* + MenuPressEvent) in
+// the same order game_state_system uses (issue #1202/#1204). Use in tests
+// that previously called `disp.update<ButtonPressEvent>()` directly.
+inline void update_press_events(entt::registry& reg) {
+    auto& disp = reg.ctx().get<entt::dispatcher>();
+    disp.update<ShapePressCircleEvent>();
+    disp.update<ShapePressSquareEvent>();
+    disp.update<ShapePressTriangleEvent>();
+    disp.update<MenuPressEvent>();
 }
 
 // Flush the dispatcher PlaySfxEvent queue and return all events that were pending.
@@ -148,19 +180,28 @@ struct TestMenuButtonData {
     uint8_t index = 0;
 };
 
-// ── Button-press injection helper (#273) ────────────────────────────────────
-// Enqueue a semantic ButtonPressEvent for a given entity, encoding the
-// payload at call time (no live entity handle stored in the event).
+// ── Button-press injection helper ──────────────────────────────────────────
+// Per #1202/#1204: enqueues the per-shape ShapePress*Event (or MenuPressEvent
+// for menu buttons) corresponding to the button's TestShapeButtonData /
+// TestMenuButtonData. The per-shape table mirrors the same function-pointer-
+// per-row mechanic used by `kEnqueueShapePress` in test_player_system.cpp.
 inline void press_button(entt::registry& reg, entt::entity btn) {
     auto& disp = reg.ctx().get<entt::dispatcher>();
     if (reg.all_of<TestShapeButtonData>(btn)) {
-        auto shape = reg.get<TestShapeButtonData>(btn).shape;
-        disp.enqueue<ButtonPressEvent>({ButtonPressKind::Shape, shape,
-                                       MenuActionKind::Confirm, 0});
+        const auto shape = reg.get<TestShapeButtonData>(btn).shape;
+        const int idx = shape_index(shape);
+        if (idx < 0) return;
+        using EnqueueFn = void (*)(entt::dispatcher&);
+        static constexpr EnqueueFn kEnqueueFns[kShapeCount] = {
+            [](entt::dispatcher& d){ d.enqueue<ShapePressCircleEvent>({});   },
+            [](entt::dispatcher& d){ d.enqueue<ShapePressSquareEvent>({});   },
+            [](entt::dispatcher& d){ d.enqueue<ShapePressTriangleEvent>({}); },
+            [](entt::dispatcher&){},  // Hexagon: never pressed; tests never set this
+        };
+        kEnqueueFns[idx](disp);
     } else if (reg.all_of<TestMenuButtonData>(btn)) {
-        auto& ma = reg.get<TestMenuButtonData>(btn);
-        disp.enqueue<ButtonPressEvent>({ButtonPressKind::Menu, Shape::Circle,
-                                        ma.kind, ma.index});
+        const auto& ma = reg.get<TestMenuButtonData>(btn);
+        disp.enqueue<MenuPressEvent>({ma.kind, ma.index});
     }
 }
 

--- a/tests/test_helpers_and_functions.cpp
+++ b/tests/test_helpers_and_functions.cpp
@@ -163,22 +163,21 @@ TEST_CASE("dispatcher: mixed go and press operations", "[input]") {
     GoCapture go_cap;
     PressCapture press_cap;
     disp.sink<GoEvent>().connect<&GoCapture::capture>(go_cap);
-    disp.sink<ButtonPressEvent>().connect<&PressCapture::capture>(press_cap);
+    disp.sink<ShapePressCircleEvent>().connect<&PressCapture::on_circle>(press_cap);
 
     disp.enqueue<GoEvent>({Direction::Up});
-    disp.enqueue<ButtonPressEvent>({ButtonPressKind::Shape, Shape::Circle});
+    disp.enqueue<ShapePressCircleEvent>({});
     disp.enqueue<GoEvent>({Direction::Down});
     disp.update<GoEvent>();
-    disp.update<ButtonPressEvent>();
+    disp.update<ShapePressCircleEvent>();
 
     disp.sink<GoEvent>().disconnect<&GoCapture::capture>(go_cap);
-    disp.sink<ButtonPressEvent>().disconnect<&PressCapture::capture>(press_cap);
+    disp.sink<ShapePressCircleEvent>().disconnect<&PressCapture::on_circle>(press_cap);
 
     REQUIRE(go_cap.count == 2);
-    REQUIRE(press_cap.count == 1);
+    REQUIRE(press_cap.shape_count() == 1);
     CHECK(go_cap.buf[0].dir == Direction::Up);
-    CHECK(press_cap.buf[0].kind  == ButtonPressKind::Shape);
-    CHECK(press_cap.buf[0].shape == Shape::Circle);
+    CHECK(press_cap.circle == 1);
     CHECK(go_cap.buf[1].dir == Direction::Down);
 }
 

--- a/tests/test_input_pipeline_behavior.cpp
+++ b/tests/test_input_pipeline_behavior.cpp
@@ -2,8 +2,8 @@
 //
 // End-to-end input pipeline behavioral tests.
 //
-// The pipeline: semantic GoEvent/ButtonPressEvent producers →
-// game_state_system drain (authoritative) → player_input listeners.
+// The pipeline: semantic GoEvent + per-shape ShapePress*Event + MenuPressEvent
+// producers → game_state_system drain (authoritative) → player_input listeners.
 //
 // All assertions are on player component state (Lane::target, ShapeWindow::phase,
 // PlayerShape::current) — never on raw event queues.
@@ -16,7 +16,7 @@
 //   - One-frame latency: swipe arrives but lane.target unchanged until next tick
 //     (would occur if game_state_system's disp.update<GoEvent>() call were
 //     removed or moved after player_input_handle_go runs)
-//   - Dropped semantic shape press: ButtonPressEvent arrives but sw.phase stays Idle
+//   - Dropped semantic shape press: ShapePress*Event arrives but sw.phase stays Idle
 //   - Wrong-phase activation: button presses fire in an inactive phase
 //   - Event replay: second pipeline tick resets lane.lerp_t (symptom: #213 bug)
 
@@ -36,7 +36,7 @@ struct SemanticInputOrderCapture {
     int order[2] = {0, 0};
     int cursor = 0;
 
-    void on_press(const ButtonPressEvent&) {
+    void on_press_triangle(const ShapePressTriangleEvent&) {
         if (cursor < 2) order[cursor++] = 1;
     }
 
@@ -150,8 +150,7 @@ TEST_CASE("pipeline: semantic shape press triggers shape change in same pipeline
     auto player = make_rhythm_player(reg);
     REQUIRE(window_phase_is_idle(reg, player));
 
-    reg.ctx().get<entt::dispatcher>().enqueue<ButtonPressEvent>(
-        {ButtonPressKind::Shape, Shape::Square, MenuActionKind::Confirm, 0});
+    reg.ctx().get<entt::dispatcher>().enqueue<ShapePressSquareEvent>({});
     run_pipeline(reg);
 
     CHECK(window_phase_is_morph_in(reg, player));
@@ -166,8 +165,7 @@ TEST_CASE("pipeline: semantic shape press does not change lane target",
     REQUIRE(lane.current == 1);
     lane.target = lane.current;
 
-    reg.ctx().get<entt::dispatcher>().enqueue<ButtonPressEvent>(
-        {ButtonPressKind::Shape, Shape::Circle, MenuActionKind::Confirm, 0});
+    reg.ctx().get<entt::dispatcher>().enqueue<ShapePressCircleEvent>({});
     run_pipeline(reg);
 
     CHECK(lane.target == 1);
@@ -320,8 +318,7 @@ TEST_CASE("pipeline: pending phase transition blocks queued shape input",
 
     gs.transition_pending = true;
     gs.next_phase = GamePhase::Paused;
-    reg.ctx().get<entt::dispatcher>().enqueue<ButtonPressEvent>(
-        {ButtonPressKind::Shape, Shape::Circle, MenuActionKind::Confirm, 0});
+    reg.ctx().get<entt::dispatcher>().enqueue<ShapePressCircleEvent>({});
 
     run_pipeline(reg);
 
@@ -441,8 +438,7 @@ TEST_CASE("pipeline: mixed swipe and tap both take effect within a single pipeli
     REQUIRE(window_phase_is_idle(reg, player));
 
     push_go(reg, Direction::Right);
-    reg.ctx().get<entt::dispatcher>().enqueue<ButtonPressEvent>(
-        {ButtonPressKind::Shape, Shape::Triangle, MenuActionKind::Confirm, 0});
+    reg.ctx().get<entt::dispatcher>().enqueue<ShapePressTriangleEvent>({});
 
     run_pipeline(reg);
 
@@ -457,12 +453,11 @@ TEST_CASE("pipeline: same-frame shape tap drains before movement",
     make_rhythm_player(reg);
     auto& disp = reg.ctx().get<entt::dispatcher>();
     SemanticInputOrderCapture capture;
-    disp.sink<ButtonPressEvent>().connect<&SemanticInputOrderCapture::on_press>(capture);
+    disp.sink<ShapePressTriangleEvent>().connect<&SemanticInputOrderCapture::on_press_triangle>(capture);
     disp.sink<GoEvent>().connect<&SemanticInputOrderCapture::on_go>(capture);
 
     push_go(reg, Direction::Right);
-    disp.enqueue<ButtonPressEvent>(
-        {ButtonPressKind::Shape, Shape::Triangle, MenuActionKind::Confirm, 0});
+    disp.enqueue<ShapePressTriangleEvent>({});
 
     run_pipeline(reg);
 
@@ -532,8 +527,7 @@ TEST_CASE("pipeline: tap consumed after first sub-tick — second sub-tick does 
     song.song_time = 5.0f;
 
     // Sub-tick 1: tap opens MorphIn.
-    reg.ctx().get<entt::dispatcher>().enqueue<ButtonPressEvent>(
-        {ButtonPressKind::Shape, Shape::Circle, MenuActionKind::Confirm, 0});
+    reg.ctx().get<entt::dispatcher>().enqueue<ShapePressCircleEvent>({});
     run_pipeline(reg);
     CHECK(window_phase_is_morph_in(reg, player));
     float start1 = sw.window_start;

--- a/tests/test_level_select_controller.cpp
+++ b/tests/test_level_select_controller.cpp
@@ -11,8 +11,8 @@ TEST_CASE("level_select_controller: select difficulty press updates state", "[le
     auto& lss = reg.ctx().get<LevelSelectState>();
     lss.selected_difficulty = 0;
 
-    level_select_handle_press(reg, ButtonPressEvent{
-        ButtonPressKind::Menu, Shape::Circle, MenuActionKind::SelectDiff, 2
+    level_select_handle_press_menu(reg, MenuPressEvent{
+        MenuActionKind::SelectDiff, 2
     });
 
     CHECK(lss.selected_difficulty == 2);
@@ -27,8 +27,8 @@ TEST_CASE("level_select_controller: select level press updates state", "[level_s
     auto& lss = reg.ctx().get<LevelSelectState>();
     lss.selected_level = 0;
 
-    level_select_handle_press(reg, ButtonPressEvent{
-        ButtonPressKind::Menu, Shape::Circle, MenuActionKind::SelectLevel, 2
+    level_select_handle_press_menu(reg, MenuPressEvent{
+        MenuActionKind::SelectLevel, 2
     });
 
     CHECK(lss.selected_level == 2);
@@ -45,11 +45,11 @@ TEST_CASE("level_select_controller: invalid semantic indices do not update selec
     lss.selected_level = 1;
     lss.selected_difficulty = 2;
 
-    level_select_handle_press(reg, ButtonPressEvent{
-        ButtonPressKind::Menu, Shape::Circle, MenuActionKind::SelectLevel, 255
+    level_select_handle_press_menu(reg, MenuPressEvent{
+        MenuActionKind::SelectLevel, 255
     });
-    level_select_handle_press(reg, ButtonPressEvent{
-        ButtonPressKind::Menu, Shape::Circle, MenuActionKind::SelectDiff, 255
+    level_select_handle_press_menu(reg, MenuPressEvent{
+        MenuActionKind::SelectDiff, 255
     });
 
     CHECK(lss.selected_level == 1);
@@ -65,8 +65,8 @@ TEST_CASE("level_select_controller: ignores menu presses during entry delay", "[
     auto& lss = reg.ctx().get<LevelSelectState>();
     lss.selected_difficulty = 1;
 
-    level_select_handle_press(reg, ButtonPressEvent{
-        ButtonPressKind::Menu, Shape::Circle, MenuActionKind::SelectDiff, 0
+    level_select_handle_press_menu(reg, MenuPressEvent{
+        MenuActionKind::SelectDiff, 0
     });
 
     CHECK(lss.selected_difficulty == 1);

--- a/tests/test_player_action_rhythm.cpp
+++ b/tests/test_player_action_rhythm.cpp
@@ -110,7 +110,7 @@ TEST_CASE("player_action: rhythm mode no action when no tap in queue", "[player_
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
 
-    // No ButtonPressEvent in queue
+    // No press event in queue
     run_semantic_input_tick(reg, 0.016f);
 
     CHECK(window_phase_is_idle(reg, player));
@@ -241,7 +241,7 @@ TEST_CASE("player_input: GoEvents consumed after first tick, lane lerp_t not res
     CHECK(lane.target == 0);
 }
 
-TEST_CASE("player_input: ButtonPressEvents consumed after first tick (#213)", "[player_rhythm]") {
+TEST_CASE("player_input: ShapePress*Events consumed after first tick (#213)", "[player_rhythm]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& sw = reg.get<ShapeWindow>(player);
@@ -261,7 +261,7 @@ TEST_CASE("player_input: ButtonPressEvents consumed after first tick (#213)", "[
     // Advance song time so a second begin_shape_window call would produce a different window_start.
     song.song_time = 6.0f;
 
-    // Second tick: ButtonPressEvent must NOT be replayed — window_start must not change.
+    // Second tick: press event must NOT be replayed — window_start must not change.
     run_semantic_input_tick(reg, 1.0f / 60.0f);
     CHECK(sw.window_start == start_after_tick1);  // unchanged
 }

--- a/tests/test_player_input_rhythm_extended.cpp
+++ b/tests/test_player_input_rhythm_extended.cpp
@@ -217,7 +217,7 @@ TEST_CASE("player_input_rhythm: circle press in lane 0 does not force mismatch b
 
     auto btn = make_shape_button(reg, Shape::Circle);
     press_button(reg, btn);
-    reg.ctx().get<entt::dispatcher>().update<ButtonPressEvent>();
+    update_press_events(reg);
     auto& song = reg.ctx().get<SongState>();
     song.song_time += song.morph_duration + 0.01f;
     shape_window_system(reg, song.morph_duration + 0.01f);

--- a/tests/test_test_player_system.cpp
+++ b/tests/test_test_player_system.cpp
@@ -142,13 +142,7 @@ TEST_CASE("test_player: pro executes lane before shape for shape+lane actions", 
 
         auto go = drain_go_events(reg);
         auto press = drain_press_events(reg);
-        bool has_shape_press = false;
-        for (int j = 0; j < press.count; ++j) {
-            if (press.buf[j].kind == ButtonPressKind::Shape) {
-                has_shape_press = true;
-                break;
-            }
-        }
+        bool has_shape_press = press.shape_count() > 0;
 
         if (go.count > 0 || has_shape_press) {
             saw_go_first = (go.count > 0);
@@ -175,7 +169,7 @@ TEST_CASE("test_player: ignores visual obstacle leftovers without Obstacle paylo
     test_player_system(reg, 0.016f);
 
     CHECK_FALSE(reg.all_of<TestPlayerPlannedTag>(visual_leftover));
-    CHECK(drain_press_events(reg).count == 0);
+    CHECK(drain_press_events(reg).count() == 0);
     CHECK(drain_go_events(reg).count == 0);
 }
 
@@ -227,9 +221,8 @@ TEST_CASE("test_player: auto-starts from title screen", "[test_player]") {
     test_player_system(reg, 0.016f);
     bool has_confirm = false;
     auto cap = drain_press_events(reg);
-    for (int i = 0; i < cap.count; ++i) {
-        if (cap.buf[i].kind == ButtonPressKind::Menu &&
-            cap.buf[i].menu_action == MenuActionKind::Confirm) {
+    for (int i = 0; i < cap.menu_count; ++i) {
+        if (cap.menu_buf[i].action == MenuActionKind::Confirm) {
             has_confirm = true;
             break;
         }

--- a/tests/test_world_systems.cpp
+++ b/tests/test_world_systems.cpp
@@ -134,8 +134,8 @@ TEST_CASE("game_state: game over keyboard confirm routes to restart", "[gamestat
     gs.phase = GamePhase::GameOver;
     gs.phase_timer = 0.5f;
 
-    reg.ctx().get<entt::dispatcher>().enqueue<ButtonPressEvent>(
-        {ButtonPressKind::Menu, Shape::Circle, MenuActionKind::Confirm, 0});
+    reg.ctx().get<entt::dispatcher>().enqueue<MenuPressEvent>(
+        {MenuActionKind::Confirm, 0});
 
     game_state_system(reg, 0.016f);
 
@@ -149,8 +149,8 @@ TEST_CASE("game_state: song complete keyboard confirm routes to restart", "[game
     gs.phase = GamePhase::SongComplete;
     gs.phase_timer = constants::SONG_COMPLETE_INPUT_DELAY + 0.1f;
 
-    reg.ctx().get<entt::dispatcher>().enqueue<ButtonPressEvent>(
-        {ButtonPressKind::Menu, Shape::Circle, MenuActionKind::Confirm, 0});
+    reg.ctx().get<entt::dispatcher>().enqueue<MenuPressEvent>(
+        {MenuActionKind::Confirm, 0});
 
     game_state_system(reg, 0.016f);
 
@@ -165,8 +165,8 @@ TEST_CASE("game_state: song complete keyboard confirm waits for button debounce"
     gs.phase = GamePhase::SongComplete;
     gs.phase_timer = 0.45f;
 
-    reg.ctx().get<entt::dispatcher>().enqueue<ButtonPressEvent>(
-        {ButtonPressKind::Menu, Shape::Circle, MenuActionKind::Confirm, 0});
+    reg.ctx().get<entt::dispatcher>().enqueue<MenuPressEvent>(
+        {MenuActionKind::Confirm, 0});
 
     game_state_system(reg, 0.0f);
 
@@ -196,8 +196,8 @@ TEST_CASE("game_state: paused menu input waits for entry debounce", "[gamestate]
     gs.phase_timer = constants::UI_ENTRY_DEBOUNCE + 0.1f;
     gs.phase_timer = 0.1f;
 
-    reg.ctx().get<entt::dispatcher>().enqueue<ButtonPressEvent>(
-        {ButtonPressKind::Menu, Shape::Circle, MenuActionKind::Confirm, 0});
+    reg.ctx().get<entt::dispatcher>().enqueue<MenuPressEvent>(
+        {MenuActionKind::Confirm, 0});
 
     game_state_system(reg, 0.0f);
 
@@ -210,8 +210,8 @@ TEST_CASE("game_state: paused menu input resumes after entry debounce", "[gamest
     gs.phase = GamePhase::Paused;
     gs.phase_timer = constants::UI_ENTRY_DEBOUNCE + 0.1f;
 
-    reg.ctx().get<entt::dispatcher>().enqueue<ButtonPressEvent>(
-        {ButtonPressKind::Menu, Shape::Circle, MenuActionKind::Confirm, 0});
+    reg.ctx().get<entt::dispatcher>().enqueue<MenuPressEvent>(
+        {MenuActionKind::Confirm, 0});
 
     game_state_system(reg, 0.0f);
 
@@ -375,7 +375,7 @@ TEST_CASE("game_state: title stays title without touch", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
     gs.phase = GamePhase::Title;
-    // No ButtonPressEvent in queue — no actions
+    // No press event in queue — no actions
 
     game_state_system(reg, 0.5f);
 


### PR DESCRIPTION
## Summary

PR **C1** of the multi-PR Shape-enum eradication tracked in #1202. Splits the discriminator-style `ButtonPressEvent` into typed events whose *identity is the choice*, following the Fabian existential-processing pattern established by #1253 (ObstacleKind), #1256 (InputSource), and #1260 (on-entity shape tags).

```
ButtonPressEvent { kind, shape, action, index }     ShapePressCircleEvent {}
ButtonPressKind  { Shape, Menu }                →   ShapePressSquareEvent {}
                                                    ShapePressTriangleEvent {}
                                                    MenuPressEvent { MenuActionKind action; int index; }
```

## Producer changes (no switch on `Shape` at enqueue site)
| Producer | Before | After |
|---|---|---|
| keyboard input | `ButtonPressEvent{Shape, ...}` per slot | direct `ShapePressXxxxEvent{}` per slot; `MenuPressEvent` for Enter/Space |
| HUD shape buttons | shared helper using shape literal | three per-shape enqueue sites |
| `test_player_system` | one helper + shape literal | `kEnqueueShapePress[]` function-pointer table |

## Consumer changes (no switch at handler entry)
| Consumer | Before | After |
|---|---|---|
| `player_input_system` | `player_input_handle_press(reg, BPE)` switching on shape | `player_input_handle_press_{circle,square,triangle}` thin wrappers + impl |
| `game_state_routing` | `game_state_handle_press(reg, BPE)` filtering on `kind==Menu` | `game_state_handle_press_menu(reg, MenuPressEvent)` |
| `level_select_controller` | `level_select_handle_press(reg, BPE)` filtering on `kind==Menu` | `level_select_handle_press_menu(reg, MenuPressEvent)` |

## Wiring
- `input_dispatcher` now holds 8 `scoped_connection`s (was 6) — 1 menu→game_state, 3 shape→player_input, 1 menu→level_select, 3 GoEvent.
- `game_state_system` drain loop dispatches all 4 press queues + GoEvent in semantic order (shape presses → menu presses → gos).
- `warm_dispatcher_event_queues` warms all 5 pools.

## Allowlist + drift sweep
- ✅ `python3 tools/check_enum_allowlist.py` → `ok: 10 enum(s) in app/, all allowlisted` (down from 11; `ButtonPressKind` removed).
- ✅ `grep -rEn '\b(virtual|override|dynamic_cast)\b' app/` → comment-only hits.
- ✅ `grep -rEn ':\s*public\s+\w' app/` → 0 matches (no inheritance).
- ✅ `switch (` count in `app/` unchanged at **12** (no new branches).

## Builds & tests
- ✅ `cmake --build build` (unity) — zero warnings, `-Wall -Wextra -Werror`.
- ✅ `cmake --build build-no-unity` — zero warnings (catches missing includes).
- ✅ `./build/shapeshifter_tests` → **All tests passed (2918 assertions in 873 test cases)**.

## Out of scope (deferred)
- PR **C2**: `BeatEntry::shape` → per-shape beat-row tags.
- PR **C3**: `TestPlayerAction::target_shape` + finally delete `Shape` enum.

Refs #1202 (Shape eradication), #1204 (allowlist invariant).