### PR TITLE
Eradicate switch (gs.phase) in ui_render_system via GamePhase*Tag dispatch (#1202 PR D)

### DIFF
--- a/app/systems/ui_render_system.cpp
+++ b/app/systems/ui_render_system.cpp
@@ -91,41 +91,24 @@ void ui_render_system(entt::registry& reg, float /*alpha*/) {
         SetMouseScale(inv_scale, inv_scale);
     }
 
-    // Dynamic screens that still need specialized rendering
-    switch (gs.phase) {
-        case GamePhase::Title: {
-            render_title_screen_ui(reg);
-            break;
-        }
-        case GamePhase::LevelSelect: {
-            render_level_select_screen_ui(reg);
-            break;
-        }
-        case GamePhase::Playing: {
-            render_gameplay_hud_screen_ui(reg);
-            break;
-        }
-        case GamePhase::Paused: {
-            render_paused_screen_ui(reg);
-            break;
-        }
-        case GamePhase::GameOver: {
-            render_game_over_screen_ui(reg);
-            break;
-        }
-        case GamePhase::SongComplete: {
-            render_song_complete_screen_ui(reg);
-            break;
-        }
-        case GamePhase::Settings: {
-            render_settings_screen_ui(reg);
-            break;
-        }
-        case GamePhase::Tutorial: {
-            render_tutorial_screen_ui(reg);
-            break;
-        }
-    }
+    // Dynamic screens that still need specialized rendering.
+    //
+    // Per Fabian's existential processing (issue #1202/#1204, PR D): each
+    // former `case GamePhase::X` is its own per-tag transform on the ctx-tag
+    // mirror seeded by `sync_game_phase_tags()` / `enter_phase()`. The mirror
+    // invariant pinned by `tests/test_game_phase_tags.cpp` guarantees that
+    // exactly one `GamePhase*Tag` is present at any time, so these eight
+    // `if` blocks are mutually exclusive even without `else` chaining and
+    // dispatch on tag presence rather than on an enum compare.
+    const auto& ctx = reg.ctx();
+    if (ctx.contains<GamePhaseTitleTag>())        { render_title_screen_ui(reg); }
+    if (ctx.contains<GamePhaseLevelSelectTag>())  { render_level_select_screen_ui(reg); }
+    if (ctx.contains<GamePhasePlayingTag>())      { render_gameplay_hud_screen_ui(reg); }
+    if (ctx.contains<GamePhasePausedTag>())       { render_paused_screen_ui(reg); }
+    if (ctx.contains<GamePhaseGameOverTag>())     { render_game_over_screen_ui(reg); }
+    if (ctx.contains<GamePhaseSongCompleteTag>()) { render_song_complete_screen_ui(reg); }
+    if (ctx.contains<GamePhaseSettingsTag>())     { render_settings_screen_ui(reg); }
+    if (ctx.contains<GamePhaseTutorialTag>())     { render_tutorial_screen_ui(reg); }
 
     // Restore raw mouse transform for non-UI systems in subsequent frames.
     SetMouseOffset(0, 0);


### PR DESCRIPTION
## Summary

Migrates the eight-case `switch (gs.phase)` in `app/systems/ui_render_system.cpp` (the screen-render dispatch at the bottom of the UI 2D pass) to eight per-tag `if (ctx.contains<GamePhase*Tag>())` transforms.

This is **PR D** in the staged `GamePhase` eradication train tracked by #1202, building on:
- PR A (#1264, `146689ec`) — tag-mirror infra
- PR B (#1265, `6889b6e9`) — render-mesh predicate
- PR C (#1266, `07293f4a`) — `next_phase` dispatch

## What changed

| File | Before | After |
|---|---|---|
| `app/systems/ui_render_system.cpp:95` | 8-arm `switch (gs.phase)` over `case GamePhase::X: render_*_screen_ui(reg); break;` | 8 per-tag `if (ctx.contains<GamePhase*Tag>()) { render_*_screen_ui(reg); }` transforms |

Net diff: **+18 / -35**, single file touched.

## Doctrinal grounding

Per Fabian's *Existential Processing* chapter (per #1202 / #1204 source-text grounding):

> "If the enum is a state or type enum previously handled by a switch or virtual call, then we don't need to look up the value, instead, we change the way we think about the problem. The solution is to run transforms taking the content of each of the switch cases or virtual methods as the operation to apply to the appropriate table, the table corresponding to the original enumeration value."

Each former `case GamePhase::X` is now its own per-tag transform. The mirror invariant pinned by `tests/test_game_phase_tags.cpp` (exactly one `GamePhase*Tag` ctx slot at any time, maintained by `enter_phase()` / `sync_game_phase_tags()`) guarantees the eight `if` blocks are mutually exclusive even without `else` chaining, so dispatch is data-driven via tag presence instead of branch-driven on an enum compare.

## Scope discipline

- The `if (gs.phase == GamePhase::Paused)` overlay check earlier in the same function (line 78) reads the *current* phase rather than dispatching on it, and is **PR F's job** (the `if (gs.phase == X)` sweep), not PR D. Left unchanged.
- The `switch (font_size)` helper at `popup_font_for_size` dispatches on `FontSize`, which is a Keep enum (UI label) per #1202 / #1204's source-text grounding, and is intentionally left alone.
- `GameState::phase` field, the `GamePhase` enum itself, and the two helper switches in `game_phase_transition.cpp` are retained during the staged migration; PR G deletes them all together.

## Verification

- `./build/shapeshifter_tests` → **878 cases / 2969 assertions pass** (identical to PR C baseline; zero behavior change).
- Zero-warning Clang build in both unity (`build/`) and per-TU (`build-no-unity/`) configurations.
- `python3 tools/check_enum_allowlist.py` → ok (10 enums in `app/`, all allowlisted; allowlist unchanged this PR — `GamePhase` row stays in Pending until PR G).

## Remaining `switch.*GamePhase` sites in `app/` after this PR

```
app/systems/game_phase_transition.cpp:13   # PR E (WASM smoke title)
app/systems/game_phase_transition.cpp:76   # sync_game_phase_tags helper (PR G)
app/systems/game_phase_transition.cpp:91   # sync_next_phase_tags helper (PR G)
```

The PR D dispatch switch at `ui_render_system.cpp:95` is **eradicated**.

## Migration plan progress (#1202)

| PR | Scope | Status |
|---|---|---|
| A | Tag-mirror infra for `gs.phase` | ✅ #1264 `146689ec` |
| B | Render predicate → ctx-tag query | ✅ #1265 `6889b6e9` |
| C | `game_state_system` next-phase dispatch | ✅ #1266 `07293f4a` |
| **D** | `ui_render_system` screen-render dispatch | **THIS PR** |
| E | `game_phase_transition` WASM smoke title | next |
| F | Remaining `if (gs.phase == X)` branches | pending |
| G | Delete `GamePhase` enum + `GameState::phase` field | pending |

Refs #1202 #1204.
