### PR TITLE
Sweep gs.phase == GamePhase::X consumers onto GamePhase*Tag ctx mirror (#1202 PR F)

### DIFF
--- a/app/components/game_state.h
+++ b/app/components/game_state.h
@@ -29,10 +29,13 @@ struct GameState {
 // the initial GameState ctx emplace; the enum-typed field is retained
 // during the staged migration so existing consumers continue to compile.
 //
-// Subsequent PRs migrate each consumer (switch sites, `if (gs.phase == X)`
-// branches) onto these tags via `reg.ctx().find<GamePhase*Tag>()`. When
-// every consumer has been migrated the field — and the enum itself — can
-// be deleted, leaving these tags as the sole authority.
+// PR F (issue #1202) finished migrating every `if (gs.phase == X)` consumer
+// in `app/` onto `reg.ctx().contains<GamePhase*Tag>()`. The only remaining
+// `gs.phase` reads in `app/` are the two helper switches inside
+// `game_phase_transition.cpp` that translate the enum into the tag mirror
+// and the `GamePhase phase` function parameter on
+// `game_state_enter_terminal_phase()`; all three die with the enum itself
+// in PR G, alongside `GameState::phase` and `GameState::next_phase`.
 //
 // Maintenance invariant: exactly one `GamePhase*Tag` ctx slot is present
 // after any `enter_phase()` call. The current entry helper erases all

--- a/app/platform_display.cpp
+++ b/app/platform_display.cpp
@@ -112,7 +112,12 @@ static EM_BOOL on_visibility_change(int /*event_type*/,
     }
 
     if (auto* gs = state->reg->ctx().find<GameState>()) {
-        if (gs->phase == GamePhase::Playing) {
+        // Per Fabian's existential processing (issue #1202/#1204, PR F): the
+        // suspend-pause predicate dispatches on the `GamePhasePlayingTag` ctx
+        // mirror rather than reading `gs->phase`. The `GameState::find`
+        // probe is retained because the registry may not yet hold the
+        // singleton during early WASM bootstrap.
+        if (state->reg->ctx().contains<GamePhasePlayingTag>()) {
             gs->transition_pending = true;
             gs->next_phase = GamePhase::Paused;
         }

--- a/app/systems/energy_bar_system.cpp
+++ b/app/systems/energy_bar_system.cpp
@@ -32,7 +32,7 @@ float flash_overlay_strength(float flash_ratio, bool reduce_motion) {
 } // namespace
 
 void energy_bar_system(entt::registry& reg, [[maybe_unused]] float dt) {
-    if (reg.ctx().get<GameState>().phase != GamePhase::Playing) return;
+    if (!reg.ctx().contains<GamePhasePlayingTag>()) return;
 
     const auto* energy = reg.ctx().find<EnergyState>();
     if (!energy) return;

--- a/app/systems/energy_system.cpp
+++ b/app/systems/energy_system.cpp
@@ -19,7 +19,7 @@ void request_energy_depleted_game_over(entt::registry& reg) {
 }  // namespace
 
 void energy_system(entt::registry& reg, float dt) {
-    if (reg.ctx().get<GameState>().phase != GamePhase::Playing) return;
+    if (!reg.ctx().contains<GamePhasePlayingTag>()) return;
     auto* energy = reg.ctx().find<EnergyState>();
     if (!energy) return;
     auto* song = reg.ctx().find<SongState>();

--- a/app/systems/game_state_end_screen_system.cpp
+++ b/app/systems/game_state_end_screen_system.cpp
@@ -4,11 +4,18 @@
 
 namespace {
 
-bool end_screen_input_ready(const GameState& gs) {
+// Per Fabian's existential processing (issue #1202/#1204, PR F): the former
+// `gs.phase == GamePhase::X` checks dispatch on tag presence in `reg.ctx()`.
+// `phase_timer` stays an enum-free scalar, so end_screen_input_ready takes
+// both — the tag from ctx and the timer from `GameState`. The tag mirror
+// invariant pinned by `tests/test_game_phase_tags.cpp` keeps the two in
+// lockstep until PR G deletes `GameState::phase` outright.
+bool end_screen_input_ready(entt::registry& reg, const GameState& gs) {
+    const auto& ctx = reg.ctx();
     const bool game_over_ready =
-        gs.phase == GamePhase::GameOver && gs.phase_timer > constants::GAME_OVER_INPUT_DELAY;
+        ctx.contains<GamePhaseGameOverTag>() && gs.phase_timer > constants::GAME_OVER_INPUT_DELAY;
     const bool song_complete_ready =
-        gs.phase == GamePhase::SongComplete && gs.phase_timer > constants::SONG_COMPLETE_INPUT_DELAY;
+        ctx.contains<GamePhaseSongCompleteTag>() && gs.phase_timer > constants::SONG_COMPLETE_INPUT_DELAY;
     return game_over_ready || song_complete_ready;
 }
 
@@ -27,7 +34,7 @@ void erase_end_choice_tags(entt::registry& reg) {
 void apply_end_choice_restart(entt::registry& reg) {
     if (!reg.ctx().find<EndChoiceRestart>()) return;
     auto& gs = reg.ctx().get<GameState>();
-    if (!end_screen_input_ready(gs)) return;
+    if (!end_screen_input_ready(reg, gs)) return;
     gs.transition_pending = true;
     gs.next_phase = GamePhase::Playing;
     erase_end_choice_tags(reg);
@@ -36,7 +43,7 @@ void apply_end_choice_restart(entt::registry& reg) {
 void apply_end_choice_level_select(entt::registry& reg) {
     if (!reg.ctx().find<EndChoiceLevelSelect>()) return;
     auto& gs = reg.ctx().get<GameState>();
-    if (!end_screen_input_ready(gs)) return;
+    if (!end_screen_input_ready(reg, gs)) return;
     gs.transition_pending = true;
     gs.next_phase = GamePhase::LevelSelect;
     erase_end_choice_tags(reg);
@@ -45,7 +52,7 @@ void apply_end_choice_level_select(entt::registry& reg) {
 void apply_end_choice_main_menu(entt::registry& reg) {
     if (!reg.ctx().find<EndChoiceMainMenu>()) return;
     auto& gs = reg.ctx().get<GameState>();
-    if (!end_screen_input_ready(gs)) return;
+    if (!end_screen_input_ready(reg, gs)) return;
     gs.transition_pending = true;
     gs.next_phase = GamePhase::Title;
     erase_end_choice_tags(reg);

--- a/app/systems/game_state_routing.cpp
+++ b/app/systems/game_state_routing.cpp
@@ -8,13 +8,20 @@
 #include "../constants.h"
 
 namespace {
+// Per Fabian's existential processing (issue #1202/#1204, PR F): the former
+// `gs.phase == GamePhase::X` consumers dispatch on the per-phase ctx-tag
+// mirror. `phase_timer`, `transition_pending`, and `next_phase` stay on
+// `GameState` until PR G deletes the enum-typed field.
 bool game_state_handle_end_screen_press(entt::registry& reg, const MenuPressEvent& evt) {
     auto& gs = reg.ctx().get<GameState>();
-    if (gs.phase != GamePhase::GameOver && gs.phase != GamePhase::SongComplete) {
+    auto& ctx = reg.ctx();
+    const bool game_over_phase     = ctx.contains<GamePhaseGameOverTag>();
+    const bool song_complete_phase = ctx.contains<GamePhaseSongCompleteTag>();
+    if (!game_over_phase && !song_complete_phase) {
         return false;
     }
 
-    const float input_delay = (gs.phase == GamePhase::SongComplete)
+    const float input_delay = song_complete_phase
         ? constants::SONG_COMPLETE_INPUT_DELAY
         : constants::GAME_OVER_INPUT_DELAY;
     if (gs.phase_timer <= input_delay) {
@@ -25,18 +32,18 @@ bool game_state_handle_end_screen_press(entt::registry& reg, const MenuPressEven
         (evt.action == MenuActionKind::Confirm) ? MenuActionKind::Restart
                                                 : evt.action;
 
-    if (auto* disp = reg.ctx().find<entt::dispatcher>()) {
+    if (auto* disp = ctx.find<entt::dispatcher>()) {
         disp->enqueue<PlayHapticEvent>({action == MenuActionKind::Restart
                                            ? HapticEvent::RetryTap
                                            : HapticEvent::UIButtonTap});
     }
 
     if (action == MenuActionKind::Restart) {
-        reg.ctx().insert_or_assign(EndChoiceRestart{});
+        ctx.insert_or_assign(EndChoiceRestart{});
     } else if (action == MenuActionKind::GoLevelSelect) {
-        reg.ctx().insert_or_assign(EndChoiceLevelSelect{});
+        ctx.insert_or_assign(EndChoiceLevelSelect{});
     } else if (action == MenuActionKind::GoMainMenu) {
-        reg.ctx().insert_or_assign(EndChoiceMainMenu{});
+        ctx.insert_or_assign(EndChoiceMainMenu{});
     }
     return true;
 }
@@ -44,7 +51,7 @@ bool game_state_handle_end_screen_press(entt::registry& reg, const MenuPressEven
 
 void game_state_handle_go(entt::registry& reg, const GoEvent& /*evt*/) {
     auto& gs = reg.ctx().get<GameState>();
-    if (gs.phase != GamePhase::Paused) return;
+    if (!reg.ctx().contains<GamePhasePausedTag>()) return;
     if (gs.phase_timer <= constants::UI_ENTRY_DEBOUNCE) return;
     // Deferred per #482 — let game_state_system perform the resume swap.
     gs.transition_pending = true;
@@ -53,14 +60,15 @@ void game_state_handle_go(entt::registry& reg, const GoEvent& /*evt*/) {
 
 void game_state_handle_press_menu(entt::registry& reg, const MenuPressEvent& evt) {
     auto& gs = reg.ctx().get<GameState>();
+    auto& ctx = reg.ctx();
 
-    if (gs.phase == GamePhase::Title) {
-        if (auto* disp = reg.ctx().find<entt::dispatcher>()) {
+    if (ctx.contains<GamePhaseTitleTag>()) {
+        if (auto* disp = ctx.find<entt::dispatcher>()) {
             disp->enqueue<PlayHapticEvent>({HapticEvent::UIButtonTap});
         }
         if (evt.action == MenuActionKind::Exit) {
 #ifndef PLATFORM_WEB
-            reg.ctx().get<InputState>().quit_requested = true;
+            ctx.get<InputState>().quit_requested = true;
 #endif
         } else if (evt.action == MenuActionKind::Confirm) {
             gs.transition_pending = true;
@@ -73,7 +81,7 @@ void game_state_handle_press_menu(entt::registry& reg, const MenuPressEvent& evt
         return;
     }
 
-    if (gs.phase == GamePhase::Tutorial) {
+    if (ctx.contains<GamePhaseTutorialTag>()) {
         if (gs.phase_timer <= constants::UI_ENTRY_DEBOUNCE) return;
         if (evt.action != MenuActionKind::Confirm) return;
         if (auto* settings_state = find_settings_state(reg)) {
@@ -87,7 +95,7 @@ void game_state_handle_press_menu(entt::registry& reg, const MenuPressEvent& evt
         return;
     }
 
-    if (gs.phase == GamePhase::Paused) {
+    if (ctx.contains<GamePhasePausedTag>()) {
         if (gs.phase_timer <= constants::UI_ENTRY_DEBOUNCE) return;
         // Deferred per #482 — see game_state_handle_go above.
         gs.transition_pending = true;

--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -30,9 +30,9 @@ void reset_web_playing_lane_marker(entt::registry& reg) {
     wasm_smoke_lane_marker_state(reg).last_lane = -1;
 }
 
-void update_web_playing_lane_marker(entt::registry& reg, const GameState& gs) {
+void update_web_playing_lane_marker(entt::registry& reg) {
     auto& marker = wasm_smoke_lane_marker_state(reg);
-    if (gs.phase != GamePhase::Playing) {
+    if (!reg.ctx().contains<GamePhasePlayingTag>()) {
         marker.last_lane = -1;
         return;
     }
@@ -122,10 +122,13 @@ void game_state_system(entt::registry& reg, float dt) {
             // See #482 for the rationale that converged screen controllers
             // and input routing on the deferred (transition_pending) path.
             //
-            // NB: this `gs.phase == GamePhase::Paused` check is on the
-            // current phase (not the dispatch target) and is migrated as
-            // part of PR F (`if (gs.phase == X)` sweep), not PR C.
-            if (gs.phase == GamePhase::Paused) {
+            // Resume-from-pause check reads the current-phase tag mirror
+            // (`GamePhasePausedTag`), not `gs.phase`, per Fabian's existential
+            // processing (issue #1202/#1204, PR F): consumers dispatch on
+            // tag presence, never on the enum value. `sync_next_phase_tags`
+            // above mutates only the `NextPhase*Tag` mirror, so the current
+            // phase tag still reflects the pre-transition phase here.
+            if (ctx.contains<GamePhasePausedTag>()) {
                 enter_phase(reg, gs, GamePhase::Playing);
             } else {
                 setup_play_session(reg);
@@ -157,7 +160,7 @@ void game_state_system(entt::registry& reg, float dt) {
 
         clear_next_phase_tags(reg);
 #if defined(__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)
-        if (gs.phase != GamePhase::Playing) {
+        if (!reg.ctx().contains<GamePhasePlayingTag>()) {
             reset_web_playing_lane_marker(reg);
         }
 #endif
@@ -165,7 +168,8 @@ void game_state_system(entt::registry& reg, float dt) {
     }
 
     // LevelSelect input handling
-    if (gs.phase == GamePhase::LevelSelect && gs.phase_timer > constants::UI_ENTRY_DEBOUNCE) {
+    if (reg.ctx().contains<GamePhaseLevelSelectTag>() &&
+        gs.phase_timer > constants::UI_ENTRY_DEBOUNCE) {
         auto& lss = reg.ctx().get<LevelSelectState>();
         if (lss.confirmed) {
             lss.confirmed = false;
@@ -178,10 +182,10 @@ void game_state_system(entt::registry& reg, float dt) {
     }
 
 #if defined(__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)
-    update_web_playing_lane_marker(reg, gs);
+    update_web_playing_lane_marker(reg);
 #endif
     // Playing → SongComplete when song finishes (all obstacles cleared)
-    if (gs.phase == GamePhase::Playing) {
+    if (reg.ctx().contains<GamePhasePlayingTag>()) {
         auto* energy = reg.ctx().find<EnergyState>();
         auto* song = reg.ctx().find<SongState>();
         if (energy && energy->energy <= 0.0f) {

--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -418,10 +418,13 @@ void input_system(entt::registry& reg, float raw_dt) {
 
     // ── Background / suspend (edge-triggered) ─────────────
     // Pause only on the frame focus is *lost*, not every frame while unfocused.
+    // Per Fabian's existential processing (issue #1202/#1204, PR F), the
+    // current-phase predicate dispatches on the `GamePhasePlayingTag` ctx
+    // mirror rather than reading `gs.phase`.
     {
         bool focused = IsWindowFocused();
         if (priv.was_focused && !focused &&
-            reg.ctx().get<GameState>().phase == GamePhase::Playing) {
+            reg.ctx().contains<GamePhasePlayingTag>()) {
             auto& gs = reg.ctx().get<GameState>();
             gs.transition_pending = true;
             gs.next_phase = GamePhase::Paused;

--- a/app/systems/player_input_system.cpp
+++ b/app/systems/player_input_system.cpp
@@ -14,8 +14,12 @@
 namespace {
 
 bool gameplay_input_enabled(entt::registry& reg) {
+    // Per Fabian's existential processing (issue #1202/#1204, PR F): dispatch
+    // on the per-phase ctx-tag mirror rather than `gs.phase`. The
+    // `transition_pending` scalar stays on `GameState` until PR G deletes the
+    // enum-typed field.
     const auto& gs = reg.ctx().get<GameState>();
-    return gs.phase == GamePhase::Playing && !gs.transition_pending;
+    return reg.ctx().contains<GamePhasePlayingTag>() && !gs.transition_pending;
 }
 
 void push_haptic(entt::registry& reg, HapticEvent event) {

--- a/app/systems/playing_systems_runner.cpp
+++ b/app/systems/playing_systems_runner.cpp
@@ -1,10 +1,12 @@
 #include "all_systems.h"
 #include "../components/game_state.h"
 
-// Runs all systems that should execute only during GamePhase::Playing.
+// Runs all systems that should execute only during the Playing phase.
 // Single phase-gate at the runner boundary; individual systems carry no guard.
+// Per Fabian's existential processing (#1202/#1204 PR F), the gate dispatches
+// on the `GamePhasePlayingTag` ctx mirror instead of reading `gs.phase`.
 void tick_playing_systems(entt::registry& reg, float dt) {
-    if (reg.ctx().get<GameState>().phase != GamePhase::Playing) return;
+    if (!reg.ctx().contains<GamePhasePlayingTag>()) return;
     beat_log_system(reg, dt);
     beat_scheduler_system(reg, dt);
     shape_window_activation_system(reg, dt);

--- a/app/systems/popup_feedback_system.cpp
+++ b/app/systems/popup_feedback_system.cpp
@@ -26,7 +26,7 @@ void drain_timed_queue(entt::registry& reg,
 }  // namespace
 
 void popup_feedback_system(entt::registry& reg, [[maybe_unused]] float dt) {
-    if (reg.ctx().get<GameState>().phase != GamePhase::Playing) return;
+    if (!reg.ctx().contains<GamePhasePlayingTag>()) return;
     auto& queue = reg.ctx().get<ScorePopupRequestQueue>();
     if (queue.perfect.empty() && queue.good.empty() && queue.ok.empty() &&
         queue.bad.empty() && queue.untimed.empty()) {

--- a/app/systems/song_playback_system.cpp
+++ b/app/systems/song_playback_system.cpp
@@ -7,11 +7,11 @@
 #include <raylib.h>
 
 void song_playback_system(entt::registry& reg, float dt) {
-    const auto& gs = reg.ctx().get<GameState>();
+    auto& ctx = reg.ctx();
 
-    auto* song  = reg.ctx().find<SongState>();
+    auto* song  = ctx.find<SongState>();
     auto* map   = find_beat_map(reg);
-    auto* music = reg.ctx().find<MusicContext>();
+    auto* music = ctx.find<MusicContext>();
     const bool music_loaded = music && music->loaded;
 
     // Must pump the stream buffer every frame to prevent audio underruns,
@@ -32,7 +32,17 @@ void song_playback_system(entt::registry& reg, float dt) {
     }
 
     // ── Music lifecycle: start / pause / resume / stop ────────
-    if (music_loaded && gs.phase == GamePhase::Playing && song && song->playing) {
+    // Per Fabian's existential processing (issue #1202/#1204, PR F), each
+    // former `gs.phase == GamePhase::X` branch dispatches on the per-phase
+    // ctx-tag mirror. The mirror invariant (`tests/test_game_phase_tags.cpp`)
+    // guarantees exactly one `GamePhase*Tag` is present at a time, so these
+    // branches stay mutually exclusive without an `else` chain.
+    const bool playing_phase       = ctx.contains<GamePhasePlayingTag>();
+    const bool paused_phase        = ctx.contains<GamePhasePausedTag>();
+    const bool game_over_phase     = ctx.contains<GamePhaseGameOverTag>();
+    const bool song_complete_phase = ctx.contains<GamePhaseSongCompleteTag>();
+
+    if (music_loaded && playing_phase && song && song->playing) {
         if (!music->started) {
             PlayMusicStream(music->stream);
             music->started = true;
@@ -41,13 +51,13 @@ void song_playback_system(entt::registry& reg, float dt) {
             ResumeMusicStream(music->stream);
             music->paused = false;
         }
-    } else if (music_loaded && gs.phase == GamePhase::Paused && music->started) {
+    } else if (music_loaded && paused_phase && music->started) {
         if (!music->paused) {
             PauseMusicStream(music->stream);
             music->paused = true;
         }
     } else if (music_loaded &&
-               (gs.phase == GamePhase::GameOver || gs.phase == GamePhase::SongComplete) &&
+               (game_over_phase || song_complete_phase) &&
                music->started) {
         StopMusicStream(music->stream);
         music->started = false;
@@ -55,7 +65,7 @@ void song_playback_system(entt::registry& reg, float dt) {
     }
 
     // ── Song time / beat advancement (Playing phase only) ─────
-    if (gs.phase != GamePhase::Playing) return;
+    if (!playing_phase) return;
     if (!song) return;
 
     if (song->finished) {

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -197,32 +197,43 @@ void test_player_system(entt::registry& reg, float dt) {
     if (!state || !state->active) return;
 
     auto& gs    = reg.ctx().get<GameState>();
-    auto& disp  = reg.ctx().get<entt::dispatcher>();
-    auto* log   = reg.ctx().find<SessionLog>();
-    auto* song  = reg.ctx().find<SongState>();
+    auto& ctx   = reg.ctx();
+    auto& disp  = ctx.get<entt::dispatcher>();
+    auto* log   = ctx.find<SessionLog>();
+    auto* song  = ctx.find<SongState>();
     float song_time = song ? song->song_time : 0.0f;
 
+    // Per Fabian's existential processing (issue #1202/#1204, PR F): each
+    // former `gs.phase == GamePhase::X` branch dispatches on the per-phase
+    // ctx-tag mirror seeded by `enter_phase()` / `sync_game_phase_tags()`.
+    // `phase_timer` stays a scalar on `GameState` until PR G deletes the
+    // enum-typed field.
+    const bool title_phase         = ctx.contains<GamePhaseTitleTag>();
+    const bool game_over_phase     = ctx.contains<GamePhaseGameOverTag>();
+    const bool song_complete_phase = ctx.contains<GamePhaseSongCompleteTag>();
+    const bool paused_phase        = ctx.contains<GamePhasePausedTag>();
+    const bool level_select_phase  = ctx.contains<GamePhaseLevelSelectTag>();
+    const bool playing_phase       = ctx.contains<GamePhasePlayingTag>();
+
     // ── AUTO-START ───────────────────────────────────────────
-    if (gs.phase == GamePhase::Title || gs.phase == GamePhase::GameOver ||
-        gs.phase == GamePhase::SongComplete) {
+    if (title_phase || game_over_phase || song_complete_phase) {
         if (gs.phase_timer > constants::TEST_PLAYER_AUTO_START_DELAY) {
             // On end screens, press Restart; on Title, press Confirm
-            auto target_action = (gs.phase == GamePhase::GameOver ||
-                                  gs.phase == GamePhase::SongComplete)
+            auto target_action = (game_over_phase || song_complete_phase)
                                  ? MenuActionKind::Restart
                                  : MenuActionKind::Confirm;
             disp.enqueue<MenuPressEvent>({target_action, 0});
             if (log) {
                 const char* phase_name =
-                    (gs.phase == GamePhase::Title) ? "Title" :
-                    (gs.phase == GamePhase::SongComplete) ? "SongComplete" : "GameOver";
+                    title_phase         ? "Title" :
+                    song_complete_phase ? "SongComplete" : "GameOver";
                 session_log_write(*log, song_time, "PLAYER",
                     "AUTO_START phase=%s", phase_name);
 
                 // Log song results before replaying
-                if (gs.phase == GamePhase::SongComplete) {
-                    auto* results = reg.ctx().find<SongResults>();
-                    auto* score = reg.ctx().find<ScoreState>();
+                if (song_complete_phase) {
+                    auto* results = ctx.find<SongResults>();
+                    auto* score = ctx.find<ScoreState>();
                     if (results && score) {
                         session_log_write(*log, song_time, "GAME",
                             "SONG_END result=CLEAR score=%d perfect=%d good=%d ok=%d bad=%d miss=%d",
@@ -237,18 +248,18 @@ void test_player_system(entt::registry& reg, float dt) {
         return;
     }
 
-    if (gs.phase == GamePhase::Paused) {
+    if (paused_phase) {
         disp.enqueue<MenuPressEvent>({MenuActionKind::Confirm, 0});
         return;
     }
 
     // Auto-confirm on LevelSelect (level/difficulty already set in main.cpp)
-    if (gs.phase == GamePhase::LevelSelect && gs.phase_timer > constants::UI_ENTRY_DEBOUNCE) {
+    if (level_select_phase && gs.phase_timer > constants::UI_ENTRY_DEBOUNCE) {
         disp.enqueue<MenuPressEvent>({MenuActionKind::Confirm, 0});
         return;
     }
 
-    if (gs.phase != GamePhase::Playing) return;
+    if (!playing_phase) return;
     if (!song) return;
 
     // Reset stale state when a new play session starts (after enter_playing

--- a/app/systems/ui_render_system.cpp
+++ b/app/systems/ui_render_system.cpp
@@ -43,7 +43,6 @@ const Font& popup_font_for_size(const TextContext& ctx, FontSize font_size) {
 
 void ui_render_system(entt::registry& reg, float /*alpha*/) {
     auto& text_ctx = reg.ctx().get<TextContext>();
-    const auto& gs = reg.ctx().get<GameState>();
     const auto& st = reg.ctx().get<ScreenTransform>();
     auto& ui_cam = ui_camera(reg).cam;
 
@@ -75,7 +74,7 @@ void ui_render_system(entt::registry& reg, float /*alpha*/) {
     }
 
     // Overlay (if active)
-    if (gs.phase == GamePhase::Paused) {
+    if (reg.ctx().contains<GamePhasePausedTag>()) {
         DrawRectangleRec({0, 0, constants::SCREEN_W_F, constants::SCREEN_H_F},
                          {0, 0, 0, 160});
     }

--- a/app/ui/level_select_controller.cpp
+++ b/app/ui/level_select_controller.cpp
@@ -4,8 +4,7 @@
 #include "../systems/input_events.h"
 
 void level_select_handle_go(entt::registry& reg, const GoEvent& evt) {
-    auto& gs = reg.ctx().get<GameState>();
-    if (gs.phase != GamePhase::LevelSelect) return;
+    if (!reg.ctx().contains<GamePhaseLevelSelectTag>()) return;
 
     auto& lss = reg.ctx().get<LevelSelectState>();
     if (evt.dir == Direction::Up) {
@@ -21,7 +20,7 @@ void level_select_handle_go(entt::registry& reg, const GoEvent& evt) {
 
 void level_select_handle_press_menu(entt::registry& reg, const MenuPressEvent& evt) {
     auto& gs = reg.ctx().get<GameState>();
-    if (gs.phase != GamePhase::LevelSelect) return;
+    if (!reg.ctx().contains<GamePhaseLevelSelectTag>()) return;
     if (gs.phase_timer < 0.05f) return;
 
     auto& lss = reg.ctx().get<LevelSelectState>();

--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
@@ -385,8 +385,7 @@ void gameplay_hud_apply_button_presses(entt::registry& reg,
                                        bool circle_pressed,
                                        bool square_pressed,
                                        bool triangle_pressed) {
-    auto& gs = reg.ctx().get<GameState>();
-    if (gs.phase != GamePhase::Playing) return;
+    if (!reg.ctx().contains<GamePhasePlayingTag>()) return;
 
     auto& disp = reg.ctx().get<entt::dispatcher>();
     if (circle_pressed) {
@@ -400,6 +399,7 @@ void gameplay_hud_apply_button_presses(entt::registry& reg,
     }
 
     if (pause_pressed) {
+        auto& gs = reg.ctx().get<GameState>();
         gs.transition_pending = true;
         gs.next_phase = GamePhase::Paused;
     }

--- a/tests/test_beat_log_system.cpp
+++ b/tests/test_beat_log_system.cpp
@@ -63,7 +63,7 @@ TEST_CASE("beat_log: no-op when log file is null", "[beat_log]") {
 
 TEST_CASE("beat_log: no-op when not in Playing phase", "[beat_log]") {
     auto reg = make_rhythm_registry();
-    reg.ctx().get<GameState>().phase = GamePhase::Title;
+    set_test_phase(reg, GamePhase::Title);
     auto& song = reg.ctx().get<SongState>();
     song.current_beat = 2;
 

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -9,7 +9,7 @@
 
 TEST_CASE("beat_scheduler: no spawn when not Playing", "[beat_scheduler]") {
     auto reg = make_rhythm_registry();
-    reg.ctx().get<GameState>().phase = GamePhase::Title;
+    set_test_phase(reg, GamePhase::Title);
 
     auto& map = beat_map(reg);
     map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});

--- a/tests/test_collision_extended.cpp
+++ b/tests/test_collision_extended.cpp
@@ -386,7 +386,7 @@ TEST_CASE("collision: multiple misses accumulate in miss_count", "[collision][rh
     // Reset game over for second collision
     auto& gs = reg.ctx().get<GameState>();
     gs.transition_pending = false;
-    gs.phase = GamePhase::Playing;
+    set_test_phase(reg, GamePhase::Playing);
 
     // Second miss
     make_shape_gate(reg, Shape::Triangle, constants::PLAYER_Y);

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -261,7 +261,7 @@ TEST_CASE("collision: no player means no collision processing", "[collision]") {
 
 TEST_CASE("collision: not in Playing phase skips processing", "[collision]") {
     auto reg = make_registry();
-    reg.ctx().get<GameState>().phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
     make_player(reg);
     make_shape_gate(reg, Shape::Triangle, constants::PLAYER_Y);
 

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -145,7 +145,7 @@ TEST_CASE("ecs: make_registry dispatcher is wired — GoEvent listeners register
     auto reg = make_registry();
 
     // Promote to Playing so player_input_handle_go has observable effect.
-    reg.ctx().get<GameState>().phase = GamePhase::Playing;
+    set_test_phase(reg, GamePhase::Playing);
     auto player = make_player(reg);
     auto& lane  = reg.get<Lane>(player);
 

--- a/tests/test_energy_system.cpp
+++ b/tests/test_energy_system.cpp
@@ -7,7 +7,7 @@
 
 TEST_CASE("energy: no action when not in Playing phase", "[energy]") {
     auto reg = make_rhythm_registry();
-    reg.ctx().get<GameState>().phase = GamePhase::Title;
+    set_test_phase(reg, GamePhase::Title);
     auto& energy = reg.ctx().get<EnergyState>();
     energy.energy = 0.0f;
 

--- a/tests/test_entt_dispatcher_contract.cpp
+++ b/tests/test_entt_dispatcher_contract.cpp
@@ -202,10 +202,9 @@ TEST_CASE("R7: GoEvent delivered in GameOver phase — player_input_handle_go no
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& lane  = reg.get<Lane>(player);
-    auto& gs    = reg.ctx().get<GameState>();
     auto& disp  = reg.ctx().get<entt::dispatcher>();
 
-    gs.phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
 
     disp.enqueue(GoEvent{Direction::Right});
     disp.update<GoEvent>();
@@ -229,7 +228,7 @@ TEST_CASE("R7: drain-first order — GoEvent processed in pre-transition phase, 
     disp.update<GoEvent>();
     CHECK(lane.target == 2);
 
-    gs.phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
 
     disp.update<GoEvent>();
     CHECK(lane.target == 2);
@@ -250,7 +249,7 @@ TEST_CASE("R7: two-tick stale-event regression — GoEvent from tick N absent in
 
     lane.lerp_t = 0.5f;
 
-    gs.phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
 
     disp.update<GoEvent>();
 

--- a/tests/test_game_over_screen_controller.cpp
+++ b/tests/test_game_over_screen_controller.cpp
@@ -54,7 +54,7 @@ TEST_CASE("game_over: ENERGY DEPLETED reason renders when EnergyDepletedDeath ta
     // Absent tag: no reason text appears.
     REQUIRE(reg.ctx().find<EnergyDepletedDeath>() == nullptr);
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
     gs.phase_timer = 0.0f;
 
     render_game_over_screen_ui(reg);
@@ -81,7 +81,7 @@ TEST_CASE("game_over: score / high score / cause are visible via registry single
     reg.ctx().insert_or_assign(EnergyDepletedDeath{});
 
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
     gs.phase_timer = 1.0f;
 
     // Controller-bound values — these are exactly the fields the
@@ -106,7 +106,7 @@ TEST_CASE("game_over: render binds score/high-score/reason into scoreboard draw 
     reg.ctx().insert_or_assign(EnergyDepletedDeath{});
 
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
     gs.phase_timer = 0.0f;
 
     render_game_over_screen_ui(reg);
@@ -129,7 +129,7 @@ TEST_CASE("game_over: render binds new-best badge and previous score", "[game_ov
     reg.ctx().insert_or_assign(EnergyDepletedDeath{});
 
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
     gs.phase_timer = 0.0f;
 
     render_game_over_screen_ui(reg);
@@ -150,7 +150,7 @@ TEST_CASE("game_over: render omits empty reason binding when no death-cause tag 
     REQUIRE(reg.ctx().find<EnergyDepletedDeath>() == nullptr);
 
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
     gs.phase_timer = 0.0f;
 
     render_game_over_screen_ui(reg);

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -10,7 +10,7 @@
 TEST_CASE("game_state: song complete when song finished and no obstacles", "[gamestate]") {
     auto reg = make_rhythm_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::Playing;
+    set_test_phase(reg, GamePhase::Playing);
     auto& song = reg.ctx().get<SongState>();
     song.finished = true;
     song.playing = false;
@@ -26,7 +26,7 @@ TEST_CASE("game_state: energy depletion beats song complete after playback finis
           "[gamestate][issue755]") {
     auto reg = make_rhythm_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::Playing;
+    set_test_phase(reg, GamePhase::Playing);
     auto& song = reg.ctx().get<SongState>();
     song.finished = true;
     song.playing = false;
@@ -43,7 +43,7 @@ TEST_CASE("game_state: energy depletion beats song complete after playback finis
 TEST_CASE("game_state: song complete waits for obstacles to clear", "[gamestate]") {
     auto reg = make_rhythm_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::Playing;
+    set_test_phase(reg, GamePhase::Playing);
     auto& song = reg.ctx().get<SongState>();
     song.finished = true;
     song.playing = false;
@@ -61,7 +61,7 @@ TEST_CASE("game_state: song complete waits for obstacles to clear", "[gamestate]
 TEST_CASE("game_state: song complete proceeds when scored obstacle is destroyed", "[gamestate]") {
     auto reg = make_rhythm_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::Playing;
+    set_test_phase(reg, GamePhase::Playing);
     auto& song = reg.ctx().get<SongState>();
     song.finished = true;
     song.playing = false;
@@ -81,7 +81,7 @@ TEST_CASE("game_state: song complete proceeds when scored obstacle is destroyed"
 TEST_CASE("game_state: song complete waits for scored obstacle to be destroyed", "[gamestate]") {
     auto reg = make_rhythm_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::Playing;
+    set_test_phase(reg, GamePhase::Playing);
     auto& song = reg.ctx().get<SongState>();
     song.finished = true;
     song.playing = false;
@@ -136,7 +136,7 @@ TEST_CASE("game_state: enter_song_complete preserves higher high_score", "[games
 TEST_CASE("game_state: song_complete button choice restart", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::SongComplete;
+    set_test_phase(reg, GamePhase::SongComplete);
     gs.phase_timer = 1.0f;
     reg.ctx().emplace<EndChoiceRestart>();
 
@@ -152,7 +152,7 @@ TEST_CASE("game_state: song_complete button choice restart", "[gamestate]") {
 TEST_CASE("game_state: song_complete button choice level_select", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::SongComplete;
+    set_test_phase(reg, GamePhase::SongComplete);
     gs.phase_timer = 1.0f;
     reg.ctx().emplace<EndChoiceLevelSelect>();
 
@@ -168,7 +168,7 @@ TEST_CASE("game_state: song_complete button choice level_select", "[gamestate]")
 TEST_CASE("game_state: song_complete button choice main_menu", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::SongComplete;
+    set_test_phase(reg, GamePhase::SongComplete);
     gs.phase_timer = 1.0f;
     reg.ctx().emplace<EndChoiceMainMenu>();
 
@@ -181,7 +181,7 @@ TEST_CASE("game_state: song_complete button choice main_menu", "[gamestate]") {
 TEST_CASE("game_state: song_complete ignores choice during delay", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::SongComplete;
+    set_test_phase(reg, GamePhase::SongComplete);
     gs.phase_timer = 0.2f;  // < 0.5s delay
     reg.ctx().emplace<EndChoiceRestart>();
 
@@ -216,7 +216,7 @@ TEST_CASE("game_state: terminal to LevelSelect hides stale world renderables",
     reg.emplace<ModelTransform>(stale);
     reg.emplace<TagWorldPass>(stale);
 
-    gs.phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
     gs.transition_pending = true;
     gs.next_phase = GamePhase::LevelSelect;
 
@@ -297,7 +297,7 @@ TEST_CASE("game_state: transition clears in-flight pointer capture", "[gamestate
 TEST_CASE("game_state: transition to Title sets phase and resets timer", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::Playing;
+    set_test_phase(reg, GamePhase::Playing);
     gs.phase_timer = 5.0f;
     gs.transition_pending = true;
     gs.next_phase = GamePhase::Title;
@@ -311,7 +311,7 @@ TEST_CASE("game_state: transition to Title sets phase and resets timer", "[games
 TEST_CASE("game_state: level select confirmed starts tutorial when FTUE is incomplete", "[gamestate][ftue][issue882]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::LevelSelect;
+    set_test_phase(reg, GamePhase::LevelSelect);
     gs.phase_timer = 0.5f;  // past 0.2s guard
     auto& lss = reg.ctx().get<LevelSelectState>();
     lss.confirmed = true;
@@ -328,7 +328,7 @@ TEST_CASE("game_state: level select confirmed triggers playing when FTUE is comp
           "[gamestate][ftue][issue882]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::LevelSelect;
+    set_test_phase(reg, GamePhase::LevelSelect);
     gs.phase_timer = 0.5f;  // past 0.2s guard
     auto& lss = reg.ctx().get<LevelSelectState>();
     lss.confirmed = true;
@@ -345,7 +345,7 @@ TEST_CASE("tutorial: continue marks FTUE complete and requests gameplay",
           "[gamestate][ftue][issue882]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::Tutorial;
+    set_test_phase(reg, GamePhase::Tutorial);
 
     auto& settings = settings_state(reg);
     settings.ftue_run_count = 0;
@@ -366,7 +366,7 @@ TEST_CASE("tutorial: menu confirm marks FTUE complete and requests gameplay",
           "[gamestate][ftue][input][issue882]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::Tutorial;
+    set_test_phase(reg, GamePhase::Tutorial);
     gs.phase_timer = 0.5f;
 
     auto& settings = settings_state(reg);
@@ -391,7 +391,7 @@ TEST_CASE("tutorial: menu confirm marks FTUE complete and requests gameplay",
 TEST_CASE("game_state: level select ignores confirmed during delay", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::LevelSelect;
+    set_test_phase(reg, GamePhase::LevelSelect);
     gs.phase_timer = 0.1f;  // within 0.2s delay
     auto& lss = reg.ctx().get<LevelSelectState>();
     lss.confirmed = true;
@@ -405,7 +405,7 @@ TEST_CASE("game_state: level select ignores confirmed during delay", "[gamestate
 TEST_CASE("game_state: game_over restart button triggers playing", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
     gs.phase_timer = 0.5f;
     reg.ctx().emplace<EndChoiceRestart>();
 
@@ -418,7 +418,7 @@ TEST_CASE("game_state: game_over restart button triggers playing", "[gamestate]"
 TEST_CASE("game_state: game_over main_menu button triggers title", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
     gs.phase_timer = 0.5f;
     reg.ctx().emplace<EndChoiceMainMenu>();
 
@@ -431,7 +431,7 @@ TEST_CASE("game_state: game_over main_menu button triggers title", "[gamestate]"
 TEST_CASE("game_state: game_over level_select button triggers level_select", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
     gs.phase_timer = 0.5f;
     reg.ctx().emplace<EndChoiceLevelSelect>();
 
@@ -447,7 +447,7 @@ TEST_CASE("game_state: game_over level_select button triggers level_select", "[g
 TEST_CASE("game_state: game_over ignores choice at readiness boundary", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
     gs.phase_timer = 0.4f;
     reg.ctx().emplace<EndChoiceRestart>();
 
@@ -462,7 +462,7 @@ TEST_CASE("game_state: game_over ignores choice at readiness boundary", "[gamest
 TEST_CASE("game_state: game_over ignores missing end choice", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
     gs.phase_timer = 0.5f;
     REQUIRE(reg.ctx().find<EndChoiceRestart>() == nullptr);
     REQUIRE(reg.ctx().find<EndChoiceLevelSelect>() == nullptr);
@@ -479,7 +479,7 @@ TEST_CASE("game_state: game_over ignores missing end choice", "[gamestate]") {
 TEST_CASE("game_state: game_over restart enters fresh play session on next tick", "[gamestate][play_session]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
     gs.phase_timer = 0.5f;
     reg.ctx().emplace<EndChoiceRestart>();
 
@@ -504,7 +504,7 @@ TEST_CASE("game_state: game_over restart enters fresh play session on next tick"
 TEST_CASE("game_state: title position tap triggers level_select", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::Title;
+    set_test_phase(reg, GamePhase::Title);
     // Simulate a tap → Confirm menu button press (title screen has full-screen confirm)
     auto btn = make_menu_button(reg, MenuActionKind::Confirm);
     press_button(reg, btn);
@@ -519,7 +519,7 @@ TEST_CASE("title settings navigation: pending Settings transition reaches Settin
           "[gamestate][ui][settings][regression]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::Title;
+    set_test_phase(reg, GamePhase::Title);
     gs.phase_timer = 2.0f;
     gs.transition_pending = true;
     gs.next_phase = GamePhase::Settings;

--- a/tests/test_haptic_system.cpp
+++ b/tests/test_haptic_system.cpp
@@ -51,7 +51,7 @@ TEST_CASE("haptic_system: safe when dispatcher absent from context", "[haptic]")
 
 TEST_CASE("game state haptic: DeathCrash enqueued on game over", "[haptic]") {
     auto reg = make_registry();
-    reg.ctx().get<GameState>().phase = GamePhase::Playing;
+    set_test_phase(reg, GamePhase::Playing);
     reg.ctx().get<GameState>().transition_pending = true;
     reg.ctx().get<GameState>().next_phase = GamePhase::GameOver;
 
@@ -124,7 +124,7 @@ TEST_CASE("game state haptic: DeathCrash still enqueued; listener gates hardware
 
 TEST_CASE("game state haptic: RetryTap enqueued when Restart pressed on end screen", "[haptic]") {
     auto reg = make_registry();
-    reg.ctx().get<GameState>().phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
     reg.ctx().get<GameState>().phase_timer = 1.0f;
 
     auto btn = make_menu_button(reg, MenuActionKind::Restart);
@@ -141,7 +141,7 @@ TEST_CASE("game state haptic: RetryTap enqueued when Restart pressed on end scre
 
 TEST_CASE("game state haptic: UIButtonTap enqueued for non-Restart end screen button", "[haptic]") {
     auto reg = make_registry();
-    reg.ctx().get<GameState>().phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
     reg.ctx().get<GameState>().phase_timer = 1.0f;
 
     auto btn = make_menu_button(reg, MenuActionKind::GoMainMenu);
@@ -160,7 +160,7 @@ TEST_CASE("game state haptic: haptic_system no-crash when haptics_enabled=false 
     // Listener gates platform call; system must complete cleanly.
     auto reg = make_registry();
     settings_state(reg).haptics_enabled = false;
-    reg.ctx().get<GameState>().phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
     reg.ctx().get<GameState>().phase_timer = 1.0f;
 
     auto btn = make_menu_button(reg, MenuActionKind::Restart);

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -25,19 +25,19 @@
 #include "entities/beat_map.h"
 #include "entities/obstacle_render_entity.h"
 #include "systems/all_systems.h"
+#include "systems/game_phase_transition.h"
 #include "systems/runtime_systems.h"
 #include "systems/input_routing.h"
 #include "systems/input_system_private.h"
 
-// Sets up a registry with all singletons in their default state
+// Sets up a registry with all singletons in their default state.
 //
-// NOTE (issue #1202 PR A): pre-existing tests that bypass `enter_phase()`
-// (writing `gs.phase = X` directly) do NOT keep the per-phase ctx-tag mirror
-// in lockstep. The strict invariant only needs to hold post-`enter_phase()`,
-// which is enforced by `test_game_phase_tags.cpp`. Production callers always
-// route through `enter_phase()`; the test fixture intentionally does not
-// prime a tag here so existing direct-write tests stay readable. Migration
-// PRs B–G move tests onto the tag path with a helper.
+// Per Fabian's existential processing (#1202/#1204, PR F): the per-phase
+// ctx-tag mirror is primed alongside the `GameState` ctx singleton so
+// downstream consumers (`if (ctx.contains<GamePhase*Tag>())`) match the
+// `GameState::phase` field set here. Tests that mutate `gs.phase` directly
+// must call `set_test_phase()` below to keep the mirror in lockstep until
+// the enum-typed field itself is deleted in PR G.
 inline entt::registry make_registry() {
     entt::registry reg;
     reg.ctx().emplace<InputState>();
@@ -49,6 +49,7 @@ inline entt::registry make_registry() {
     reg.ctx().emplace<GameState>(GameState{
         GamePhase::Playing, 0.0f, false, GamePhase::Playing
     });
+    sync_game_phase_tags(reg, GamePhase::Playing);
     reg.ctx().emplace<ScoreState>();
     reg.ctx().emplace<ScoreDisplay>();
     reg.ctx().emplace<CurrentSongHighScore>();
@@ -63,6 +64,15 @@ inline entt::registry make_registry() {
     reg.ctx().emplace<HighScoreSession>();
     runtime_system_scratch_init(reg);
     return reg;
+}
+
+// Mutate the phase in tests without going through `enter_phase()` (which
+// also resets `phase_timer` and would defeat tests that pin a specific
+// timer value). Keeps the per-phase ctx-tag mirror invariant intact so
+// the migrated consumers in `app/` dispatch on the new phase immediately.
+inline void set_test_phase(entt::registry& reg, GamePhase phase) {
+    reg.ctx().get<GameState>().phase = phase;
+    sync_game_phase_tags(reg, phase);
 }
 
 struct GoCapture {

--- a/tests/test_input_pipeline_behavior.cpp
+++ b/tests/test_input_pipeline_behavior.cpp
@@ -415,7 +415,7 @@ TEST_CASE("pipeline: gameplay HUD proximity ring progresses through far near per
 TEST_CASE("pipeline: gameplay HUD raygui shape presses ignored outside Playing",
           "[input_pipeline][hud]") {
     auto reg = make_rhythm_registry();
-    reg.ctx().get<GameState>().phase = GamePhase::Paused;
+    set_test_phase(reg, GamePhase::Paused);
     auto player = make_rhythm_player(reg);
     REQUIRE(window_phase_is_idle(reg, player));
     gameplay_hud_apply_button_presses(reg,

--- a/tests/test_level_select_controller.cpp
+++ b/tests/test_level_select_controller.cpp
@@ -5,7 +5,7 @@
 TEST_CASE("level_select_controller: select difficulty press updates state", "[level_select][ui]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::LevelSelect;
+    set_test_phase(reg, GamePhase::LevelSelect);
     gs.phase_timer = 0.2f;
 
     auto& lss = reg.ctx().get<LevelSelectState>();
@@ -21,7 +21,7 @@ TEST_CASE("level_select_controller: select difficulty press updates state", "[le
 TEST_CASE("level_select_controller: select level press updates state", "[level_select][ui]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::LevelSelect;
+    set_test_phase(reg, GamePhase::LevelSelect);
     gs.phase_timer = 0.2f;
 
     auto& lss = reg.ctx().get<LevelSelectState>();
@@ -38,7 +38,7 @@ TEST_CASE("level_select_controller: invalid semantic indices do not update selec
           "[level_select][ui][issue738]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::LevelSelect;
+    set_test_phase(reg, GamePhase::LevelSelect);
     gs.phase_timer = 0.2f;
 
     auto& lss = reg.ctx().get<LevelSelectState>();
@@ -59,7 +59,7 @@ TEST_CASE("level_select_controller: invalid semantic indices do not update selec
 TEST_CASE("level_select_controller: ignores menu presses during entry delay", "[level_select][ui]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::LevelSelect;
+    set_test_phase(reg, GamePhase::LevelSelect);
     gs.phase_timer = 0.01f;
 
     auto& lss = reg.ctx().get<LevelSelectState>();

--- a/tests/test_miss_detection_regression.cpp
+++ b/tests/test_miss_detection_regression.cpp
@@ -171,7 +171,7 @@ TEST_CASE("miss_detection: visual obstacle leftovers without Obstacle payload ar
 TEST_CASE("miss_detection: no-op when game phase is not Playing",
           "[miss_detection][regression][issue336]") {
     auto reg = make_registry();
-    reg.ctx().get<GameState>().phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
 
     auto obs = make_expired_obstacle(reg);
 

--- a/tests/test_phase_runner.cpp
+++ b/tests/test_phase_runner.cpp
@@ -12,7 +12,7 @@ using Catch::Matchers::WithinAbs;
 
 TEST_CASE("tick_playing_systems: no-op when phase is Paused", "[phase_guard]") {
     auto reg = make_rhythm_registry();
-    reg.ctx().get<GameState>().phase = GamePhase::Paused;
+    set_test_phase(reg, GamePhase::Paused);
 
     // Observable state that at least three different playing systems would mutate:
     //   scoring_system    → ScoreState::score (distance bonus each tick)
@@ -38,7 +38,7 @@ TEST_CASE("tick_playing_systems: no-op when phase is Paused", "[phase_guard]") {
 
 TEST_CASE("tick_playing_systems: no-op when phase is GameOver", "[phase_guard]") {
     auto reg = make_rhythm_registry();
-    reg.ctx().get<GameState>().phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
 
     // Expired obstacle to match Paused coverage (MissTag / ScoredTag guard).
     auto obs = reg.create();
@@ -134,7 +134,7 @@ TEST_CASE("tick_playing_systems: shape window activates before collision", "[pha
 TEST_CASE("tick_fixed_systems: popup_feedback and energy run in score-feedback chain", "[phase_guard][integration][order_regression]") {
     auto reg = make_rhythm_registry();
     // Phase must be Playing for popup_feedback and energy guards to pass.
-    reg.ctx().get<GameState>().phase = GamePhase::Playing;
+    set_test_phase(reg, GamePhase::Playing);
 
     // Pre-seed a popup request directly (bypasses scoring_system path; tests
     // that popup_feedback_system is wired and consumes the queue).

--- a/tests/test_player_systems.cpp
+++ b/tests/test_player_systems.cpp
@@ -304,7 +304,7 @@ TEST_CASE("player_movement: slide returns to grounded", "[player]") {
 
 TEST_CASE("player_action: not in Playing phase skips processing", "[player]") {
     auto reg = make_registry();
-    reg.ctx().get<GameState>().phase = GamePhase::Title;
+    set_test_phase(reg, GamePhase::Title);
     make_player(reg);
 
     reg.ctx().get<entt::dispatcher>().enqueue<GoEvent>({Direction::Up});
@@ -319,7 +319,7 @@ TEST_CASE("player_action: not in Playing phase skips processing", "[player]") {
 
 TEST_CASE("player_movement: not in Playing phase skips processing", "[player]") {
     auto reg = make_registry();
-    reg.ctx().get<GameState>().phase = GamePhase::Paused;
+    set_test_phase(reg, GamePhase::Paused);
     auto p = make_player(reg);
     reg.get<PlayerShape>(p).morph_t = 0.0f;
 

--- a/tests/test_redfoot_testflight_ui.cpp
+++ b/tests/test_redfoot_testflight_ui.cpp
@@ -25,6 +25,7 @@
 #include "components/transform.h"
 #include "constants.h"
 #include "systems/all_systems.h"
+#include "systems/game_phase_transition.h"
 
 #include "util/shape_tag.h"
 
@@ -112,7 +113,9 @@ entt::entity spawn_obstacle(entt::registry& reg, float y) {
 TEST_CASE("redfoot/#168: collision miss is non-terminal cause context",
            "[ui][redfoot][game_over][wiring]") {
     entt::registry reg;
-    reg.ctx().emplace<GameState>().phase = GamePhase::Playing;
+    auto& gs = reg.ctx().emplace<GameState>();
+    gs.phase = GamePhase::Playing;
+    sync_game_phase_tags(reg, GamePhase::Playing);
     reg.ctx().emplace<EnergyState>();
     reg.ctx().emplace<ScoreState>();
     reg.ctx().emplace<ScoreDisplay>();
@@ -134,7 +137,9 @@ TEST_CASE("redfoot/#168: collision miss is non-terminal cause context",
 TEST_CASE("redfoot/#168: energy depletion falls back to ENERGY DEPLETED",
           "[ui][redfoot][game_over][wiring]") {
     entt::registry reg;
-    reg.ctx().emplace<GameState>().phase = GamePhase::Playing;
+    auto& gs = reg.ctx().emplace<GameState>();
+    gs.phase = GamePhase::Playing;
+    sync_game_phase_tags(reg, GamePhase::Playing);
     reg.ctx().emplace<entt::dispatcher>();
     auto& energy = reg.ctx().emplace<EnergyState>();
     auto& song = reg.ctx().emplace<SongState>();
@@ -149,7 +154,9 @@ TEST_CASE("redfoot/#168: energy depletion falls back to ENERGY DEPLETED",
 TEST_CASE("redfoot/#168: energy depletion writes terminal cause",
            "[ui][redfoot][game_over][wiring]") {
     entt::registry reg;
-    reg.ctx().emplace<GameState>().phase = GamePhase::Playing;
+    auto& gs = reg.ctx().emplace<GameState>();
+    gs.phase = GamePhase::Playing;
+    sync_game_phase_tags(reg, GamePhase::Playing);
     reg.ctx().emplace<entt::dispatcher>();
     auto& energy = reg.ctx().emplace<EnergyState>();
     auto& song = reg.ctx().emplace<SongState>();

--- a/tests/test_scoring_system.cpp
+++ b/tests/test_scoring_system.cpp
@@ -211,7 +211,7 @@ TEST_CASE("scoring: ScoreDisplay rolls up toward score", "[scoring]") {
 
 TEST_CASE("scoring: not in Playing phase skips processing", "[scoring]") {
     auto reg = make_registry();
-    reg.ctx().get<GameState>().phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
 
     tick_playing_systems(reg, 1.0f);
 

--- a/tests/test_shape_window_extended.cpp
+++ b/tests/test_shape_window_extended.cpp
@@ -128,7 +128,7 @@ TEST_CASE("shape_window: not in Playing phase skips processing", "[shape_window]
     auto player = make_rhythm_player(reg);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
-    reg.ctx().get<GameState>().phase = GamePhase::Paused;
+    set_test_phase(reg, GamePhase::Paused);
 
     set_window_phase_morph_in(reg, player);
     sw.window_start = song.song_time;

--- a/tests/test_shape_window_system.cpp
+++ b/tests/test_shape_window_system.cpp
@@ -204,7 +204,7 @@ TEST_CASE("shape_window: full cycle MorphIn -> Active -> MorphOut -> Idle", "[sh
 
 TEST_CASE("shape_window: no processing when not Playing", "[shape_window]") {
     auto reg = make_rhythm_registry();
-    reg.ctx().get<GameState>().phase = GamePhase::Paused;
+    set_test_phase(reg, GamePhase::Paused);
     auto player = make_rhythm_player(reg);
     auto& sw = reg.get<ShapeWindow>(player);
     set_window_phase_morph_in(reg, player);

--- a/tests/test_signal_lifecycle_nogated.cpp
+++ b/tests/test_signal_lifecycle_nogated.cpp
@@ -18,7 +18,7 @@ TEST_CASE("game_state: finished song waits for obstacle drain before SongComplet
           "[game_state][runtime]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::Playing;
+    set_test_phase(reg, GamePhase::Playing);
     gs.transition_pending = false;
 
     auto& song = reg.ctx().get<SongState>();

--- a/tests/test_song_playback_extended.cpp
+++ b/tests/test_song_playback_extended.cpp
@@ -45,7 +45,7 @@ TEST_CASE("song_playback: song ends when duration exceeded", "[song_playback]") 
 
 TEST_CASE("song_playback: does nothing when not in Playing phase", "[song_playback]") {
     auto reg = make_rhythm_registry();
-    reg.ctx().get<GameState>().phase = GamePhase::Title;
+    set_test_phase(reg, GamePhase::Title);
     auto& song = reg.ctx().get<SongState>();
     float original_time = song.song_time;
 

--- a/tests/test_song_playback_system.cpp
+++ b/tests/test_song_playback_system.cpp
@@ -34,7 +34,7 @@ TEST_CASE("song_playback: song_time advances by dt", "[song_playback]") {
 
 TEST_CASE("song_playback: no advancement when not Playing", "[song_playback]") {
     auto reg = make_rhythm_registry();
-    reg.ctx().get<GameState>().phase = GamePhase::Title;
+    set_test_phase(reg, GamePhase::Title);
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 1.0f;
 
@@ -190,7 +190,7 @@ TEST_CASE("song_playback: obstacles can clear after playback ends without soft-l
           "[song_playback][gamestate][issue444]") {
     auto reg = make_rhythm_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::Playing;
+    set_test_phase(reg, GamePhase::Playing);
 
     auto& song = reg.ctx().get<SongState>();
     song.duration_sec = 1.0f;
@@ -221,7 +221,7 @@ TEST_CASE("song_playback: end-of-song transitions to SongComplete and remains st
           "[song_playback][gamestate][song_complete][regression]") {
     auto reg = make_rhythm_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::Playing;
+    set_test_phase(reg, GamePhase::Playing);
 
     auto& song = reg.ctx().get<SongState>();
     song.duration_sec = 1.0f;
@@ -293,7 +293,6 @@ TEST_CASE("song_playback: zero beat_period handled safely", "[song_playback]") {
 TEST_CASE("song_playback: pause to playing resume guard is one-shot",
           "[song_playback][regression][issue504]") {
     auto reg = make_rhythm_registry();
-    auto& gs = reg.ctx().get<GameState>();
     auto& song = reg.ctx().get<SongState>();
 
     auto& music = reg.ctx().emplace<MusicContext>();
@@ -301,7 +300,7 @@ TEST_CASE("song_playback: pause to playing resume guard is one-shot",
     music.started = true;
     music.paused = true;
 
-    gs.phase = GamePhase::Playing;
+    set_test_phase(reg, GamePhase::Playing);
     song.playing = true;
 
     song_playback_system(reg, 0.016f);

--- a/tests/test_test_player_system.cpp
+++ b/tests/test_test_player_system.cpp
@@ -212,7 +212,7 @@ TEST_CASE("test_player: auto-starts from title screen", "[test_player]") {
     auto reg = make_test_player_registry();
     make_rhythm_player(reg);
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::Title;
+    set_test_phase(reg, GamePhase::Title);
     gs.phase_timer = 1.0f;
 
     // Create a Confirm menu button (as title screen would have)

--- a/tests/test_world_systems.cpp
+++ b/tests/test_world_systems.cpp
@@ -102,7 +102,7 @@ TEST_CASE("cleanup: non-obstacle entities are untouched", "[cleanup]") {
 
 TEST_CASE("game_state: title to level select on touch", "[gamestate]") {
     auto reg = make_registry();
-    reg.ctx().get<GameState>().phase = GamePhase::Title;
+    set_test_phase(reg, GamePhase::Title);
     auto btn = make_menu_button(reg, MenuActionKind::Confirm);
     press_button(reg, btn);
 
@@ -116,7 +116,7 @@ TEST_CASE("game_state: title to level select on touch", "[gamestate]") {
 TEST_CASE("game_state: game over button choice after delay", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
     gs.phase_timer = 0.5f;
     auto btn = make_menu_button(reg, MenuActionKind::GoLevelSelect);
     press_button(reg, btn);
@@ -131,7 +131,7 @@ TEST_CASE("game_state: game over button choice after delay", "[gamestate]") {
 TEST_CASE("game_state: game over keyboard confirm routes to restart", "[gamestate][input][regression]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
     gs.phase_timer = 0.5f;
 
     reg.ctx().get<entt::dispatcher>().enqueue<MenuPressEvent>(
@@ -146,7 +146,7 @@ TEST_CASE("game_state: game over keyboard confirm routes to restart", "[gamestat
 TEST_CASE("game_state: song complete keyboard confirm routes to restart", "[gamestate][input][regression]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::SongComplete;
+    set_test_phase(reg, GamePhase::SongComplete);
     gs.phase_timer = constants::SONG_COMPLETE_INPUT_DELAY + 0.1f;
 
     reg.ctx().get<entt::dispatcher>().enqueue<MenuPressEvent>(
@@ -162,7 +162,7 @@ TEST_CASE("game_state: song complete keyboard confirm waits for button debounce"
           "[gamestate][input][regression]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::SongComplete;
+    set_test_phase(reg, GamePhase::SongComplete);
     gs.phase_timer = 0.45f;
 
     reg.ctx().get<entt::dispatcher>().enqueue<MenuPressEvent>(
@@ -179,7 +179,7 @@ TEST_CASE("game_state: song complete keyboard confirm waits for button debounce"
 TEST_CASE("game_state: game over ignores touch during delay", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::GameOver;
+    set_test_phase(reg, GamePhase::GameOver);
     gs.phase_timer = 0.2f;  // within GAME_OVER_INPUT_DELAY
     auto btn = make_menu_button(reg, MenuActionKind::Confirm);
     press_button(reg, btn);
@@ -192,7 +192,7 @@ TEST_CASE("game_state: game over ignores touch during delay", "[gamestate]") {
 TEST_CASE("game_state: paused menu input waits for entry debounce", "[gamestate][input]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::Paused;
+    set_test_phase(reg, GamePhase::Paused);
     gs.phase_timer = constants::UI_ENTRY_DEBOUNCE + 0.1f;
     gs.phase_timer = 0.1f;
 
@@ -207,7 +207,7 @@ TEST_CASE("game_state: paused menu input waits for entry debounce", "[gamestate]
 TEST_CASE("game_state: paused menu input resumes after entry debounce", "[gamestate][input]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::Paused;
+    set_test_phase(reg, GamePhase::Paused);
     gs.phase_timer = constants::UI_ENTRY_DEBOUNCE + 0.1f;
 
     reg.ctx().get<entt::dispatcher>().enqueue<MenuPressEvent>(
@@ -313,7 +313,7 @@ TEST_CASE("game_state: enter_game_over preserves high score if lower", "[gamesta
 TEST_CASE("game_state: paused to playing on touch", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::Paused;
+    set_test_phase(reg, GamePhase::Paused);
     gs.phase_timer = constants::UI_ENTRY_DEBOUNCE + 0.1f;
     auto btn = make_menu_button(reg, MenuActionKind::Confirm);
     press_button(reg, btn);
@@ -327,7 +327,7 @@ TEST_CASE("game_state: paused to playing on touch", "[gamestate]") {
 TEST_CASE("game_state: paused resume preserves active play session state", "[gamestate][regression]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::Paused;
+    set_test_phase(reg, GamePhase::Paused);
     gs.phase_timer = constants::UI_ENTRY_DEBOUNCE + 0.1f;
 
     auto player = make_player(reg);
@@ -374,7 +374,7 @@ TEST_CASE("game_state: paused resume preserves active play session state", "[gam
 TEST_CASE("game_state: title stays title without touch", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::Title;
+    set_test_phase(reg, GamePhase::Title);
     // No press event in queue — no actions
 
     game_state_system(reg, 0.5f);
@@ -386,7 +386,7 @@ TEST_CASE("game_state: title stays title without touch", "[gamestate]") {
 TEST_CASE("game_state: transition to Paused sets phase", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::Playing;
+    set_test_phase(reg, GamePhase::Playing);
     gs.transition_pending = true;
     gs.next_phase = GamePhase::Paused;
 
@@ -400,7 +400,7 @@ TEST_CASE("game_state: transition to Paused sets phase", "[gamestate]") {
 TEST_CASE("game_state: transition to Settings sets phase", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    gs.phase = GamePhase::Title;
+    set_test_phase(reg, GamePhase::Title);
     gs.transition_pending = true;
     gs.next_phase = GamePhase::Settings;
 
@@ -428,7 +428,7 @@ TEST_CASE("game_state: enter_playing resets score", "[gamestate]") {
 
 TEST_CASE("scroll: no movement when not in Playing phase", "[scroll]") {
     auto reg = make_registry();
-    reg.ctx().get<GameState>().phase = GamePhase::Title;
+    set_test_phase(reg, GamePhase::Title);
     auto e = reg.create();
     reg.emplace<WorldTransform>(e, WorldTransform{{100.0f, 200.0f}});
     reg.emplace<Vector2>(e, Vector2{10.0f, 20.0f});
@@ -441,7 +441,7 @@ TEST_CASE("scroll: no movement when not in Playing phase", "[scroll]") {
 
 TEST_CASE("motion: no movement when not in Playing phase", "[motion]") {
     auto reg = make_registry();
-    reg.ctx().get<GameState>().phase = GamePhase::Title;
+    set_test_phase(reg, GamePhase::Title);
     auto e = reg.create();
     reg.emplace<WorldTransform>(e, WorldTransform{{100.0f, 200.0f}});
     reg.emplace<Vector2>(e, Vector2{10.0f, 20.0f});


### PR DESCRIPTION
Per Fabian's existential processing chapter (issue #1202/#1204, **PR F**), every remaining `if (gs.phase == GamePhase::X)` consumer in `app/` now dispatches on the per-phase ctx-tag mirror seeded by `enter_phase()` / `sync_game_phase_tags()`. The mirror invariant pinned by `tests/test_game_phase_tags.cpp` guarantees exactly one `GamePhase*Tag` is present at any time, so each former enum compare becomes a tag-presence query with identical mutual-exclusion semantics.

### Migrated sites

| File | Sites |
|---|---|
| `app/systems/game_state_system.cpp` | 4 (incl. the deferred Paused→Playing resume check at line 128 that PR C explicitly deferred to PR F) |
| `app/systems/game_state_end_screen_system.cpp` | GameOver / SongComplete input-ready predicate |
| `app/systems/game_state_routing.cpp` | end-screen, Title, Paused, Tutorial routing |
| `app/systems/song_playback_system.cpp` | Playing / Paused / GameOver / SongComplete music lifecycle + beat advance gate |
| `app/systems/test_player_system.cpp` | Title / GameOver / SongComplete / Paused / LevelSelect / Playing auto-start cascade |
| `app/systems/player_input_system.cpp` | gameplay_input_enabled |
| `app/systems/input_system.cpp` | focus-lost → Paused edge |
| `app/platform_display.cpp` | WASM visibilitychange → Paused |
| `app/systems/energy_system.cpp`, `energy_bar_system.cpp`, `popup_feedback_system.cpp`, `playing_systems_runner.cpp` | Playing-only gates |
| `app/systems/ui_render_system.cpp` | Paused dim overlay |
| `app/ui/level_select_controller.cpp`, `ui/screen_controllers/gameplay_hud_screen_controller.cpp` | LevelSelect / Playing input gates |

### Test fixture updates

- `tests/test_helpers.h`: `make_registry()` now primes the tag mirror to `GamePhasePlayingTag` (matching the default `gs.phase = Playing` it sets), and a new `set_test_phase(reg, phase)` helper writes both `gs.phase` and the tag in lockstep so direct-write tests stay valid through PR G.
- 24 test files migrated from `gs.phase = X` to `set_test_phase(reg, X)`. The replacement is mechanical — no test semantics change.

### Remaining `GamePhase` reads in `app/` after this PR

```
app/systems/game_phase_transition.cpp:74   # sync_game_phase_tags helper (PR G)
app/systems/game_phase_transition.cpp:89   # sync_next_phase_tags helper (PR G)
app/systems/game_state_terminal_phase_system.cpp:65,83  # GamePhase function param (PR G)
```

All three are the explicit enum→tag bridges and the function parameter that will be deleted alongside `GameState::phase`, `GameState::next_phase`, and the `GamePhase` enum itself in PR G.

### Verification

- `./build/shapeshifter_tests "~[bench]"` → **878 cases / 2969 assertions pass** (baseline matches `main`).
- `./build-no-unity/shapeshifter_tests "~[bench]"` → **878 cases / 2969 assertions pass**.
- `python3 tools/check_enum_allowlist.py` → ok (10 enums in `app/`, allowlist unchanged).
- Zero warnings on Clang `-Wall -Wextra -Werror` in both unity and non-unity builds.

### Drift check this cycle

- `virtual` / `override` / `dynamic_cast` keyword hits in `app/`: **0** (5 grep hits are in comments — `virtual pixel coords`, `Runtime override:`).
- `: public ` inheritance outside raylib/EnTT wrappers: **0**.
- Tags single-header (`app/tags/tags.h`): ✓. `GamePhase*Tag` / `NextPhase*Tag` continue to live in `game_state.h` during the staged migration — they move to `tags/` when PR G deletes the enum.
- `enum` / `enum class` in `app/`: **10**, matching `.allowed-enums.txt` exactly.
- Folder layout under `app/`: `components/ entities/ systems/ tags/ ui/ util/` — unchanged.
- Cyclomatic ratchet: ~20 `if`/`else` branches on `gs.phase == GamePhase::X` eradicated; no new enum compares introduced in `app/`.

### Plan

| PR | Scope | Status |
|---|---|---|
| A | Tag-mirror infra for `gs.phase` | ✅ #1264 |
| B | Render predicate → ctx-tag query | ✅ #1265 |
| C | `game_state_system.cpp:107` next-phase dispatch | ✅ #1266 |
| D | `ui_render_system.cpp:95` screen-render dispatch | ✅ #1267 |
| E | `game_phase_transition.cpp:13` WASM smoke title | ✅ #1269 |
| **F** | **Remaining `if (gs.phase == X)` branches** | **🟡 this PR** |
| G | Delete `GameState::phase` / `next_phase` field + `GamePhase` enum + bridges | pending |

Refs #1202, #1204.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
