### PR TITLE
Eradicate switch (gs.next_phase) via NextPhase*Tag dispatch (refs #1202, #1204 PR C)

### DIFF
--- a/app/components/game_state.h
+++ b/app/components/game_state.h
@@ -46,6 +46,26 @@ struct GamePhaseSongCompleteTag {};
 struct GamePhaseSettingsTag     {};
 struct GamePhaseTutorialTag     {};
 
+// ── Pending phase transition (per-tag ctx tables) ──────────────────────
+// Per Fabian existential processing (issue #1202/#1204, PR C), the
+// per-frame "transition request" target is mirrored 1:1 into per-tag ctx
+// slots so the transition dispatch in `game_state_system` can run as
+// per-tag transforms instead of a `switch (gs.next_phase)`. The mirror
+// is populated from `gs.next_phase` at the top of the dispatch block via
+// `sync_next_phase_tags()` and cleared at the bottom via
+// `clear_next_phase_tags()`; outside of that block exactly zero
+// `NextPhase*Tag` ctx slots are present. The enum-typed field is retained
+// during the staged migration (PRs C–F) and deleted with the enum itself
+// in PR G.
+struct NextPhaseTitleTag        {};
+struct NextPhaseLevelSelectTag  {};
+struct NextPhasePlayingTag      {};
+struct NextPhasePausedTag       {};
+struct NextPhaseGameOverTag     {};
+struct NextPhaseSongCompleteTag {};
+struct NextPhaseSettingsTag     {};
+struct NextPhaseTutorialTag     {};
+
 // ── End-screen menu choice (per-choice ctx tables) ───────────
 // Per Fabian's existential processing (issue #1202/#1204), each former
 // EndScreenChoice value is its own zero-column table on `registry.ctx()`.

--- a/app/systems/game_phase_transition.cpp
+++ b/app/systems/game_phase_transition.cpp
@@ -56,6 +56,18 @@ void erase_all_game_phase_tags(entt::registry& reg) {
     if (ctx.find<GamePhaseTutorialTag>())     ctx.erase<GamePhaseTutorialTag>();
 }
 
+void erase_all_next_phase_tags(entt::registry& reg) {
+    auto& ctx = reg.ctx();
+    if (ctx.find<NextPhaseTitleTag>())        ctx.erase<NextPhaseTitleTag>();
+    if (ctx.find<NextPhaseLevelSelectTag>())  ctx.erase<NextPhaseLevelSelectTag>();
+    if (ctx.find<NextPhasePlayingTag>())      ctx.erase<NextPhasePlayingTag>();
+    if (ctx.find<NextPhasePausedTag>())       ctx.erase<NextPhasePausedTag>();
+    if (ctx.find<NextPhaseGameOverTag>())     ctx.erase<NextPhaseGameOverTag>();
+    if (ctx.find<NextPhaseSongCompleteTag>()) ctx.erase<NextPhaseSongCompleteTag>();
+    if (ctx.find<NextPhaseSettingsTag>())     ctx.erase<NextPhaseSettingsTag>();
+    if (ctx.find<NextPhaseTutorialTag>())     ctx.erase<NextPhaseTutorialTag>();
+}
+
 }  // namespace
 
 void sync_game_phase_tags(entt::registry& reg, GamePhase phase) {
@@ -71,6 +83,25 @@ void sync_game_phase_tags(entt::registry& reg, GamePhase phase) {
         case GamePhase::Settings:     ctx.emplace<GamePhaseSettingsTag>();     break;
         case GamePhase::Tutorial:     ctx.emplace<GamePhaseTutorialTag>();     break;
     }
+}
+
+void sync_next_phase_tags(entt::registry& reg, GamePhase phase) {
+    erase_all_next_phase_tags(reg);
+    auto& ctx = reg.ctx();
+    switch (phase) {
+        case GamePhase::Title:        ctx.emplace<NextPhaseTitleTag>();        break;
+        case GamePhase::LevelSelect:  ctx.emplace<NextPhaseLevelSelectTag>();  break;
+        case GamePhase::Playing:      ctx.emplace<NextPhasePlayingTag>();      break;
+        case GamePhase::Paused:       ctx.emplace<NextPhasePausedTag>();       break;
+        case GamePhase::GameOver:     ctx.emplace<NextPhaseGameOverTag>();     break;
+        case GamePhase::SongComplete: ctx.emplace<NextPhaseSongCompleteTag>(); break;
+        case GamePhase::Settings:     ctx.emplace<NextPhaseSettingsTag>();     break;
+        case GamePhase::Tutorial:     ctx.emplace<NextPhaseTutorialTag>();     break;
+    }
+}
+
+void clear_next_phase_tags(entt::registry& reg) {
+    erase_all_next_phase_tags(reg);
 }
 
 void enter_phase(entt::registry& reg, GameState& gs, GamePhase next_phase) {

--- a/app/systems/game_phase_transition.h
+++ b/app/systems/game_phase_transition.h
@@ -12,3 +12,14 @@ void enter_phase(entt::registry& reg, GameState& gs, GamePhase next_phase);
 // same moment they install the GameState ctx singleton. `enter_phase()`
 // invokes this internally on every transition.
 void sync_game_phase_tags(entt::registry& reg, GamePhase phase);
+
+// Pending-transition tag mirror (issue #1202 / PR C). `sync_next_phase_tags`
+// erases all eight `NextPhase*Tag` ctx slots and emplaces the single tag
+// matching `phase`; `clear_next_phase_tags` erases all eight. The pair is
+// called by `game_state_system`'s transition dispatch — sync at the top,
+// clear at the bottom — so each scheduled transition produces exactly one
+// pulse of "which phase was requested". This is the existential-processing
+// substrate for replacing the former `switch (gs.next_phase)` with per-tag
+// transforms (one if-block per phase).
+void sync_next_phase_tags(entt::registry& reg, GamePhase phase);
+void clear_next_phase_tags(entt::registry& reg);

--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -104,45 +104,58 @@ void game_state_system(entt::registry& reg, float dt) {
         // InputSystemPrivate (issue #1196).
         input_system_clear_pointer_state(reg);
 
-        switch (gs.next_phase) {
-            case GamePhase::Playing:
-                // Resume from Paused must NOT re-init the play session — that
-                // would discard score/energy/obstacles. All other paths into
-                // Playing (Title/LevelSelect/etc.) bootstrap a fresh session.
-                // See #482 for the rationale that converged screen controllers
-                // and input routing on the deferred (transition_pending) path.
-                if (gs.phase == GamePhase::Paused) {
-                    enter_phase(reg, gs, GamePhase::Playing);
-                } else {
-                    setup_play_session(reg);
-                }
-                break;
-            case GamePhase::GameOver:
-                game_state_enter_terminal_phase(reg, GamePhase::GameOver);
-                break;
-            case GamePhase::SongComplete:
-                game_state_enter_terminal_phase(reg, GamePhase::SongComplete);
-                break;
-            case GamePhase::Paused:
-                enter_phase(reg, gs, GamePhase::Paused);
-                break;
-            case GamePhase::Title:
-                enter_phase(reg, gs, GamePhase::Title);
-                break;
-            case GamePhase::LevelSelect:
-                enter_phase(reg, gs, GamePhase::LevelSelect);
-                {
-                    auto& lss = reg.ctx().get<LevelSelectState>();
-                    lss.confirmed = false;
-                }
-                break;
-            case GamePhase::Settings:
-                enter_phase(reg, gs, GamePhase::Settings);
-                break;
-            case GamePhase::Tutorial:
-                enter_phase(reg, gs, GamePhase::Tutorial);
-                break;
+        // Per Fabian's existential processing (issue #1202/#1204, PR C):
+        // each former `case GamePhase::X` is now its own per-tag transform.
+        // `sync_next_phase_tags` mirrors `gs.next_phase` into exactly one
+        // `NextPhase*Tag` ctx slot; the transforms below dispatch on tag
+        // presence; `clear_next_phase_tags` drains the mirror so a stale
+        // request cannot fire again next frame. The `gs.next_phase` field
+        // is retained during the staged migration; PR G deletes it along
+        // with the `GamePhase` enum itself.
+        sync_next_phase_tags(reg, gs.next_phase);
+        auto& ctx = reg.ctx();
+
+        if (ctx.contains<NextPhasePlayingTag>()) {
+            // Resume from Paused must NOT re-init the play session — that
+            // would discard score/energy/obstacles. All other paths into
+            // Playing (Title/LevelSelect/etc.) bootstrap a fresh session.
+            // See #482 for the rationale that converged screen controllers
+            // and input routing on the deferred (transition_pending) path.
+            //
+            // NB: this `gs.phase == GamePhase::Paused` check is on the
+            // current phase (not the dispatch target) and is migrated as
+            // part of PR F (`if (gs.phase == X)` sweep), not PR C.
+            if (gs.phase == GamePhase::Paused) {
+                enter_phase(reg, gs, GamePhase::Playing);
+            } else {
+                setup_play_session(reg);
+            }
         }
+        if (ctx.contains<NextPhaseGameOverTag>()) {
+            game_state_enter_terminal_phase(reg, GamePhase::GameOver);
+        }
+        if (ctx.contains<NextPhaseSongCompleteTag>()) {
+            game_state_enter_terminal_phase(reg, GamePhase::SongComplete);
+        }
+        if (ctx.contains<NextPhasePausedTag>()) {
+            enter_phase(reg, gs, GamePhase::Paused);
+        }
+        if (ctx.contains<NextPhaseTitleTag>()) {
+            enter_phase(reg, gs, GamePhase::Title);
+        }
+        if (ctx.contains<NextPhaseLevelSelectTag>()) {
+            enter_phase(reg, gs, GamePhase::LevelSelect);
+            auto& lss = reg.ctx().get<LevelSelectState>();
+            lss.confirmed = false;
+        }
+        if (ctx.contains<NextPhaseSettingsTag>()) {
+            enter_phase(reg, gs, GamePhase::Settings);
+        }
+        if (ctx.contains<NextPhaseTutorialTag>()) {
+            enter_phase(reg, gs, GamePhase::Tutorial);
+        }
+
+        clear_next_phase_tags(reg);
 #if defined(__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)
         if (gs.phase != GamePhase::Playing) {
             reset_web_playing_lane_marker(reg);

--- a/tests/test_game_phase_tags.cpp
+++ b/tests/test_game_phase_tags.cpp
@@ -7,6 +7,14 @@
 // `sync_game_phase_tags()` are the only writers that keep the mirror correct;
 // these tests pin the invariant so the mirror cannot drift as subsequent
 // migration PRs migrate consumers off `gs.phase`.
+//
+// PR C (`NextPhase*Tag`) adds a second mirror for the pending-transition
+// target (`gs.next_phase`). The mirror is pulsed by `sync_next_phase_tags()`
+// at the top of the dispatch block and drained by `clear_next_phase_tags()`
+// at the bottom — exactly one `NextPhase*Tag` between those two points,
+// zero outside the block. These tests also pin that invariant so the
+// pending-transition dispatch (per-tag transforms in `game_state_system`)
+// cannot drift either.
 
 #include <catch2/catch_test_macros.hpp>
 #include <entt/entt.hpp>
@@ -27,6 +35,20 @@ int count_phase_tags(entt::registry& reg) {
     if (ctx.find<GamePhaseSongCompleteTag>()) ++n;
     if (ctx.find<GamePhaseSettingsTag>())     ++n;
     if (ctx.find<GamePhaseTutorialTag>())     ++n;
+    return n;
+}
+
+int count_next_phase_tags(entt::registry& reg) {
+    auto& ctx = reg.ctx();
+    int n = 0;
+    if (ctx.find<NextPhaseTitleTag>())        ++n;
+    if (ctx.find<NextPhaseLevelSelectTag>())  ++n;
+    if (ctx.find<NextPhasePlayingTag>())      ++n;
+    if (ctx.find<NextPhasePausedTag>())       ++n;
+    if (ctx.find<NextPhaseGameOverTag>())     ++n;
+    if (ctx.find<NextPhaseSongCompleteTag>()) ++n;
+    if (ctx.find<NextPhaseSettingsTag>())     ++n;
+    if (ctx.find<NextPhaseTutorialTag>())     ++n;
     return n;
 }
 
@@ -102,5 +124,61 @@ TEST_CASE("game_phase_tags: every phase value has a matching tag",
     for (GamePhase p : all) {
         enter_phase(reg, gs, p);
         CHECK(count_phase_tags(reg) == 1);
+    }
+}
+
+TEST_CASE("next_phase_tags: sync emplaces exactly the matching tag",
+          "[game_phase][tags][ecs_refactor][issue_1202]") {
+    entt::registry reg;
+
+    sync_next_phase_tags(reg, GamePhase::Title);
+    CHECK(count_next_phase_tags(reg) == 1);
+    CHECK(reg.ctx().find<NextPhaseTitleTag>() != nullptr);
+
+    sync_next_phase_tags(reg, GamePhase::Playing);
+    CHECK(count_next_phase_tags(reg) == 1);
+    CHECK(reg.ctx().find<NextPhaseTitleTag>() == nullptr);
+    CHECK(reg.ctx().find<NextPhasePlayingTag>() != nullptr);
+
+    sync_next_phase_tags(reg, GamePhase::GameOver);
+    CHECK(count_next_phase_tags(reg) == 1);
+    CHECK(reg.ctx().find<NextPhaseGameOverTag>() != nullptr);
+
+    sync_next_phase_tags(reg, GamePhase::SongComplete);
+    CHECK(count_next_phase_tags(reg) == 1);
+    CHECK(reg.ctx().find<NextPhaseSongCompleteTag>() != nullptr);
+}
+
+TEST_CASE("next_phase_tags: clear drains every tag",
+          "[game_phase][tags][ecs_refactor][issue_1202]") {
+    entt::registry reg;
+    sync_next_phase_tags(reg, GamePhase::Tutorial);
+    REQUIRE(count_next_phase_tags(reg) == 1);
+
+    clear_next_phase_tags(reg);
+    CHECK(count_next_phase_tags(reg) == 0);
+
+    // Idempotent — clearing an already-clear mirror is a no-op.
+    clear_next_phase_tags(reg);
+    CHECK(count_next_phase_tags(reg) == 0);
+}
+
+TEST_CASE("next_phase_tags: every phase value has a matching tag",
+          "[game_phase][tags][ecs_refactor][issue_1202]") {
+    entt::registry reg;
+
+    const GamePhase all[] = {
+        GamePhase::Title,
+        GamePhase::LevelSelect,
+        GamePhase::Playing,
+        GamePhase::Paused,
+        GamePhase::GameOver,
+        GamePhase::SongComplete,
+        GamePhase::Settings,
+        GamePhase::Tutorial,
+    };
+    for (GamePhase p : all) {
+        sync_next_phase_tags(reg, p);
+        CHECK(count_next_phase_tags(reg) == 1);
     }
 }


### PR DESCRIPTION
## Summary

Eradicates the eight-case `switch (gs.next_phase)` at `app/systems/game_state_system.cpp:107` via per-tag transforms — the next step in the `GamePhase` migration plan from issue #1202 (PR A #1264 added the `GamePhase*Tag` mirror, PR B #1265 migrated the render predicate, this is PR C).

Per Fabian's *Existential Processing*: each former `switch` case is its own per-tag transform; the dispatcher partitions by component presence, not by branching on an enum.

## Mechanic

Mirrors PR A's mechanic, applied to the pending-transition target instead of the current phase:

1. Add eight `NextPhase*Tag` zero-column structs in `app/components/game_state.h` (Title / LevelSelect / Playing / Paused / GameOver / SongComplete / Settings / Tutorial).
2. Add `sync_next_phase_tags(reg, phase)` and `clear_next_phase_tags(reg)` in `app/systems/game_phase_transition.{h,cpp}`.
3. In `game_state_system`, the `transition_pending` block now:
   1. calls `sync_next_phase_tags(reg, gs.next_phase)` at the top,
   2. dispatches via per-tag `if (ctx.contains<NextPhase*Tag>())` blocks,
   3. calls `clear_next_phase_tags(reg)` at the bottom.

Exactly one transform fires per scheduled transition — `sync_next_phase_tags` erases the seven other tags first, mirroring the switch's mutual exclusivity.

## Out of scope (handled later)

- The internal `if (gs.phase == GamePhase::Paused)` check inside the Playing-target case is **left unchanged**. It reads the *current* phase, not the dispatch target, and migrates as part of PR F's `if (gs.phase == X)` sweep — not PR C. A comment marks the deferral.
- `gs.next_phase` field is retained; deletion lands in PR G along with the `GamePhase` enum.
- `switch` in `ui_render_system.cpp:95` → PR D.
- `switch` in `game_phase_transition.cpp` (WASM smoke title + sync helper) → PRs E / G.

## Verification

| Check | Result |
|---|---|
| `./build/shapeshifter_tests` (unity build) | **878 cases / 2969 assertions pass** (baseline 875 / 2949 → +3 cases, +20 assertions from new invariant tests) |
| `./build-no-unity/shapeshifter_tests` (non-unity) | All pass |
| Clang `-Wall -Wextra -Werror` | Zero warnings, both build trees |
| `ctest -R check_enum_allowlist` | Pass — no new enums |
| Runtime binary (`shapeshifter` target) | Built clean |

### Remaining `switch` on `GamePhase` in `app/` after this PR

```
app/systems/ui_render_system.cpp:95         # PR D
app/systems/game_phase_transition.cpp:13    # PR E (WASM smoke title)
app/systems/game_phase_transition.cpp:64    # PR G (sync helper — dies with enum)
```

(The PR C target site at `game_state_system.cpp:107` is gone.)

## Tests added

`tests/test_game_phase_tags.cpp` — three new test cases pinning the `NextPhase*Tag` mirror invariants:

- `next_phase_tags: sync emplaces exactly the matching tag`
- `next_phase_tags: clear drains every tag` (also covers idempotency)
- `next_phase_tags: every phase value has a matching tag`

These mirror the existing PR A invariant tests for `GamePhase*Tag` so the pending-transition mirror cannot silently drift.

## Drift check this cycle

- `virtual` / `override` / `dynamic_cast` in `app/`: **0**
- `: public ` inheritance outside raylib/EnTT wrappers: **0**
- Tags single-header (`app/tags/tags.h`): ✓
- `switch` sites on Eradicate-allowlist enums: only `GamePhase` remaining (tracked in #1202).
- Folder allowlist under `app/`: `components/ entities/ systems/ tags/ util/ ui/` — unchanged.

Refs #1202, #1204.