### PR TITLE
Eradicate switch (phase) in WASM smoke title via GamePhase*Tag dispatch (#1202 PR E)

### DIFF
--- a/app/systems/game_phase_transition.cpp
+++ b/app/systems/game_phase_transition.cpp
@@ -9,31 +9,8 @@
 namespace {
 
 #if defined(__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)
-const char* game_phase_name(GamePhase phase) {
-    switch (phase) {
-        case GamePhase::Title:
-            return "Title";
-        case GamePhase::LevelSelect:
-            return "LevelSelect";
-        case GamePhase::Playing:
-            return "Playing";
-        case GamePhase::Paused:
-            return "Paused";
-        case GamePhase::GameOver:
-            return "GameOver";
-        case GamePhase::SongComplete:
-            return "SongComplete";
-        case GamePhase::Settings:
-            return "Settings";
-        case GamePhase::Tutorial:
-            return "Tutorial";
-        default:
-            return "Unknown";
-    }
-}
-
-void update_web_title(GamePhase phase) {
-    const std::string title = std::string("SHAPESHIFTER [") + game_phase_name(phase) + "]";
+void set_web_title(const char* phase_name) {
+    const std::string title = std::string("SHAPESHIFTER [") + phase_name + "]";
     EM_ASM(
         {
             if (typeof document !== 'undefined') {
@@ -41,6 +18,27 @@ void update_web_title(GamePhase phase) {
             }
         },
         title.c_str());
+}
+
+// Per Fabian's existential processing (issue #1202/#1204, PR E): the former
+// eight-case `switch (phase)` over the WASM smoke title is replaced by per-tag
+// transforms on the `GamePhase*Tag` ctx mirror seeded by
+// `sync_game_phase_tags()`. The mirror invariant pinned by
+// `tests/test_game_phase_tags.cpp` guarantees that exactly one
+// `GamePhase*Tag` is present at any time, so these eight `if` blocks are
+// mutually exclusive even without `else` chaining and dispatch on tag
+// presence rather than on an enum compare. Callers must invoke this only
+// after `sync_game_phase_tags()` so the mirror reflects the new phase.
+void update_web_title(entt::registry& reg) {
+    const auto& ctx = reg.ctx();
+    if (ctx.contains<GamePhaseTitleTag>())        { set_web_title("Title"); }
+    if (ctx.contains<GamePhaseLevelSelectTag>())  { set_web_title("LevelSelect"); }
+    if (ctx.contains<GamePhasePlayingTag>())      { set_web_title("Playing"); }
+    if (ctx.contains<GamePhasePausedTag>())       { set_web_title("Paused"); }
+    if (ctx.contains<GamePhaseGameOverTag>())     { set_web_title("GameOver"); }
+    if (ctx.contains<GamePhaseSongCompleteTag>()) { set_web_title("SongComplete"); }
+    if (ctx.contains<GamePhaseSettingsTag>())     { set_web_title("Settings"); }
+    if (ctx.contains<GamePhaseTutorialTag>())     { set_web_title("Tutorial"); }
 }
 #endif
 
@@ -109,6 +107,6 @@ void enter_phase(entt::registry& reg, GameState& gs, GamePhase next_phase) {
     gs.phase_timer = 0.0f;
     sync_game_phase_tags(reg, gs.phase);
 #if defined(__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)
-    update_web_title(gs.phase);
+    update_web_title(reg);
 #endif
 }


### PR DESCRIPTION
## Summary

Migrates the eight-case `switch (phase)` at `app/systems/game_phase_transition.cpp:13` (the WASM browser-title smoke marker `SHAPESHIFTER [<phase>]` helper) to eight per-tag `if (ctx.contains<GamePhase*Tag>())` transforms.

Per Fabian existential processing (issue #1202 / #1204): each former `case GamePhase::X` becomes its own per-tag transform. The mirror invariant pinned by `tests/test_game_phase_tags.cpp` (exactly one `GamePhase*Tag` ctx slot at any time after `sync_game_phase_tags()`) guarantees the eight `if` blocks are mutually exclusive even without `else` chaining, so dispatch is data-driven via tag presence instead of branch-driven on an enum compare.

## Mechanic

- `game_phase_name(GamePhase)` — the helper that owned the switch — is deleted outright. Its body fused into the per-tag transforms.
- `update_web_title` now takes `entt::registry&` and reads the `GamePhase*Tag` ctx mirror. Called inside `enter_phase()` immediately after `sync_game_phase_tags(reg, gs.phase)`, so the mirror reflects the new phase at the moment the title is emitted.
- A new `set_web_title(const char*)` helper isolates the `std::string("SHAPESHIFTER [") + name + "]" + EM_ASM` payload so each per-tag transform is a single call.
- The two source-contract checks in `tests/test_wasm_beforeunload_lifecycle.cpp` ("wasm smoke phase title markers are compile-gated") — the `SHAPESHIFTER [` literal and the `__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)` guard string — are preserved verbatim.

## Scope discipline

- The two remaining `switch (phase)` sites in this file (`sync_game_phase_tags` at :74 and `sync_next_phase_tags` at :89) are the explicit enum→tag bridges that exist solely as long as the `GamePhase` enum does. They are deleted alongside the enum itself in PR G, not here.
- No changes to `gs.phase` reads, the `GamePhase` enum, or the `.allowed-enums.txt` allowlist (`GamePhase` row stays in Pending until PR G).

## Verification

- `./build/shapeshifter_tests` → **878 cases / 2969 assertions pass** (identical to PR D baseline; zero behaviour change).
- `./build-no-unity/shapeshifter_tests` → 878 cases / 2969 assertions pass.
- Zero-warning Clang build in both unity (`build/`) and per-TU (`build-no-unity/`) configurations.
- `python3 tools/check_enum_allowlist.py` → ok (10 enums in `app/`, all allowlisted; allowlist unchanged this PR).

## Migration plan progress (#1202)

| PR | Scope | Status |
|---|---|---|
| A | Tag-mirror infra for `gs.phase` | ✅ #1264 |
| B | Render predicate → ctx-tag query | ✅ #1265 |
| C | `game_state_system.cpp:107` next-phase dispatch | ✅ #1266 |
| D | `ui_render_system.cpp:95` screen-render dispatch | ✅ #1267 |
| **E** | **`game_phase_transition.cpp:13` WASM smoke title** | **🟡 this PR** |
| F | Remaining `if (gs.phase == X)` branches | pending |
| G | Delete `GameState::phase` / `next_phase` + `GamePhase` enum + `sync_*_phase_tags` helper switches + `.allowed-enums.txt` row | pending |

Refs #1202, #1204.
