### PR TITLE
Eradicate BeatEntry::shape via per-shape beat vectors (refs #1202, #1204)

### DIFF
--- a/app/components/beat_map.h
+++ b/app/components/beat_map.h
@@ -5,16 +5,19 @@
 #include <string>
 #include <vector>
 
-// ── Beat Entry (one row in a per-kind beat vector) ──────────
-// The former `ObstacleKind kind` discriminator (issue #1202/#1204) was
-// removed: the kind is identified by which per-kind vector in `BeatMap`
-// the row lives in (`shape_gate_beats` / `split_path_beats` /
-// `onset_marker_beats`). For OnsetMarker rows `shape` is unused (defaults
-// to Circle); for ShapeGate rows `lane` is positional only; for SplitPath
-// rows `lane` is the required dodge lane.
+// ── Beat Entry (one row in a per-(kind,shape) beat vector) ──────────
+// Both former discriminator enums on the row are eradicated (issue #1202/#1204):
+//
+//   - `ObstacleKind kind` -- identified by which per-kind vector in BeatMap
+//     the row lives in (shape_gate / split_path / onset_marker).
+//   - `Shape shape` -- identified by which per-shape sub-vector in BeatMap
+//     the row lives in (`shape_gate_circle_beats`, ..., `split_path_triangle_beats`).
+//     OnsetMarker has no shape -- only one vector `onset_marker_beats`.
+//
+// For ShapeGate rows `lane` is positional only; for SplitPath rows `lane`
+// is the required dodge lane; for OnsetMarker rows `lane` is unused.
 struct BeatEntry {
     int    beat_index   = 0;
-    Shape  shape        = Shape::Circle;
     int8_t lane         = 1;
     float  time_sec     = 0.0f;
     bool   has_time_sec = false;
@@ -34,11 +37,16 @@ struct BeatEntry {
 // compile-time error. Use std::move() when transferring ownership.
 //
 // The chart is normalized per Fabian's relational mechanic (#1204): each
-// former `ObstacleKind` value gets its own table (vector). Cross-kind
-// ordering (e.g. monotonic beat indices) is validated by merging the
-// per-kind vectors in beat-index order; intra-kind rules walk only the
-// relevant vector. Each per-kind vector is independently `stable_sort`-ed
-// by beat_index after parsing.
+// former `ObstacleKind` and each former `Shape` value gets its own table
+// (vector). Cross-table ordering (e.g. monotonic beat indices) is validated
+// by merging the per-(kind, shape) vectors in beat-index order; intra-table
+// rules walk only the relevant vector. Each vector is independently
+// `stable_sort`-ed by beat_index after parsing.
+//
+// Shape::Hexagon is not a valid required shape for shape_gate / split_path
+// (`current_required_shape` returns Hexagon as a sentinel meaning "no
+// required shape"); the loader rejects shape_gate / split_path rows whose
+// shape parses as Hexagon, so no `*_hexagon_beats` vector exists.
 struct BeatMap {
     std::string song_id;
     std::string title;
@@ -50,8 +58,12 @@ struct BeatMap {
     std::string difficulty;
     std::vector<float> beat_times;
 
-    std::vector<BeatEntry> shape_gate_beats;
-    std::vector<BeatEntry> split_path_beats;
+    std::vector<BeatEntry> shape_gate_circle_beats;
+    std::vector<BeatEntry> shape_gate_square_beats;
+    std::vector<BeatEntry> shape_gate_triangle_beats;
+    std::vector<BeatEntry> split_path_circle_beats;
+    std::vector<BeatEntry> split_path_square_beats;
+    std::vector<BeatEntry> split_path_triangle_beats;
     std::vector<BeatEntry> onset_marker_beats;
 
     BeatMap()                          = default;
@@ -60,3 +72,39 @@ struct BeatMap {
     BeatMap(BeatMap&&)                 = default;
     BeatMap& operator=(BeatMap&&)      = default;
 };
+
+// Total scoring-eligible (ShapeGate + SplitPath) beat count across the
+// six per-(kind, shape) vectors. OnsetMarker beats are non-scorable cues
+// and are excluded.
+inline size_t beat_map_required_count(const BeatMap& m) noexcept {
+    return m.shape_gate_circle_beats.size()
+         + m.shape_gate_square_beats.size()
+         + m.shape_gate_triangle_beats.size()
+         + m.split_path_circle_beats.size()
+         + m.split_path_square_beats.size()
+         + m.split_path_triangle_beats.size();
+}
+
+// Total ShapeGate beat count across the three per-shape vectors.
+inline size_t shape_gate_count(const BeatMap& m) noexcept {
+    return m.shape_gate_circle_beats.size()
+         + m.shape_gate_square_beats.size()
+         + m.shape_gate_triangle_beats.size();
+}
+
+// Total SplitPath beat count across the three per-shape vectors.
+inline size_t split_path_count(const BeatMap& m) noexcept {
+    return m.split_path_circle_beats.size()
+         + m.split_path_square_beats.size()
+         + m.split_path_triangle_beats.size();
+}
+
+// Total beat count across all seven per-(kind, shape) vectors.
+inline size_t beat_map_total_count(const BeatMap& m) noexcept {
+    return beat_map_required_count(m) + m.onset_marker_beats.size();
+}
+
+// True iff the beat map has zero authored beats across all seven vectors.
+inline bool beat_map_empty(const BeatMap& m) noexcept {
+    return beat_map_total_count(m) == 0;
+}

--- a/app/components/song_state.h
+++ b/app/components/song_state.h
@@ -39,14 +39,21 @@ struct SongState {
     bool   restart_music = false;  // set true by setup_play_session; consumed/cleared
                                    //   on the next tick by song_playback_system
 
-    // ── Beat-schedule cursors (per-kind, reset at session init) ─────────────
+    // ── Beat-schedule cursors (per-(kind, shape), reset at session init) ────
     // Replaces the former `next_spawn_idx` single cursor (issue #1202/#1204).
-    // beat_scheduler_system runs one per-kind transform per cursor; each
-    // cursor advances independently over its own per-kind vector in
-    // BeatMap.
-    size_t next_shape_gate_idx    = 0;
-    size_t next_split_path_idx    = 0;
-    size_t next_onset_marker_idx  = 0;
+    // Each former enum value (`ObstacleKind`, `Shape`) was a hidden lookup
+    // table; per Fabian's relational-database mechanic, each value gets its
+    // own row in BeatMap and its own cursor here. beat_scheduler_system runs
+    // one per-cursor transform; each cursor advances independently over its
+    // own vector in BeatMap. Shape::Hexagon is not a valid required shape
+    // for shape_gate / split_path, so no `*_hexagon_idx` cursor exists.
+    size_t next_shape_gate_circle_idx    = 0;
+    size_t next_shape_gate_square_idx    = 0;
+    size_t next_shape_gate_triangle_idx  = 0;
+    size_t next_split_path_circle_idx    = 0;
+    size_t next_split_path_square_idx    = 0;
+    size_t next_split_path_triangle_idx  = 0;
+    size_t next_onset_marker_idx         = 0;
 };
 
 // ── Song Results (singleton, accumulates during play) ─

--- a/app/entities/beat_map.cpp
+++ b/app/entities/beat_map.cpp
@@ -1,6 +1,8 @@
 #include "beat_map.h"
 #include "../util/rhythm_math.h"
+#include "../util/shape_lane_mapping.h"
 #include <nlohmann/json.hpp>
+#include <array>
 #include <cmath>
 #include <algorithm>
 #include <limits>
@@ -259,8 +261,33 @@ static std::optional<Shape> parse_shape(const std::string& s) {
     if (s == "circle")   return Shape::Circle;
     if (s == "square")   return Shape::Square;
     if (s == "triangle") return Shape::Triangle;
+    if (s == "hexagon")  return Shape::Hexagon;
     return std::nullopt;
 }
+
+// ── Per-(kind, shape) beat-entry sinks (issue #1202/#1204) ──────────
+// The former `BeatEntry::shape` discriminator is encoded by which per-shape
+// vector receives the entry. The sink table is indexed by `shape_index()`;
+// Shape::Hexagon is not a valid required shape for shape_gate / split_path,
+// so its slot returns nullptr — the loader treats nullptr as a parse error
+// and emits a "Shape 'hexagon' is not a valid required shape" message.
+using ShapeBinAccessor = std::vector<BeatEntry>* (*)(BeatMap&);
+
+std::vector<BeatEntry>* sg_circle_sink  (BeatMap& m) { return &m.shape_gate_circle_beats; }
+std::vector<BeatEntry>* sg_square_sink  (BeatMap& m) { return &m.shape_gate_square_beats; }
+std::vector<BeatEntry>* sg_triangle_sink(BeatMap& m) { return &m.shape_gate_triangle_beats; }
+std::vector<BeatEntry>* sg_hexagon_sink (BeatMap& m) { (void)m; return nullptr; }
+std::vector<BeatEntry>* sp_circle_sink  (BeatMap& m) { return &m.split_path_circle_beats; }
+std::vector<BeatEntry>* sp_square_sink  (BeatMap& m) { return &m.split_path_square_beats; }
+std::vector<BeatEntry>* sp_triangle_sink(BeatMap& m) { return &m.split_path_triangle_beats; }
+std::vector<BeatEntry>* sp_hexagon_sink (BeatMap& m) { (void)m; return nullptr; }
+
+inline constexpr std::array<ShapeBinAccessor, kShapeCount> kShapeGateSinks{
+    &sg_circle_sink, &sg_square_sink, &sg_triangle_sink, &sg_hexagon_sink
+};
+inline constexpr std::array<ShapeBinAccessor, kShapeCount> kSplitPathSinks{
+    &sp_circle_sink, &sp_square_sink, &sp_triangle_sink, &sp_hexagon_sink
+};
 
 // ── Per-kind beat-entry sinks (issue #1202/#1204) ───────────
 // Parsing dispatches into per-kind vectors directly by the JSON `kind`
@@ -297,8 +324,12 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
     }
 
     // ── Metadata ─────────────────────────────────────────────
-    out.shape_gate_beats.clear();
-    out.split_path_beats.clear();
+    out.shape_gate_circle_beats.clear();
+    out.shape_gate_square_beats.clear();
+    out.shape_gate_triangle_beats.clear();
+    out.split_path_circle_beats.clear();
+    out.split_path_square_beats.clear();
+    out.split_path_triangle_beats.clear();
     out.onset_marker_beats.clear();
     out.beat_times.clear();
     out.song_id.clear();
@@ -435,6 +466,8 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
         }
 
         BeatEntry entry;
+        Shape    parsed_shape   = Shape::Hexagon;
+        bool     has_parsed_shape = false;
         if (!b.contains("beat")) {
             errors.push_back({-1, "Missing required beat for obstacle entry"});
             parse_ok = false;
@@ -470,7 +503,8 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
                 parse_ok = false;
                 continue;
             }
-            entry.shape = *shape_opt;
+            parsed_shape = *shape_opt;
+            has_parsed_shape = true;
         } else if (kind_string_requires_shape(kind_str)) {
             errors.push_back({entry.beat_index,
                 "Missing required shape for obstacle kind '" + kind_str + "' at beat "
@@ -543,23 +577,38 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
             continue;
         }
 
-        // Per-kind dispatch into the appropriate vector (issue #1202/#1204).
-        // No discriminator enum survives in the data model — the row lives
-        // in exactly one of three per-kind tables.
-        if (kind_str == "shape_gate") {
-            out.shape_gate_beats.push_back(entry);
-        } else if (kind_str == "split_path") {
-            out.split_path_beats.push_back(entry);
-        } else {
+        // Per-(kind, shape) dispatch into the appropriate vector (issue
+        // #1202/#1204). No discriminator enum survives in the data model —
+        // the row lives in exactly one of seven per-(kind, shape) tables.
+        // Hexagon is not a valid required shape for shape_gate / split_path;
+        // the sink table returns nullptr in that slot so the loader rejects
+        // it explicitly.
+        if (kind_str == "onset_marker") {
             out.onset_marker_beats.push_back(entry);
+        } else {
+            const auto& sinks = (kind_str == "shape_gate") ? kShapeGateSinks
+                                                           : kSplitPathSinks;
+            const int idx = shape_index(parsed_shape);
+            std::vector<BeatEntry>* sink = (idx >= 0) ? sinks[static_cast<size_t>(idx)](out)
+                                                      : nullptr;
+            if (!sink) {
+                errors.push_back({entry.beat_index,
+                    "Shape 'hexagon' is not a valid required shape for obstacle kind '"
+                    + kind_str + "' at beat " + std::to_string(entry.beat_index)});
+                parse_ok = false;
+                continue;
+            }
+            sink->push_back(entry);
         }
+        (void)has_parsed_shape;
     }
 
     if (!parse_ok) return false;
 
-    // Sort each per-kind vector by beat_index; for ties, sort by resolved
-    // time_sec so authored timing within the same beat stays schedulable
-    // in-order. Stable sort preserves authored order when keys are identical.
+    // Sort each per-(kind, shape) vector by beat_index; for ties, sort by
+    // resolved time_sec so authored timing within the same beat stays
+    // schedulable in-order. Stable sort preserves authored order when keys
+    // are identical.
     auto by_beat = [](const BeatEntry& a, const BeatEntry& b) {
         if (a.beat_index != b.beat_index) {
             return a.beat_index < b.beat_index;
@@ -569,15 +618,27 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
         }
         return false;
     };
-    std::stable_sort(out.shape_gate_beats.begin(),   out.shape_gate_beats.end(),   by_beat);
-    std::stable_sort(out.split_path_beats.begin(),   out.split_path_beats.end(),   by_beat);
-    std::stable_sort(out.onset_marker_beats.begin(), out.onset_marker_beats.end(), by_beat);
+    auto sort_bin = [&](std::vector<BeatEntry>& v) { std::stable_sort(v.begin(), v.end(), by_beat); };
+    sort_bin(out.shape_gate_circle_beats);
+    sort_bin(out.shape_gate_square_beats);
+    sort_bin(out.shape_gate_triangle_beats);
+    sort_bin(out.split_path_circle_beats);
+    sort_bin(out.split_path_square_beats);
+    sort_bin(out.split_path_triangle_beats);
+    sort_bin(out.onset_marker_beats);
 
     if (out.beat_times.empty()) {
         int max_beat = -1;
-        if (!out.shape_gate_beats.empty())   max_beat = std::max(max_beat, out.shape_gate_beats.back().beat_index);
-        if (!out.split_path_beats.empty())   max_beat = std::max(max_beat, out.split_path_beats.back().beat_index);
-        if (!out.onset_marker_beats.empty()) max_beat = std::max(max_beat, out.onset_marker_beats.back().beat_index);
+        auto consider_max = [&](const std::vector<BeatEntry>& v) {
+            if (!v.empty()) max_beat = std::max(max_beat, v.back().beat_index);
+        };
+        consider_max(out.shape_gate_circle_beats);
+        consider_max(out.shape_gate_square_beats);
+        consider_max(out.shape_gate_triangle_beats);
+        consider_max(out.split_path_circle_beats);
+        consider_max(out.split_path_square_beats);
+        consider_max(out.split_path_triangle_beats);
+        consider_max(out.onset_marker_beats);
 
         if (max_beat >= 0) {
             const auto max_derived_beat = max_derived_beat_for_metadata(out.bpm, out.duration);
@@ -676,11 +737,8 @@ bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors,
         valid = false;
     }
 
-    // Rule 10: at least 1 beat entry across all per-kind tables
-    const bool any_beats = !map.shape_gate_beats.empty() ||
-                           !map.split_path_beats.empty() ||
-                           !map.onset_marker_beats.empty();
-    if (!any_beats) {
+    // Rule 10: at least 1 beat entry across all per-(kind, shape) tables
+    if (beat_map_empty(map)) {
         errors.push_back({-1, "Beat map must have at least 1 beat entry"});
         valid = false;
     }
@@ -712,13 +770,13 @@ bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors,
         }
     }
 
-    // Per-row rules: walk each per-kind vector once. Cross-kind ordering
-    // rules (Rule 1 — monotonic beat indices, intra-beat resolved-time
-    // monotonicity, time_sec monotonicity) are evaluated by walking a
-    // beat-index merge over the three vectors below.
+    // Per-row rules: walk each per-(kind, shape) vector once. Cross-table
+    // ordering rules (Rule 1 — monotonic beat indices, intra-beat
+    // resolved-time monotonicity, time_sec monotonicity) are evaluated by
+    // walking a beat-index merge over the seven vectors below.
     //
     // Kind-specific rule references:
-    //   has_shape       — true for shape_gate_beats and split_path_beats
+    //   has_shape       — true for shape_gate_* and split_path_* vectors
     //   requires_lane   — same set (onset_marker_beats default lane is
     //                     not validated against [0,2] semantics)
     auto validate_per_entry = [&](const BeatEntry& entry,
@@ -764,19 +822,44 @@ bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors,
         (void)has_shape;
     };
 
-    for (const auto& entry : map.shape_gate_beats)   validate_per_entry(entry, true,  true);
-    for (const auto& entry : map.split_path_beats)   validate_per_entry(entry, true,  true);
-    for (const auto& entry : map.onset_marker_beats) validate_per_entry(entry, false, false);
+    for (const auto& entry : map.shape_gate_circle_beats)   validate_per_entry(entry, true,  true);
+    for (const auto& entry : map.shape_gate_square_beats)   validate_per_entry(entry, true,  true);
+    for (const auto& entry : map.shape_gate_triangle_beats) validate_per_entry(entry, true,  true);
+    for (const auto& entry : map.split_path_circle_beats)   validate_per_entry(entry, true,  true);
+    for (const auto& entry : map.split_path_square_beats)   validate_per_entry(entry, true,  true);
+    for (const auto& entry : map.split_path_triangle_beats) validate_per_entry(entry, true,  true);
+    for (const auto& entry : map.onset_marker_beats)        validate_per_entry(entry, false, false);
 
-    // Cross-kind ordering: walk the three sorted vectors in beat-index
+    // Cross-table ordering: walk the seven sorted vectors in beat-index
     // merge order so Rule 1 (monotonic), the intra-beat resolved-time
     // rule, and Rule 6 (different-shape gates) see the same total order
     // the parser produced.
-    size_t i_sg = 0, i_sp = 0, i_om = 0;
+    //
+    // Each vector carries an int8_t shape_idx (0=Circle, 1=Square, 2=Triangle,
+    // -1 for onset_marker which has no shape). Rule 6 compares shape_idx
+    // values instead of a `Shape` field on the row — the discriminator
+    // lives in the vector identity, not on the entry.
+    struct MergeVectorRef {
+        const std::vector<BeatEntry>* entries;
+        size_t* cursor;
+        int8_t shape_idx;
+    };
+    size_t i_sg_c = 0, i_sg_s = 0, i_sg_t = 0;
+    size_t i_sp_c = 0, i_sp_s = 0, i_sp_t = 0;
+    size_t i_om   = 0;
+    const std::array<MergeVectorRef, 7> merge_vectors{{
+        {&map.shape_gate_circle_beats,   &i_sg_c,  0},
+        {&map.shape_gate_square_beats,   &i_sg_s,  1},
+        {&map.shape_gate_triangle_beats, &i_sg_t,  2},
+        {&map.split_path_circle_beats,   &i_sp_c,  0},
+        {&map.split_path_square_beats,   &i_sp_s,  1},
+        {&map.split_path_triangle_beats, &i_sp_t,  2},
+        {&map.onset_marker_beats,        &i_om,   -1},
+    }};
+
     int prev_beat = -1;
     int prev_shape_beat = -1;
-    Shape prev_shape = Shape::Circle;
-    bool prev_had_shape = false;
+    int8_t prev_shape_idx = -1;
     bool has_prev_authored_time = false;
     float prev_authored_time = 0.0f;
     bool has_prev_resolved_time_for_beat = false;
@@ -798,33 +881,29 @@ bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors,
     };
 
     // Pick the next-smallest entry by (beat_index, time_sec) across the
-    // three sorted vectors. Each kind tag's vector advances its own cursor.
-    auto step_merge = [&](bool& has_shape_out) -> const BeatEntry* {
-        const BeatEntry* sg = (i_sg < map.shape_gate_beats.size())   ? &map.shape_gate_beats[i_sg]   : nullptr;
-        const BeatEntry* sp = (i_sp < map.split_path_beats.size())   ? &map.split_path_beats[i_sp]   : nullptr;
-        const BeatEntry* om = (i_om < map.onset_marker_beats.size()) ? &map.onset_marker_beats[i_om] : nullptr;
+    // seven sorted vectors. Each merge_vectors row advances its own cursor.
+    auto step_merge = [&](int8_t& shape_idx_out) -> const BeatEntry* {
         const BeatEntry* best = nullptr;
         size_t* best_cursor = nullptr;
-        has_shape_out = false;
-        auto consider = [&](const BeatEntry* cand, size_t* cursor, bool cand_has_shape) {
-            if (!cand) return;
-            if (!best) { best = cand; best_cursor = cursor; has_shape_out = cand_has_shape; return; }
-            if (cand->beat_index < best->beat_index ||
+        int8_t  best_shape_idx = -1;
+        for (const auto& v : merge_vectors) {
+            if (*v.cursor >= v.entries->size()) continue;
+            const auto* cand = &(*v.entries)[*v.cursor];
+            if (!best ||
+                cand->beat_index < best->beat_index ||
                 (cand->beat_index == best->beat_index && cand->time_sec < best->time_sec)) {
                 best = cand;
-                best_cursor = cursor;
-                has_shape_out = cand_has_shape;
+                best_cursor = v.cursor;
+                best_shape_idx = v.shape_idx;
             }
-        };
-        consider(sg, &i_sg, true);
-        consider(sp, &i_sp, true);
-        consider(om, &i_om, false);
+        }
         if (best_cursor) (*best_cursor)++;
+        shape_idx_out = best_shape_idx;
         return best;
     };
 
-    bool entry_has_shape = false;
-    while (const auto* entry_ptr = step_merge(entry_has_shape)) {
+    int8_t entry_shape_idx = -1;
+    while (const auto* entry_ptr = step_merge(entry_shape_idx)) {
         const auto& entry = *entry_ptr;
         const float resolved_time = resolve_time(entry);
 
@@ -858,18 +937,18 @@ bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors,
             has_prev_authored_time = true;
         }
 
-        // Rule 6: different-shape gates must be >= min_shape_change_gap beats apart
-        if (entry_has_shape && prev_had_shape &&
-            entry.shape != prev_shape &&
+        // Rule 6: different-shape gates must be >= min_shape_change_gap beats apart.
+        // shape_idx encodes the row's shape (0/1/2) or -1 for no-shape (onset).
+        if (entry_shape_idx >= 0 && prev_shape_idx >= 0 &&
+            entry_shape_idx != prev_shape_idx &&
             (entry.beat_index - prev_shape_beat) < vc.min_shape_change_gap) {
             errors.push_back({entry.beat_index,
                 "Different-shape gates must be >= " + std::to_string(vc.min_shape_change_gap) + " beats apart"});
             valid = false;
         }
-        if (entry_has_shape) {
+        if (entry_shape_idx >= 0) {
             prev_shape_beat = entry.beat_index;
-            prev_shape = entry.shape;
-            prev_had_shape = true;
+            prev_shape_idx  = entry_shape_idx;
         }
     }
 
@@ -885,8 +964,12 @@ void init_song_state(SongState& state, const BeatMap& map) {
     state.current_beat = -1;
     state.playing      = false;
     state.finished     = false;
-    state.next_shape_gate_idx   = 0;
-    state.next_split_path_idx   = 0;
-    state.next_onset_marker_idx = 0;
+    state.next_shape_gate_circle_idx   = 0;
+    state.next_shape_gate_square_idx   = 0;
+    state.next_shape_gate_triangle_idx = 0;
+    state.next_split_path_circle_idx   = 0;
+    state.next_split_path_square_idx   = 0;
+    state.next_split_path_triangle_idx = 0;
+    state.next_onset_marker_idx        = 0;
     song_state_compute_derived(state);
 }

--- a/app/systems/beat_scheduler_system.cpp
+++ b/app/systems/beat_scheduler_system.cpp
@@ -13,7 +13,7 @@
 
 namespace {
 
-// Per-kind schedule context shared across the 3 spawn transforms.
+// Per-kind schedule context shared across the per-(kind, shape) spawn transforms.
 struct ScheduleContext {
     entt::registry& reg;
     SongState&      song;
@@ -63,12 +63,18 @@ void warn_invalid_lane_once(int lane) {
     }
 }
 
-// Per-kind transforms: one while-loop per kind cursor. Replaces the
-// former single switch-on-discriminator loop (issue #1202/#1204).
+// Per-(kind, shape) transforms: one while-loop per cursor. Replaces the
+// former per-kind loops that switched on `entry.shape` to pick the spawn
+// target (issue #1202/#1204). The shape is now encoded by which vector
+// the cursor walks and the shape literal each transform passes to the
+// spawn function.
 
-void schedule_shape_gates(ScheduleContext& ctx) {
-    while (ctx.song.next_shape_gate_idx < ctx.map.shape_gate_beats.size()) {
-        const auto& entry = ctx.map.shape_gate_beats[ctx.song.next_shape_gate_idx];
+void schedule_shape_gate_bin(ScheduleContext& ctx,
+                             const std::vector<BeatEntry>& bin,
+                             size_t& cursor,
+                             Shape required_shape) {
+    while (cursor < bin.size()) {
+        const auto& entry = bin[cursor];
         float calibrated_arrival_time = 0.0f;
         float effective_spawn_time    = 0.0f;
         float start_y                 = 0.0f;
@@ -80,15 +86,18 @@ void schedule_shape_gates(ScheduleContext& ctx) {
         warn_invalid_lane_once(static_cast<int>(entry.lane));
 
         const BeatInfo bi{entry.beat_index, calibrated_arrival_time, effective_spawn_time};
-        spawn_shape_gate_rhythm(ctx.reg, {x_pos, start_y, entry.shape,
+        spawn_shape_gate_rhythm(ctx.reg, {x_pos, start_y, required_shape,
                                           ctx.song.scroll_speed}, bi);
-        ctx.song.next_shape_gate_idx++;
+        cursor++;
     }
 }
 
-void schedule_split_paths(ScheduleContext& ctx) {
-    while (ctx.song.next_split_path_idx < ctx.map.split_path_beats.size()) {
-        const auto& entry = ctx.map.split_path_beats[ctx.song.next_split_path_idx];
+void schedule_split_path_bin(ScheduleContext& ctx,
+                             const std::vector<BeatEntry>& bin,
+                             size_t& cursor,
+                             Shape required_shape) {
+    while (cursor < bin.size()) {
+        const auto& entry = bin[cursor];
         float calibrated_arrival_time = 0.0f;
         float effective_spawn_time    = 0.0f;
         float start_y                 = 0.0f;
@@ -100,9 +109,9 @@ void schedule_split_paths(ScheduleContext& ctx) {
         warn_invalid_lane_once(static_cast<int>(entry.lane));
 
         const BeatInfo bi{entry.beat_index, calibrated_arrival_time, effective_spawn_time};
-        spawn_split_path_rhythm(ctx.reg, {x_pos, start_y, entry.shape,
+        spawn_split_path_rhythm(ctx.reg, {x_pos, start_y, required_shape,
                                           spawn_lane, ctx.song.scroll_speed}, bi);
-        ctx.song.next_split_path_idx++;
+        cursor++;
     }
 }
 
@@ -144,7 +153,17 @@ void beat_scheduler_system(entt::registry& reg, [[maybe_unused]] float dt) {
     const float audio_offset_sec = settings ? settings::audio_offset_seconds(*settings) : 0.0f;
 
     ScheduleContext ctx{reg, *song, *map, audio_offset_sec};
-    schedule_shape_gates(ctx);
-    schedule_split_paths(ctx);
+    schedule_shape_gate_bin(ctx, ctx.map.shape_gate_circle_beats,
+                            ctx.song.next_shape_gate_circle_idx, Shape::Circle);
+    schedule_shape_gate_bin(ctx, ctx.map.shape_gate_square_beats,
+                            ctx.song.next_shape_gate_square_idx, Shape::Square);
+    schedule_shape_gate_bin(ctx, ctx.map.shape_gate_triangle_beats,
+                            ctx.song.next_shape_gate_triangle_idx, Shape::Triangle);
+    schedule_split_path_bin(ctx, ctx.map.split_path_circle_beats,
+                            ctx.song.next_split_path_circle_idx, Shape::Circle);
+    schedule_split_path_bin(ctx, ctx.map.split_path_square_beats,
+                            ctx.song.next_split_path_square_idx, Shape::Square);
+    schedule_split_path_bin(ctx, ctx.map.split_path_triangle_beats,
+                            ctx.song.next_split_path_triangle_idx, Shape::Triangle);
     schedule_onset_markers(ctx);
 }

--- a/app/systems/play_session.cpp
+++ b/app/systems/play_session.cpp
@@ -35,11 +35,10 @@ bool is_runtime_allowed_validation_error(const BeatMapError& error) {
 }
 
 int count_result_notes(const BeatMap& beatmap) {
-    // Per-kind tables (#1202/#1204): result-counted notes are the
+    // Per-(kind, shape) tables (#1202/#1204): result-counted notes are the
     // scoring-eligible kinds — ShapeGate + SplitPath. OnsetMarker
     // entries are non-scorable cues and don't contribute.
-    return static_cast<int>(beatmap.shape_gate_beats.size() +
-                            beatmap.split_path_beats.size());
+    return static_cast<int>(beat_map_required_count(beatmap));
 }
 
 bool load_runtime_beat_map(const char* path,
@@ -144,9 +143,7 @@ void setup_play_session(entt::registry& reg) {
     for (const char* path : paths) {
         load_errors.clear();
         if (load_runtime_beat_map(path, beatmap, load_errors, difficulty_key)) {
-            const size_t total_beats = beatmap.shape_gate_beats.size() +
-                                       beatmap.split_path_beats.size() +
-                                       beatmap.onset_marker_beats.size();
+            const size_t total_beats = beat_map_total_count(beatmap);
             TraceLog(LOG_INFO, "Loaded beatmap: %s (%zu beats, difficulty=%s)",
                      path, total_beats, beatmap.difficulty.c_str());
             loaded = true;
@@ -183,9 +180,7 @@ void setup_play_session(entt::registry& reg) {
         return;
     }
     runtime_system_scratch_init(reg);
-    runtime_system_scratch_reserve(reg, beatmap.shape_gate_beats.size() +
-                                        beatmap.split_path_beats.size() +
-                                        beatmap.onset_marker_beats.size());
+    runtime_system_scratch_reserve(reg, beat_map_total_count(beatmap));
 
     assign_or_emplace_ctx(reg, ScoreState{});
     assign_or_emplace_ctx(reg, ScoreDisplay{});
@@ -212,10 +207,7 @@ void setup_play_session(entt::registry& reg) {
 
     // Init song state
     auto& song = assign_or_emplace_ctx(reg, SongState{});
-    const bool any_beats = !beatmap.shape_gate_beats.empty() ||
-                           !beatmap.split_path_beats.empty() ||
-                           !beatmap.onset_marker_beats.empty();
-    if (any_beats) {
+    if (!beat_map_empty(beatmap)) {
         init_song_state(song, beatmap);
     } else {
         song.bpm = 120.0f;

--- a/tests/test_audio_offset_calibration.cpp
+++ b/tests/test_audio_offset_calibration.cpp
@@ -48,7 +48,7 @@ ScheduleResult schedule_one(int16_t audio_offset_ms,
     song.song_time = song_time_when_scheduling;
 
     auto& map = beat_map(reg);
-    map.shape_gate_beats.push_back({beat_index, Shape::Circle, 1, 0, false});
+    map.shape_gate_circle_beats.push_back({beat_index, 1, 0, false});
 
     beat_scheduler_system(reg, 0.016f);
 
@@ -162,10 +162,10 @@ TEST_CASE("beat_scheduler: audio_offset gates spawn before calibrated spawn time
     auto& song = reg.ctx().get<SongState>();
     song.lead_time = 0.0f;
     song.song_time = 0.1f;
-    song.next_shape_gate_idx = 0;
+    song.next_shape_gate_circle_idx = 0;
 
     auto& map = beat_map(reg);
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0, false});
 
     beat_scheduler_system(reg, 0.016f);
     CHECK(count_obstacles(reg) == 0);
@@ -197,21 +197,21 @@ TEST_CASE("audio_offset: zero setting matches absent SettingsState",
     auto scheduler_with_zero = make_rhythm_registry();
     auto& zero_schedule_song = scheduler_with_zero.ctx().get<SongState>();
     zero_schedule_song.song_time = 1.0f;
-    zero_schedule_song.next_shape_gate_idx = 0;
-    beat_map(scheduler_with_zero).shape_gate_beats.push_back(
-        {2, Shape::Circle, 1, 0, false});
+    zero_schedule_song.next_shape_gate_circle_idx = 0;
+    beat_map(scheduler_with_zero).shape_gate_circle_beats.push_back(
+        {2, 1, 0, false});
     beat_scheduler_system(scheduler_with_zero, 0.016f);
 
     auto scheduler_without_settings = make_rhythm_registry();
     destroy_settings_entity(scheduler_without_settings);
     auto& absent_schedule_song = scheduler_without_settings.ctx().get<SongState>();
     absent_schedule_song.song_time = 1.0f;
-    absent_schedule_song.next_shape_gate_idx = 0;
-    beat_map(scheduler_without_settings).shape_gate_beats.push_back(
-        {2, Shape::Circle, 1, 0, false});
+    absent_schedule_song.next_shape_gate_circle_idx = 0;
+    beat_map(scheduler_without_settings).shape_gate_circle_beats.push_back(
+        {2, 1, 0, false});
     beat_scheduler_system(scheduler_without_settings, 0.016f);
 
-    CHECK(absent_schedule_song.next_shape_gate_idx == zero_schedule_song.next_shape_gate_idx);
+    CHECK(absent_schedule_song.next_shape_gate_circle_idx == zero_schedule_song.next_shape_gate_circle_idx);
     CHECK(count_obstacles(scheduler_without_settings) == count_obstacles(scheduler_with_zero));
 }
 
@@ -250,7 +250,7 @@ OffsetGameplayResult run_calibrated_on_arrival_hit(int16_t audio_offset_ms) {
 
     constexpr int kBeatIndex = 4;
     auto& map = beat_map(reg);
-    map.shape_gate_beats.push_back({kBeatIndex, Shape::Circle, 1, 0, false});
+    map.shape_gate_circle_beats.push_back({kBeatIndex, 1, 0, false});
 
     const float beat_time = song.offset + static_cast<float>(kBeatIndex) * song.beat_period;
     const float spawn_time = beat_time - song.lead_time + settings::audio_offset_seconds(settings);

--- a/tests/test_beat_map_parser_unknown_fields.cpp
+++ b/tests/test_beat_map_parser_unknown_fields.cpp
@@ -37,8 +37,8 @@ TEST_CASE("parse: unknown kind does not silently become ShapeGate", "[parse][kin
     bool ok = parse_beat_map(json, map, errors);
     CHECK_FALSE(ok);
     // Beat must not have been silently added with a default kind
-    CHECK(map.shape_gate_beats.empty());
-    CHECK(map.split_path_beats.empty());
+    CHECK((shape_gate_count(map) == 0));
+    CHECK((split_path_count(map) == 0));
     CHECK(map.onset_marker_beats.empty());
 }
 
@@ -89,8 +89,8 @@ TEST_CASE("parse: unknown shape does not silently become Circle", "[parse][shape
 
     bool ok = parse_beat_map(json, map, errors);
     CHECK_FALSE(ok);
-    CHECK(map.shape_gate_beats.empty());
-    CHECK(map.split_path_beats.empty());
+    CHECK((shape_gate_count(map) == 0));
+    CHECK((split_path_count(map) == 0));
     CHECK(map.onset_marker_beats.empty());
 }
 
@@ -116,7 +116,7 @@ TEST_CASE("parse: all active kinds parse without errors", "[parse][kind][issue87
         })";
         INFO("Testing kind: " << kind);
         CHECK(parse_beat_map(json, map, errors));
-        CHECK(map.shape_gate_beats.size() + map.split_path_beats.size() + map.onset_marker_beats.size() == 1);
+        CHECK(shape_gate_count(map) + split_path_count(map) + map.onset_marker_beats.size() == 1);
     }
 }
 
@@ -134,7 +134,7 @@ TEST_CASE("parse: all valid shapes parse without errors", "[parse][shape]") {
         })";
         INFO("Testing shape: " << shape);
         CHECK(parse_beat_map(json, map, errors));
-        CHECK(map.shape_gate_beats.size() + map.split_path_beats.size() + map.onset_marker_beats.size() == 1);
+        CHECK(shape_gate_count(map) + split_path_count(map) + map.onset_marker_beats.size() == 1);
     }
 }
 
@@ -243,8 +243,8 @@ TEST_CASE("parse: missing beat is rejected", "[parse][beat][required][issue757]"
     REQUIRE_FALSE(errors.empty());
     CHECK(errors[0].beat_index == -1);
     CHECK(errors[0].message.find("beat") != std::string::npos);
-    CHECK(map.shape_gate_beats.empty());
-    CHECK(map.split_path_beats.empty());
+    CHECK((shape_gate_count(map) == 0));
+    CHECK((split_path_count(map) == 0));
     CHECK(map.onset_marker_beats.empty());
 }
 
@@ -262,8 +262,8 @@ TEST_CASE("parse: missing shape gate lane is rejected", "[parse][lane][required]
     REQUIRE_FALSE(errors.empty());
     CHECK(errors[0].beat_index == 4);
     CHECK(errors[0].message.find("lane") != std::string::npos);
-    CHECK(map.shape_gate_beats.empty());
-    CHECK(map.split_path_beats.empty());
+    CHECK((shape_gate_count(map) == 0));
+    CHECK((split_path_count(map) == 0));
     CHECK(map.onset_marker_beats.empty());
 }
 
@@ -281,8 +281,8 @@ TEST_CASE("parse: unshipped obstacle kinds are rejected", "[parse][kind][issue87
     REQUIRE_FALSE(errors.empty());
     CHECK(errors[0].beat_index == 8);
     CHECK(errors[0].message.find("Unknown obstacle kind") != std::string::npos);
-    CHECK(map.shape_gate_beats.empty());
-    CHECK(map.split_path_beats.empty());
+    CHECK((shape_gate_count(map) == 0));
+    CHECK((split_path_count(map) == 0));
     CHECK(map.onset_marker_beats.empty());
 }
 

--- a/tests/test_beat_map_validation.cpp
+++ b/tests/test_beat_map_validation.cpp
@@ -35,7 +35,7 @@ TEST_CASE("validate: valid BPM passes", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -48,7 +48,7 @@ TEST_CASE("validate: BPM below 60 fails", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -61,7 +61,7 @@ TEST_CASE("validate: BPM above 300 fails", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -73,7 +73,7 @@ TEST_CASE("validate: BPM at 60 boundary passes", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -85,7 +85,7 @@ TEST_CASE("validate: BPM at 300 boundary passes", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -99,7 +99,7 @@ TEST_CASE("validate: anchored small negative offset passes", "[validate]") {
     map.offset = -0.1f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -112,7 +112,7 @@ TEST_CASE("validate: offset below anchored negative floor fails", "[validate]") 
     map.offset = -0.11f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -124,7 +124,7 @@ TEST_CASE("validate: offset above 5.0 fails", "[validate]") {
     map.offset = 5.1f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -138,7 +138,7 @@ TEST_CASE("validate: lead_beats below 2 fails", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 1;
     map.duration = 60.0f;
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -150,7 +150,7 @@ TEST_CASE("validate: lead_beats above 8 fails", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 9;
     map.duration = 60.0f;
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -164,7 +164,7 @@ TEST_CASE("validate: negative beat index fails", "[validate][issue132]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_beats.push_back({-1, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({-1, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -190,8 +190,8 @@ TEST_CASE("validate: duplicate beat indices pass when timing order is non-decrea
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
-    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -204,8 +204,8 @@ TEST_CASE("validate: non-monotonic beat indices fail", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_beats.push_back({5, Shape::Circle, 1, 0.0f, false});
-    map.shape_gate_beats.push_back({3, Shape::Square, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({5, 1, 0.0f, false});
+    map.shape_gate_square_beats.push_back({3, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -217,7 +217,7 @@ TEST_CASE("validate: beat index beyond duration fails", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 10.0f;  // max_beat = 10 / 0.5 = 20
-    map.shape_gate_beats.push_back({25, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({25, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -231,8 +231,8 @@ TEST_CASE("validate: different shapes >= 3 beats apart passes", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
-    map.shape_gate_beats.push_back({3, Shape::Square, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_square_beats.push_back({3, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -244,8 +244,8 @@ TEST_CASE("validate: different shapes < 3 beats apart fails", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
-    map.shape_gate_beats.push_back({2, Shape::Square, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_square_beats.push_back({2, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -257,8 +257,8 @@ TEST_CASE("validate: same shapes close together is OK", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
-    map.shape_gate_beats.push_back({1, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({1, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -272,7 +272,7 @@ TEST_CASE("validate: shape_gate invalid lane fails", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_beats.push_back({0, Shape::Circle, 5, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 5, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -284,7 +284,7 @@ TEST_CASE("validate: split_path invalid lane fails", "[validate][issue932]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.split_path_beats.push_back({0, Shape::Circle, 5, 0.0f, false});
+    map.split_path_circle_beats.push_back({0, 5, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -313,7 +313,7 @@ TEST_CASE("validate: split_path is supported in active beatmaps", "[validate][ki
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.split_path_beats.push_back({4, Shape::Circle, 2, 0.0f, false});
+    map.split_path_circle_beats.push_back({4, 2, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -349,8 +349,8 @@ TEST_CASE("init_song_state: resets playback state", "[init_song]") {
     state.current_beat = 10;
     state.playing = true;
     state.finished = true;
-    state.next_shape_gate_idx = 5;
-    state.next_split_path_idx = 7;
+    state.next_shape_gate_circle_idx = 5;
+    state.next_split_path_circle_idx = 7;
     state.next_onset_marker_idx = 3;
 
     init_song_state(state, map);
@@ -359,8 +359,8 @@ TEST_CASE("init_song_state: resets playback state", "[init_song]") {
     CHECK(state.current_beat == -1);
     CHECK_FALSE(state.playing);
     CHECK_FALSE(state.finished);
-    CHECK(state.next_shape_gate_idx == 0);
-    CHECK(state.next_split_path_idx == 0);
+    CHECK(state.next_shape_gate_circle_idx == 0);
+    CHECK(state.next_split_path_circle_idx == 0);
     CHECK(state.next_onset_marker_idx == 0);
 }
 
@@ -532,8 +532,8 @@ TEST_CASE("load_and_validate_beat_map rejects invalid BPM at load time", "[load]
     CHECK_FALSE(load_and_validate_beat_map(file.path.string(), map, errors));
     REQUIRE_FALSE(errors.empty());
     CHECK(errors[0].message.find("BPM") != std::string::npos);
-    CHECK(map.shape_gate_beats.empty());
-    CHECK(map.split_path_beats.empty());
+    CHECK((shape_gate_count(map) == 0));
+    CHECK((split_path_count(map) == 0));
     CHECK(map.onset_marker_beats.empty());
 }
 
@@ -555,8 +555,8 @@ TEST_CASE("load_and_validate_beat_map rejects negative beat_index at load time",
     CHECK_FALSE(load_and_validate_beat_map(file.path.string(), map, errors));
     REQUIRE_FALSE(errors.empty());
     CHECK(errors[0].message.find("Beat index") != std::string::npos);
-    CHECK(map.shape_gate_beats.empty());
-    CHECK(map.split_path_beats.empty());
+    CHECK((shape_gate_count(map) == 0));
+    CHECK((split_path_count(map) == 0));
     CHECK(map.onset_marker_beats.empty());
 }
 
@@ -577,7 +577,7 @@ TEST_CASE("load_and_validate_beat_map accepts valid beatmaps at load time",
     std::vector<BeatMapError> errors;
     REQUIRE(load_and_validate_beat_map(file.path.string(), map, errors));
     CHECK(errors.empty());
-    REQUIRE(map.shape_gate_beats.size() == 1);
+    REQUIRE(shape_gate_count(map) == 1);
     CHECK(map.song_id == "valid_load");
 }
 
@@ -591,7 +591,7 @@ TEST_CASE("validate_beat_map explicit constants: custom BPM range is respected",
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors, vc));
@@ -609,7 +609,7 @@ TEST_CASE("validate_beat_map explicit constants: BPM within custom range passes"
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors, vc));
@@ -626,8 +626,8 @@ TEST_CASE("validate_beat_map explicit constants: custom shape gap is respected",
     map.lead_beats = 4;
     map.duration = 60.0f;
     // 3 beats apart — passes default rule but must fail the stricter custom rule
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
-    map.shape_gate_beats.push_back({3, Shape::Square, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_square_beats.push_back({3, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors, vc));
@@ -651,10 +651,10 @@ TEST_CASE("parse: beat_times and per-obstacle time_sec are loaded", "[parse][bea
     })";
 
     CHECK(parse_beat_map(json, map, errors));
-    REQUIRE(map.shape_gate_beats.size() == 1);
+    REQUIRE(shape_gate_count(map) == 1);
     REQUIRE(map.beat_times.size() == 3);
-    CHECK_THAT(map.shape_gate_beats[0].time_sec, Catch::Matchers::WithinAbs(1.4f, 0.001f));
-    CHECK(map.shape_gate_beats[0].has_time_sec);
+    CHECK_THAT(map.shape_gate_circle_beats[0].time_sec, Catch::Matchers::WithinAbs(1.4f, 0.001f));
+    CHECK(map.shape_gate_circle_beats[0].has_time_sec);
 }
 
 TEST_CASE("parse: non-positive BPM is rejected before deriving beat timing",
@@ -676,8 +676,8 @@ TEST_CASE("parse: non-positive BPM is rejected before deriving beat timing",
     CHECK_FALSE(parse_beat_map(json, map, errors));
     REQUIRE_FALSE(errors.empty());
     CHECK(errors[0].message.find("BPM") != std::string::npos);
-    CHECK(map.shape_gate_beats.empty());
-    CHECK(map.split_path_beats.empty());
+    CHECK((shape_gate_count(map) == 0));
+    CHECK((split_path_count(map) == 0));
     CHECK(map.onset_marker_beats.empty());
 }
 
@@ -699,8 +699,8 @@ TEST_CASE("parse: non-positive lead_beats is rejected before runtime timing",
     CHECK_FALSE(parse_beat_map(json, map, errors));
     REQUIRE_FALSE(errors.empty());
     CHECK(errors[0].message.find("lead_beats") != std::string::npos);
-    CHECK(map.shape_gate_beats.empty());
-    CHECK(map.split_path_beats.empty());
+    CHECK((shape_gate_count(map) == 0));
+    CHECK((split_path_count(map) == 0));
     CHECK(map.onset_marker_beats.empty());
 }
 
@@ -720,9 +720,9 @@ TEST_CASE("parse: beat without time_sec falls back to beat_times", "[parse][beat
     })";
 
     CHECK(parse_beat_map(json, map, errors));
-    REQUIRE(map.shape_gate_beats.size() == 1);
-    CHECK_FALSE(map.shape_gate_beats[0].has_time_sec);
-    CHECK_THAT(map.shape_gate_beats[0].time_sec, Catch::Matchers::WithinAbs(1.4f, 0.001f));
+    REQUIRE(shape_gate_count(map) == 1);
+    CHECK_FALSE(map.shape_gate_circle_beats[0].has_time_sec);
+    CHECK_THAT(map.shape_gate_circle_beats[0].time_sec, Catch::Matchers::WithinAbs(1.4f, 0.001f));
 }
 
 TEST_CASE("parse: beat_times must be finite", "[parse][beat_times][issue995]") {
@@ -787,7 +787,7 @@ TEST_CASE("parse: missing selected difficulty falls back to valid difficulty",
 
     CHECK(parse_beat_map(json, map, errors, "hard"));
     CHECK(map.difficulty == "medium");
-    REQUIRE(map.shape_gate_beats.size() == 1);
+    REQUIRE(shape_gate_count(map) == 1);
     REQUIRE_FALSE(errors.empty());
     CHECK(errors[0].message.find("falling back to 'medium'") != std::string::npos);
 }
@@ -825,8 +825,8 @@ TEST_CASE("parse: malformed selected difficulty fails without fallback",
 
         INFO("difficulty json: " << tc.difficulty_json);
         CHECK_FALSE(parse_beat_map(json, map, errors, "hard"));
-        CHECK(map.shape_gate_beats.empty());
-        CHECK(map.split_path_beats.empty());
+        CHECK((shape_gate_count(map) == 0));
+        CHECK((split_path_count(map) == 0));
         CHECK(map.onset_marker_beats.empty());
         REQUIRE_FALSE(errors.empty());
         CHECK(errors[0].message.find(tc.expected_message) != std::string::npos);
@@ -887,12 +887,11 @@ TEST_CASE("parse: split_path loads required shape and lane", "[parse][issue932]"
     })";
 
     CHECK(parse_beat_map(json, map, errors));
-    REQUIRE(map.split_path_beats.size() == 1);
-    CHECK(map.split_path_beats[0].shape == Shape::Triangle);
-    CHECK(map.split_path_beats[0].lane == 2);
+    REQUIRE(split_path_count(map) == 1);
+    CHECK(map.split_path_triangle_beats[0].lane == 2);
 }
 
-TEST_CASE("parse: same beat_index entries are ordered by resolved time_sec", "[parse][beat_times][ordering]") {
+TEST_CASE("parse: same beat_index entries within a per-shape vector are ordered by resolved time_sec", "[parse][beat_times][ordering]") {
     BeatMap map;
     std::vector<BeatMapError> errors;
     std::string json = R"({
@@ -903,17 +902,17 @@ TEST_CASE("parse: same beat_index entries are ordered by resolved time_sec", "[p
         "duration_sec": 60.0,
         "beat_times": [0.1, 0.7, 1.4],
         "beats": [
-            { "beat": 2, "time_sec": 1.6, "kind": "shape_gate", "shape": "square", "lane": 1 },
-            { "beat": 2, "kind": "shape_gate", "shape": "triangle", "lane": 1 },
+            { "beat": 2, "time_sec": 1.6, "kind": "shape_gate", "shape": "circle", "lane": 1 },
+            { "beat": 2, "kind": "shape_gate", "shape": "circle", "lane": 1 },
             { "beat": 2, "time_sec": 1.3, "kind": "shape_gate", "shape": "circle", "lane": 1 }
         ]
     })";
 
     REQUIRE(parse_beat_map(json, map, errors));
-    REQUIRE(map.shape_gate_beats.size() == 3);
-    CHECK_THAT(map.shape_gate_beats[0].time_sec, Catch::Matchers::WithinAbs(1.3f, 0.001f));
-    CHECK_THAT(map.shape_gate_beats[1].time_sec, Catch::Matchers::WithinAbs(1.4f, 0.001f));
-    CHECK_THAT(map.shape_gate_beats[2].time_sec, Catch::Matchers::WithinAbs(1.6f, 0.001f));
+    REQUIRE(map.shape_gate_circle_beats.size() == 3);
+    CHECK_THAT(map.shape_gate_circle_beats[0].time_sec, Catch::Matchers::WithinAbs(1.3f, 0.001f));
+    CHECK_THAT(map.shape_gate_circle_beats[1].time_sec, Catch::Matchers::WithinAbs(1.4f, 0.001f));
+    CHECK_THAT(map.shape_gate_circle_beats[2].time_sec, Catch::Matchers::WithinAbs(1.6f, 0.001f));
 }
 
 TEST_CASE("parse: same beat_index entries keep authored order for identical timing", "[parse][beat_times][ordering]") {
@@ -926,15 +925,15 @@ TEST_CASE("parse: same beat_index entries keep authored order for identical timi
         "lead_beats": 4,
         "duration_sec": 60.0,
         "beats": [
-            { "beat": 2, "time_sec": 1.4, "kind": "shape_gate", "shape": "square", "lane": 1 },
-            { "beat": 2, "time_sec": 1.4, "kind": "shape_gate", "shape": "triangle", "lane": 1 }
+            { "beat": 2, "time_sec": 1.4, "kind": "shape_gate", "shape": "circle", "lane": 1 },
+            { "beat": 2, "time_sec": 1.4, "kind": "shape_gate", "shape": "circle", "lane": 2 }
         ]
     })";
 
     REQUIRE(parse_beat_map(json, map, errors));
-    REQUIRE(map.shape_gate_beats.size() == 2);
-    CHECK(map.shape_gate_beats[0].shape == Shape::Square);
-    CHECK(map.shape_gate_beats[1].shape == Shape::Triangle);
+    REQUIRE(map.shape_gate_circle_beats.size() == 2);
+    CHECK(map.shape_gate_circle_beats[0].lane == 1);
+    CHECK(map.shape_gate_circle_beats[1].lane == 2);
 }
 
 TEST_CASE("parse: blocked lane arrays are rejected from active beatmaps", "[parse][blocked_mask][issue873]") {
@@ -1049,7 +1048,7 @@ TEST_CASE("validate: unsupported timing range fails before beat range conversion
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = std::numeric_limits<float>::max();
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -1063,8 +1062,8 @@ TEST_CASE("validate: authored time_sec beyond duration fails", "[validate][beat_
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 3.0f;
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.5f, true});
-    map.shape_gate_beats.push_back({4, Shape::Square, 1, 3.5f, true});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.5f, true});
+    map.shape_gate_square_beats.push_back({4, 1, 3.5f, true});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -1078,8 +1077,8 @@ TEST_CASE("validate: authored time_sec must be non-decreasing", "[validate][beat
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 1.2f, true});
-    map.shape_gate_beats.push_back({2, Shape::Circle, 1, 1.1f, true});
+    map.shape_gate_circle_beats.push_back({0, 1, 1.2f, true});
+    map.shape_gate_circle_beats.push_back({2, 1, 1.1f, true});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -1093,10 +1092,10 @@ TEST_CASE("validate: mixed authored time_sec edge cases are checked", "[validate
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 10.0f;
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, true});
-    map.shape_gate_beats.push_back({1, Shape::Circle, 1, 0.0f, false});
-    map.shape_gate_beats.push_back({2, Shape::Circle, 1, 1.0f, true});
-    map.shape_gate_beats.push_back({3, Shape::Circle, 1, std::numeric_limits<float>::quiet_NaN(), true});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, true});
+    map.shape_gate_circle_beats.push_back({1, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({2, 1, 1.0f, true});
+    map.shape_gate_circle_beats.push_back({3, 1, std::numeric_limits<float>::quiet_NaN(), true});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -1110,8 +1109,8 @@ TEST_CASE("validate: same beat_index requires non-decreasing resolved time", "[v
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 10.0f;
-    map.shape_gate_beats.push_back({2, Shape::Circle, 1, 1.5f, true});
-    map.shape_gate_beats.push_back({2, Shape::Square, 1, 1.4f, true});
+    map.shape_gate_circle_beats.push_back({2, 1, 1.5f, true});
+    map.shape_gate_circle_beats.push_back({2, 1, 1.4f, true});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -1126,7 +1125,7 @@ TEST_CASE("validate: beat index out of range for beat_times fails", "[validate][
     map.lead_beats = 4;
     map.duration = 60.0f;
     map.beat_times = {0.0f, 0.5f}; // valid indices: 0..1
-    map.shape_gate_beats.push_back({2, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({2, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -1141,7 +1140,7 @@ TEST_CASE("validate: beat_times must be finite", "[validate][beat_times][issue99
     map.lead_beats = 4;
     map.duration = 60.0f;
     map.beat_times = {0.0f, std::numeric_limits<float>::infinity()};
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -1156,8 +1155,8 @@ TEST_CASE("validate: beat_times must be non-decreasing", "[validate][beat_times]
     map.lead_beats = 4;
     map.duration = 60.0f;
     map.beat_times = {1.0f, 0.5f};
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
-    map.shape_gate_beats.push_back({1, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({1, 1, 0.0f, false});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));

--- a/tests/test_beat_scheduler_offset.cpp
+++ b/tests/test_beat_scheduler_offset.cpp
@@ -61,7 +61,7 @@ TEST_CASE("offset_semantics: beat_index=0 arrives at exactly offset", "[beat_sch
     auto& map  = beat_map(reg);
 
     song.offset = 1.5f;
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
 
     advance_to_spawn_all(reg);
 
@@ -76,7 +76,7 @@ TEST_CASE("offset_semantics: beat_index=0 with zero offset arrives at t=0", "[be
     auto& map  = beat_map(reg);
 
     song.offset = 0.0f;
-    map.shape_gate_beats.push_back({0, Shape::Square, 1, 0.0f, false});
+    map.shape_gate_square_beats.push_back({0, 1, 0.0f, false});
 
     advance_to_spawn_all(reg);
 
@@ -96,7 +96,7 @@ TEST_CASE("offset_semantics: beat_index=N arrives at offset + N*period", "[beat_
     song.bpm    = 120.0f;
     song.offset = 0.35f;
     song_state_compute_derived(song);
-    map.shape_gate_beats.push_back({8, Shape::Triangle, 1, 0.0f, false});
+    map.shape_gate_triangle_beats.push_back({8, 1, 0.0f, false});
 
     advance_to_spawn_all(reg);
 
@@ -115,8 +115,8 @@ TEST_CASE("offset_semantics: two beat_indices are exactly period apart", "[beat_
     song.bpm    = 160.0f;
     song.offset = 2.27f;
     song_state_compute_derived(song);
-    map.shape_gate_beats.push_back({10, Shape::Circle, 1, 0.0f, false});
-    map.shape_gate_beats.push_back({11, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({10, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({11, 1, 0.0f, false});
 
     advance_to_spawn_all(reg);
 
@@ -142,7 +142,7 @@ TEST_CASE("offset_semantics: doubling offset shifts arrival by same delta", "[be
         song.bpm    = 120.0f;
         song.offset = offset_val;
         song_state_compute_derived(song);
-        map.shape_gate_beats.push_back({beat_idx, Shape::Circle, 1, 0.0f, false});
+        map.shape_gate_circle_beats.push_back({beat_idx, 1, 0.0f, false});
         advance_to_spawn_all(reg);
         return single_arrival_time(reg);
     };
@@ -173,7 +173,7 @@ TEST_CASE("offset_semantics: first authored beat_index=N>0 arrives after offset"
 
     // Simulate a typical shipped-beatmap first obstacle (beat_index >= 2)
     const int first_idx = 4;
-    map.shape_gate_beats.push_back({first_idx, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({first_idx, 1, 0.0f, false});
 
     advance_to_spawn_all(reg);
 
@@ -203,7 +203,7 @@ TEST_CASE("offset_semantics: offset must not be zero when pipeline sets it from 
     song_state_compute_derived(song);
 
     // First authored obstacle on hard: beat_index = 2
-    map.shape_gate_beats.push_back({2, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({2, 1, 0.0f, false});
 
     advance_to_spawn_all(reg);
 
@@ -258,7 +258,7 @@ TEST_CASE("offset_semantics: uniform-beat assumption valid within per-beat toler
     song_state_compute_derived(song);
 
     for (int i = 0; i <= N; i += 10) {
-        map.shape_gate_beats.push_back({i, Shape::Circle, 1, 0.0f, false});
+        map.shape_gate_circle_beats.push_back({i, 1, 0.0f, false});
     }
 
     advance_to_spawn_all(reg);
@@ -284,7 +284,7 @@ TEST_CASE("offset_semantics: halving BPM doubles all collision intervals", "[bea
         song.bpm    = bpm;
         song.offset = 0.0f;
         song_state_compute_derived(song);
-        map.shape_gate_beats.push_back({beat_idx, Shape::Circle, 1, 0.0f, false});
+        map.shape_gate_circle_beats.push_back({beat_idx, 1, 0.0f, false});
         advance_to_spawn_all(reg);
         return single_arrival_time(reg);
     };

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -12,7 +12,7 @@ TEST_CASE("beat_scheduler: no spawn when not Playing", "[beat_scheduler]") {
     reg.ctx().get<GameState>().phase = GamePhase::Title;
 
     auto& map = beat_map(reg);
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
 
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 10.0f;
@@ -40,7 +40,7 @@ TEST_CASE("beat_scheduler: no spawn when song not playing", "[beat_scheduler]") 
     reg.ctx().get<SongState>().playing = false;
 
     auto& map = beat_map(reg);
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
 
     beat_scheduler_system(reg, 0.016f);
 
@@ -67,14 +67,14 @@ TEST_CASE("beat_scheduler: spawns ShapeGate when time passes spawn_time", "[beat
     auto& map = beat_map(reg);
 
     // Add a beat at index 0
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
 
     // The spawn_time = offset + beat_index * beat_period - lead_time
     // For beat 0: spawn_time = 0 + 0 * 0.5 - 2.0 = -2.0
     // So any song_time >= -2.0 should trigger spawn
     song.song_time = 0.0f;
-    song.next_shape_gate_idx = 0;
-    song.next_split_path_idx = 0;
+    song.next_shape_gate_circle_idx = 0;
+    song.next_split_path_circle_idx = 0;
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
@@ -98,10 +98,10 @@ TEST_CASE("beat_scheduler: defaults invalid ShapeGate lane to center lane", "[be
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.shape_gate_beats.push_back({0, Shape::Circle, 9, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 9, 0.0f, false});
     song.song_time = 0.0f;
-    song.next_shape_gate_idx = 0;
-    song.next_split_path_idx = 0;
+    song.next_shape_gate_circle_idx = 0;
+    song.next_split_path_circle_idx = 0;
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
@@ -120,11 +120,11 @@ TEST_CASE("beat_scheduler: does not spawn before spawn_time", "[beat_scheduler]"
     auto& map = beat_map(reg);
 
     // Beat at index 20 — spawn_time = 0 + 20 * 0.5 - 2.0 = 8.0
-    map.shape_gate_beats.push_back({20, Shape::Square, 1, 0.0f, false});
+    map.shape_gate_square_beats.push_back({20, 1, 0.0f, false});
 
     song.song_time = 5.0f;  // Before spawn_time of 8.0
-    song.next_shape_gate_idx = 0;
-    song.next_split_path_idx = 0;
+    song.next_shape_gate_circle_idx = 0;
+    song.next_split_path_circle_idx = 0;
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
@@ -138,15 +138,15 @@ TEST_CASE("beat_scheduler: increments per-kind cursor after spawn", "[beat_sched
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
     song.song_time = 10.0f;
-    song.next_shape_gate_idx = 0;
-    song.next_split_path_idx = 0;
+    song.next_shape_gate_circle_idx = 0;
+    song.next_split_path_circle_idx = 0;
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
-    CHECK(song.next_shape_gate_idx == 1);
-    CHECK(song.next_split_path_idx == 0);
+    CHECK(song.next_shape_gate_circle_idx == 1);
+    CHECK(song.next_split_path_circle_idx == 0);
     CHECK(song.next_onset_marker_idx == 0);
 }
 
@@ -160,11 +160,11 @@ TEST_CASE("beat_scheduler: uses beat_times array for arrival time when present",
     song.bpm = 120.0f;
     song_state_compute_derived(song);
     map.beat_times = {0.3f, 0.85f, 1.47f};
-    map.shape_gate_beats.push_back({2, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({2, 1, 0.0f, false});
 
     song.song_time = 0.0f;
-    song.next_shape_gate_idx = 0;
-    song.next_split_path_idx = 0;
+    song.next_shape_gate_circle_idx = 0;
+    song.next_split_path_circle_idx = 0;
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
@@ -189,15 +189,14 @@ TEST_CASE("beat_scheduler: uses BeatEntry time_sec for arrival time when authore
 
     BeatEntry authored_entry;
     authored_entry.beat_index = 2;
-    authored_entry.shape = Shape::Circle;
     authored_entry.lane = 1;
     authored_entry.time_sec = 1.33f;
     authored_entry.has_time_sec = true;
-    map.shape_gate_beats.push_back(authored_entry);
+    map.shape_gate_circle_beats.push_back(authored_entry);
 
     song.song_time = 0.0f;
-    song.next_shape_gate_idx = 0;
-    song.next_split_path_idx = 0;
+    song.next_shape_gate_circle_idx = 0;
+    song.next_split_path_circle_idx = 0;
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
@@ -220,11 +219,11 @@ TEST_CASE("beat_scheduler: falls back to beat_times when BeatEntry time_sec is a
     song.bpm = 120.0f;
     song_state_compute_derived(song);
     map.beat_times = {0.3f, 0.85f, 1.47f};
-    map.shape_gate_beats.push_back({2, Shape::Circle, 1, 99.0f, false});
+    map.shape_gate_circle_beats.push_back({2, 1, 99.0f, false});
 
     song.song_time = 30.0f;
-    song.next_shape_gate_idx = 0;
-    song.next_split_path_idx = 0;
+    song.next_shape_gate_circle_idx = 0;
+    song.next_split_path_circle_idx = 0;
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
@@ -261,8 +260,8 @@ TEST_CASE("beat_scheduler: same beat_index honors authored time_sec ordering",
     // Spawn window reached for 1.3s arrival (spawn at -0.7), but not yet for
     // 1.7s arrival (spawn at -0.3).
     song.song_time = -0.5f;
-    song.next_shape_gate_idx = 0;
-    song.next_split_path_idx = 0;
+    song.next_shape_gate_circle_idx = 0;
+    song.next_split_path_circle_idx = 0;
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
@@ -279,23 +278,25 @@ TEST_CASE("beat_scheduler: spawns multiple beats when time is past all", "[beat_
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
-    map.shape_gate_beats.push_back({2, Shape::Square, 1, 0.0f, false});
-    map.onset_marker_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
-    map.shape_gate_beats.push_back({6, Shape::Triangle, 2, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_square_beats.push_back({2, 1, 0.0f, false});
+    map.onset_marker_beats.push_back({4, 1, 0.0f, false});
+    map.shape_gate_triangle_beats.push_back({6, 2, 0.0f, false});
 
     song.song_time = 30.0f;  // Well past all spawn times
-    song.next_shape_gate_idx = 0;
-    song.next_split_path_idx = 0;
+    song.next_shape_gate_circle_idx = 0;
+    song.next_split_path_circle_idx = 0;
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
     int count = 0;
     for (auto e : reg.view<ObstacleTag>()) { ++count; (void)e; }
     CHECK(count == 4);
-    CHECK(song.next_shape_gate_idx == 3);
+    CHECK(song.next_shape_gate_circle_idx == 1);
+    CHECK(song.next_shape_gate_square_idx == 1);
+    CHECK(song.next_shape_gate_triangle_idx == 1);
     CHECK(song.next_onset_marker_idx == 1);
-    CHECK(song.next_split_path_idx == 0);
+    CHECK(song.next_split_path_circle_idx == 0);
 }
 
 // ── beat_scheduler: obstacle types ───────────────────────────
@@ -309,10 +310,10 @@ TEST_CASE("beat_scheduler: spawns OnsetMarker as visible non-scorable cue",
     auto& energy = reg.ctx().get<EnergyState>();
     auto& results = reg.ctx().get<SongResults>();
 
-    map.onset_marker_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.onset_marker_beats.push_back({0, 1, 0.0f, false});
     song.song_time = 10.0f;
-    song.next_shape_gate_idx = 0;
-    song.next_split_path_idx = 0;
+    song.next_shape_gate_circle_idx = 0;
+    song.next_split_path_circle_idx = 0;
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
@@ -363,10 +364,10 @@ TEST_CASE("beat_scheduler: spawns SplitPath in authored lane", "[beat_scheduler]
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.split_path_beats.push_back({0, Shape::Triangle, 2, 0.0f, false});
+    map.split_path_triangle_beats.push_back({0, 2, 0.0f, false});
     song.song_time = 10.0f;
-    song.next_shape_gate_idx = 0;
-    song.next_split_path_idx = 0;
+    song.next_shape_gate_circle_idx = 0;
+    song.next_split_path_circle_idx = 0;
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
@@ -377,7 +378,7 @@ TEST_CASE("beat_scheduler: spawns SplitPath in authored lane", "[beat_scheduler]
         CHECK(current_required_shape(reg, e) == Shape::Triangle);
         CHECK(lane.lane == 2);
     }
-    CHECK(song.next_split_path_idx == 1);
+    CHECK(song.next_split_path_triangle_idx == 1);
 }
 
 TEST_CASE("beat_scheduler: defaults invalid SplitPath lane to center lane", "[beat_scheduler][issue1046]") {
@@ -385,10 +386,10 @@ TEST_CASE("beat_scheduler: defaults invalid SplitPath lane to center lane", "[be
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.split_path_beats.push_back({0, Shape::Square, 9, 0.0f, false});
+    map.split_path_square_beats.push_back({0, 9, 0.0f, false});
     song.song_time = 10.0f;
-    song.next_shape_gate_idx = 0;
-    song.next_split_path_idx = 0;
+    song.next_shape_gate_circle_idx = 0;
+    song.next_split_path_circle_idx = 0;
     song.next_onset_marker_idx = 0;
     CHECK_NOTHROW(beat_scheduler_system(reg, 0.016f));
 
@@ -404,7 +405,7 @@ TEST_CASE("beat_scheduler: defaults invalid SplitPath lane to center lane", "[be
             CHECK(reg.all_of<MeshChild>(children.children[i]));
         }
     }
-    CHECK(song.next_split_path_idx == 1);
+    CHECK(song.next_split_path_square_idx == 1);
 }
 
 TEST_CASE("beat_scheduler: spawns all queued beats from BeatMap entries", "[beat_scheduler]") {
@@ -412,12 +413,12 @@ TEST_CASE("beat_scheduler: spawns all queued beats from BeatMap entries", "[beat
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.shape_gate_beats.push_back({0, Shape::Square, 1, 0.0f, false});
-    map.onset_marker_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
-    map.shape_gate_beats.push_back({0, Shape::Triangle, 2, 0.0f, false});
+    map.shape_gate_square_beats.push_back({0, 1, 0.0f, false});
+    map.onset_marker_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_triangle_beats.push_back({0, 2, 0.0f, false});
     song.song_time = 10.0f;
-    song.next_shape_gate_idx = 0;
-    song.next_split_path_idx = 0;
+    song.next_shape_gate_circle_idx = 0;
+    song.next_split_path_circle_idx = 0;
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
@@ -431,9 +432,10 @@ TEST_CASE("beat_scheduler: spawns all queued beats from BeatMap entries", "[beat
     }
     CHECK(obstacle_count == 3);
     CHECK(shape_gate_count == 2);
-    CHECK(song.next_shape_gate_idx == 2);
+    CHECK(song.next_shape_gate_square_idx == 1);
+    CHECK(song.next_shape_gate_triangle_idx == 1);
     CHECK(song.next_onset_marker_idx == 1);
-    CHECK(song.next_split_path_idx == 0);
+    CHECK(song.next_split_path_circle_idx == 0);
 }
 
 TEST_CASE("beat_scheduler: all spawned obstacles have BeatInfo", "[beat_scheduler]") {
@@ -441,10 +443,10 @@ TEST_CASE("beat_scheduler: all spawned obstacles have BeatInfo", "[beat_schedule
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
     song.song_time = 30.0f;
-    song.next_shape_gate_idx = 0;
-    song.next_split_path_idx = 0;
+    song.next_shape_gate_circle_idx = 0;
+    song.next_split_path_circle_idx = 0;
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
@@ -463,10 +465,10 @@ TEST_CASE("beat_scheduler: obstacles spawn with overshoot compensation", "[beat_
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
     song.song_time = 10.0f;
-    song.next_shape_gate_idx = 0;
-    song.next_split_path_idx = 0;
+    song.next_shape_gate_circle_idx = 0;
+    song.next_split_path_circle_idx = 0;
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
@@ -483,10 +485,10 @@ TEST_CASE("beat_scheduler: rhythm obstacles omit Vector2", "[beat_scheduler]") {
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
     song.song_time = 10.0f;
-    song.next_shape_gate_idx = 0;
-    song.next_split_path_idx = 0;
+    song.next_shape_gate_circle_idx = 0;
+    song.next_split_path_circle_idx = 0;
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
@@ -505,10 +507,10 @@ TEST_CASE("beat_scheduler: ShapeGate Circle has blue color", "[beat_scheduler]")
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
     song.song_time = 10.0f;
-    song.next_shape_gate_idx = 0;
-    song.next_split_path_idx = 0;
+    song.next_shape_gate_circle_idx = 0;
+    song.next_split_path_circle_idx = 0;
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
@@ -525,10 +527,10 @@ TEST_CASE("beat_scheduler: ShapeGate Square has red color", "[beat_scheduler]") 
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.shape_gate_beats.push_back({0, Shape::Square, 1, 0.0f, false});
+    map.shape_gate_square_beats.push_back({0, 1, 0.0f, false});
     song.song_time = 10.0f;
-    song.next_shape_gate_idx = 0;
-    song.next_split_path_idx = 0;
+    song.next_shape_gate_circle_idx = 0;
+    song.next_split_path_circle_idx = 0;
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
@@ -545,10 +547,10 @@ TEST_CASE("beat_scheduler: ShapeGate Triangle has green color", "[beat_scheduler
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.shape_gate_beats.push_back({0, Shape::Triangle, 1, 0.0f, false});
+    map.shape_gate_triangle_beats.push_back({0, 1, 0.0f, false});
     song.song_time = 10.0f;
-    song.next_shape_gate_idx = 0;
-    song.next_split_path_idx = 0;
+    song.next_shape_gate_circle_idx = 0;
+    song.next_split_path_circle_idx = 0;
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
@@ -557,26 +559,6 @@ TEST_CASE("beat_scheduler: ShapeGate Triangle has green color", "[beat_scheduler
         CHECK(dc.r == 100);
         CHECK(dc.g == 255);
         CHECK(dc.b == 100);
-    }
-}
-
-TEST_CASE("beat_scheduler: ShapeGate Hexagon has hexagon color", "[beat_scheduler]") {
-    auto reg = make_rhythm_registry();
-    auto& song = reg.ctx().get<SongState>();
-    auto& map = beat_map(reg);
-
-    map.shape_gate_beats.push_back({0, Shape::Hexagon, 1, 0.0f, false});
-    song.song_time = 10.0f;
-    song.next_shape_gate_idx = 0;
-    song.next_split_path_idx = 0;
-    song.next_onset_marker_idx = 0;
-    beat_scheduler_system(reg, 0.016f);
-
-    auto view = reg.view<ObstacleTag, Color>();
-    for (auto [e, dc] : view.each()) {
-        CHECK(dc.r == 80);
-        CHECK(dc.g == 180);
-        CHECK(dc.b == 255);
     }
 }
 
@@ -592,11 +574,11 @@ TEST_CASE("beat_scheduler: clamped late-spawn stores adjusted spawn_time in Beat
     auto& map = beat_map(reg);
 
     // Use beat 0 whose spawn_time is deeply in the past
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
     // Set song_time so the overshoot pushes start_y well past PLAYER_Y
     song.song_time = 100.0f;
-    song.next_shape_gate_idx = 0;
-    song.next_split_path_idx = 0;
+    song.next_shape_gate_circle_idx = 0;
+    song.next_split_path_circle_idx = 0;
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
@@ -623,16 +605,16 @@ TEST_CASE("beat_scheduler: invalid scroll_speed skips late-spawn division", "[be
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.shape_gate_beats.push_back({0, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
     song.song_time = 100.0f;
     song.scroll_speed = 0.0f;
-    song.next_shape_gate_idx = 0;
-    song.next_split_path_idx = 0;
+    song.next_shape_gate_circle_idx = 0;
+    song.next_split_path_circle_idx = 0;
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
-    CHECK(song.next_shape_gate_idx == 0);
-    CHECK(song.next_split_path_idx == 0);
+    CHECK(song.next_shape_gate_circle_idx == 0);
+    CHECK(song.next_split_path_circle_idx == 0);
     CHECK(song.next_onset_marker_idx == 0);
     CHECK(reg.view<ObstacleTag>().begin() == reg.view<ObstacleTag>().end());
     CHECK(reg.view<ObstacleTag, BeatInfo>().begin() == reg.view<ObstacleTag, BeatInfo>().end());
@@ -640,16 +622,16 @@ TEST_CASE("beat_scheduler: invalid scroll_speed skips late-spawn division", "[be
     song.scroll_speed = -1.0f;
     beat_scheduler_system(reg, 0.016f);
 
-    CHECK(song.next_shape_gate_idx == 0);
-    CHECK(song.next_split_path_idx == 0);
+    CHECK(song.next_shape_gate_circle_idx == 0);
+    CHECK(song.next_split_path_circle_idx == 0);
     CHECK(song.next_onset_marker_idx == 0);
     CHECK(reg.view<ObstacleTag>().begin() == reg.view<ObstacleTag>().end());
 
     song.scroll_speed = std::numeric_limits<float>::quiet_NaN();
     beat_scheduler_system(reg, 0.016f);
 
-    CHECK(song.next_shape_gate_idx == 0);
-    CHECK(song.next_split_path_idx == 0);
+    CHECK(song.next_shape_gate_circle_idx == 0);
+    CHECK(song.next_split_path_circle_idx == 0);
     CHECK(song.next_onset_marker_idx == 0);
     CHECK(reg.view<ObstacleTag>().begin() == reg.view<ObstacleTag>().end());
 }

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -39,8 +39,8 @@ struct TempBeatMapFile {
 };
 
 int count_result_notes(const BeatMap& beatmap) {
-    return static_cast<int>(beatmap.shape_gate_beats.size() +
-                            beatmap.split_path_beats.size());
+    return static_cast<int>(shape_gate_count(beatmap) +
+                            split_path_count(beatmap));
 }
 
 int count_mesh_children(entt::registry& reg) {
@@ -133,9 +133,7 @@ TEST_CASE("Play session: missing selected beatmap returns to level select withou
     CHECK_FALSE(lss.confirmed);
     {
         const auto& bm = beat_map(reg);
-        CHECK(bm.shape_gate_beats.empty());
-        CHECK(bm.split_path_beats.empty());
-        CHECK(bm.onset_marker_beats.empty());
+        CHECK(beat_map_empty(bm));
     }
     CHECK(reg.view<PlayerTag>().empty());
     CHECK(reg.ctx().find<ScoreState>() == nullptr);
@@ -200,8 +198,8 @@ TEST_CASE("Play session: SongResults total_notes excludes onset marker metadata"
             setup_play_session(reg);
 
             const auto& beatmap = beat_map(reg);
-            const size_t total_beats = beatmap.shape_gate_beats.size() +
-                                       beatmap.split_path_beats.size() +
+            const size_t total_beats = shape_gate_count(beatmap) +
+                                       split_path_count(beatmap) +
                                        beatmap.onset_marker_beats.size();
             REQUIRE(total_beats > 0);
             saw_onset_marker = saw_onset_marker || !beatmap.onset_marker_beats.empty();

--- a/tests/test_rhythm_system.cpp
+++ b/tests/test_rhythm_system.cpp
@@ -30,11 +30,12 @@ TEST_CASE("beatmap: parse minimal valid JSON", "[rhythm][beatmap]") {
     CHECK(map.bpm == 120.0f);
     CHECK(map.offset == 0.2f);
     CHECK(map.lead_beats == 4);
-    CHECK(map.shape_gate_beats.size() == 2);
-    CHECK(map.shape_gate_beats[0].beat_index == 4);
-    CHECK(map.shape_gate_beats[0].shape == Shape::Circle);
-    CHECK(map.shape_gate_beats[1].beat_index == 8);
-    CHECK(map.shape_gate_beats[1].shape == Shape::Triangle);
+    REQUIRE(map.shape_gate_circle_beats.size() == 1);
+    REQUIRE(map.shape_gate_triangle_beats.size() == 1);
+    CHECK(map.shape_gate_square_beats.empty());
+    CHECK(shape_gate_count(map) == 2);
+    CHECK(map.shape_gate_circle_beats[0].beat_index == 4);
+    CHECK(map.shape_gate_triangle_beats[0].beat_index == 8);
 }
 
 TEST_CASE("beatmap: parse active obstacle kinds", "[rhythm][beatmap][issue873]") {
@@ -49,9 +50,9 @@ TEST_CASE("beatmap: parse active obstacle kinds", "[rhythm][beatmap][issue873]")
     })";
 
     REQUIRE(parse_beat_map(json, map, errors));
-    REQUIRE(map.shape_gate_beats.size() == 1);
+    REQUIRE(map.shape_gate_circle_beats.size() == 1);
     REQUIRE(map.onset_marker_beats.size() == 1);
-    CHECK(map.shape_gate_beats[0].beat_index == 4);
+    CHECK(map.shape_gate_circle_beats[0].beat_index == 4);
     CHECK(map.onset_marker_beats[0].beat_index == 8);
 }
 
@@ -70,7 +71,7 @@ TEST_CASE("beatmap: tempo_changes in JSON are ignored", "[rhythm][beatmap]") {
 
     REQUIRE(parse_beat_map(json, map, errors));
     CHECK(map.bpm == 120.0f);
-    CHECK(map.shape_gate_beats.size() == 1);
+    CHECK(shape_gate_count(map) == 1);
 }
 
 TEST_CASE("beatmap: invalid JSON returns error", "[rhythm][beatmap]") {
@@ -80,7 +81,7 @@ TEST_CASE("beatmap: invalid JSON returns error", "[rhythm][beatmap]") {
     REQUIRE_FALSE(errors.empty());
 }
 
-TEST_CASE("beatmap: beats sorted by beat_index", "[rhythm][beatmap]") {
+TEST_CASE("beatmap: beats sorted by beat_index within per-shape vectors", "[rhythm][beatmap]") {
     BeatMap map;
     std::vector<BeatMapError> errors;
     std::string json = R"({
@@ -93,10 +94,12 @@ TEST_CASE("beatmap: beats sorted by beat_index", "[rhythm][beatmap]") {
     })";
 
     REQUIRE(parse_beat_map(json, map, errors));
-    REQUIRE(map.shape_gate_beats.size() == 3);
-    CHECK(map.shape_gate_beats[0].beat_index == 4);
-    CHECK(map.shape_gate_beats[1].beat_index == 8);
-    CHECK(map.shape_gate_beats[2].beat_index == 12);
+    REQUIRE(shape_gate_count(map) == 3);
+    REQUIRE(map.shape_gate_circle_beats.size() == 2);
+    REQUIRE(map.shape_gate_square_beats.size() == 1);
+    CHECK(map.shape_gate_circle_beats[0].beat_index == 4);
+    CHECK(map.shape_gate_circle_beats[1].beat_index == 8);
+    CHECK(map.shape_gate_square_beats[0].beat_index == 12);
 }
 
 // Beat Map Validation
@@ -104,7 +107,7 @@ TEST_CASE("beatmap: beats sorted by beat_index", "[rhythm][beatmap]") {
 TEST_CASE("beatmap: validate BPM range", "[rhythm][beatmap]") {
     BeatMap map;
     map.bpm = 50.0f; map.offset = 0.0f; map.lead_beats = 4; map.duration = 60.0f;
-    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
 
@@ -118,7 +121,7 @@ TEST_CASE("beatmap: validate BPM range", "[rhythm][beatmap]") {
 TEST_CASE("beatmap: validate offset range", "[rhythm][beatmap]") {
     BeatMap map;
     map.bpm = 120.0f; map.offset = -1.0f; map.lead_beats = 4; map.duration = 60.0f;
-    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
 }
@@ -126,7 +129,7 @@ TEST_CASE("beatmap: validate offset range", "[rhythm][beatmap]") {
 TEST_CASE("beatmap: validate lead_beats range", "[rhythm][beatmap]") {
     BeatMap map;
     map.bpm = 120.0f; map.offset = 0.0f; map.lead_beats = 1; map.duration = 60.0f;
-    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
 }
@@ -141,8 +144,8 @@ TEST_CASE("beatmap: validate empty beats rejected", "[rhythm][beatmap]") {
 TEST_CASE("beatmap: validate different-shape gates min spacing", "[rhythm][beatmap]") {
     BeatMap map;
     map.bpm = 120.0f; map.offset = 0.0f; map.lead_beats = 4; map.duration = 60.0f;
-    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
-    map.shape_gate_beats.push_back({5, Shape::Triangle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
+    map.shape_gate_triangle_beats.push_back({5, 1, 0.0f, false});
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
 }
@@ -150,8 +153,8 @@ TEST_CASE("beatmap: validate different-shape gates min spacing", "[rhythm][beatm
 TEST_CASE("beatmap: same-shape gates can be adjacent", "[rhythm][beatmap]") {
     BeatMap map;
     map.bpm = 120.0f; map.offset = 0.0f; map.lead_beats = 4; map.duration = 60.0f;
-    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
-    map.shape_gate_beats.push_back({5, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({5, 1, 0.0f, false});
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
 }
@@ -159,7 +162,7 @@ TEST_CASE("beatmap: same-shape gates can be adjacent", "[rhythm][beatmap]") {
 TEST_CASE("beatmap: validate beat index beyond duration", "[rhythm][beatmap]") {
     BeatMap map;
     map.bpm = 120.0f; map.offset = 0.0f; map.lead_beats = 4; map.duration = 10.0f;
-    map.shape_gate_beats.push_back({100, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({100, 1, 0.0f, false});
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
 }
@@ -247,7 +250,7 @@ TEST_CASE("beat_scheduler: spawns obstacle at spawn_time", "[rhythm][scheduler]"
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
-    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
     song.playing = true;
     // Advance past spawn_time
     song.song_time = 0.1f;
@@ -259,7 +262,7 @@ TEST_CASE("beat_scheduler: obstacle has correct BeatInfo", "[rhythm][scheduler]"
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
-    map.shape_gate_beats.push_back({8, Shape::Triangle, 1, 0.0f, false});
+    map.shape_gate_triangle_beats.push_back({8, 1, 0.0f, false});
     song.playing = true; song.song_time = 2.5f;
     beat_scheduler_system(reg, 0.016f);
     auto obs_view = reg.view<ObstacleTag, BeatInfo>();
@@ -275,7 +278,7 @@ TEST_CASE("beat_scheduler: does not spawn before spawn_time", "[rhythm][schedule
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
-    map.shape_gate_beats.push_back({20, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({20, 1, 0.0f, false});
     song.playing = true; song.song_time = 0.5f;
     beat_scheduler_system(reg, 0.016f);
     CHECK(reg.view<ObstacleTag>().size() == 0);
@@ -285,8 +288,8 @@ TEST_CASE("beat_scheduler: spawns multiple when time catches up", "[rhythm][sche
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
-    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
-    map.shape_gate_beats.push_back({8, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({8, 1, 0.0f, false});
     song.playing = true; song.song_time = 3.0f;
     beat_scheduler_system(reg, 0.016f);
     CHECK(reg.view<ObstacleTag>().size() == 2);
@@ -296,7 +299,7 @@ TEST_CASE("beat_scheduler: rhythm obstacles use BeatInfo without Vector2", "[rhy
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
-    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
     song.playing = true; song.song_time = 0.1f;
     beat_scheduler_system(reg, 0.016f);
     auto obs_view = reg.view<ObstacleTag, BeatInfo>();
@@ -862,7 +865,7 @@ TEST_CASE("integration: obstacle arrives on-beat within 1 frame", "[rhythm][inte
     make_rhythm_player(reg);
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
-    map.shape_gate_beats.push_back({4, Shape::Circle, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
     song.playing = true; song.song_time = 0.1f;
     constexpr float dt = 1.0f / 60.0f;
     bool obstacle_at_player = false;

--- a/tests/test_shipped_beatmap_difficulty_ramp.cpp
+++ b/tests/test_shipped_beatmap_difficulty_ramp.cpp
@@ -73,14 +73,19 @@ TEST_CASE("difficulty ramp: easy contains only shape_gate obstacles or onset mar
 
         // Per #1202/#1204: kind is identified by which per-kind vector the
         // entry lives in. Easy permits only shape_gate and onset_marker; any
-        // entry in split_path_beats is a violation.
-        for (const auto& beat : map.split_path_beats) {
-            FAIL_CHECK("easy shape_gate_only: " << path
-                       << " contains unsupported easy obstacle (split_path) at beat "
-                       << beat.beat_index
-                       << " (easy required obstacles must be shape_gate-only per #125; "
-                          "onset_marker is non-blocking metadata per #642)");
-        }
+        // entry in split_path_* is a violation.
+        auto check_split_path_violations = [&](const std::vector<BeatEntry>& bin, const char* shape_name) {
+            for (const auto& beat : bin) {
+                FAIL_CHECK("easy shape_gate_only: " << path
+                           << " contains unsupported easy obstacle (split_path " << shape_name
+                           << ") at beat " << beat.beat_index
+                           << " (easy required obstacles must be shape_gate-only per #125; "
+                              "onset_marker is non-blocking metadata per #642)");
+            }
+        };
+        check_split_path_violations(map.split_path_circle_beats, "circle");
+        check_split_path_violations(map.split_path_square_beats, "square");
+        check_split_path_violations(map.split_path_triangle_beats, "triangle");
     }
 }
 
@@ -103,7 +108,7 @@ TEST_CASE("difficulty ramp: shape-gate count increases with difficulty",
                            << " difficulty=" << diffs[i]);
                 continue;
             }
-            counts[i] = static_cast<int>(map.shape_gate_beats.size());
+            counts[i] = static_cast<int>(shape_gate_count(map));
         }
 
         if (counts[0] == 0 || counts[1] == 0 || counts[2] == 0) {

--- a/tests/test_shipped_beatmap_first_collision.cpp
+++ b/tests/test_shipped_beatmap_first_collision.cpp
@@ -71,8 +71,12 @@ TEST_CASE("first collision: every shipped difficulty has a valid first beat",
                     }
                 }
             };
-            consider(map.shape_gate_beats);
-            consider(map.split_path_beats);
+            consider(map.shape_gate_circle_beats);
+            consider(map.shape_gate_square_beats);
+            consider(map.shape_gate_triangle_beats);
+            consider(map.split_path_circle_beats);
+            consider(map.split_path_square_beats);
+            consider(map.split_path_triangle_beats);
             consider(map.onset_marker_beats);
             if (!any) continue;
 

--- a/tests/test_shipped_beatmap_gap_one_readability.cpp
+++ b/tests/test_shipped_beatmap_gap_one_readability.cpp
@@ -60,14 +60,19 @@ TEST_CASE("gap=1 readability: adjacent authored beats remain shape gates",
             if (!load_beat_map(path, map, errors, difficulty)) continue;
 
             std::vector<RequiredEntry> required_beats;
-            required_beats.reserve(map.shape_gate_beats.size() +
-                                   map.split_path_beats.size());
-            for (const auto& b : map.shape_gate_beats) {
-                required_beats.push_back({RequiredKind::ShapeGate, b.beat_index});
-            }
-            for (const auto& b : map.split_path_beats) {
-                required_beats.push_back({RequiredKind::SplitPath, b.beat_index});
-            }
+            required_beats.reserve(shape_gate_count(map) + split_path_count(map));
+            auto add_shape_gate = [&](const std::vector<BeatEntry>& bin) {
+                for (const auto& b : bin) required_beats.push_back({RequiredKind::ShapeGate, b.beat_index});
+            };
+            auto add_split_path = [&](const std::vector<BeatEntry>& bin) {
+                for (const auto& b : bin) required_beats.push_back({RequiredKind::SplitPath, b.beat_index});
+            };
+            add_shape_gate(map.shape_gate_circle_beats);
+            add_shape_gate(map.shape_gate_square_beats);
+            add_shape_gate(map.shape_gate_triangle_beats);
+            add_split_path(map.split_path_circle_beats);
+            add_split_path(map.split_path_square_beats);
+            add_split_path(map.split_path_triangle_beats);
             std::stable_sort(required_beats.begin(), required_beats.end(),
                              [](const RequiredEntry& a, const RequiredEntry& b) {
                                  return a.beat_index < b.beat_index;

--- a/tests/test_shipped_beatmap_max_gap.cpp
+++ b/tests/test_shipped_beatmap_max_gap.cpp
@@ -73,12 +73,17 @@ TEST_CASE("shipped beatmaps: authored beats are strictly increasing",
             // ordering invariant we merge the three vectors into one flat
             // sorted view (by beat_index, then time_sec).
             std::vector<BeatEntry> merged;
-            merged.reserve(map.shape_gate_beats.size() +
-                           map.split_path_beats.size() +
-                           map.onset_marker_beats.size());
-            merged.insert(merged.end(), map.shape_gate_beats.begin(),   map.shape_gate_beats.end());
-            merged.insert(merged.end(), map.split_path_beats.begin(),   map.split_path_beats.end());
-            merged.insert(merged.end(), map.onset_marker_beats.begin(), map.onset_marker_beats.end());
+            merged.reserve(beat_map_total_count(map));
+            auto append = [&](const std::vector<BeatEntry>& v) {
+                merged.insert(merged.end(), v.begin(), v.end());
+            };
+            append(map.shape_gate_circle_beats);
+            append(map.shape_gate_square_beats);
+            append(map.shape_gate_triangle_beats);
+            append(map.split_path_circle_beats);
+            append(map.split_path_square_beats);
+            append(map.split_path_triangle_beats);
+            append(map.onset_marker_beats);
             std::stable_sort(merged.begin(), merged.end(),
                              [](const BeatEntry& a, const BeatEntry& b) {
                                  if (a.beat_index != b.beat_index) return a.beat_index < b.beat_index;

--- a/tests/test_shipped_beatmap_medium_balance.cpp
+++ b/tests/test_shipped_beatmap_medium_balance.cpp
@@ -62,27 +62,24 @@ TEST_CASE("medium balance: shipped beatmaps keep motif lane mapping",
         std::vector<BeatMapError> errors;
         if (!load_beat_map(path, map, errors, "medium")) continue;
 
-        // Per #1202/#1204: shape-gate entries live in their own per-kind vector.
+        // Per #1202/#1204: shape-gate entries live in their own per-(kind, shape) vectors.
         int total_shape_gates = 0;
-
-        for (const auto& beat : map.shape_gate_beats) {
-            ++total_shape_gates;
-            const int expected_lane = expected_lane_for_shape(beat.shape);
-            if (expected_lane < 0) {
-                FAIL_CHECK("medium balance: " << path
-                           << " beat " << beat.beat_index
-                           << " has unknown shape enum="
-                           << static_cast<int>(beat.shape));
-                continue;
+        auto check_bin = [&](const std::vector<BeatEntry>& bin, Shape shape) {
+            const int expected_lane = expected_lane_for_shape(shape);
+            for (const auto& beat : bin) {
+                ++total_shape_gates;
+                if (beat.lane != expected_lane) {
+                    FAIL_CHECK("medium balance: " << path
+                               << " beat " << beat.beat_index
+                               << " shape enum=" << static_cast<int>(shape)
+                               << " expected lane " << expected_lane
+                               << " but found lane " << static_cast<int>(beat.lane));
+                }
             }
-            if (beat.lane != expected_lane) {
-                FAIL_CHECK("medium balance: " << path
-                           << " beat " << beat.beat_index
-                           << " shape enum=" << static_cast<int>(beat.shape)
-                           << " expected lane " << expected_lane
-                           << " but found lane " << static_cast<int>(beat.lane));
-            }
-        }
+        };
+        check_bin(map.shape_gate_circle_beats,   Shape::Circle);
+        check_bin(map.shape_gate_square_beats,   Shape::Square);
+        check_bin(map.shape_gate_triangle_beats, Shape::Triangle);
         REQUIRE(total_shape_gates > 0);
     }
 }


### PR DESCRIPTION
## Summary

The `BeatEntry::shape` field was a row discriminator. Per Fabian's relational-DB mechanic (Principle 1), each former enum value becomes its own table:

- `BeatMap::shape_gate_beats` → `shape_gate_{circle,square,triangle}_beats`
- `BeatMap::split_path_beats` → `split_path_{circle,square,triangle}_beats`
- `SongState` cursors split similarly (6 per-(kind, shape) + 1 onset)

The row's shape is encoded by which vector it lives in. No `switch` on a discriminator, no `Shape shape` field on `BeatEntry`.

This is **PR C2** of the enum-eradication migration tracked in #1202. PR C1 (#1261) eradicated `ButtonPressEvent`; PR C3 will remove the last `Shape` carrier (`TestPlayerAction::target_shape`) and delete the enum itself.

## Mechanics

- **Parser dispatch**: function-pointer sink table indexed by `shape_index(parsed_shape)`. Hexagon's sinks return `nullptr` so the loader rejects hexagon-shaped `shape_gate` / `split_path` rows with an explicit error: `Shape 'hexagon' is not a valid required shape for obstacle kind '<kind>'`.
- **Scheduler**: each per-(kind, shape) helper is invoked with a literal `Shape` argument (constant per call site, not a switch). Three calls each for `shape_gate` and `split_path`, plus one for `onset_marker`.
- **Validator merge**: walks the seven sorted vectors in beat-index order, carrying an `int8_t shape_idx` (0/1/2 or -1 for onset) through the merge so Rule 6 (different-shape gate min gap) compares vector identity instead of an `entry.shape` field.

## Helpers added (free functions; `BeatMap` stays a plain data struct)

- `beat_map_required_count(m)`, `beat_map_total_count(m)`, `beat_map_empty(m)`
- `shape_gate_count(m)`, `split_path_count(m)`

## Test changes

- All loader / scheduler / validator tests push entries into the appropriate per-shape vector.
- Iteration tests aggregate across the six vectors using `shape_gate_count` / `split_path_count` or per-vector loops.
- Two ordering tests rewritten to push into a single per-shape vector (so the validator actually sees the authored order under test).
- `beat_scheduler: ShapeGate Hexagon has hexagon color` removed — Hexagon is no longer reachable through the BeatMap data path.

## Verification

- `cmake --build build -j 8` — zero warnings on Clang `-Wall -Wextra -Werror`
- `./build/shapeshifter_tests` — **872 test cases / 2918 assertions pass**
- `tools/check_enum_allowlist.py` — ok, 10 allowlisted enums unchanged (`Shape` survives until PR C3)

## Acceptance checklist

- [x] `BeatEntry` has no `Shape shape` field
- [x] No `switch (shape)` reintroduced
- [x] Validator catches cross-shape ordering via merge instead of field comparison
- [x] Zero warnings on Clang
- [x] Full test suite passes
- [x] Enum count unchanged (10)
- [ ] (Next PR C3) delete `Shape` enum after `TestPlayerAction::target_shape` migration

Closes-when-merged: nothing yet — #1202 stays open until PR C3 deletes the `Shape` enum.