### PR TITLE
Migrate game_render_should_draw_world_meshes to ctx-tag query (refs #1202, #1204 PR B)

### DIFF
--- a/app/systems/game_render_system.cpp
+++ b/app/systems/game_render_system.cpp
@@ -56,7 +56,6 @@ static void draw_meshes(const entt::registry& reg) {
 
 
 void game_render_system(const entt::registry& reg, float /*alpha*/) {
-    auto& gs = reg.ctx().get<GameState>();
     auto& camera = game_camera(reg).cam;
 
     ClearBackground({15, 15, 25, 255});
@@ -67,7 +66,7 @@ void game_render_system(const entt::registry& reg, float /*alpha*/) {
     // ── Render passes ──────────────────────────────────────────
     floor_render_system(reg);
 
-    if (game_render_should_draw_world_meshes(gs.phase)) {
+    if (game_render_should_draw_world_meshes(reg)) {
         rlDrawRenderBatchActive();
         rlDisableDepthTest();
         draw_meshes(reg);

--- a/app/systems/runtime_systems.h
+++ b/app/systems/runtime_systems.h
@@ -3,20 +3,17 @@
 #include <entt/entt.hpp>
 #include "components/game_state.h"
 
-[[nodiscard]] constexpr bool game_render_should_draw_world_meshes(GamePhase phase) noexcept {
-    switch (phase) {
-        case GamePhase::Playing:
-        case GamePhase::Paused:
-        case GamePhase::GameOver:
-        case GamePhase::SongComplete:
-            return true;
-        case GamePhase::Title:
-        case GamePhase::LevelSelect:
-        case GamePhase::Settings:
-        case GamePhase::Tutorial:
-            return false;
-    }
-    return false;
+// Per Fabian existential processing (#1202/#1204), this predicate queries
+// the per-phase ctx-tag mirror instead of switching on `GamePhase`. The
+// "world meshes are drawn" set is the union of four phases (Playing,
+// Paused, GameOver, SongComplete); presence of any one of their tags is
+// the answer. No switch, no enum dispatch.
+[[nodiscard]] inline bool game_render_should_draw_world_meshes(const entt::registry& reg) noexcept {
+    const auto& ctx = reg.ctx();
+    return ctx.contains<GamePhasePlayingTag>()
+        || ctx.contains<GamePhasePausedTag>()
+        || ctx.contains<GamePhaseGameOverTag>()
+        || ctx.contains<GamePhaseSongCompleteTag>();
 }
 
 // Runtime-only systems require a live platform/audio/render context and are

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include "systems/game_phase_transition.h"
 #include "systems/game_state_system.h"
 #include "test_helpers.h"
 #include "ui/screen_controllers/tutorial_screen_controller.h"
@@ -225,19 +226,28 @@ TEST_CASE("game_state: terminal to LevelSelect hides stale world renderables",
     CHECK_FALSE(lss.confirmed);
     REQUIRE(reg.valid(stale));
     CHECK(reg.all_of<ModelTransform, TagWorldPass>(stale));
-    CHECK_FALSE(game_render_should_draw_world_meshes(gs.phase));
+    CHECK_FALSE(game_render_should_draw_world_meshes(reg));
 }
 
 TEST_CASE("game_state: Settings hides stale world renderables",
           "[gamestate][render][regression][issue966]") {
-    CHECK(game_render_should_draw_world_meshes(GamePhase::Playing));
-    CHECK(game_render_should_draw_world_meshes(GamePhase::Paused));
-    CHECK(game_render_should_draw_world_meshes(GamePhase::GameOver));
-    CHECK(game_render_should_draw_world_meshes(GamePhase::SongComplete));
-    CHECK_FALSE(game_render_should_draw_world_meshes(GamePhase::Title));
-    CHECK_FALSE(game_render_should_draw_world_meshes(GamePhase::LevelSelect));
-    CHECK_FALSE(game_render_should_draw_world_meshes(GamePhase::Settings));
-    CHECK_FALSE(game_render_should_draw_world_meshes(GamePhase::Tutorial));
+    auto reg = make_registry();
+    sync_game_phase_tags(reg, GamePhase::Playing);
+    CHECK(game_render_should_draw_world_meshes(reg));
+    sync_game_phase_tags(reg, GamePhase::Paused);
+    CHECK(game_render_should_draw_world_meshes(reg));
+    sync_game_phase_tags(reg, GamePhase::GameOver);
+    CHECK(game_render_should_draw_world_meshes(reg));
+    sync_game_phase_tags(reg, GamePhase::SongComplete);
+    CHECK(game_render_should_draw_world_meshes(reg));
+    sync_game_phase_tags(reg, GamePhase::Title);
+    CHECK_FALSE(game_render_should_draw_world_meshes(reg));
+    sync_game_phase_tags(reg, GamePhase::LevelSelect);
+    CHECK_FALSE(game_render_should_draw_world_meshes(reg));
+    sync_game_phase_tags(reg, GamePhase::Settings);
+    CHECK_FALSE(game_render_should_draw_world_meshes(reg));
+    sync_game_phase_tags(reg, GamePhase::Tutorial);
+    CHECK_FALSE(game_render_should_draw_world_meshes(reg));
 }
 
 TEST_CASE("wasm smoke lane marker state is registry-owned and reset with runtime scratch",


### PR DESCRIPTION
## Summary

Second PR in the GamePhase eradication chain for #1202 / #1204 (PR A was #1264, `146689ec`).

Eradicates the `switch (GamePhase)` in [`app/systems/runtime_systems.h:7`](../tree/main/app/systems/runtime_systems.h) by querying the per-phase ctx-tag mirror introduced in PR A. **Zero behavior change.**

## Doctrinal grounding

Per Richard Fabian, *Data-Oriented Design* — Existential Processing:

> The solution is to run transforms taking the content of each of the switch cases or virtual methods as the operation to apply to the appropriate table, the table corresponding to the original enumeration value.

In this case the predicate's truth table is exactly "phase ∈ { Playing, Paused, GameOver, SongComplete }". The four ctx tags for those phases already exist (PR A); presence of any one of them is the answer. The switch dispatch disappears because the registry already partitions ctx state by tag type.

## Mechanic

| Before | After |
|---|---|
| `constexpr bool fn(GamePhase phase)` | `inline bool fn(const entt::registry& reg)` |
| `switch (phase) { case Playing: case Paused: ... return true; ... }` | `ctx.contains<GamePhasePlayingTag>() \|\| ctx.contains<GamePhasePausedTag>() \|\| ctx.contains<GamePhaseGameOverTag>() \|\| ctx.contains<GamePhaseSongCompleteTag>()` |

## Changes

- `app/systems/runtime_systems.h` — predicate body rewritten as 4-way ctx-tag OR; signature now takes `const entt::registry&`.
- `app/systems/game_render_system.cpp` — pass `reg` instead of `gs.phase`; drop the now-unused `GameState` ctx lookup.
- `tests/test_game_state_extended.cpp` — the two existing predicate tests now drive the tag mirror via `sync_game_phase_tags()`. The `[gamestate][render][regression][issue921]` test already went through `enter_phase()` so it just consumes `reg` post-system-call. The `[issue966]` coverage matrix migrated from raw `GamePhase::X` arguments to `sync_game_phase_tags(reg, GamePhase::X)` priming.

## Acceptance

- [x] No `switch (phase)` remains in `app/systems/runtime_systems.h`.
- [x] Predicate's public signature now consumes `const entt::registry&`; never names `GamePhase`.
- [x] All call sites (production + tests) consume `reg`.
- [x] Pre-existing predicate coverage (8-phase truth table + post-terminal regression) preserved verbatim through the tag mirror.
- [x] Zero-warning Clang build (`-Wall -Wextra -Werror`, unity).
- [x] `./build/shapeshifter_tests` → **875 cases / 2949 assertions pass** (identical to PR A baseline — confirms zero behavior change).
- [x] `GameState::phase` field still exists; this PR only removes one switch on it. Subsequent PRs C–F remove the remaining switches / `if (gs.phase == X)` branches before PR G can delete the field + enum.

## Migration plan progress (from #1264)

| PR | Scope | Status |
|---|---|---|
| A | Tag-mirror infra (`sync_game_phase_tags`, 8 ctx tags, `enter_phase()` wires both) | ✅ merged `146689ec` (#1264) |
| **B** | **`game_render_should_draw_world_meshes` predicate → ctx-tag query (this PR)** | **🔄 this PR** |
| C | `game_state_system.cpp:107` next-phase dispatch → per-tag transforms | pending |
| D | `ui_render_system.cpp:95` screen-render dispatch → per-tag transforms | pending |
| E | `game_phase_transition.cpp:13` WASM smoke title helper → per-tag transforms or delete | pending |
| F | Remaining `if (gs.phase == X)` branches across input/playing/screen-controller code | pending |
| G | Delete `GameState::phase` / `next_phase` / `GamePhase` enum; remove from `.allowed-enums.txt` | pending |

Refs #1202, #1204.