### PR TITLE
#1202 PR G: eradicate GamePhase enum + GameState::phase/next_phase/transition_pending

### DIFF
--- a/app/.allowed-enums.txt
+++ b/app/.allowed-enums.txt
@@ -48,4 +48,3 @@ Shape              # lookup key — perfect-hash index into per-shape function-p
 # Each row below is a control-flow enum awaiting migration to per-case tags
 # or component tables. Removing a row here = the migration landed.
 # Adding a row here would be drift; eradicate instead.
-GamePhase             # #1202: per-phase tag/struct mix; blocked on game_state.h split

--- a/app/components/game_state.h
+++ b/app/components/game_state.h
@@ -3,43 +3,21 @@
 #include <cstdint>
 #include <entt/entt.hpp>
 
-enum class GamePhase : uint8_t {
-    Title        = 0,
-    LevelSelect  = 1,
-    Playing      = 2,
-    Paused       = 3,
-    GameOver     = 4,
-    SongComplete = 5,
-    Settings     = 6,
-    Tutorial     = 7
-};
-
+// Per Fabian's existential processing (issue #1202/#1204): the former
+// `GamePhase` enum and its `GameState::phase`/`next_phase`/`transition_pending`
+// mirror fields have been eradicated. Active phase and pending-transition
+// requests are now expressed entirely as ctx-singleton tag presence on
+// `entt::registry` (see the `GamePhase*Tag` / `NextPhase*Tag` struct sets
+// below and `app/systems/game_phase_transition.h` for the API).
 struct GameState {
-    GamePhase phase            = GamePhase::Title;
-    float     phase_timer      = 0.0f;
-    bool      transition_pending = false;
-    GamePhase next_phase       = GamePhase::Title;
+    float phase_timer = 0.0f;
 };
 
 // ── Game phase (per-tag ctx tables; exactly one present at any time) ──
 // Per Fabian's existential processing (issue #1202/#1204), each former
 // GamePhase enum value gets its own zero-column table on `registry.ctx()`.
-// Presence of exactly one of these tags mirrors `GameState::phase` 1:1.
-// Both representations are maintained in lockstep by `enter_phase()` and
-// the initial GameState ctx emplace; the enum-typed field is retained
-// during the staged migration so existing consumers continue to compile.
-//
-// PR F (issue #1202) finished migrating every `if (gs.phase == X)` consumer
-// in `app/` onto `reg.ctx().contains<GamePhase*Tag>()`. The only remaining
-// `gs.phase` reads in `app/` are the two helper switches inside
-// `game_phase_transition.cpp` that translate the enum into the tag mirror
-// and the `GamePhase phase` function parameter on
-// `game_state_enter_terminal_phase()`; all three die with the enum itself
-// in PR G, alongside `GameState::phase` and `GameState::next_phase`.
-//
-// Maintenance invariant: exactly one `GamePhase*Tag` ctx slot is present
-// after any `enter_phase()` call. The current entry helper erases all
-// eight before emplacing the matching tag; tests pin the invariant.
+// Exactly one of these tags is present at any time; `enter_phase<...>()`
+// (see `systems/game_phase_transition.h`) is the sole writer.
 struct GamePhaseTitleTag        {};
 struct GamePhaseLevelSelectTag  {};
 struct GamePhasePlayingTag      {};
@@ -50,16 +28,13 @@ struct GamePhaseSettingsTag     {};
 struct GamePhaseTutorialTag     {};
 
 // ── Pending phase transition (per-tag ctx tables) ──────────────────────
-// Per Fabian existential processing (issue #1202/#1204, PR C), the
-// per-frame "transition request" target is mirrored 1:1 into per-tag ctx
-// slots so the transition dispatch in `game_state_system` can run as
-// per-tag transforms instead of a `switch (gs.next_phase)`. The mirror
-// is populated from `gs.next_phase` at the top of the dispatch block via
-// `sync_next_phase_tags()` and cleared at the bottom via
-// `clear_next_phase_tags()`; outside of that block exactly zero
-// `NextPhase*Tag` ctx slots are present. The enum-typed field is retained
-// during the staged migration (PRs C–F) and deleted with the enum itself
-// in PR G.
+// Per Fabian existential processing (issue #1202/#1204), the per-frame
+// "transition request" target is expressed as ctx-tag presence. UI / input
+// systems call `request_phase_transition<NextPhase*Tag>()` instead of
+// writing an enum field; `game_state_system` reads tag presence at the top
+// of its dispatch block, performs the per-tag swap, and drains the mirror
+// via `clear_next_phase_tags()`. Outside that block exactly zero
+// `NextPhase*Tag` ctx slots are present; inside it, exactly one.
 struct NextPhaseTitleTag        {};
 struct NextPhaseLevelSelectTag  {};
 struct NextPhasePlayingTag      {};

--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -178,12 +178,8 @@ bool game_loop_init(entt::registry& reg,
     wire_input_dispatcher(reg);
     wire_audio_haptic_dispatcher(reg);
     input_system_init(reg);
-    reset_ctx_singleton<GameState>(reg, GameState{
-        .phase = GamePhase::Title,
-        .phase_timer = 0.0f, .transition_pending = false,
-        .next_phase = GamePhase::Title
-    });
-    sync_game_phase_tags(reg, GamePhase::Title);
+    reset_ctx_singleton<GameState>(reg, GameState{});
+    sync_game_phase_tags<GamePhaseTitleTag>(reg);
     reset_ctx_singleton<ScoreState>(reg);
     reset_ctx_singleton<ScoreDisplay>(reg);
     reset_ctx_singleton<CurrentSongHighScore>(reg);

--- a/app/platform_display.cpp
+++ b/app/platform_display.cpp
@@ -112,14 +112,14 @@ static EM_BOOL on_visibility_change(int /*event_type*/,
     }
 
     if (auto* gs = state->reg->ctx().find<GameState>()) {
-        // Per Fabian's existential processing (issue #1202/#1204, PR F): the
+        (void)gs;
+        // Per Fabian's existential processing (issue #1202/#1204): the
         // suspend-pause predicate dispatches on the `GamePhasePlayingTag` ctx
-        // mirror rather than reading `gs->phase`. The `GameState::find`
-        // probe is retained because the registry may not yet hold the
-        // singleton during early WASM bootstrap.
+        // mirror; the request is expressed as `NextPhasePausedTag` presence.
+        // The `GameState` probe is retained because the registry may not
+        // yet hold the singleton during early WASM bootstrap.
         if (state->reg->ctx().contains<GamePhasePlayingTag>()) {
-            gs->transition_pending = true;
-            gs->next_phase = GamePhase::Paused;
+            request_phase_transition<NextPhasePausedTag>(*state->reg);
         }
     }
     return EM_FALSE;

--- a/app/systems/all_systems.h
+++ b/app/systems/all_systems.h
@@ -11,7 +11,8 @@ void test_player_system(entt::registry& reg, float dt);
 
 // Phase 2: Game State
 void game_state_system(entt::registry& reg, float dt);
-void game_state_enter_terminal_phase(entt::registry& reg, GamePhase phase);
+void game_state_enter_terminal_phase_game_over(entt::registry& reg);
+void game_state_enter_terminal_phase_song_complete(entt::registry& reg);
 void game_state_end_screen_system(entt::registry& reg, float dt);
 
 // Phase 3: Rhythm Engine (headless)

--- a/app/systems/energy_system.cpp
+++ b/app/systems/energy_system.cpp
@@ -1,5 +1,6 @@
 #include "all_systems.h"
 #include "../components/game_state.h"
+#include "game_phase_transition.h"
 #include "gameplay_intents.h"
 #include "../components/rhythm.h"
 #include "../constants.h"
@@ -8,12 +9,10 @@
 namespace {
 
 void request_energy_depleted_game_over(entt::registry& reg) {
-    auto& gs = reg.ctx().get<GameState>();
-    if (gs.transition_pending) return;
+    if (is_phase_transition_pending(reg)) return;
 
     reg.ctx().insert_or_assign(EnergyDepletedDeath{});
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::GameOver;
+    request_phase_transition<NextPhaseGameOverTag>(reg);
 }
 
 }  // namespace

--- a/app/systems/game_phase_transition.cpp
+++ b/app/systems/game_phase_transition.cpp
@@ -2,13 +2,14 @@
 
 #if defined(__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)
 #include <emscripten/emscripten.h>
+#include <string>
 #endif
 
-#include <string>
-
-namespace {
+namespace phase_transition_detail {
 
 #if defined(__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)
+namespace {
+
 void set_web_title(const char* phase_name) {
     const std::string title = std::string("SHAPESHIFTER [") + phase_name + "]";
     EM_ASM(
@@ -20,15 +21,13 @@ void set_web_title(const char* phase_name) {
         title.c_str());
 }
 
-// Per Fabian's existential processing (issue #1202/#1204, PR E): the former
+// Per Fabian's existential processing (issue #1202/#1204, PR G): the former
 // eight-case `switch (phase)` over the WASM smoke title is replaced by per-tag
-// transforms on the `GamePhase*Tag` ctx mirror seeded by
-// `sync_game_phase_tags()`. The mirror invariant pinned by
-// `tests/test_game_phase_tags.cpp` guarantees that exactly one
-// `GamePhase*Tag` is present at any time, so these eight `if` blocks are
-// mutually exclusive even without `else` chaining and dispatch on tag
-// presence rather than on an enum compare. Callers must invoke this only
-// after `sync_game_phase_tags()` so the mirror reflects the new phase.
+// transforms on the `GamePhase*Tag` ctx mirror seeded by `enter_phase<...>()`.
+// The mirror invariant pinned by `tests/test_game_phase_tags.cpp` guarantees
+// that exactly one `GamePhase*Tag` is present at any time, so these eight
+// `if` blocks are mutually exclusive even without `else` chaining and
+// dispatch on tag presence rather than on an enum compare.
 void update_web_title(entt::registry& reg) {
     const auto& ctx = reg.ctx();
     if (ctx.contains<GamePhaseTitleTag>())        { set_web_title("Title"); }
@@ -40,73 +39,16 @@ void update_web_title(entt::registry& reg) {
     if (ctx.contains<GamePhaseSettingsTag>())     { set_web_title("Settings"); }
     if (ctx.contains<GamePhaseTutorialTag>())     { set_web_title("Tutorial"); }
 }
-#endif
-
-void erase_all_game_phase_tags(entt::registry& reg) {
-    auto& ctx = reg.ctx();
-    if (ctx.find<GamePhaseTitleTag>())        ctx.erase<GamePhaseTitleTag>();
-    if (ctx.find<GamePhaseLevelSelectTag>())  ctx.erase<GamePhaseLevelSelectTag>();
-    if (ctx.find<GamePhasePlayingTag>())      ctx.erase<GamePhasePlayingTag>();
-    if (ctx.find<GamePhasePausedTag>())       ctx.erase<GamePhasePausedTag>();
-    if (ctx.find<GamePhaseGameOverTag>())     ctx.erase<GamePhaseGameOverTag>();
-    if (ctx.find<GamePhaseSongCompleteTag>()) ctx.erase<GamePhaseSongCompleteTag>();
-    if (ctx.find<GamePhaseSettingsTag>())     ctx.erase<GamePhaseSettingsTag>();
-    if (ctx.find<GamePhaseTutorialTag>())     ctx.erase<GamePhaseTutorialTag>();
-}
-
-void erase_all_next_phase_tags(entt::registry& reg) {
-    auto& ctx = reg.ctx();
-    if (ctx.find<NextPhaseTitleTag>())        ctx.erase<NextPhaseTitleTag>();
-    if (ctx.find<NextPhaseLevelSelectTag>())  ctx.erase<NextPhaseLevelSelectTag>();
-    if (ctx.find<NextPhasePlayingTag>())      ctx.erase<NextPhasePlayingTag>();
-    if (ctx.find<NextPhasePausedTag>())       ctx.erase<NextPhasePausedTag>();
-    if (ctx.find<NextPhaseGameOverTag>())     ctx.erase<NextPhaseGameOverTag>();
-    if (ctx.find<NextPhaseSongCompleteTag>()) ctx.erase<NextPhaseSongCompleteTag>();
-    if (ctx.find<NextPhaseSettingsTag>())     ctx.erase<NextPhaseSettingsTag>();
-    if (ctx.find<NextPhaseTutorialTag>())     ctx.erase<NextPhaseTutorialTag>();
-}
 
 }  // namespace
+#endif
 
-void sync_game_phase_tags(entt::registry& reg, GamePhase phase) {
-    erase_all_game_phase_tags(reg);
-    auto& ctx = reg.ctx();
-    switch (phase) {
-        case GamePhase::Title:        ctx.emplace<GamePhaseTitleTag>();        break;
-        case GamePhase::LevelSelect:  ctx.emplace<GamePhaseLevelSelectTag>();  break;
-        case GamePhase::Playing:      ctx.emplace<GamePhasePlayingTag>();      break;
-        case GamePhase::Paused:       ctx.emplace<GamePhasePausedTag>();       break;
-        case GamePhase::GameOver:     ctx.emplace<GamePhaseGameOverTag>();     break;
-        case GamePhase::SongComplete: ctx.emplace<GamePhaseSongCompleteTag>(); break;
-        case GamePhase::Settings:     ctx.emplace<GamePhaseSettingsTag>();     break;
-        case GamePhase::Tutorial:     ctx.emplace<GamePhaseTutorialTag>();     break;
-    }
-}
-
-void sync_next_phase_tags(entt::registry& reg, GamePhase phase) {
-    erase_all_next_phase_tags(reg);
-    auto& ctx = reg.ctx();
-    switch (phase) {
-        case GamePhase::Title:        ctx.emplace<NextPhaseTitleTag>();        break;
-        case GamePhase::LevelSelect:  ctx.emplace<NextPhaseLevelSelectTag>();  break;
-        case GamePhase::Playing:      ctx.emplace<NextPhasePlayingTag>();      break;
-        case GamePhase::Paused:       ctx.emplace<NextPhasePausedTag>();       break;
-        case GamePhase::GameOver:     ctx.emplace<NextPhaseGameOverTag>();     break;
-        case GamePhase::SongComplete: ctx.emplace<NextPhaseSongCompleteTag>(); break;
-        case GamePhase::Settings:     ctx.emplace<NextPhaseSettingsTag>();     break;
-        case GamePhase::Tutorial:     ctx.emplace<NextPhaseTutorialTag>();     break;
-    }
-}
-
-void clear_next_phase_tags(entt::registry& reg) {
-    erase_all_next_phase_tags(reg);
-}
-
-void enter_phase(entt::registry& reg, GameState& gs, GamePhase next_phase) {
-    gs.phase = next_phase;
-    gs.phase_timer = 0.0f;
-    sync_game_phase_tags(reg, gs.phase);
+void notify_phase_changed(entt::registry& reg) {
 #if defined(__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)
     update_web_title(reg);
+#else
+    (void)reg;
 #endif
 }
+
+}  // namespace phase_transition_detail

--- a/app/systems/game_phase_transition.h
+++ b/app/systems/game_phase_transition.h
@@ -4,22 +4,108 @@
 
 #include "../components/game_state.h"
 
-void enter_phase(entt::registry& reg, GameState& gs, GamePhase next_phase);
+// ── Phase-transition API (issue #1202 PR G) ───────────────────────────────
+//
+// Per Fabian's existential processing, the former `GamePhase` enum is gone.
+// Each former enum value is now a zero-column ctx table:
+//   - `GamePhase*Tag`  : the active phase (exactly one present at any time).
+//   - `NextPhase*Tag`  : the pending-transition target (exactly zero outside
+//                       the dispatch block, exactly one between
+//                       `request_phase_transition<...>` and
+//                       `clear_next_phase_tags`).
+//
+// Public entry points dispatch on the tag type at the *call site* — there is
+// no runtime enum compare, no `switch`, no virtual dispatch. The compiler
+// instantiates one transform per tag the program actually uses, exactly
+// matching the "transform per row of the former enum table" mechanic.
+//
+// Direct callers of `enter_phase<...>` are restricted by the architectural
+// allow-list pinned by `tests/test_phase_transition_canonical.cpp`
+// (issue #482/#503): only `play_session.cpp`, `game_state_system.cpp`, and
+// `game_state_terminal_phase_system.cpp` may invoke it. UI and input
+// systems request transitions via `request_phase_transition<...>` and let
+// `game_state_system` perform the swap on the next tick (issue #482).
 
-// Erases all eight `GamePhase*Tag` ctx slots and emplaces the single tag
-// matching `phase`. Public so `reset_ctx_singleton<GameState>(reg, ...)`
-// callers (game_loop bootstrap, test setup) can prime the mirror at the
-// same moment they install the GameState ctx singleton. `enter_phase()`
-// invokes this internally on every transition.
-void sync_game_phase_tags(entt::registry& reg, GamePhase phase);
+namespace phase_transition_detail {
 
-// Pending-transition tag mirror (issue #1202 / PR C). `sync_next_phase_tags`
-// erases all eight `NextPhase*Tag` ctx slots and emplaces the single tag
-// matching `phase`; `clear_next_phase_tags` erases all eight. The pair is
-// called by `game_state_system`'s transition dispatch — sync at the top,
-// clear at the bottom — so each scheduled transition produces exactly one
-// pulse of "which phase was requested". This is the existential-processing
-// substrate for replacing the former `switch (gs.next_phase)` with per-tag
-// transforms (one if-block per phase).
-void sync_next_phase_tags(entt::registry& reg, GamePhase phase);
-void clear_next_phase_tags(entt::registry& reg);
+inline void erase_all_game_phase_tags(entt::registry& reg) {
+    auto& ctx = reg.ctx();
+    if (ctx.find<GamePhaseTitleTag>())        ctx.erase<GamePhaseTitleTag>();
+    if (ctx.find<GamePhaseLevelSelectTag>())  ctx.erase<GamePhaseLevelSelectTag>();
+    if (ctx.find<GamePhasePlayingTag>())      ctx.erase<GamePhasePlayingTag>();
+    if (ctx.find<GamePhasePausedTag>())       ctx.erase<GamePhasePausedTag>();
+    if (ctx.find<GamePhaseGameOverTag>())     ctx.erase<GamePhaseGameOverTag>();
+    if (ctx.find<GamePhaseSongCompleteTag>()) ctx.erase<GamePhaseSongCompleteTag>();
+    if (ctx.find<GamePhaseSettingsTag>())     ctx.erase<GamePhaseSettingsTag>();
+    if (ctx.find<GamePhaseTutorialTag>())     ctx.erase<GamePhaseTutorialTag>();
+}
+
+inline void erase_all_next_phase_tags(entt::registry& reg) {
+    auto& ctx = reg.ctx();
+    if (ctx.find<NextPhaseTitleTag>())        ctx.erase<NextPhaseTitleTag>();
+    if (ctx.find<NextPhaseLevelSelectTag>())  ctx.erase<NextPhaseLevelSelectTag>();
+    if (ctx.find<NextPhasePlayingTag>())      ctx.erase<NextPhasePlayingTag>();
+    if (ctx.find<NextPhasePausedTag>())       ctx.erase<NextPhasePausedTag>();
+    if (ctx.find<NextPhaseGameOverTag>())     ctx.erase<NextPhaseGameOverTag>();
+    if (ctx.find<NextPhaseSongCompleteTag>()) ctx.erase<NextPhaseSongCompleteTag>();
+    if (ctx.find<NextPhaseSettingsTag>())     ctx.erase<NextPhaseSettingsTag>();
+    if (ctx.find<NextPhaseTutorialTag>())     ctx.erase<NextPhaseTutorialTag>();
+}
+
+// WASM smoke-marker hook; defined in `game_phase_transition.cpp` so the
+// `<emscripten.h>` include stays out of the header. No-op on native builds.
+void notify_phase_changed(entt::registry& reg);
+
+}  // namespace phase_transition_detail
+
+// Erases all eight `GamePhase*Tag` ctx slots and emplaces `PhaseTag`. Use
+// when priming the mirror without resetting `phase_timer` (e.g. test setup
+// helpers that pin specific timer values). `enter_phase<...>()` calls this
+// internally on every transition.
+template <typename PhaseTag>
+inline void sync_game_phase_tags(entt::registry& reg) {
+    phase_transition_detail::erase_all_game_phase_tags(reg);
+    reg.ctx().emplace<PhaseTag>();
+}
+
+// Transitions the registry to the phase identified by `PhaseTag`: swaps the
+// active `GamePhase*Tag` ctx slot, resets `GameState::phase_timer`, and
+// fires the WASM smoke-marker title hook. Dispatch happens at the call site
+// via the template parameter — no runtime enum compare, no `switch`.
+template <typename PhaseTag>
+inline void enter_phase(entt::registry& reg) {
+    sync_game_phase_tags<PhaseTag>(reg);
+    reg.ctx().get<GameState>().phase_timer = 0.0f;
+    phase_transition_detail::notify_phase_changed(reg);
+}
+
+// Requests a phase transition: erases all `NextPhase*Tag` ctx slots and
+// emplaces `NextPhaseTag`. The next `game_state_system` tick reads the tag
+// presence and performs the swap (deferred-transition pattern per #482).
+template <typename NextPhaseTag>
+inline void request_phase_transition(entt::registry& reg) {
+    phase_transition_detail::erase_all_next_phase_tags(reg);
+    reg.ctx().emplace<NextPhaseTag>();
+}
+
+// Drains all eight `NextPhase*Tag` ctx slots. Called by
+// `game_state_system` at the bottom of the dispatch block so a stale
+// request cannot fire again next frame.
+inline void clear_next_phase_tags(entt::registry& reg) {
+    phase_transition_detail::erase_all_next_phase_tags(reg);
+}
+
+// True iff any `NextPhase*Tag` is present on `reg.ctx()` — i.e. a
+// `request_phase_transition<...>` is pending. Replaces the former
+// `GameState::transition_pending` boolean.
+inline bool is_phase_transition_pending(const entt::registry& reg) {
+    const auto& ctx = reg.ctx();
+    return ctx.contains<NextPhaseTitleTag>()
+        || ctx.contains<NextPhaseLevelSelectTag>()
+        || ctx.contains<NextPhasePlayingTag>()
+        || ctx.contains<NextPhasePausedTag>()
+        || ctx.contains<NextPhaseGameOverTag>()
+        || ctx.contains<NextPhaseSongCompleteTag>()
+        || ctx.contains<NextPhaseSettingsTag>()
+        || ctx.contains<NextPhaseTutorialTag>();
+}

--- a/app/systems/game_state_end_screen_system.cpp
+++ b/app/systems/game_state_end_screen_system.cpp
@@ -1,15 +1,16 @@
 #include "all_systems.h"
 #include "../components/game_state.h"
+#include "game_phase_transition.h"
 #include "../constants.h"
 
 namespace {
 
-// Per Fabian's existential processing (issue #1202/#1204, PR F): the former
-// `gs.phase == GamePhase::X` checks dispatch on tag presence in `reg.ctx()`.
-// `phase_timer` stays an enum-free scalar, so end_screen_input_ready takes
-// both — the tag from ctx and the timer from `GameState`. The tag mirror
-// invariant pinned by `tests/test_game_phase_tags.cpp` keeps the two in
-// lockstep until PR G deletes `GameState::phase` outright.
+// Per Fabian's existential processing (issue #1202/#1204, PR G): the former
+// `gs.phase == GamePhase::X` checks dispatch on tag presence in `reg.ctx()`;
+// the former `gs.transition_pending = true; gs.next_phase = X` pair is now
+// `request_phase_transition<NextPhase*Tag>()`. `phase_timer` is read directly
+// from `GameState` because the input-delay clock is per-phase data, not a
+// control-flow discriminator.
 bool end_screen_input_ready(entt::registry& reg, const GameState& gs) {
     const auto& ctx = reg.ctx();
     const bool game_over_ready =
@@ -35,8 +36,7 @@ void apply_end_choice_restart(entt::registry& reg) {
     if (!reg.ctx().find<EndChoiceRestart>()) return;
     auto& gs = reg.ctx().get<GameState>();
     if (!end_screen_input_ready(reg, gs)) return;
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::Playing;
+    request_phase_transition<NextPhasePlayingTag>(reg);
     erase_end_choice_tags(reg);
 }
 
@@ -44,8 +44,7 @@ void apply_end_choice_level_select(entt::registry& reg) {
     if (!reg.ctx().find<EndChoiceLevelSelect>()) return;
     auto& gs = reg.ctx().get<GameState>();
     if (!end_screen_input_ready(reg, gs)) return;
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::LevelSelect;
+    request_phase_transition<NextPhaseLevelSelectTag>(reg);
     erase_end_choice_tags(reg);
 }
 
@@ -53,8 +52,7 @@ void apply_end_choice_main_menu(entt::registry& reg) {
     if (!reg.ctx().find<EndChoiceMainMenu>()) return;
     auto& gs = reg.ctx().get<GameState>();
     if (!end_screen_input_ready(reg, gs)) return;
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::Title;
+    request_phase_transition<NextPhaseTitleTag>(reg);
     erase_end_choice_tags(reg);
 }
 

--- a/app/systems/game_state_routing.cpp
+++ b/app/systems/game_state_routing.cpp
@@ -1,5 +1,6 @@
 #include "input_routing.h"
 #include "../components/game_state.h"
+#include "game_phase_transition.h"
 #include "input.h"
 #include "input_events.h"
 #include "audio_events.h"
@@ -8,10 +9,12 @@
 #include "../constants.h"
 
 namespace {
-// Per Fabian's existential processing (issue #1202/#1204, PR F): the former
+// Per Fabian's existential processing (issue #1202/#1204, PR G): the former
 // `gs.phase == GamePhase::X` consumers dispatch on the per-phase ctx-tag
-// mirror. `phase_timer`, `transition_pending`, and `next_phase` stay on
-// `GameState` until PR G deletes the enum-typed field.
+// mirror; the former `gs.transition_pending = true; gs.next_phase = X` pair
+// is now `request_phase_transition<NextPhase*Tag>()` — presence of the tag
+// IS the pending request, and `game_state_system` swaps phases on the next
+// tick (deferred-transition pattern per #482).
 bool game_state_handle_end_screen_press(entt::registry& reg, const MenuPressEvent& evt) {
     auto& gs = reg.ctx().get<GameState>();
     auto& ctx = reg.ctx();
@@ -54,8 +57,7 @@ void game_state_handle_go(entt::registry& reg, const GoEvent& /*evt*/) {
     if (!reg.ctx().contains<GamePhasePausedTag>()) return;
     if (gs.phase_timer <= constants::UI_ENTRY_DEBOUNCE) return;
     // Deferred per #482 — let game_state_system perform the resume swap.
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::Playing;
+    request_phase_transition<NextPhasePlayingTag>(reg);
 }
 
 void game_state_handle_press_menu(entt::registry& reg, const MenuPressEvent& evt) {
@@ -71,8 +73,7 @@ void game_state_handle_press_menu(entt::registry& reg, const MenuPressEvent& evt
             ctx.get<InputState>().quit_requested = true;
 #endif
         } else if (evt.action == MenuActionKind::Confirm) {
-            gs.transition_pending = true;
-            gs.next_phase = GamePhase::LevelSelect;
+            request_phase_transition<NextPhaseLevelSelectTag>(reg);
         }
         return;
     }
@@ -90,16 +91,14 @@ void game_state_handle_press_menu(entt::registry& reg, const MenuPressEvent& evt
                 settings::mark_dirty_and_save(*persistence, *settings_state);
             }
         }
-        gs.transition_pending = true;
-        gs.next_phase = GamePhase::Playing;
+        request_phase_transition<NextPhasePlayingTag>(reg);
         return;
     }
 
     if (ctx.contains<GamePhasePausedTag>()) {
         if (gs.phase_timer <= constants::UI_ENTRY_DEBOUNCE) return;
         // Deferred per #482 — see game_state_handle_go above.
-        gs.transition_pending = true;
-        gs.next_phase = GamePhase::Playing;
+        request_phase_transition<NextPhasePlayingTag>(reg);
         return;
     }
 }

--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -95,24 +95,19 @@ void game_state_system(entt::registry& reg, float dt) {
     disp.update<MenuPressEvent>();
     disp.update<GoEvent>();
 
-    if (gs.transition_pending) {
-        gs.transition_pending = false;
-
+    if (is_phase_transition_pending(reg)) {
         // Clear any in-flight pointer capture when changing screens so
         // down/up state from the previous phase cannot leak into the next UI.
         // Owned by input_system because suppress_mouse_release lives in
         // InputSystemPrivate (issue #1196).
         input_system_clear_pointer_state(reg);
 
-        // Per Fabian's existential processing (issue #1202/#1204, PR C):
-        // each former `case GamePhase::X` is now its own per-tag transform.
-        // `sync_next_phase_tags` mirrors `gs.next_phase` into exactly one
-        // `NextPhase*Tag` ctx slot; the transforms below dispatch on tag
-        // presence; `clear_next_phase_tags` drains the mirror so a stale
-        // request cannot fire again next frame. The `gs.next_phase` field
-        // is retained during the staged migration; PR G deletes it along
-        // with the `GamePhase` enum itself.
-        sync_next_phase_tags(reg, gs.next_phase);
+        // Per Fabian's existential processing (issue #1202/#1204, PR G):
+        // each former `case GamePhase::X` is its own per-tag transform.
+        // `request_phase_transition<NextPhase*Tag>()` (called by UI / input /
+        // upstream systems) is the sole writer of the `NextPhase*Tag` mirror;
+        // the transforms below dispatch on tag presence; `clear_next_phase_tags`
+        // drains the mirror so a stale request cannot fire again next frame.
         auto& ctx = reg.ctx();
 
         if (ctx.contains<NextPhasePlayingTag>()) {
@@ -123,39 +118,39 @@ void game_state_system(entt::registry& reg, float dt) {
             // and input routing on the deferred (transition_pending) path.
             //
             // Resume-from-pause check reads the current-phase tag mirror
-            // (`GamePhasePausedTag`), not `gs.phase`, per Fabian's existential
-            // processing (issue #1202/#1204, PR F): consumers dispatch on
-            // tag presence, never on the enum value. `sync_next_phase_tags`
-            // above mutates only the `NextPhase*Tag` mirror, so the current
-            // phase tag still reflects the pre-transition phase here.
+            // (`GamePhasePausedTag`), per Fabian's existential processing
+            // (issue #1202/#1204): consumers dispatch on tag presence,
+            // never on an enum value. `request_phase_transition` mutates
+            // only the `NextPhase*Tag` mirror, so the current phase tag
+            // still reflects the pre-transition phase here.
             if (ctx.contains<GamePhasePausedTag>()) {
-                enter_phase(reg, gs, GamePhase::Playing);
+                enter_phase<GamePhasePlayingTag>(reg);
             } else {
                 setup_play_session(reg);
             }
         }
         if (ctx.contains<NextPhaseGameOverTag>()) {
-            game_state_enter_terminal_phase(reg, GamePhase::GameOver);
+            game_state_enter_terminal_phase_game_over(reg);
         }
         if (ctx.contains<NextPhaseSongCompleteTag>()) {
-            game_state_enter_terminal_phase(reg, GamePhase::SongComplete);
+            game_state_enter_terminal_phase_song_complete(reg);
         }
         if (ctx.contains<NextPhasePausedTag>()) {
-            enter_phase(reg, gs, GamePhase::Paused);
+            enter_phase<GamePhasePausedTag>(reg);
         }
         if (ctx.contains<NextPhaseTitleTag>()) {
-            enter_phase(reg, gs, GamePhase::Title);
+            enter_phase<GamePhaseTitleTag>(reg);
         }
         if (ctx.contains<NextPhaseLevelSelectTag>()) {
-            enter_phase(reg, gs, GamePhase::LevelSelect);
+            enter_phase<GamePhaseLevelSelectTag>(reg);
             auto& lss = reg.ctx().get<LevelSelectState>();
             lss.confirmed = false;
         }
         if (ctx.contains<NextPhaseSettingsTag>()) {
-            enter_phase(reg, gs, GamePhase::Settings);
+            enter_phase<GamePhaseSettingsTag>(reg);
         }
         if (ctx.contains<NextPhaseTutorialTag>()) {
-            enter_phase(reg, gs, GamePhase::Tutorial);
+            enter_phase<GamePhaseTutorialTag>(reg);
         }
 
         clear_next_phase_tags(reg);
@@ -174,10 +169,11 @@ void game_state_system(entt::registry& reg, float dt) {
         if (lss.confirmed) {
             lss.confirmed = false;
             const auto* settings_ptr = find_settings_state(reg);
-            gs.transition_pending = true;
-            gs.next_phase = settings_ptr && !settings::ftue_complete(*settings_ptr)
-                ? GamePhase::Tutorial
-                : GamePhase::Playing;
+            if (settings_ptr && !settings::ftue_complete(*settings_ptr)) {
+                request_phase_transition<NextPhaseTutorialTag>(reg);
+            } else {
+                request_phase_transition<NextPhasePlayingTag>(reg);
+            }
         }
     }
 
@@ -190,16 +186,14 @@ void game_state_system(entt::registry& reg, float dt) {
         auto* song = reg.ctx().find<SongState>();
         if (energy && energy->energy <= 0.0f) {
             reg.ctx().insert_or_assign(EnergyDepletedDeath{});
-            gs.transition_pending = true;
-            gs.next_phase = GamePhase::GameOver;
+            request_phase_transition<NextPhaseGameOverTag>(reg);
             return;
         }
 
         if (song && song->finished) {
             // Wait until all obstacle entities have been destroyed.
             if (reg.view<ObstacleTag>().empty()) {
-                gs.transition_pending = true;
-                gs.next_phase = GamePhase::SongComplete;
+                request_phase_transition<NextPhaseSongCompleteTag>(reg);
             }
         }
     }

--- a/app/systems/game_state_terminal_phase_system.cpp
+++ b/app/systems/game_state_terminal_phase_system.cpp
@@ -58,14 +58,21 @@ bool update_and_persist_high_score(entt::registry& reg) {
     return recorded_new_high_score;
 }
 
-void emit_terminal_feedback(entt::registry& reg, GamePhase phase, bool is_new_high_score) {
+void emit_terminal_feedback_game_over(entt::registry& reg, bool is_new_high_score) {
     auto* disp = reg.ctx().find<entt::dispatcher>();
     if (!disp) return;
 
-    if (phase == GamePhase::GameOver) {
-        disp->enqueue<PlaySfxEvent>({SFX::Crash});
-        disp->enqueue<PlayHapticEvent>({HapticEvent::DeathCrash});
+    disp->enqueue<PlaySfxEvent>({SFX::Crash});
+    disp->enqueue<PlayHapticEvent>({HapticEvent::DeathCrash});
+    if (is_new_high_score) {
+        disp->enqueue<PlayHapticEvent>({HapticEvent::NewHighScore});
     }
+}
+
+void emit_terminal_feedback_song_complete(entt::registry& reg, bool is_new_high_score) {
+    auto* disp = reg.ctx().find<entt::dispatcher>();
+    if (!disp) return;
+
     if (is_new_high_score) {
         disp->enqueue<PlayHapticEvent>({HapticEvent::NewHighScore});
     }
@@ -73,17 +80,21 @@ void emit_terminal_feedback(entt::registry& reg, GamePhase phase, bool is_new_hi
 
 }  // namespace
 
-void game_state_enter_terminal_phase(entt::registry& reg, GamePhase phase) {
+void game_state_enter_terminal_phase_game_over(entt::registry& reg) {
     const bool is_new_high_score = update_and_persist_high_score(reg);
-    emit_terminal_feedback(reg, phase, is_new_high_score);
+    emit_terminal_feedback_game_over(reg, is_new_high_score);
 
-    auto& gs = reg.ctx().get<GameState>();
-    enter_phase(reg, gs, phase);
-
-    if (phase != GamePhase::GameOver) return;
+    enter_phase<GamePhaseGameOverTag>(reg);
 
     if (auto* song = reg.ctx().find<SongState>()) {
         song->finished = true;
         song->playing = false;
     }
+}
+
+void game_state_enter_terminal_phase_song_complete(entt::registry& reg) {
+    const bool is_new_high_score = update_and_persist_high_score(reg);
+    emit_terminal_feedback_song_complete(reg, is_new_high_score);
+
+    enter_phase<GamePhaseSongCompleteTag>(reg);
 }

--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -1,5 +1,6 @@
 #include "all_systems.h"
 #include "camera_system.h"
+#include "game_phase_transition.h"
 #include "input_system_private.h"
 #include "web_input_policy.h"
 #include "input.h"
@@ -425,9 +426,7 @@ void input_system(entt::registry& reg, float raw_dt) {
         bool focused = IsWindowFocused();
         if (priv.was_focused && !focused &&
             reg.ctx().contains<GamePhasePlayingTag>()) {
-            auto& gs = reg.ctx().get<GameState>();
-            gs.transition_pending = true;
-            gs.next_phase = GamePhase::Paused;
+            request_phase_transition<NextPhasePausedTag>(reg);
         }
         priv.was_focused = focused;
     }

--- a/app/systems/play_session.cpp
+++ b/app/systems/play_session.cpp
@@ -175,8 +175,7 @@ void setup_play_session(entt::registry& reg) {
         erase_ctx_if_exists<EndChoiceLevelSelect>(reg);
         erase_ctx_if_exists<EndChoiceMainMenu>(reg);
         lss.confirmed = false;
-        auto& gs = reg.ctx().get<GameState>();
-        enter_phase(reg, gs, GamePhase::LevelSelect);
+        enter_phase<GamePhaseLevelSelectTag>(reg);
         return;
     }
     runtime_system_scratch_init(reg);
@@ -264,6 +263,5 @@ void setup_play_session(entt::registry& reg) {
 
     spawn_session_player(reg);
     // Transition game state
-    auto& gs = reg.ctx().get<GameState>();
-    enter_phase(reg, gs, GamePhase::Playing);
+    enter_phase<GamePhasePlayingTag>(reg);
 }

--- a/app/systems/player_input_system.cpp
+++ b/app/systems/player_input_system.cpp
@@ -1,5 +1,6 @@
 #include "all_systems.h"
 #include "../components/game_state.h"
+#include "game_phase_transition.h"
 #include "../components/player.h"
 #include "../components/rendering.h"
 #include "input_events.h"
@@ -14,12 +15,10 @@
 namespace {
 
 bool gameplay_input_enabled(entt::registry& reg) {
-    // Per Fabian's existential processing (issue #1202/#1204, PR F): dispatch
-    // on the per-phase ctx-tag mirror rather than `gs.phase`. The
-    // `transition_pending` scalar stays on `GameState` until PR G deletes the
-    // enum-typed field.
-    const auto& gs = reg.ctx().get<GameState>();
-    return reg.ctx().contains<GamePhasePlayingTag>() && !gs.transition_pending;
+    // Per Fabian's existential processing (issue #1202/#1204): dispatch on the
+    // per-phase ctx-tag mirror; the pending-transition signal is the presence
+    // of any `NextPhase*Tag` on `reg.ctx()` (`is_phase_transition_pending`).
+    return reg.ctx().contains<GamePhasePlayingTag>() && !is_phase_transition_pending(reg);
 }
 
 void push_haptic(entt::registry& reg, HapticEvent event) {

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -205,7 +205,7 @@ void test_player_system(entt::registry& reg, float dt) {
 
     // Per Fabian's existential processing (issue #1202/#1204, PR F): each
     // former `gs.phase == GamePhase::X` branch dispatches on the per-phase
-    // ctx-tag mirror seeded by `enter_phase()` / `sync_game_phase_tags()`.
+    // ctx-tag mirror seeded by `enter_phase<...>()`.
     // `phase_timer` stays a scalar on `GameState` until PR G deletes the
     // enum-typed field.
     const bool title_phase         = ctx.contains<GamePhaseTitleTag>();

--- a/app/systems/ui_render_system.cpp
+++ b/app/systems/ui_render_system.cpp
@@ -94,7 +94,7 @@ void ui_render_system(entt::registry& reg, float /*alpha*/) {
     //
     // Per Fabian's existential processing (issue #1202/#1204, PR D): each
     // former `case GamePhase::X` is its own per-tag transform on the ctx-tag
-    // mirror seeded by `sync_game_phase_tags()` / `enter_phase()`. The mirror
+    // mirror seeded by `enter_phase<...>()`. The mirror
     // invariant pinned by `tests/test_game_phase_tags.cpp` guarantees that
     // exactly one `GamePhase*Tag` is present at any time, so these eight
     // `if` blocks are mutually exclusive even without `else` chaining and

--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
@@ -2,6 +2,7 @@
 
 #include "../../components/game_state.h"
 #include "../../components/energy_bar.h"
+#include "../../systems/game_phase_transition.h"
 #include "../../systems/input.h"
 #include "../../systems/input_events.h"
 #include "../../components/obstacle.h"
@@ -399,9 +400,7 @@ void gameplay_hud_apply_button_presses(entt::registry& reg,
     }
 
     if (pause_pressed) {
-        auto& gs = reg.ctx().get<GameState>();
-        gs.transition_pending = true;
-        gs.next_phase = GamePhase::Paused;
+        request_phase_transition<NextPhasePausedTag>(reg);
     }
 }
 

--- a/app/ui/screen_controllers/paused_screen_controller.cpp
+++ b/app/ui/screen_controllers/paused_screen_controller.cpp
@@ -1,6 +1,7 @@
 // Paused screen controller - renders raygui layout and dispatches resume/menu actions.
 
 #include "../../components/game_state.h"
+#include "../../systems/game_phase_transition.h"
 #include "../../systems/input.h"
 #include "../../constants.h"
 #include "screen_controller_base.h"
@@ -31,12 +32,10 @@ void render_paused_screen_ui(entt::registry& reg) {
     if (controller.state().ResumeButtonPressed) {
         // Deferred per #482 — the canonical state-machine swap (game_state_system)
         // routes Paused→Playing as a resume that preserves session state.
-        gs.transition_pending = true;
-        gs.next_phase = GamePhase::Playing;
+        request_phase_transition<NextPhasePlayingTag>(reg);
     }
 
     if (controller.state().MenuButtonPressed) {
-        gs.transition_pending = true;
-        gs.next_phase = GamePhase::Title;
+        request_phase_transition<NextPhaseTitleTag>(reg);
     }
 }

--- a/app/ui/screen_controllers/settings_screen_controller.cpp
+++ b/app/ui/screen_controllers/settings_screen_controller.cpp
@@ -2,6 +2,7 @@
 // and dispatches settings mutations and back-navigation to game state.
 
 #include "../../components/game_state.h"
+#include "../../systems/game_phase_transition.h"
 #include "../../entities/settings.h"
 #include "../../systems/haptics_backend.h"
 #include "screen_controller_base.h"
@@ -27,7 +28,6 @@ void init_settings_screen_ui() {
 void render_settings_screen_ui(entt::registry& reg) {
     auto& controller = screen_controller<SettingsController>(reg);
     auto* st = find_settings_state(reg);
-    auto& gs = reg.ctx().get<GameState>();
 
     // Static controls: heading, audio offset label, +/- buttons, back button
     controller.render();
@@ -99,8 +99,7 @@ void render_settings_screen_ui(entt::registry& reg) {
     // Dispatch actions
     const bool close_pressed = controller.state().CloseButtonPressed;
     if (!st && close_pressed) {
-        gs.transition_pending = true;
-        gs.next_phase = GamePhase::Title;
+        request_phase_transition<NextPhaseTitleTag>(reg);
         return;
     }
     if (!st) return;
@@ -139,7 +138,6 @@ void render_settings_screen_ui(entt::registry& reg) {
     }
 
     if (close_pressed) {
-        gs.transition_pending = true;
-        gs.next_phase = GamePhase::Title;
+        request_phase_transition<NextPhaseTitleTag>(reg);
     }
 }

--- a/app/ui/screen_controllers/title_screen_controller.cpp
+++ b/app/ui/screen_controllers/title_screen_controller.cpp
@@ -1,6 +1,7 @@
 // Title screen controller - bridges generated rguilayout output to game systems.
 
 #include "../../components/game_state.h"
+#include "../../systems/game_phase_transition.h"
 #include "../../systems/input.h"
 #include "screen_controller_base.h"
 #include <raygui.h>
@@ -58,14 +59,10 @@ void render_title_screen_ui(entt::registry& reg) {
 #endif
 
     if (state.SettingsButtonPressed) {
-        auto& gs = reg.ctx().get<GameState>();
-        gs.transition_pending = true;
-        gs.next_phase = GamePhase::Settings;
+        request_phase_transition<NextPhaseSettingsTag>(reg);
     }
 
     if (is_start_tap(reg, state)) {
-        auto& gs = reg.ctx().get<GameState>();
-        gs.transition_pending = true;
-        gs.next_phase = GamePhase::LevelSelect;
+        request_phase_transition<NextPhaseLevelSelectTag>(reg);
     }
 }

--- a/app/ui/screen_controllers/tutorial_screen_controller.cpp
+++ b/app/ui/screen_controllers/tutorial_screen_controller.cpp
@@ -1,6 +1,7 @@
 // Tutorial screen controller - renders raygui layout and dispatches start action.
 
 #include "../../components/game_state.h"
+#include "../../systems/game_phase_transition.h"
 #include "../../systems/input.h"
 #include "../../constants.h"
 #include "../../entities/settings.h"
@@ -60,9 +61,7 @@ void tutorial_screen_continue(entt::registry& reg) {
         }
     }
 
-    auto& gs = reg.ctx().get<GameState>();
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::Playing;
+    request_phase_transition<NextPhasePlayingTag>(reg);
 }
 
 void render_tutorial_screen_ui(entt::registry& reg) {

--- a/benchmarks/bench_systems.cpp
+++ b/benchmarks/bench_systems.cpp
@@ -16,6 +16,7 @@
 #include "systems/audio_routing.h"
 #include "constants.h"
 #include "systems/all_systems.h"
+#include "systems/game_phase_transition.h"
 #include "systems/input_routing.h"
 #include "util/shape_tag.h"
 
@@ -27,9 +28,8 @@ static entt::registry make_bench_registry() {
     reg.ctx().emplace<entt::dispatcher>();
     wire_input_dispatcher(reg);
     wire_audio_haptic_dispatcher(reg);
-    reg.ctx().emplace<GameState>(GameState{
-        GamePhase::Playing, 0.0f, false, GamePhase::Playing
-    });
+    reg.ctx().emplace<GameState>(GameState{ 0.0f });
+    sync_game_phase_tags<GamePhasePlayingTag>(reg);
     reg.ctx().emplace<ScoreState>();
     reg.ctx().emplace<SongState>();
     runtime_system_scratch_init(reg);
@@ -127,7 +127,7 @@ TEST_CASE("Bench: collision_system", "[!benchmark][bench]") {
         set_required_shape_tag(reg, obs, Shape::Circle);
         meter.measure([&] {
             if (reg.all_of<ScoredTag>(obs)) reg.remove<ScoredTag>(obs);
-            reg.ctx().get<GameState>().transition_pending = false;
+            clear_next_phase_tags(reg);
             collision_system(reg, DT);
         });
     };
@@ -136,7 +136,7 @@ TEST_CASE("Bench: collision_system", "[!benchmark][bench]") {
         make_bench_player(reg);
         spawn_obstacles(reg, 10);
         meter.measure([&] {
-            reg.ctx().get<GameState>().transition_pending = false;
+            clear_next_phase_tags(reg);
             collision_system(reg, DT);
         });
     };

--- a/tests/test_beat_log_system.cpp
+++ b/tests/test_beat_log_system.cpp
@@ -63,7 +63,7 @@ TEST_CASE("beat_log: no-op when log file is null", "[beat_log]") {
 
 TEST_CASE("beat_log: no-op when not in Playing phase", "[beat_log]") {
     auto reg = make_rhythm_registry();
-    set_test_phase(reg, GamePhase::Title);
+    set_test_phase<GamePhaseTitleTag>(reg);
     auto& song = reg.ctx().get<SongState>();
     song.current_beat = 2;
 

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -9,7 +9,7 @@
 
 TEST_CASE("beat_scheduler: no spawn when not Playing", "[beat_scheduler]") {
     auto reg = make_rhythm_registry();
-    set_test_phase(reg, GamePhase::Title);
+    set_test_phase<GamePhaseTitleTag>(reg);
 
     auto& map = beat_map(reg);
     map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});

--- a/tests/test_collision_extended.cpp
+++ b/tests/test_collision_extended.cpp
@@ -62,8 +62,7 @@ TEST_CASE("collision: Hexagon shape never matches shape gate", "[collision]") {
     scoring_system(reg, 0.016f);
     energy_system(reg, 0.016f);
 
-    auto& gs = reg.ctx().get<GameState>();
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
     auto& energy = reg.ctx().get<EnergyState>();
     CHECK(energy.energy < 1.0f);
     CHECK(energy.flash_timer > 0.0f);
@@ -91,8 +90,7 @@ TEST_CASE("collision: Hexagon fails even when matching gate shape", "[collision]
     energy_system(reg, 0.016f);
 
     // Hexagon should NEVER clear shape gates
-    auto& gs = reg.ctx().get<GameState>();
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
     auto& energy = reg.ctx().get<EnergyState>();
     CHECK(energy.energy < 1.0f);
     CHECK(energy.flash_timer > 0.0f);
@@ -384,9 +382,8 @@ TEST_CASE("collision: multiple misses accumulate in miss_count", "[collision][rh
     energy_system(reg, 0.016f);
 
     // Reset game over for second collision
-    auto& gs = reg.ctx().get<GameState>();
-    gs.transition_pending = false;
-    set_test_phase(reg, GamePhase::Playing);
+    clear_next_phase_tags(reg);
+    set_test_phase<GamePhasePlayingTag>(reg);
 
     // Second miss
     make_shape_gate(reg, Shape::Triangle, constants::PLAYER_Y);

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -11,7 +11,7 @@ TEST_CASE("collision: shape gate cleared with matching shape", "[collision]") {
     collision_system(reg, 0.016f);
 
     CHECK(reg.all_of<ScoredTag>(obs));
-    CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("collision: shape gate drains energy with wrong shape", "[collision]") {
@@ -26,8 +26,7 @@ TEST_CASE("collision: shape gate drains energy with wrong shape", "[collision]")
     scoring_system(reg, 0.016f);
     energy_system(reg, 0.016f);
 
-    auto& gs = reg.ctx().get<GameState>();
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
     auto& energy = reg.ctx().get<EnergyState>();
     CHECK(energy.energy < 1.0f);
     CHECK(energy.flash_timer > 0.0f);
@@ -135,7 +134,7 @@ TEST_CASE("collision: obstacle too far away is ignored", "[collision]") {
 
     collision_system(reg, 0.016f);
 
-    CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("collision: beat line is collision point",
@@ -165,7 +164,7 @@ TEST_CASE("collision: already scored obstacles are skipped", "[collision]") {
 
     collision_system(reg, 0.016f);
 
-    CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("collision: resolved hit obstacle is not re-tagged after scoring cleanup",
@@ -214,7 +213,7 @@ TEST_CASE("collision: split path cleared with matching shape and lane", "[collis
     collision_system(reg, 0.016f);
 
     CHECK(reg.all_of<ScoredTag>(obs));
-    CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("collision: split path fails with wrong shape", "[collision]") {
@@ -227,7 +226,7 @@ TEST_CASE("collision: split path fails with wrong shape", "[collision]") {
     scoring_system(reg, 0.016f);
     energy_system(reg, 0.016f);
 
-    CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
     auto& energy = reg.ctx().get<EnergyState>();
     CHECK(energy.energy < 1.0f);
     CHECK(energy.flash_timer > 0.0f);
@@ -243,7 +242,7 @@ TEST_CASE("collision: split path fails with wrong lane", "[collision]") {
     scoring_system(reg, 0.016f);
     energy_system(reg, 0.016f);
 
-    CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
     auto& energy = reg.ctx().get<EnergyState>();
     CHECK(energy.energy < 1.0f);
     CHECK(energy.flash_timer > 0.0f);
@@ -256,18 +255,18 @@ TEST_CASE("collision: no player means no collision processing", "[collision]") {
 
     collision_system(reg, 0.016f);
 
-    CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("collision: not in Playing phase skips processing", "[collision]") {
     auto reg = make_registry();
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
     make_player(reg);
     make_shape_gate(reg, Shape::Triangle, constants::PLAYER_Y);
 
     collision_system(reg, 0.016f);
 
-    CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -3,6 +3,7 @@
 #include "test_helpers.h"
 #include "components/audio.h"
 #include "systems/audio_events.h"
+#include "systems/game_phase_transition.h"
 #include "entities/obstacle_entity.h"
 #include "entities/obstacle_render_entity.h"
 
@@ -109,9 +110,12 @@ TEST_CASE("components: CurrentSongHighScore defaults to zero", "[components]") {
 }
 
 TEST_CASE("components: GameState defaults to title", "[components]") {
-    GameState gs{};
-    CHECK(gs.phase == GamePhase::Title);
-    CHECK_FALSE(gs.transition_pending);
+    entt::registry reg;
+    auto& gs = reg.ctx().emplace<GameState>();
+    sync_game_phase_tags<GamePhaseTitleTag>(reg);
+    CHECK(gs.phase_timer == 0.0f);
+    CHECK(reg.ctx().contains<GamePhaseTitleTag>());
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("ecs: make_registry creates all singletons", "[ecs]") {
@@ -145,7 +149,7 @@ TEST_CASE("ecs: make_registry dispatcher is wired — GoEvent listeners register
     auto reg = make_registry();
 
     // Promote to Playing so player_input_handle_go has observable effect.
-    set_test_phase(reg, GamePhase::Playing);
+    set_test_phase<GamePhasePlayingTag>(reg);
     auto player = make_player(reg);
     auto& lane  = reg.get<Lane>(player);
 

--- a/tests/test_death_model_unified.cpp
+++ b/tests/test_death_model_unified.cpp
@@ -24,9 +24,9 @@ TEST_CASE("death_model: one miss drains energy without immediate GameOver", "[de
                Catch::Matchers::WithinAbs(constants::ENERGY_MAX - constants::ENERGY_DRAIN_MISS,
                                             0.0001f));
     CHECK(energy.flash_timer > 0.0f);
-    CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 
-    CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("death_model: GameOver is requested when energy depletes", "[death_model]") {
@@ -52,7 +52,7 @@ TEST_CASE("death_model: GameOver is requested when energy depletes", "[death_mod
                Catch::Matchers::WithinAbs(
                    constants::ENERGY_MAX - static_cast<float>(SAFE_MISS_COUNT) * constants::ENERGY_DRAIN_MISS,
                    0.0001f));
-    CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 
     make_shape_gate(reg, Shape::Triangle, constants::PLAYER_Y);
     collision_system(reg, 0.016f);
@@ -60,13 +60,12 @@ TEST_CASE("death_model: GameOver is requested when energy depletes", "[death_mod
     energy_system(reg, 0.016f);
 
     CHECK(energy.energy == 0.0f);
-    CHECK(reg.ctx().get<GameState>().transition_pending);
-    CHECK(reg.ctx().get<GameState>().next_phase == GamePhase::GameOver);
+    CHECK(is_phase_transition_pending(reg));
+    CHECK(reg.ctx().contains<NextPhaseGameOverTag>());
 
     game_state_system(reg, 0.016f);
 
-    const auto& state = reg.ctx().get<GameState>();
-    CHECK(state.phase == GamePhase::GameOver);
+    CHECK(reg.ctx().contains<GamePhaseGameOverTag>());
     CHECK_FALSE(reg.ctx().get<SongState>().playing);
 }
 
@@ -95,7 +94,7 @@ TEST_CASE("death_model: timing recovery can preserve survival margin", "[death_m
                Catch::Matchers::WithinAbs(0.15f + constants::ENERGY_RECOVER_PERFECT -
                                                constants::ENERGY_DRAIN_MISS,
                                            0.0001f));
-    CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("death_model: close hit banks points without instant GameOver", "[death_model]") {
@@ -115,7 +114,7 @@ TEST_CASE("death_model: close hit banks points without instant GameOver", "[deat
 
     CHECK(reg.all_of<ScoredTag>(obstacle));
     CHECK(reg.ctx().get<EnergyState>().energy == constants::ENERGY_MAX);
-    CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("death_model: close miss drains energy instead of instant GameOver", "[death_model]") {
@@ -139,7 +138,7 @@ TEST_CASE("death_model: close miss drains energy instead of instant GameOver", "
     CHECK_THAT(reg.ctx().get<EnergyState>().energy,
                Catch::Matchers::WithinAbs(constants::ENERGY_MAX - constants::ENERGY_DRAIN_MISS,
                                            0.0001f));
-    CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("death_model: collision clamps depleted energy and requests GameOver", "[death_model]") {
@@ -155,11 +154,11 @@ TEST_CASE("death_model: collision clamps depleted energy and requests GameOver",
     energy_system(reg, 0.016f);
 
     CHECK(energy.energy == 0.0f);
-    CHECK(reg.ctx().get<GameState>().transition_pending);
-    CHECK(reg.ctx().get<GameState>().next_phase == GamePhase::GameOver);
+    CHECK(is_phase_transition_pending(reg));
+    CHECK(reg.ctx().contains<NextPhaseGameOverTag>());
 
     game_state_system(reg, 0.016f);
-    CHECK(reg.ctx().get<GameState>().phase == GamePhase::GameOver);
+    CHECK(reg.ctx().contains<GamePhaseGameOverTag>());
 }
 
 TEST_CASE("death_model: scroll-past miss drains energy and requests GameOver", "[death_model]") {
@@ -180,18 +179,18 @@ TEST_CASE("death_model: scroll-past miss drains energy and requests GameOver", "
     CHECK(reg.all_of<MissTag>(obstacle));
     CHECK(reg.all_of<ScoredTag>(obstacle));
     // Energy not yet drained — scoring_system hasn't run.
-    CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 
     scoring_system(reg, 0.016f);
     energy_system(reg, 0.016f);
 
     CHECK(energy.energy == 0.0f);
     CHECK(reg.ctx().get<SongResults>().miss_count == 1);
-    CHECK(reg.ctx().get<GameState>().transition_pending);
-    CHECK(reg.ctx().get<GameState>().next_phase == GamePhase::GameOver);
+    CHECK(is_phase_transition_pending(reg));
+    CHECK(reg.ctx().contains<NextPhaseGameOverTag>());
 
     game_state_system(reg, 0.016f);
-    CHECK(reg.ctx().get<GameState>().phase == GamePhase::GameOver);
+    CHECK(reg.ctx().contains<GamePhaseGameOverTag>());
 }
 
 // Regression: a scroll-past miss that depletes energy to 0 triggers GameOver
@@ -212,11 +211,11 @@ TEST_CASE("death_model: scroll-past fatal miss triggers GameOver same frame", "[
     energy_system(reg, 0.016f);
 
     CHECK(energy.energy == 0.0f);
-    CHECK(reg.ctx().get<GameState>().transition_pending);
-    CHECK(reg.ctx().get<GameState>().next_phase == GamePhase::GameOver);
+    CHECK(is_phase_transition_pending(reg));
+    CHECK(reg.ctx().contains<NextPhaseGameOverTag>());
 
     game_state_system(reg, 0.016f);
-    CHECK(reg.ctx().get<GameState>().phase == GamePhase::GameOver);
+    CHECK(reg.ctx().contains<GamePhaseGameOverTag>());
 }
 
 // Regression: a scroll-past miss must not double-drain (energy delta = exactly

--- a/tests/test_energy_system.cpp
+++ b/tests/test_energy_system.cpp
@@ -7,14 +7,13 @@
 
 TEST_CASE("energy: no action when not in Playing phase", "[energy]") {
     auto reg = make_rhythm_registry();
-    set_test_phase(reg, GamePhase::Title);
+    set_test_phase<GamePhaseTitleTag>(reg);
     auto& energy = reg.ctx().get<EnergyState>();
     energy.energy = 0.0f;
 
     energy_system(reg, 0.016f);
 
-    auto& gs = reg.ctx().get<GameState>();
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("energy: no action when energy is positive", "[energy]") {
@@ -24,8 +23,7 @@ TEST_CASE("energy: no action when energy is positive", "[energy]") {
 
     energy_system(reg, 0.016f);
 
-    auto& gs = reg.ctx().get<GameState>();
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
     CHECK(reg.ctx().get<SongState>().playing);
 }
 
@@ -103,9 +101,7 @@ TEST_CASE("energy: game_state triggers game over when energy reaches zero", "[en
 
     game_state_system(reg, 0.016f);
 
-    auto& gs = reg.ctx().get<GameState>();
-    CHECK(gs.transition_pending);
-    CHECK(gs.next_phase == GamePhase::GameOver);
+    CHECK(reg.ctx().contains<NextPhaseGameOverTag>());
     CHECK(reg.ctx().find<EnergyDepletedDeath>() != nullptr);
 }
 
@@ -113,16 +109,13 @@ TEST_CASE("energy: no action when SongState not present", "[energy]") {
     entt::registry bare_reg;
     bare_reg.ctx().emplace<InputState>();
     
-    bare_reg.ctx().emplace<GameState>(GameState{
-        GamePhase::Playing, 0.0f, false, GamePhase::Playing
-    });
+    bare_reg.ctx().emplace<GameState>(GameState{ 0.0f });
     bare_reg.ctx().emplace<EnergyState>(EnergyState{0.0f, 0.0f, 0.0f});
     runtime_system_scratch_init(bare_reg);
 
     energy_system(bare_reg, 0.016f);
 
-    auto& gs = bare_reg.ctx().get<GameState>();
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(bare_reg));
 }
 
 TEST_CASE("energy: depleted energy requests game over when song is not playing", "[energy][issue961]") {
@@ -133,9 +126,7 @@ TEST_CASE("energy: depleted energy requests game over when song is not playing",
 
     energy_system(reg, 0.016f);
 
-    auto& gs = reg.ctx().get<GameState>();
-    CHECK(gs.transition_pending);
-    CHECK(gs.next_phase == GamePhase::GameOver);
+    CHECK(reg.ctx().contains<NextPhaseGameOverTag>());
     CHECK(reg.ctx().find<EnergyDepletedDeath>() != nullptr);
 }
 
@@ -143,16 +134,13 @@ TEST_CASE("energy: no action when EnergyState not present", "[energy]") {
     entt::registry bare_reg;
     bare_reg.ctx().emplace<InputState>();
     
-    bare_reg.ctx().emplace<GameState>(GameState{
-        GamePhase::Playing, 0.0f, false, GamePhase::Playing
-    });
+    bare_reg.ctx().emplace<GameState>(GameState{ 0.0f });
     auto& song = bare_reg.ctx().emplace<SongState>();
     song.playing = true;
 
     energy_system(bare_reg, 0.016f);
 
-    auto& gs = bare_reg.ctx().get<GameState>();
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(bare_reg));
 }
 
 TEST_CASE("energy: small positive energy does not trigger game over", "[energy]") {
@@ -162,8 +150,7 @@ TEST_CASE("energy: small positive energy does not trigger game over", "[energy]"
 
     game_state_system(reg, 0.016f);
 
-    auto& gs = reg.ctx().get<GameState>();
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
     CHECK(reg.ctx().get<SongState>().playing);
 }
 
@@ -193,9 +180,7 @@ TEST_CASE("energy: flash timer decrements", "[energy]") {
 
 TEST_CASE("energy: enter_game_over owns song stop", "[energy][gamestate]") {
     auto reg = make_rhythm_registry();
-    auto& gs = reg.ctx().get<GameState>();
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::GameOver;
+    request_phase_transition<NextPhaseGameOverTag>(reg);
 
     game_state_system(reg, 0.016f);
 

--- a/tests/test_entt_dispatcher_contract.cpp
+++ b/tests/test_entt_dispatcher_contract.cpp
@@ -204,7 +204,7 @@ TEST_CASE("R7: GoEvent delivered in GameOver phase — player_input_handle_go no
     auto& lane  = reg.get<Lane>(player);
     auto& disp  = reg.ctx().get<entt::dispatcher>();
 
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
 
     disp.enqueue(GoEvent{Direction::Right});
     disp.update<GoEvent>();
@@ -218,17 +218,16 @@ TEST_CASE("R7: drain-first order — GoEvent processed in pre-transition phase, 
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& lane = reg.get<Lane>(player);
-    auto& gs   = reg.ctx().get<GameState>();
     auto& disp = reg.ctx().get<entt::dispatcher>();
 
-    REQUIRE(gs.phase == GamePhase::Playing);
+    REQUIRE(reg.ctx().contains<GamePhasePlayingTag>());
 
     disp.enqueue(GoEvent{Direction::Right});
 
     disp.update<GoEvent>();
     CHECK(lane.target == 2);
 
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
 
     disp.update<GoEvent>();
     CHECK(lane.target == 2);
@@ -239,17 +238,16 @@ TEST_CASE("R7: two-tick stale-event regression — GoEvent from tick N absent in
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& lane = reg.get<Lane>(player);
-    auto& gs   = reg.ctx().get<GameState>();
     auto& disp = reg.ctx().get<entt::dispatcher>();
 
-    REQUIRE(gs.phase == GamePhase::Playing);
+    REQUIRE(reg.ctx().contains<GamePhasePlayingTag>());
     disp.enqueue(GoEvent{Direction::Right});
     disp.update<GoEvent>();
     CHECK(lane.target == 2);
 
     lane.lerp_t = 0.5f;
 
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
 
     disp.update<GoEvent>();
 

--- a/tests/test_game_over_screen_controller.cpp
+++ b/tests/test_game_over_screen_controller.cpp
@@ -54,7 +54,7 @@ TEST_CASE("game_over: ENERGY DEPLETED reason renders when EnergyDepletedDeath ta
     // Absent tag: no reason text appears.
     REQUIRE(reg.ctx().find<EnergyDepletedDeath>() == nullptr);
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
     gs.phase_timer = 0.0f;
 
     render_game_over_screen_ui(reg);
@@ -81,7 +81,7 @@ TEST_CASE("game_over: score / high score / cause are visible via registry single
     reg.ctx().insert_or_assign(EnergyDepletedDeath{});
 
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
     gs.phase_timer = 1.0f;
 
     // Controller-bound values — these are exactly the fields the
@@ -106,7 +106,7 @@ TEST_CASE("game_over: render binds score/high-score/reason into scoreboard draw 
     reg.ctx().insert_or_assign(EnergyDepletedDeath{});
 
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
     gs.phase_timer = 0.0f;
 
     render_game_over_screen_ui(reg);
@@ -129,7 +129,7 @@ TEST_CASE("game_over: render binds new-best badge and previous score", "[game_ov
     reg.ctx().insert_or_assign(EnergyDepletedDeath{});
 
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
     gs.phase_timer = 0.0f;
 
     render_game_over_screen_ui(reg);
@@ -150,7 +150,7 @@ TEST_CASE("game_over: render omits empty reason binding when no death-cause tag 
     REQUIRE(reg.ctx().find<EnergyDepletedDeath>() == nullptr);
 
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
     gs.phase_timer = 0.0f;
 
     render_game_over_screen_ui(reg);

--- a/tests/test_game_phase_tags.cpp
+++ b/tests/test_game_phase_tags.cpp
@@ -1,17 +1,16 @@
-// Per-phase ctx-tag mirror invariant — issue #1202 / #1204 (GamePhase PR A).
+// Per-phase ctx-tag mirror invariant — issue #1202 / #1204 (GamePhase PR G).
 //
 // Per Fabian's existential processing chapter, each former enum value gets its
-// own zero-column table. For GamePhase, the value-typed `gs.phase` field is
-// mirrored 1:1 by a ctx-tag — exactly one of GamePhase{Title,...,Tutorial}Tag
-// is present on `reg.ctx()` at any time. `enter_phase()` and the public
-// `sync_game_phase_tags()` are the only writers that keep the mirror correct;
-// these tests pin the invariant so the mirror cannot drift as subsequent
-// migration PRs migrate consumers off `gs.phase`.
+// own zero-column table. For the active game phase, exactly one of
+// `GamePhase{Title,...,Tutorial}Tag` is present on `reg.ctx()` at any time;
+// `enter_phase<...>()` and `sync_game_phase_tags<...>()` are the only writers
+// that keep the mirror correct. These tests pin the invariant so it cannot
+// drift as future systems migrate or new phases are introduced.
 //
-// PR C (`NextPhase*Tag`) adds a second mirror for the pending-transition
-// target (`gs.next_phase`). The mirror is pulsed by `sync_next_phase_tags()`
-// at the top of the dispatch block and drained by `clear_next_phase_tags()`
-// at the bottom — exactly one `NextPhase*Tag` between those two points,
+// A second per-tag table (`NextPhase*Tag`) carries the pending-transition
+// target. The mirror is pulsed by `request_phase_transition<...>` at the
+// request site and drained by `clear_next_phase_tags()` at the bottom of the
+// dispatch block — exactly one `NextPhase*Tag` between those two points,
 // zero outside the block. These tests also pin that invariant so the
 // pending-transition dispatch (per-tag transforms in `game_state_system`)
 // cannot drift either.
@@ -59,20 +58,20 @@ TEST_CASE("game_phase_tags: sync emplaces exactly the matching tag",
     entt::registry reg;
     reg.ctx().emplace<GameState>();
 
-    sync_game_phase_tags(reg, GamePhase::Title);
+    sync_game_phase_tags<GamePhaseTitleTag>(reg);
     CHECK(count_phase_tags(reg) == 1);
     CHECK(reg.ctx().find<GamePhaseTitleTag>() != nullptr);
 
-    sync_game_phase_tags(reg, GamePhase::Playing);
+    sync_game_phase_tags<GamePhasePlayingTag>(reg);
     CHECK(count_phase_tags(reg) == 1);
     CHECK(reg.ctx().find<GamePhaseTitleTag>() == nullptr);
     CHECK(reg.ctx().find<GamePhasePlayingTag>() != nullptr);
 
-    sync_game_phase_tags(reg, GamePhase::GameOver);
+    sync_game_phase_tags<GamePhaseGameOverTag>(reg);
     CHECK(count_phase_tags(reg) == 1);
     CHECK(reg.ctx().find<GamePhaseGameOverTag>() != nullptr);
 
-    sync_game_phase_tags(reg, GamePhase::SongComplete);
+    sync_game_phase_tags<GamePhaseSongCompleteTag>(reg);
     CHECK(count_phase_tags(reg) == 1);
     CHECK(reg.ctx().find<GamePhaseSongCompleteTag>() != nullptr);
 }
@@ -80,71 +79,65 @@ TEST_CASE("game_phase_tags: sync emplaces exactly the matching tag",
 TEST_CASE("game_phase_tags: enter_phase keeps the tag mirror in lockstep",
           "[game_phase][tags][ecs_refactor][issue_1202]") {
     entt::registry reg;
-    auto& gs = reg.ctx().emplace<GameState>();
-    sync_game_phase_tags(reg, gs.phase);
+    reg.ctx().emplace<GameState>();
+    sync_game_phase_tags<GamePhaseTitleTag>(reg);
     REQUIRE(reg.ctx().find<GamePhaseTitleTag>() != nullptr);
 
-    enter_phase(reg, gs, GamePhase::Playing);
-    CHECK(gs.phase == GamePhase::Playing);
+    enter_phase<GamePhasePlayingTag>(reg);
+    CHECK(reg.ctx().contains<GamePhasePlayingTag>());
     CHECK(count_phase_tags(reg) == 1);
     CHECK(reg.ctx().find<GamePhasePlayingTag>() != nullptr);
     CHECK(reg.ctx().find<GamePhaseTitleTag>() == nullptr);
 
-    enter_phase(reg, gs, GamePhase::Paused);
-    CHECK(gs.phase == GamePhase::Paused);
+    enter_phase<GamePhasePausedTag>(reg);
+    CHECK(reg.ctx().contains<GamePhasePausedTag>());
     CHECK(count_phase_tags(reg) == 1);
     CHECK(reg.ctx().find<GamePhasePausedTag>() != nullptr);
 
-    enter_phase(reg, gs, GamePhase::GameOver);
-    CHECK(gs.phase == GamePhase::GameOver);
+    enter_phase<GamePhaseGameOverTag>(reg);
+    CHECK(reg.ctx().contains<GamePhaseGameOverTag>());
     CHECK(count_phase_tags(reg) == 1);
     CHECK(reg.ctx().find<GamePhaseGameOverTag>() != nullptr);
 
-    enter_phase(reg, gs, GamePhase::Tutorial);
-    CHECK(gs.phase == GamePhase::Tutorial);
+    enter_phase<GamePhaseTutorialTag>(reg);
+    CHECK(reg.ctx().contains<GamePhaseTutorialTag>());
     CHECK(count_phase_tags(reg) == 1);
     CHECK(reg.ctx().find<GamePhaseTutorialTag>() != nullptr);
 }
 
-TEST_CASE("game_phase_tags: every phase value has a matching tag",
+TEST_CASE("game_phase_tags: every phase tag exercise keeps mirror count at one",
           "[game_phase][tags][ecs_refactor][issue_1202]") {
     entt::registry reg;
-    auto& gs = reg.ctx().emplace<GameState>();
+    reg.ctx().emplace<GameState>();
 
-    const GamePhase all[] = {
-        GamePhase::Title,
-        GamePhase::LevelSelect,
-        GamePhase::Playing,
-        GamePhase::Paused,
-        GamePhase::GameOver,
-        GamePhase::SongComplete,
-        GamePhase::Settings,
-        GamePhase::Tutorial,
-    };
-    for (GamePhase p : all) {
-        enter_phase(reg, gs, p);
-        CHECK(count_phase_tags(reg) == 1);
-    }
+    enter_phase<GamePhaseTitleTag>(reg);        CHECK(count_phase_tags(reg) == 1);
+    enter_phase<GamePhaseLevelSelectTag>(reg);  CHECK(count_phase_tags(reg) == 1);
+    enter_phase<GamePhasePlayingTag>(reg);      CHECK(count_phase_tags(reg) == 1);
+    enter_phase<GamePhasePausedTag>(reg);       CHECK(count_phase_tags(reg) == 1);
+    enter_phase<GamePhaseGameOverTag>(reg);     CHECK(count_phase_tags(reg) == 1);
+    enter_phase<GamePhaseSongCompleteTag>(reg); CHECK(count_phase_tags(reg) == 1);
+    enter_phase<GamePhaseSettingsTag>(reg);     CHECK(count_phase_tags(reg) == 1);
+    enter_phase<GamePhaseTutorialTag>(reg);     CHECK(count_phase_tags(reg) == 1);
 }
 
-TEST_CASE("next_phase_tags: sync emplaces exactly the matching tag",
+TEST_CASE("next_phase_tags: request_phase_transition emplaces exactly the matching tag",
           "[game_phase][tags][ecs_refactor][issue_1202]") {
     entt::registry reg;
 
-    sync_next_phase_tags(reg, GamePhase::Title);
+    request_phase_transition<NextPhaseTitleTag>(reg);
     CHECK(count_next_phase_tags(reg) == 1);
     CHECK(reg.ctx().find<NextPhaseTitleTag>() != nullptr);
 
-    sync_next_phase_tags(reg, GamePhase::Playing);
+    request_phase_transition<NextPhasePlayingTag>(reg);
     CHECK(count_next_phase_tags(reg) == 1);
     CHECK(reg.ctx().find<NextPhaseTitleTag>() == nullptr);
     CHECK(reg.ctx().find<NextPhasePlayingTag>() != nullptr);
 
-    sync_next_phase_tags(reg, GamePhase::GameOver);
+    request_phase_transition<NextPhaseGameOverTag>(reg);
     CHECK(count_next_phase_tags(reg) == 1);
     CHECK(reg.ctx().find<NextPhaseGameOverTag>() != nullptr);
 
-    sync_next_phase_tags(reg, GamePhase::SongComplete);
+    request_phase_transition<NextPhaseSongCompleteTag>(reg);
     CHECK(count_next_phase_tags(reg) == 1);
     CHECK(reg.ctx().find<NextPhaseSongCompleteTag>() != nullptr);
 }
@@ -152,7 +145,7 @@ TEST_CASE("next_phase_tags: sync emplaces exactly the matching tag",
 TEST_CASE("next_phase_tags: clear drains every tag",
           "[game_phase][tags][ecs_refactor][issue_1202]") {
     entt::registry reg;
-    sync_next_phase_tags(reg, GamePhase::Tutorial);
+    request_phase_transition<NextPhaseTutorialTag>(reg);
     REQUIRE(count_next_phase_tags(reg) == 1);
 
     clear_next_phase_tags(reg);
@@ -163,22 +156,32 @@ TEST_CASE("next_phase_tags: clear drains every tag",
     CHECK(count_next_phase_tags(reg) == 0);
 }
 
-TEST_CASE("next_phase_tags: every phase value has a matching tag",
+TEST_CASE("next_phase_tags: every phase tag exercise keeps mirror count at one",
           "[game_phase][tags][ecs_refactor][issue_1202]") {
     entt::registry reg;
 
-    const GamePhase all[] = {
-        GamePhase::Title,
-        GamePhase::LevelSelect,
-        GamePhase::Playing,
-        GamePhase::Paused,
-        GamePhase::GameOver,
-        GamePhase::SongComplete,
-        GamePhase::Settings,
-        GamePhase::Tutorial,
-    };
-    for (GamePhase p : all) {
-        sync_next_phase_tags(reg, p);
-        CHECK(count_next_phase_tags(reg) == 1);
-    }
+    request_phase_transition<NextPhaseTitleTag>(reg);        CHECK(count_next_phase_tags(reg) == 1);
+    request_phase_transition<NextPhaseLevelSelectTag>(reg);  CHECK(count_next_phase_tags(reg) == 1);
+    request_phase_transition<NextPhasePlayingTag>(reg);      CHECK(count_next_phase_tags(reg) == 1);
+    request_phase_transition<NextPhasePausedTag>(reg);       CHECK(count_next_phase_tags(reg) == 1);
+    request_phase_transition<NextPhaseGameOverTag>(reg);     CHECK(count_next_phase_tags(reg) == 1);
+    request_phase_transition<NextPhaseSongCompleteTag>(reg); CHECK(count_next_phase_tags(reg) == 1);
+    request_phase_transition<NextPhaseSettingsTag>(reg);     CHECK(count_next_phase_tags(reg) == 1);
+    request_phase_transition<NextPhaseTutorialTag>(reg);     CHECK(count_next_phase_tags(reg) == 1);
+}
+
+TEST_CASE("phase_transition: is_phase_transition_pending reflects NextPhase*Tag presence",
+          "[game_phase][tags][ecs_refactor][issue_1202]") {
+    entt::registry reg;
+
+    CHECK_FALSE(is_phase_transition_pending(reg));
+
+    request_phase_transition<NextPhasePlayingTag>(reg);
+    CHECK(is_phase_transition_pending(reg));
+
+    clear_next_phase_tags(reg);
+    CHECK_FALSE(is_phase_transition_pending(reg));
+
+    request_phase_transition<NextPhaseGameOverTag>(reg);
+    CHECK(is_phase_transition_pending(reg));
 }

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -9,8 +9,7 @@
 
 TEST_CASE("game_state: song complete when song finished and no obstacles", "[gamestate]") {
     auto reg = make_rhythm_registry();
-    auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::Playing);
+    set_test_phase<GamePhasePlayingTag>(reg);
     auto& song = reg.ctx().get<SongState>();
     song.finished = true;
     song.playing = false;
@@ -18,15 +17,13 @@ TEST_CASE("game_state: song complete when song finished and no obstacles", "[gam
 
     game_state_system(reg, 0.016f);
 
-    CHECK(gs.transition_pending);
-    CHECK(gs.next_phase == GamePhase::SongComplete);
+    CHECK(reg.ctx().contains<NextPhaseSongCompleteTag>());
 }
 
 TEST_CASE("game_state: energy depletion beats song complete after playback finishes",
           "[gamestate][issue755]") {
     auto reg = make_rhythm_registry();
-    auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::Playing);
+    set_test_phase<GamePhasePlayingTag>(reg);
     auto& song = reg.ctx().get<SongState>();
     song.finished = true;
     song.playing = false;
@@ -35,15 +32,13 @@ TEST_CASE("game_state: energy depletion beats song complete after playback finis
 
     game_state_system(reg, 0.016f);
 
-    CHECK(gs.transition_pending);
-    CHECK(gs.next_phase == GamePhase::GameOver);
+    CHECK(reg.ctx().contains<NextPhaseGameOverTag>());
     CHECK(reg.ctx().find<EnergyDepletedDeath>() != nullptr);
 }
 
 TEST_CASE("game_state: song complete waits for obstacles to clear", "[gamestate]") {
     auto reg = make_rhythm_registry();
-    auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::Playing);
+    set_test_phase<GamePhasePlayingTag>(reg);
     auto& song = reg.ctx().get<SongState>();
     song.finished = true;
     song.playing = false;
@@ -55,13 +50,12 @@ TEST_CASE("game_state: song complete waits for obstacles to clear", "[gamestate]
 
     game_state_system(reg, 0.016f);
 
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("game_state: song complete proceeds when scored obstacle is destroyed", "[gamestate]") {
     auto reg = make_rhythm_registry();
-    auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::Playing);
+    set_test_phase<GamePhasePlayingTag>(reg);
     auto& song = reg.ctx().get<SongState>();
     song.finished = true;
     song.playing = false;
@@ -74,14 +68,12 @@ TEST_CASE("game_state: song complete proceeds when scored obstacle is destroyed"
 
     game_state_system(reg, 0.016f);
 
-    CHECK(gs.transition_pending);
-    CHECK(gs.next_phase == GamePhase::SongComplete);
+    CHECK(reg.ctx().contains<NextPhaseSongCompleteTag>());
 }
 
 TEST_CASE("game_state: song complete waits for scored obstacle to be destroyed", "[gamestate]") {
     auto reg = make_rhythm_registry();
-    auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::Playing);
+    set_test_phase<GamePhasePlayingTag>(reg);
     auto& song = reg.ctx().get<SongState>();
     song.finished = true;
     song.playing = false;
@@ -94,7 +86,7 @@ TEST_CASE("game_state: song complete waits for scored obstacle to be destroyed",
 
     game_state_system(reg, 0.016f);
 
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("game_state: enter_song_complete updates high score", "[gamestate]") {
@@ -104,14 +96,12 @@ TEST_CASE("game_state: enter_song_complete updates high score", "[gamestate]") {
     score.score = 8000;
     current.value = 5000;
 
-    auto& gs = reg.ctx().get<GameState>();
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::SongComplete;
+    request_phase_transition<NextPhaseSongCompleteTag>(reg);
 
     game_state_system(reg, 0.016f);
 
     CHECK(current.value == 8000);
-    CHECK(gs.phase == GamePhase::SongComplete);
+    CHECK(reg.ctx().contains<GamePhaseSongCompleteTag>());
     const auto& terminal = reg.ctx().get<TerminalResultState>();
     CHECK(terminal.new_best);
     CHECK(terminal.previous_best == 5000);
@@ -124,9 +114,7 @@ TEST_CASE("game_state: enter_song_complete preserves higher high_score", "[games
     score.score = 1000;
     current.value = 9000;
 
-    auto& gs = reg.ctx().get<GameState>();
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::SongComplete;
+    request_phase_transition<NextPhaseSongCompleteTag>(reg);
 
     game_state_system(reg, 0.016f);
 
@@ -136,14 +124,13 @@ TEST_CASE("game_state: enter_song_complete preserves higher high_score", "[games
 TEST_CASE("game_state: song_complete button choice restart", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::SongComplete);
+    set_test_phase<GamePhaseSongCompleteTag>(reg);
     gs.phase_timer = 1.0f;
     reg.ctx().emplace<EndChoiceRestart>();
 
     game_state_system(reg, 0.016f);
 
-    CHECK(gs.transition_pending);
-    CHECK(gs.next_phase == GamePhase::Playing);
+    CHECK(reg.ctx().contains<NextPhasePlayingTag>());
     CHECK(reg.ctx().find<EndChoiceRestart>() == nullptr);
     CHECK(reg.ctx().find<EndChoiceLevelSelect>() == nullptr);
     CHECK(reg.ctx().find<EndChoiceMainMenu>() == nullptr);
@@ -152,14 +139,13 @@ TEST_CASE("game_state: song_complete button choice restart", "[gamestate]") {
 TEST_CASE("game_state: song_complete button choice level_select", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::SongComplete);
+    set_test_phase<GamePhaseSongCompleteTag>(reg);
     gs.phase_timer = 1.0f;
     reg.ctx().emplace<EndChoiceLevelSelect>();
 
     game_state_system(reg, 0.016f);
 
-    CHECK(gs.transition_pending);
-    CHECK(gs.next_phase == GamePhase::LevelSelect);
+    CHECK(reg.ctx().contains<NextPhaseLevelSelectTag>());
     CHECK(reg.ctx().find<EndChoiceRestart>() == nullptr);
     CHECK(reg.ctx().find<EndChoiceLevelSelect>() == nullptr);
     CHECK(reg.ctx().find<EndChoiceMainMenu>() == nullptr);
@@ -168,47 +154,43 @@ TEST_CASE("game_state: song_complete button choice level_select", "[gamestate]")
 TEST_CASE("game_state: song_complete button choice main_menu", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::SongComplete);
+    set_test_phase<GamePhaseSongCompleteTag>(reg);
     gs.phase_timer = 1.0f;
     reg.ctx().emplace<EndChoiceMainMenu>();
 
     game_state_system(reg, 0.016f);
 
-    CHECK(gs.transition_pending);
-    CHECK(gs.next_phase == GamePhase::Title);
+    CHECK(reg.ctx().contains<NextPhaseTitleTag>());
 }
 
 TEST_CASE("game_state: song_complete ignores choice during delay", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::SongComplete);
+    set_test_phase<GamePhaseSongCompleteTag>(reg);
     gs.phase_timer = 0.2f;  // < 0.5s delay
     reg.ctx().emplace<EndChoiceRestart>();
 
     game_state_system(reg, 0.016f);
 
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("game_state: transition to LevelSelect resets confirmed", "[gamestate]") {
     auto reg = make_registry();
-    auto& gs = reg.ctx().get<GameState>();
     auto& lss = reg.ctx().get<LevelSelectState>();
     lss.confirmed = true;
 
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::LevelSelect;
+    request_phase_transition<NextPhaseLevelSelectTag>(reg);
 
     game_state_system(reg, 0.016f);
 
-    CHECK(gs.phase == GamePhase::LevelSelect);
+    CHECK(reg.ctx().contains<GamePhaseLevelSelectTag>());
     CHECK_FALSE(lss.confirmed);
 }
 
 TEST_CASE("game_state: terminal to LevelSelect hides stale world renderables",
           "[gamestate][render][regression][issue921]") {
     auto reg = make_registry();
-    auto& gs = reg.ctx().get<GameState>();
     auto& lss = reg.ctx().get<LevelSelectState>();
     lss.confirmed = true;
 
@@ -216,13 +198,12 @@ TEST_CASE("game_state: terminal to LevelSelect hides stale world renderables",
     reg.emplace<ModelTransform>(stale);
     reg.emplace<TagWorldPass>(stale);
 
-    set_test_phase(reg, GamePhase::GameOver);
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::LevelSelect;
+    set_test_phase<GamePhaseGameOverTag>(reg);
+    request_phase_transition<NextPhaseLevelSelectTag>(reg);
 
     game_state_system(reg, 0.016f);
 
-    CHECK(gs.phase == GamePhase::LevelSelect);
+    CHECK(reg.ctx().contains<GamePhaseLevelSelectTag>());
     CHECK_FALSE(lss.confirmed);
     REQUIRE(reg.valid(stale));
     CHECK(reg.all_of<ModelTransform, TagWorldPass>(stale));
@@ -232,21 +213,21 @@ TEST_CASE("game_state: terminal to LevelSelect hides stale world renderables",
 TEST_CASE("game_state: Settings hides stale world renderables",
           "[gamestate][render][regression][issue966]") {
     auto reg = make_registry();
-    sync_game_phase_tags(reg, GamePhase::Playing);
+    sync_game_phase_tags<GamePhasePlayingTag>(reg);
     CHECK(game_render_should_draw_world_meshes(reg));
-    sync_game_phase_tags(reg, GamePhase::Paused);
+    sync_game_phase_tags<GamePhasePausedTag>(reg);
     CHECK(game_render_should_draw_world_meshes(reg));
-    sync_game_phase_tags(reg, GamePhase::GameOver);
+    sync_game_phase_tags<GamePhaseGameOverTag>(reg);
     CHECK(game_render_should_draw_world_meshes(reg));
-    sync_game_phase_tags(reg, GamePhase::SongComplete);
+    sync_game_phase_tags<GamePhaseSongCompleteTag>(reg);
     CHECK(game_render_should_draw_world_meshes(reg));
-    sync_game_phase_tags(reg, GamePhase::Title);
+    sync_game_phase_tags<GamePhaseTitleTag>(reg);
     CHECK_FALSE(game_render_should_draw_world_meshes(reg));
-    sync_game_phase_tags(reg, GamePhase::LevelSelect);
+    sync_game_phase_tags<GamePhaseLevelSelectTag>(reg);
     CHECK_FALSE(game_render_should_draw_world_meshes(reg));
-    sync_game_phase_tags(reg, GamePhase::Settings);
+    sync_game_phase_tags<GamePhaseSettingsTag>(reg);
     CHECK_FALSE(game_render_should_draw_world_meshes(reg));
-    sync_game_phase_tags(reg, GamePhase::Tutorial);
+    sync_game_phase_tags<GamePhaseTutorialTag>(reg);
     CHECK_FALSE(game_render_should_draw_world_meshes(reg));
 }
 
@@ -269,7 +250,6 @@ TEST_CASE("wasm smoke lane marker state is registry-owned and reset with runtime
 
 TEST_CASE("game_state: transition clears in-flight pointer capture", "[gamestate][input]") {
     auto reg = make_registry();
-    auto& gs = reg.ctx().get<GameState>();
     auto& input = reg.ctx().get<InputState>();
     auto& priv = reg.ctx().get<InputSystemPrivate>();
 
@@ -280,8 +260,7 @@ TEST_CASE("game_state: transition clears in-flight pointer capture", "[gamestate
     priv.suppress_mouse_release = true;
     input.duration = 0.25f;
 
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::LevelSelect;
+    request_phase_transition<NextPhaseLevelSelectTag>(reg);
 
     game_state_system(reg, 0.016f);
 
@@ -297,21 +276,20 @@ TEST_CASE("game_state: transition clears in-flight pointer capture", "[gamestate
 TEST_CASE("game_state: transition to Title sets phase and resets timer", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::Playing);
+    set_test_phase<GamePhasePlayingTag>(reg);
     gs.phase_timer = 5.0f;
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::Title;
+    request_phase_transition<NextPhaseTitleTag>(reg);
 
     game_state_system(reg, 0.016f);
 
-    CHECK(gs.phase == GamePhase::Title);
+    CHECK(reg.ctx().contains<GamePhaseTitleTag>());
     CHECK(gs.phase_timer == 0.0f);
 }
 
 TEST_CASE("game_state: level select confirmed starts tutorial when FTUE is incomplete", "[gamestate][ftue][issue882]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::LevelSelect);
+    set_test_phase<GamePhaseLevelSelectTag>(reg);
     gs.phase_timer = 0.5f;  // past 0.2s guard
     auto& lss = reg.ctx().get<LevelSelectState>();
     lss.confirmed = true;
@@ -319,8 +297,7 @@ TEST_CASE("game_state: level select confirmed starts tutorial when FTUE is incom
 
     game_state_system(reg, 0.016f);
 
-    CHECK(gs.transition_pending);
-    CHECK(gs.next_phase == GamePhase::Tutorial);
+    CHECK(reg.ctx().contains<NextPhaseTutorialTag>());
     CHECK_FALSE(lss.confirmed);
 }
 
@@ -328,7 +305,7 @@ TEST_CASE("game_state: level select confirmed triggers playing when FTUE is comp
           "[gamestate][ftue][issue882]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::LevelSelect);
+    set_test_phase<GamePhaseLevelSelectTag>(reg);
     gs.phase_timer = 0.5f;  // past 0.2s guard
     auto& lss = reg.ctx().get<LevelSelectState>();
     lss.confirmed = true;
@@ -336,16 +313,14 @@ TEST_CASE("game_state: level select confirmed triggers playing when FTUE is comp
 
     game_state_system(reg, 0.016f);
 
-    CHECK(gs.transition_pending);
-    CHECK(gs.next_phase == GamePhase::Playing);
+    CHECK(reg.ctx().contains<NextPhasePlayingTag>());
     CHECK_FALSE(lss.confirmed);
 }
 
 TEST_CASE("tutorial: continue marks FTUE complete and requests gameplay",
           "[gamestate][ftue][issue882]") {
     auto reg = make_registry();
-    auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::Tutorial);
+    set_test_phase<GamePhaseTutorialTag>(reg);
 
     auto& settings = settings_state(reg);
     settings.ftue_run_count = 0;
@@ -358,15 +333,14 @@ TEST_CASE("tutorial: continue marks FTUE complete and requests gameplay",
     CHECK(settings::ftue_complete(settings));
     CHECK(persistence.dirty);
     CHECK(persistence.last_save.status == persistence::Status::PathUnavailable);
-    CHECK(gs.transition_pending);
-    CHECK(gs.next_phase == GamePhase::Playing);
+    CHECK(reg.ctx().contains<NextPhasePlayingTag>());
 }
 
 TEST_CASE("tutorial: menu confirm marks FTUE complete and requests gameplay",
           "[gamestate][ftue][input][issue882]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::Tutorial);
+    set_test_phase<GamePhaseTutorialTag>(reg);
     gs.phase_timer = 0.5f;
 
     auto& settings = settings_state(reg);
@@ -384,14 +358,14 @@ TEST_CASE("tutorial: menu confirm marks FTUE complete and requests gameplay",
     CHECK(settings::ftue_complete(saved_settings));
     CHECK(saved_persistence.dirty);
     CHECK(saved_persistence.last_save.status == persistence::Status::PathUnavailable);
-    CHECK_FALSE(gs.transition_pending);
-    CHECK(gs.phase == GamePhase::Playing);
+    CHECK_FALSE(is_phase_transition_pending(reg));
+    CHECK(reg.ctx().contains<GamePhasePlayingTag>());
 }
 
 TEST_CASE("game_state: level select ignores confirmed during delay", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::LevelSelect);
+    set_test_phase<GamePhaseLevelSelectTag>(reg);
     gs.phase_timer = 0.1f;  // within 0.2s delay
     auto& lss = reg.ctx().get<LevelSelectState>();
     lss.confirmed = true;
@@ -399,46 +373,43 @@ TEST_CASE("game_state: level select ignores confirmed during delay", "[gamestate
     game_state_system(reg, 0.016f);
 
     // confirmed still true, no transition yet
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("game_state: game_over restart button triggers playing", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
     gs.phase_timer = 0.5f;
     reg.ctx().emplace<EndChoiceRestart>();
 
     game_state_system(reg, 0.016f);
 
-    CHECK(gs.transition_pending);
-    CHECK(gs.next_phase == GamePhase::Playing);
+    CHECK(reg.ctx().contains<NextPhasePlayingTag>());
 }
 
 TEST_CASE("game_state: game_over main_menu button triggers title", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
     gs.phase_timer = 0.5f;
     reg.ctx().emplace<EndChoiceMainMenu>();
 
     game_state_system(reg, 0.016f);
 
-    CHECK(gs.transition_pending);
-    CHECK(gs.next_phase == GamePhase::Title);
+    CHECK(reg.ctx().contains<NextPhaseTitleTag>());
 }
 
 TEST_CASE("game_state: game_over level_select button triggers level_select", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
     gs.phase_timer = 0.5f;
     reg.ctx().emplace<EndChoiceLevelSelect>();
 
     game_state_system(reg, 0.016f);
 
-    CHECK(gs.transition_pending);
-    CHECK(gs.next_phase == GamePhase::LevelSelect);
+    CHECK(reg.ctx().contains<NextPhaseLevelSelectTag>());
     CHECK(reg.ctx().find<EndChoiceRestart>() == nullptr);
     CHECK(reg.ctx().find<EndChoiceLevelSelect>() == nullptr);
     CHECK(reg.ctx().find<EndChoiceMainMenu>() == nullptr);
@@ -447,13 +418,13 @@ TEST_CASE("game_state: game_over level_select button triggers level_select", "[g
 TEST_CASE("game_state: game_over ignores choice at readiness boundary", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
     gs.phase_timer = 0.4f;
     reg.ctx().emplace<EndChoiceRestart>();
 
     game_state_system(reg, 0.0f);
 
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
     // Tag persists across the input-delay window so the press is honored
     // once the delay elapses (pre-migration semantics).
     CHECK(reg.ctx().find<EndChoiceRestart>() != nullptr);
@@ -462,7 +433,7 @@ TEST_CASE("game_state: game_over ignores choice at readiness boundary", "[gamest
 TEST_CASE("game_state: game_over ignores missing end choice", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
     gs.phase_timer = 0.5f;
     REQUIRE(reg.ctx().find<EndChoiceRestart>() == nullptr);
     REQUIRE(reg.ctx().find<EndChoiceLevelSelect>() == nullptr);
@@ -470,7 +441,7 @@ TEST_CASE("game_state: game_over ignores missing end choice", "[gamestate]") {
 
     game_state_system(reg, 0.016f);
 
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
     CHECK(reg.ctx().find<EndChoiceRestart>() == nullptr);
     CHECK(reg.ctx().find<EndChoiceLevelSelect>() == nullptr);
     CHECK(reg.ctx().find<EndChoiceMainMenu>() == nullptr);
@@ -479,7 +450,7 @@ TEST_CASE("game_state: game_over ignores missing end choice", "[gamestate]") {
 TEST_CASE("game_state: game_over restart enters fresh play session on next tick", "[gamestate][play_session]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
     gs.phase_timer = 0.5f;
     reg.ctx().emplace<EndChoiceRestart>();
 
@@ -489,13 +460,12 @@ TEST_CASE("game_state: game_over restart enters fresh play session on next tick"
     reg.ctx().get<ScoreState>().score = 3210;
 
     game_state_system(reg, 0.016f);
-    REQUIRE(gs.transition_pending);
-    REQUIRE(gs.next_phase == GamePhase::Playing);
+    REQUIRE(reg.ctx().contains<NextPhasePlayingTag>());
 
     game_state_system(reg, 0.016f);
 
-    CHECK_FALSE(gs.transition_pending);
-    CHECK(gs.phase == GamePhase::Playing);
+    CHECK_FALSE(is_phase_transition_pending(reg));
+    CHECK(reg.ctx().contains<GamePhasePlayingTag>());
     CHECK_FALSE(reg.valid(stale));
     CHECK_FALSE(reg.view<PlayerTag>().empty());
     CHECK(reg.ctx().get<ScoreState>().score == 0);
@@ -503,44 +473,40 @@ TEST_CASE("game_state: game_over restart enters fresh play session on next tick"
 
 TEST_CASE("game_state: title position tap triggers level_select", "[gamestate]") {
     auto reg = make_registry();
-    auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::Title);
+    set_test_phase<GamePhaseTitleTag>(reg);
     // Simulate a tap → Confirm menu button press (title screen has full-screen confirm)
     auto btn = make_menu_button(reg, MenuActionKind::Confirm);
     press_button(reg, btn);
 
     game_state_system(reg, 0.016f);
 
-    CHECK_FALSE(gs.transition_pending);
-    CHECK(gs.phase == GamePhase::LevelSelect);
+    CHECK_FALSE(is_phase_transition_pending(reg));
+    CHECK(reg.ctx().contains<GamePhaseLevelSelectTag>());
 }
 
 TEST_CASE("title settings navigation: pending Settings transition reaches Settings screen",
           "[gamestate][ui][settings][regression]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::Title);
+    set_test_phase<GamePhaseTitleTag>(reg);
     gs.phase_timer = 2.0f;
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::Settings;
+    request_phase_transition<NextPhaseSettingsTag>(reg);
 
     // Proxy for title gear click path: title_screen_controller sets
     // transition_pending + next_phase=Settings, then fixed-step consumes it.
     game_state_system(reg, 0.016f);
-    REQUIRE(gs.phase == GamePhase::Settings);
-    CHECK_FALSE(gs.transition_pending);
+    REQUIRE(reg.ctx().contains<GamePhaseSettingsTag>());
+    CHECK_FALSE(is_phase_transition_pending(reg));
     CHECK(gs.phase_timer == 0.0f);
 }
 
 TEST_CASE("game_state: transition_pending consumed on execution", "[gamestate]") {
     auto reg = make_registry();
-    auto& gs = reg.ctx().get<GameState>();
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::Paused;
+    request_phase_transition<NextPhasePausedTag>(reg);
 
     game_state_system(reg, 0.016f);
 
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 // ── song_complete: score retention after transition ───────────────────────────
@@ -556,13 +522,11 @@ TEST_CASE("song_complete: score.score is retained (not zeroed) after enter_song_
     score.score = 12345;
     current.value = 10000;
 
-    auto& gs = reg.ctx().get<GameState>();
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::SongComplete;
+    request_phase_transition<NextPhaseSongCompleteTag>(reg);
 
     game_state_system(reg, 0.016f);
 
     // score.score must NOT be zeroed — it is the final value rendered on the results screen
     CHECK(score.score == 12345);
-    CHECK(gs.phase == GamePhase::SongComplete);
+    CHECK(reg.ctx().contains<GamePhaseSongCompleteTag>());
 }

--- a/tests/test_haptic_system.cpp
+++ b/tests/test_haptic_system.cpp
@@ -51,9 +51,8 @@ TEST_CASE("haptic_system: safe when dispatcher absent from context", "[haptic]")
 
 TEST_CASE("game state haptic: DeathCrash enqueued on game over", "[haptic]") {
     auto reg = make_registry();
-    set_test_phase(reg, GamePhase::Playing);
-    reg.ctx().get<GameState>().transition_pending = true;
-    reg.ctx().get<GameState>().next_phase = GamePhase::GameOver;
+    set_test_phase<GamePhasePlayingTag>(reg);
+    request_phase_transition<NextPhaseGameOverTag>(reg);
 
     game_state_system(reg, 0.016f);
 
@@ -70,8 +69,7 @@ TEST_CASE("game state haptic: NewHighScore enqueued when score exceeds high scor
     auto& current = reg.ctx().get<CurrentSongHighScore>();
     score.score = 1000;
     current.value = 500;
-    reg.ctx().get<GameState>().transition_pending = true;
-    reg.ctx().get<GameState>().next_phase = GamePhase::GameOver;
+    request_phase_transition<NextPhaseGameOverTag>(reg);
 
     game_state_system(reg, 0.016f);
 
@@ -88,8 +86,7 @@ TEST_CASE("game state haptic: NewHighScore NOT enqueued when no new high score o
     auto& current = reg.ctx().get<CurrentSongHighScore>();
     score.score = 400;
     current.value = 500;
-    reg.ctx().get<GameState>().transition_pending = true;
-    reg.ctx().get<GameState>().next_phase = GamePhase::GameOver;
+    request_phase_transition<NextPhaseGameOverTag>(reg);
 
     game_state_system(reg, 0.016f);
 
@@ -107,8 +104,7 @@ TEST_CASE("game state haptic: DeathCrash still enqueued; listener gates hardware
     // haptic_system completes without crash when the listener gates the hardware call.
     auto reg = make_registry();
     settings_state(reg).haptics_enabled = false;
-    reg.ctx().get<GameState>().transition_pending = true;
-    reg.ctx().get<GameState>().next_phase = GamePhase::GameOver;
+    request_phase_transition<NextPhaseGameOverTag>(reg);
 
     game_state_system(reg, 0.016f);
 
@@ -124,7 +120,7 @@ TEST_CASE("game state haptic: DeathCrash still enqueued; listener gates hardware
 
 TEST_CASE("game state haptic: RetryTap enqueued when Restart pressed on end screen", "[haptic]") {
     auto reg = make_registry();
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
     reg.ctx().get<GameState>().phase_timer = 1.0f;
 
     auto btn = make_menu_button(reg, MenuActionKind::Restart);
@@ -141,7 +137,7 @@ TEST_CASE("game state haptic: RetryTap enqueued when Restart pressed on end scre
 
 TEST_CASE("game state haptic: UIButtonTap enqueued for non-Restart end screen button", "[haptic]") {
     auto reg = make_registry();
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
     reg.ctx().get<GameState>().phase_timer = 1.0f;
 
     auto btn = make_menu_button(reg, MenuActionKind::GoMainMenu);
@@ -160,7 +156,7 @@ TEST_CASE("game state haptic: haptic_system no-crash when haptics_enabled=false 
     // Listener gates platform call; system must complete cleanly.
     auto reg = make_registry();
     settings_state(reg).haptics_enabled = false;
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
     reg.ctx().get<GameState>().phase_timer = 1.0f;
 
     auto btn = make_menu_button(reg, MenuActionKind::Restart);

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -32,12 +32,10 @@
 
 // Sets up a registry with all singletons in their default state.
 //
-// Per Fabian's existential processing (#1202/#1204, PR F): the per-phase
-// ctx-tag mirror is primed alongside the `GameState` ctx singleton so
-// downstream consumers (`if (ctx.contains<GamePhase*Tag>())`) match the
-// `GameState::phase` field set here. Tests that mutate `gs.phase` directly
-// must call `set_test_phase()` below to keep the mirror in lockstep until
-// the enum-typed field itself is deleted in PR G.
+// Per Fabian's existential processing (#1202/#1204, PR G): there is no enum
+// phase field anymore — the per-phase ctx-tag is the active phase, and
+// tests prime it directly via `enter_phase<...>()` (or `set_test_phase<...>`
+// below when they need to pin a specific `phase_timer` value).
 inline entt::registry make_registry() {
     entt::registry reg;
     reg.ctx().emplace<InputState>();
@@ -46,10 +44,8 @@ inline entt::registry make_registry() {
     reg.ctx().emplace<entt::dispatcher>();
     wire_input_dispatcher(reg);
     wire_audio_haptic_dispatcher(reg);
-    reg.ctx().emplace<GameState>(GameState{
-        GamePhase::Playing, 0.0f, false, GamePhase::Playing
-    });
-    sync_game_phase_tags(reg, GamePhase::Playing);
+    reg.ctx().emplace<GameState>();
+    sync_game_phase_tags<GamePhasePlayingTag>(reg);
     reg.ctx().emplace<ScoreState>();
     reg.ctx().emplace<ScoreDisplay>();
     reg.ctx().emplace<CurrentSongHighScore>();
@@ -66,13 +62,13 @@ inline entt::registry make_registry() {
     return reg;
 }
 
-// Mutate the phase in tests without going through `enter_phase()` (which
+// Mutate the phase in tests without going through `enter_phase<...>()` (which
 // also resets `phase_timer` and would defeat tests that pin a specific
-// timer value). Keeps the per-phase ctx-tag mirror invariant intact so
-// the migrated consumers in `app/` dispatch on the new phase immediately.
-inline void set_test_phase(entt::registry& reg, GamePhase phase) {
-    reg.ctx().get<GameState>().phase = phase;
-    sync_game_phase_tags(reg, phase);
+// timer value). Keeps the per-phase ctx-tag mirror invariant intact so the
+// migrated consumers in `app/` dispatch on the new phase immediately.
+template <typename PhaseTag>
+inline void set_test_phase(entt::registry& reg) {
+    sync_game_phase_tags<PhaseTag>(reg);
 }
 
 struct GoCapture {

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -7,6 +7,7 @@
 #include "entities/camera_entity.h"
 #include "entities/obstacle_entity.h"
 #include "entities/obstacle_render_entity.h"
+#include "systems/game_phase_transition.h"
 #include "systems/play_session.h"
 #include "test_helpers.h"
 #include "systems/high_score_system.h"
@@ -116,7 +117,6 @@ TEST_CASE("Play session: restart clears obstacle mesh children without stale lis
 TEST_CASE("Play session: missing selected beatmap returns to level select without score session",
           "[play_session][issue835]") {
     auto reg = make_registry();
-    auto& gs = reg.ctx().get<GameState>();
     auto& lss = reg.ctx().get<LevelSelectState>();
     auto& high_scores = reg.ctx().get<HighScoreState>();
     high_score::set_score(high_scores, "1_stomper|medium", 4321);
@@ -129,7 +129,7 @@ TEST_CASE("Play session: missing selected beatmap returns to level select withou
 
     setup_play_session(reg);
 
-    CHECK(gs.phase == GamePhase::LevelSelect);
+    CHECK(reg.ctx().contains<GamePhaseLevelSelectTag>());
     CHECK_FALSE(lss.confirmed);
     {
         const auto& bm = beat_map(reg);
@@ -148,7 +148,7 @@ TEST_CASE("Play session: missing selected beatmap returns to level select withou
     REQUIRE_NOTHROW(setup_play_session(reg));
     CHECK(reg.ctx().find<SongState>() != nullptr);
     CHECK(reg.ctx().find<ScoreState>() != nullptr);
-    CHECK(gs.phase == GamePhase::Playing);
+    CHECK(reg.ctx().contains<GamePhasePlayingTag>());
     CHECK_FALSE(reg.view<PlayerTag>().empty());
 }
 
@@ -229,9 +229,7 @@ TEST_CASE("High score integration: new song-complete high score persists",
     current.value = 1000;
     score.score = 2500;
 
-    auto& gs = reg.ctx().get<GameState>();
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::SongComplete;
+    request_phase_transition<NextPhaseSongCompleteTag>(reg);
 
     game_state_system(reg, 0.016f);
 
@@ -262,9 +260,7 @@ TEST_CASE("High score integration: lower game-over score does not overwrite pers
     current.value = 3000;
     score.score = 1000;
 
-    auto& gs = reg.ctx().get<GameState>();
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::GameOver;
+    request_phase_transition<NextPhaseGameOverTag>(reg);
 
     game_state_system(reg, 0.016f);
 
@@ -290,9 +286,7 @@ TEST_CASE("High score integration: missing active entry does not report new best
     current.value = 1000;
     score.score = 2500;
 
-    auto& gs = reg.ctx().get<GameState>();
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::SongComplete;
+    request_phase_transition<NextPhaseSongCompleteTag>(reg);
 
     game_state_system(reg, 0.016f);
 
@@ -327,9 +321,7 @@ TEST_CASE("High score integration: failed save keeps dirty state for retry",
     current.value = 1000;
     score.score = 2500;
 
-    auto& gs = reg.ctx().get<GameState>();
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::SongComplete;
+    request_phase_transition<NextPhaseSongCompleteTag>(reg);
 
     game_state_system(reg, 0.016f);
 
@@ -341,8 +333,7 @@ TEST_CASE("High score integration: failed save keeps dirty state for retry",
     const auto retry_file = root / "high_scores.json";
     reg.ctx().get<HighScorePersistence>().path = retry_file.string();
     score.score = 1000;
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::GameOver;
+    request_phase_transition<NextPhaseGameOverTag>(reg);
 
     game_state_system(reg, 0.016f);
 
@@ -371,9 +362,9 @@ TEST_CASE("High score bootstrap: persistence path is populated for save call sit
     CHECK(high_score::load_high_scores(loaded_at_bootstrap, file).ok());
     reg.ctx().get<HighScoreState>() = loaded_at_bootstrap;
     reg.ctx().get<HighScorePersistence>() = HighScorePersistence{file.string()};
-    reg.ctx().get<GameState>() = GameState{
-        GamePhase::Playing, 0.0f, true, GamePhase::SongComplete
-    };
+    reg.ctx().get<GameState>() = GameState{ 0.0f };
+    sync_game_phase_tags<GamePhasePlayingTag>(reg);
+    request_phase_transition<NextPhaseSongCompleteTag>(reg);
     auto& score = reg.ctx().get<ScoreState>();
     auto& current = reg.ctx().get<CurrentSongHighScore>();
     current.value = 1000;

--- a/tests/test_input_pipeline_behavior.cpp
+++ b/tests/test_input_pipeline_behavior.cpp
@@ -271,8 +271,7 @@ TEST_CASE("pipeline: gameplay HUD pause release is collected before the fixed ti
           "[input_pipeline][hud][issue833]") {
     auto reg = make_rhythm_registry();
     auto& input = reg.ctx().get<InputState>();
-    auto& gs = reg.ctx().get<GameState>();
-    REQUIRE(gs.phase == GamePhase::Playing);
+    REQUIRE(reg.ctx().contains<GamePhasePlayingTag>());
 
     input.click = true;
     input.end_x = 660.0f;
@@ -281,16 +280,15 @@ TEST_CASE("pipeline: gameplay HUD pause release is collected before the fixed ti
     gameplay_hud_process_button_input(reg);
     run_pipeline(reg);
 
-    CHECK(gs.phase == GamePhase::Paused);
-    CHECK_FALSE(gs.transition_pending);
+    CHECK(reg.ctx().contains<GamePhasePausedTag>());
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("pipeline: gameplay HUD touch release can pause before the fixed tick",
           "[input_pipeline][hud][mobile][issue986]") {
     auto reg = make_rhythm_registry();
     auto& input = reg.ctx().get<InputState>();
-    auto& gs = reg.ctx().get<GameState>();
-    REQUIRE(gs.phase == GamePhase::Playing);
+    REQUIRE(reg.ctx().contains<GamePhasePlayingTag>());
 
     input.touch_up = true;
     input.end_x = 660.0f;
@@ -299,31 +297,29 @@ TEST_CASE("pipeline: gameplay HUD touch release can pause before the fixed tick"
     gameplay_hud_process_button_input(reg);
     run_pipeline(reg);
 
-    CHECK(gs.phase == GamePhase::Paused);
-    CHECK_FALSE(gs.transition_pending);
+    CHECK(reg.ctx().contains<GamePhasePausedTag>());
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("pipeline: pending phase transition blocks queued shape input",
           "[input_pipeline][transition][issue823]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& gs = reg.ctx().get<GameState>();
     auto& lane = reg.get<Lane>(player);
 
-    REQUIRE(gs.phase == GamePhase::Playing);
+    REQUIRE(reg.ctx().contains<GamePhasePlayingTag>());
     REQUIRE(window_phase_is_idle(reg, player));
     REQUIRE(lane.current == 1);
     lane.target = lane.current;
     REQUIRE(lane.target == 1);
 
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::Paused;
+    request_phase_transition<NextPhasePausedTag>(reg);
     reg.ctx().get<entt::dispatcher>().enqueue<ShapePressCircleEvent>({});
 
     run_pipeline(reg);
 
-    CHECK(gs.phase == GamePhase::Paused);
-    CHECK_FALSE(gs.transition_pending);
+    CHECK(reg.ctx().contains<GamePhasePausedTag>());
+    CHECK_FALSE(is_phase_transition_pending(reg));
     CHECK(window_phase_is_idle(reg, player));
     CHECK(current_target_shape(reg, player) == Shape::Hexagon);
     CHECK(lane.target == 1);
@@ -333,24 +329,22 @@ TEST_CASE("pipeline: pending phase transition blocks queued go input",
           "[input_pipeline][transition][issue823]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& gs = reg.ctx().get<GameState>();
     auto& lane = reg.get<Lane>(player);
 
-    REQUIRE(gs.phase == GamePhase::Playing);
+    REQUIRE(reg.ctx().contains<GamePhasePlayingTag>());
     REQUIRE(lane.current == 1);
     lane.target = lane.current;
     REQUIRE(lane.target == 1);
     REQUIRE_FALSE(reg.any_of<Jumping, Sliding>(player));
 
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::Paused;
+    request_phase_transition<NextPhasePausedTag>(reg);
     push_go(reg, Direction::Right);
     push_go(reg, Direction::Up);
 
     run_pipeline(reg);
 
-    CHECK(gs.phase == GamePhase::Paused);
-    CHECK_FALSE(gs.transition_pending);
+    CHECK(reg.ctx().contains<GamePhasePausedTag>());
+    CHECK_FALSE(is_phase_transition_pending(reg));
     CHECK(lane.target == 1);
     CHECK_FALSE(reg.any_of<Jumping, Sliding>(player));
 }
@@ -415,7 +409,7 @@ TEST_CASE("pipeline: gameplay HUD proximity ring progresses through far near per
 TEST_CASE("pipeline: gameplay HUD raygui shape presses ignored outside Playing",
           "[input_pipeline][hud]") {
     auto reg = make_rhythm_registry();
-    set_test_phase(reg, GamePhase::Paused);
+    set_test_phase<GamePhasePausedTag>(reg);
     auto player = make_rhythm_player(reg);
     REQUIRE(window_phase_is_idle(reg, player));
     gameplay_hud_apply_button_presses(reg,

--- a/tests/test_level_select_controller.cpp
+++ b/tests/test_level_select_controller.cpp
@@ -5,7 +5,7 @@
 TEST_CASE("level_select_controller: select difficulty press updates state", "[level_select][ui]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::LevelSelect);
+    set_test_phase<GamePhaseLevelSelectTag>(reg);
     gs.phase_timer = 0.2f;
 
     auto& lss = reg.ctx().get<LevelSelectState>();
@@ -21,7 +21,7 @@ TEST_CASE("level_select_controller: select difficulty press updates state", "[le
 TEST_CASE("level_select_controller: select level press updates state", "[level_select][ui]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::LevelSelect);
+    set_test_phase<GamePhaseLevelSelectTag>(reg);
     gs.phase_timer = 0.2f;
 
     auto& lss = reg.ctx().get<LevelSelectState>();
@@ -38,7 +38,7 @@ TEST_CASE("level_select_controller: invalid semantic indices do not update selec
           "[level_select][ui][issue738]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::LevelSelect);
+    set_test_phase<GamePhaseLevelSelectTag>(reg);
     gs.phase_timer = 0.2f;
 
     auto& lss = reg.ctx().get<LevelSelectState>();
@@ -59,7 +59,7 @@ TEST_CASE("level_select_controller: invalid semantic indices do not update selec
 TEST_CASE("level_select_controller: ignores menu presses during entry delay", "[level_select][ui]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::LevelSelect);
+    set_test_phase<GamePhaseLevelSelectTag>(reg);
     gs.phase_timer = 0.01f;
 
     auto& lss = reg.ctx().get<LevelSelectState>();

--- a/tests/test_miss_detection_regression.cpp
+++ b/tests/test_miss_detection_regression.cpp
@@ -171,7 +171,7 @@ TEST_CASE("miss_detection: visual obstacle leftovers without Obstacle payload ar
 TEST_CASE("miss_detection: no-op when game phase is not Playing",
           "[miss_detection][regression][issue336]") {
     auto reg = make_registry();
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
 
     auto obs = make_expired_obstacle(reg);
 

--- a/tests/test_phase_runner.cpp
+++ b/tests/test_phase_runner.cpp
@@ -12,7 +12,7 @@ using Catch::Matchers::WithinAbs;
 
 TEST_CASE("tick_playing_systems: no-op when phase is Paused", "[phase_guard]") {
     auto reg = make_rhythm_registry();
-    set_test_phase(reg, GamePhase::Paused);
+    set_test_phase<GamePhasePausedTag>(reg);
 
     // Observable state that at least three different playing systems would mutate:
     //   scoring_system    → ScoreState::score (distance bonus each tick)
@@ -38,7 +38,7 @@ TEST_CASE("tick_playing_systems: no-op when phase is Paused", "[phase_guard]") {
 
 TEST_CASE("tick_playing_systems: no-op when phase is GameOver", "[phase_guard]") {
     auto reg = make_rhythm_registry();
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
 
     // Expired obstacle to match Paused coverage (MissTag / ScoredTag guard).
     auto obs = reg.create();
@@ -134,7 +134,7 @@ TEST_CASE("tick_playing_systems: shape window activates before collision", "[pha
 TEST_CASE("tick_fixed_systems: popup_feedback and energy run in score-feedback chain", "[phase_guard][integration][order_regression]") {
     auto reg = make_rhythm_registry();
     // Phase must be Playing for popup_feedback and energy guards to pass.
-    set_test_phase(reg, GamePhase::Playing);
+    set_test_phase<GamePhasePlayingTag>(reg);
 
     // Pre-seed a popup request directly (bypasses scoring_system path; tests
     // that popup_feedback_system is wired and consumes the queue).
@@ -169,7 +169,6 @@ TEST_CASE("tick_fixed_systems: popup_feedback and energy run in score-feedback c
 TEST_CASE("tick_fixed_systems: energy depletion requests GameOver before next Playing pass",
           "[phase_guard][energy][regression][issue781]") {
     auto reg = make_rhythm_registry();
-    auto& gs = reg.ctx().get<GameState>();
     auto& energy = reg.ctx().get<EnergyState>();
     auto& pending = reg.ctx().get<PendingEnergyEffects>();
     auto& results = reg.ctx().get<SongResults>();
@@ -180,8 +179,7 @@ TEST_CASE("tick_fixed_systems: energy depletion requests GameOver before next Pl
     tick_fixed_systems(reg, 0.016f);
 
     REQUIRE(energy.energy == 0.0f);
-    REQUIRE(gs.transition_pending);
-    REQUIRE(gs.next_phase == GamePhase::GameOver);
+    REQUIRE(reg.ctx().contains<NextPhaseGameOverTag>());
     CHECK(reg.ctx().find<EnergyDepletedDeath>() != nullptr);
     CHECK(pending.events.empty());
 
@@ -193,7 +191,7 @@ TEST_CASE("tick_fixed_systems: energy depletion requests GameOver before next Pl
 
     tick_fixed_systems(reg, 0.016f);
 
-    CHECK(gs.phase == GamePhase::GameOver);
+    CHECK(reg.ctx().contains<GamePhaseGameOverTag>());
     CHECK(results.miss_count == 0);
 
     const auto sfx = drain_sfx_events(reg);
@@ -212,7 +210,6 @@ TEST_CASE("tick_fixed_systems: energy depletion requests GameOver before next Pl
 TEST_CASE("tick_fixed_systems: fatal final drain wins after song finishes",
           "[phase_guard][energy][regression][issue961]") {
     auto reg = make_rhythm_registry();
-    auto& gs = reg.ctx().get<GameState>();
     auto& song = reg.ctx().get<SongState>();
     auto& energy = reg.ctx().get<EnergyState>();
     auto& pending = reg.ctx().get<PendingEnergyEffects>();
@@ -228,7 +225,6 @@ TEST_CASE("tick_fixed_systems: fatal final drain wins after song finishes",
     CHECK(song.finished);
     CHECK_FALSE(song.playing);
     REQUIRE(energy.energy == 0.0f);
-    REQUIRE(gs.transition_pending);
-    CHECK(gs.next_phase == GamePhase::GameOver);
+    REQUIRE(reg.ctx().contains<NextPhaseGameOverTag>());
     CHECK(reg.ctx().find<EnergyDepletedDeath>() != nullptr);
 }

--- a/tests/test_phase_transition_canonical.cpp
+++ b/tests/test_phase_transition_canonical.cpp
@@ -135,7 +135,7 @@ bool is_type_like_prev_char(char c) {
 }
 
 bool has_direct_enter_phase_call(const std::string& source) {
-    static const std::regex kEnterPhaseToken(R"(\benter_phase\s*\()");
+    static const std::regex kEnterPhaseToken(R"(\benter_phase\s*[<(])");
     const std::string sanitized = strip_comments_and_literals(source);
 
     for (std::sregex_iterator it(sanitized.begin(), sanitized.end(), kEnterPhaseToken), end;
@@ -249,9 +249,9 @@ TEST_CASE("phase_transition: app sources enforce canonical enter_phase allow-lis
 TEST_CASE("phase_transition: enforcement catches non-UI/non-input direct callers (#503)",
           "[phase_transition][architecture]") {
     const std::vector<SourceRecord> fixtures = {
-        {"app/systems/game_state_system.cpp", "void ok(GameState& gs){ enter_phase(gs, GamePhase::Paused); }"},
-        {"app/systems/rogue_system.cpp", "void bad(GameState& gs){ enter_phase(gs, GamePhase::Title); }"},
-        {"app/ui/screen_controllers/title_screen_controller.cpp", "void ui(GameState& gs){ gs.transition_pending = true; }"},
+        {"app/systems/game_state_system.cpp", "void ok(entt::registry& reg){ enter_phase<GamePhasePausedTag>(reg); }"},
+        {"app/systems/rogue_system.cpp", "void bad(entt::registry& reg){ enter_phase<GamePhaseTitleTag>(reg); }"},
+        {"app/ui/screen_controllers/title_screen_controller.cpp", "void ui(entt::registry& reg){ request_phase_transition<NextPhasePausedTag>(reg); }"},
     };
 
     const auto offenders = collect_enter_phase_offenders(fixtures, canonical_enter_phase_allowlist());
@@ -273,24 +273,31 @@ TEST_CASE("phase_transition: Tutorial and Paused controllers guard entry input",
 TEST_CASE("phase_transition matcher catches whitespace variants and ignores strings/comments",
           "[phase_transition][architecture]") {
     const std::string direct_call = R"cpp(
-        void bad(GameState& gs) {
-            enter_phase ( gs, GamePhase::Title );
+        void bad(entt::registry& reg) {
+            enter_phase<GamePhaseTitleTag>(reg);
+        }
+    )cpp";
+    const std::string template_with_spaces = R"cpp(
+        void bad(entt::registry& reg) {
+            enter_phase < GamePhaseTitleTag > ( reg );
         }
     )cpp";
     const std::string string_literal_only = R"cpp(
-        const char* text = "enter_phase( should not trigger";
+        const char* text = "enter_phase<GamePhaseTitleTag>( should not trigger";
     )cpp";
     const std::string comments_only = R"cpp(
-        // enter_phase(gs, GamePhase::Title);
+        // enter_phase<GamePhaseTitleTag>(reg);
         /*
-          enter_phase ( gs, GamePhase::Title );
+          enter_phase < GamePhaseTitleTag > ( reg );
         */
     )cpp";
     const std::string declaration_only = R"cpp(
-        void enter_phase(GameState&, GamePhase);
+        template <typename PhaseTag>
+        void enter_phase(entt::registry& reg);
     )cpp";
 
     CHECK(has_direct_enter_phase_call(direct_call));
+    CHECK(has_direct_enter_phase_call(template_with_spaces));
     CHECK_FALSE(has_direct_enter_phase_call(string_literal_only));
     CHECK_FALSE(has_direct_enter_phase_call(comments_only));
     CHECK_FALSE(has_direct_enter_phase_call(declaration_only));

--- a/tests/test_player_systems.cpp
+++ b/tests/test_player_systems.cpp
@@ -304,7 +304,7 @@ TEST_CASE("player_movement: slide returns to grounded", "[player]") {
 
 TEST_CASE("player_action: not in Playing phase skips processing", "[player]") {
     auto reg = make_registry();
-    set_test_phase(reg, GamePhase::Title);
+    set_test_phase<GamePhaseTitleTag>(reg);
     make_player(reg);
 
     reg.ctx().get<entt::dispatcher>().enqueue<GoEvent>({Direction::Up});
@@ -319,7 +319,7 @@ TEST_CASE("player_action: not in Playing phase skips processing", "[player]") {
 
 TEST_CASE("player_movement: not in Playing phase skips processing", "[player]") {
     auto reg = make_registry();
-    set_test_phase(reg, GamePhase::Paused);
+    set_test_phase<GamePhasePausedTag>(reg);
     auto p = make_player(reg);
     reg.get<PlayerShape>(p).morph_t = 0.0f;
 

--- a/tests/test_redfoot_testflight_ui.cpp
+++ b/tests/test_redfoot_testflight_ui.cpp
@@ -113,9 +113,8 @@ entt::entity spawn_obstacle(entt::registry& reg, float y) {
 TEST_CASE("redfoot/#168: collision miss is non-terminal cause context",
            "[ui][redfoot][game_over][wiring]") {
     entt::registry reg;
-    auto& gs = reg.ctx().emplace<GameState>();
-    gs.phase = GamePhase::Playing;
-    sync_game_phase_tags(reg, GamePhase::Playing);
+    reg.ctx().emplace<GameState>();
+    sync_game_phase_tags<GamePhasePlayingTag>(reg);
     reg.ctx().emplace<EnergyState>();
     reg.ctx().emplace<ScoreState>();
     reg.ctx().emplace<ScoreDisplay>();
@@ -137,9 +136,8 @@ TEST_CASE("redfoot/#168: collision miss is non-terminal cause context",
 TEST_CASE("redfoot/#168: energy depletion falls back to ENERGY DEPLETED",
           "[ui][redfoot][game_over][wiring]") {
     entt::registry reg;
-    auto& gs = reg.ctx().emplace<GameState>();
-    gs.phase = GamePhase::Playing;
-    sync_game_phase_tags(reg, GamePhase::Playing);
+    reg.ctx().emplace<GameState>();
+    sync_game_phase_tags<GamePhasePlayingTag>(reg);
     reg.ctx().emplace<entt::dispatcher>();
     auto& energy = reg.ctx().emplace<EnergyState>();
     auto& song = reg.ctx().emplace<SongState>();
@@ -154,9 +152,8 @@ TEST_CASE("redfoot/#168: energy depletion falls back to ENERGY DEPLETED",
 TEST_CASE("redfoot/#168: energy depletion writes terminal cause",
            "[ui][redfoot][game_over][wiring]") {
     entt::registry reg;
-    auto& gs = reg.ctx().emplace<GameState>();
-    gs.phase = GamePhase::Playing;
-    sync_game_phase_tags(reg, GamePhase::Playing);
+    reg.ctx().emplace<GameState>();
+    sync_game_phase_tags<GamePhasePlayingTag>(reg);
     reg.ctx().emplace<entt::dispatcher>();
     auto& energy = reg.ctx().emplace<EnergyState>();
     auto& song = reg.ctx().emplace<SongState>();

--- a/tests/test_rhythm_system.cpp
+++ b/tests/test_rhythm_system.cpp
@@ -457,8 +457,7 @@ TEST_CASE("collision: hexagon fails shape gates — drains energy", "[rhythm][co
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
     energy_system(reg, 0.016f);
-    auto& gs = reg.ctx().get<GameState>();
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
     auto& energy = reg.ctx().get<EnergyState>();
     CHECK(energy.energy < 1.0f);
     CHECK(energy.flash_timer > 0.0f);
@@ -473,8 +472,7 @@ TEST_CASE("collision: MISS drains energy", "[rhythm][collision]") {
     collision_system(reg, 0.016f);
     scoring_system(reg, 0.016f);
     energy_system(reg, 0.016f);
-    auto& gs = reg.ctx().get<GameState>();
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
     auto& energy = reg.ctx().get<EnergyState>();
     CHECK(energy.energy < 1.0f);
     CHECK(energy.flash_timer > 0.0f);
@@ -615,7 +613,7 @@ TEST_CASE("collision: PERFECT clears obstacle without game over", "[rhythm][coll
     reg.emplace<BeatInfo>(obs, 0, 5.0f, 5.0f - song.lead_time);
     collision_system(reg, 0.016f);
     CHECK(reg.all_of<ScoredTag>(obs));
-    CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("collision: SongResults updated", "[rhythm][collision]") {
@@ -639,15 +637,15 @@ TEST_CASE("game_state: triggers game over at 0 energy", "[rhythm][energy]") {
     auto reg = make_rhythm_registry();
     reg.ctx().get<EnergyState>().energy = 0.0f;
     game_state_system(reg, 0.016f);
-    CHECK(reg.ctx().get<GameState>().transition_pending);
-    CHECK(reg.ctx().get<GameState>().next_phase == GamePhase::GameOver);
+    CHECK(is_phase_transition_pending(reg));
+    CHECK(reg.ctx().contains<NextPhaseGameOverTag>());
 }
 
 TEST_CASE("energy_system: does nothing when energy is positive", "[rhythm][energy]") {
     auto reg = make_rhythm_registry();
     reg.ctx().get<EnergyState>().energy = 0.5f;
     energy_system(reg, 0.016f);
-    CHECK_FALSE(reg.ctx().get<GameState>().transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("game_state: enter_game_over marks song finished on depletion", "[rhythm][energy]") {

--- a/tests/test_scoring_system.cpp
+++ b/tests/test_scoring_system.cpp
@@ -211,7 +211,7 @@ TEST_CASE("scoring: ScoreDisplay rolls up toward score", "[scoring]") {
 
 TEST_CASE("scoring: not in Playing phase skips processing", "[scoring]") {
     auto reg = make_registry();
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
 
     tick_playing_systems(reg, 1.0f);
 

--- a/tests/test_shape_window_extended.cpp
+++ b/tests/test_shape_window_extended.cpp
@@ -128,7 +128,7 @@ TEST_CASE("shape_window: not in Playing phase skips processing", "[shape_window]
     auto player = make_rhythm_player(reg);
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
-    set_test_phase(reg, GamePhase::Paused);
+    set_test_phase<GamePhasePausedTag>(reg);
 
     set_window_phase_morph_in(reg, player);
     sw.window_start = song.song_time;

--- a/tests/test_shape_window_system.cpp
+++ b/tests/test_shape_window_system.cpp
@@ -204,7 +204,7 @@ TEST_CASE("shape_window: full cycle MorphIn -> Active -> MorphOut -> Idle", "[sh
 
 TEST_CASE("shape_window: no processing when not Playing", "[shape_window]") {
     auto reg = make_rhythm_registry();
-    set_test_phase(reg, GamePhase::Paused);
+    set_test_phase<GamePhasePausedTag>(reg);
     auto player = make_rhythm_player(reg);
     auto& sw = reg.get<ShapeWindow>(player);
     set_window_phase_morph_in(reg, player);

--- a/tests/test_signal_lifecycle_nogated.cpp
+++ b/tests/test_signal_lifecycle_nogated.cpp
@@ -17,9 +17,8 @@ TEST_CASE("obstacle_runtime: obstacle view emptiness tracks obstacle entity life
 TEST_CASE("game_state: finished song waits for obstacle drain before SongComplete",
           "[game_state][runtime]") {
     auto reg = make_registry();
-    auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::Playing);
-    gs.transition_pending = false;
+    set_test_phase<GamePhasePlayingTag>(reg);
+    clear_next_phase_tags(reg);
 
     auto& song = reg.ctx().get<SongState>();
     song.playing = true;
@@ -32,10 +31,9 @@ TEST_CASE("game_state: finished song waits for obstacle drain before SongComplet
     reg.emplace<ObstacleTag>(e);
 
     game_state_system(reg, 1.0f / 60.0f);
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 
     reg.destroy(e);
     game_state_system(reg, 1.0f / 60.0f);
-    CHECK(gs.transition_pending);
-    CHECK(gs.next_phase == GamePhase::SongComplete);
+    CHECK(reg.ctx().contains<NextPhaseSongCompleteTag>());
 }

--- a/tests/test_song_playback_extended.cpp
+++ b/tests/test_song_playback_extended.cpp
@@ -45,7 +45,7 @@ TEST_CASE("song_playback: song ends when duration exceeded", "[song_playback]") 
 
 TEST_CASE("song_playback: does nothing when not in Playing phase", "[song_playback]") {
     auto reg = make_rhythm_registry();
-    set_test_phase(reg, GamePhase::Title);
+    set_test_phase<GamePhaseTitleTag>(reg);
     auto& song = reg.ctx().get<SongState>();
     float original_time = song.song_time;
 

--- a/tests/test_song_playback_system.cpp
+++ b/tests/test_song_playback_system.cpp
@@ -34,7 +34,7 @@ TEST_CASE("song_playback: song_time advances by dt", "[song_playback]") {
 
 TEST_CASE("song_playback: no advancement when not Playing", "[song_playback]") {
     auto reg = make_rhythm_registry();
-    set_test_phase(reg, GamePhase::Title);
+    set_test_phase<GamePhaseTitleTag>(reg);
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 1.0f;
 
@@ -189,8 +189,7 @@ TEST_CASE("song_playback: finished song stays latched and does not restart on la
 TEST_CASE("song_playback: obstacles can clear after playback ends without soft-lock",
           "[song_playback][gamestate][issue444]") {
     auto reg = make_rhythm_registry();
-    auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::Playing);
+    set_test_phase<GamePhasePlayingTag>(reg);
 
     auto& song = reg.ctx().get<SongState>();
     song.duration_sec = 1.0f;
@@ -213,15 +212,13 @@ TEST_CASE("song_playback: obstacles can clear after playback ends without soft-l
     CHECK(reg.view<ObstacleTag>().empty());
 
     tick_fixed_systems(reg, 0.016f);
-    CHECK(gs.transition_pending);
-    CHECK(gs.next_phase == GamePhase::SongComplete);
+    CHECK(reg.ctx().contains<NextPhaseSongCompleteTag>());
 }
 
 TEST_CASE("song_playback: end-of-song transitions to SongComplete and remains stopped",
           "[song_playback][gamestate][song_complete][regression]") {
     auto reg = make_rhythm_registry();
-    auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::Playing);
+    set_test_phase<GamePhasePlayingTag>(reg);
 
     auto& song = reg.ctx().get<SongState>();
     song.duration_sec = 1.0f;
@@ -235,12 +232,11 @@ TEST_CASE("song_playback: end-of-song transitions to SongComplete and remains st
     REQUIRE_FALSE(song.playing);
 
     game_state_system(reg, 0.016f);
-    REQUIRE(gs.transition_pending);
-    REQUIRE(gs.next_phase == GamePhase::SongComplete);
+    REQUIRE(reg.ctx().contains<NextPhaseSongCompleteTag>());
 
     game_state_system(reg, 0.016f);
-    REQUIRE_FALSE(gs.transition_pending);
-    REQUIRE(gs.phase == GamePhase::SongComplete);
+    REQUIRE_FALSE(is_phase_transition_pending(reg));
+    REQUIRE(reg.ctx().contains<GamePhaseSongCompleteTag>());
 
     const float terminal_song_time = song.song_time;
     song_playback_system(reg, 1.0f);
@@ -300,7 +296,7 @@ TEST_CASE("song_playback: pause to playing resume guard is one-shot",
     music.started = true;
     music.paused = true;
 
-    set_test_phase(reg, GamePhase::Playing);
+    set_test_phase<GamePhasePlayingTag>(reg);
     song.playing = true;
 
     song_playback_system(reg, 0.016f);

--- a/tests/test_test_player_system.cpp
+++ b/tests/test_test_player_system.cpp
@@ -48,7 +48,7 @@ static void tick_systems(entt::registry& reg, int frames, float dt = 1.0f / 60.0
         scoring_system(reg, dt);
         obstacle_despawn_system(reg, dt);
         // Stop early if game over
-        if (reg.ctx().get<GameState>().transition_pending) break;
+        if (is_phase_transition_pending(reg)) break;
     }
 }
 
@@ -74,8 +74,7 @@ TEST_CASE("test_player: init level fallback uses canonical default", "[test_play
 #endif
 
 static bool survived(entt::registry& reg) {
-    auto& gs = reg.ctx().get<GameState>();
-    return gs.phase == GamePhase::Playing && !gs.transition_pending;
+    return reg.ctx().contains<GamePhasePlayingTag>() && !is_phase_transition_pending(reg);
 }
 
 static entt::entity make_loggable_obstacle(entt::registry& reg) {
@@ -212,7 +211,7 @@ TEST_CASE("test_player: auto-starts from title screen", "[test_player]") {
     auto reg = make_test_player_registry();
     make_rhythm_player(reg);
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::Title);
+    set_test_phase<GamePhaseTitleTag>(reg);
     gs.phase_timer = 1.0f;
 
     // Create a Confirm menu button (as title screen would have)
@@ -316,8 +315,7 @@ TEST_CASE("session_logger: non-fatal MissTag logs result MISS (#111)",
 TEST_CASE("session_logger: fatal MissTag logs result MISS (#111)",
           "[session_logger][issue-111]") {
     auto reg = make_rhythm_registry();
-    reg.ctx().get<GameState>().transition_pending = true;
-    reg.ctx().get<GameState>().next_phase = GamePhase::GameOver;
+    request_phase_transition<NextPhaseGameOverTag>(reg);
     auto& log = reg.ctx().emplace<SessionLog>();
     log.file = std::tmpfile();
     REQUIRE(log.file != nullptr);

--- a/tests/test_wasm_beforeunload_lifecycle.cpp
+++ b/tests/test_wasm_beforeunload_lifecycle.cpp
@@ -65,7 +65,7 @@ TEST_CASE("wasm lifecycle: visibilitychange callback pauses active play",
 
     CHECK(platform_source.find("emscripten_set_visibilitychange_callback") != std::string::npos);
     CHECK(platform_source.find("on_visibility_change") != std::string::npos);
-    CHECK(platform_source.find("gs->next_phase = GamePhase::Paused;") != std::string::npos);
+    CHECK(platform_source.find("request_phase_transition<NextPhasePausedTag>") != std::string::npos);
 }
 
 TEST_CASE("wasm smoke phase title markers are compile-gated",

--- a/tests/test_world_systems.cpp
+++ b/tests/test_world_systems.cpp
@@ -102,21 +102,20 @@ TEST_CASE("cleanup: non-obstacle entities are untouched", "[cleanup]") {
 
 TEST_CASE("game_state: title to level select on touch", "[gamestate]") {
     auto reg = make_registry();
-    set_test_phase(reg, GamePhase::Title);
+    set_test_phase<GamePhaseTitleTag>(reg);
     auto btn = make_menu_button(reg, MenuActionKind::Confirm);
     press_button(reg, btn);
 
     game_state_system(reg, 0.016f);
 
-    auto& gs = reg.ctx().get<GameState>();
-    CHECK_FALSE(gs.transition_pending);
-    CHECK(gs.phase == GamePhase::LevelSelect);
+    CHECK_FALSE(is_phase_transition_pending(reg));
+    CHECK(reg.ctx().contains<GamePhaseLevelSelectTag>());
 }
 
 TEST_CASE("game_state: game over button choice after delay", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
     gs.phase_timer = 0.5f;
     auto btn = make_menu_button(reg, MenuActionKind::GoLevelSelect);
     press_button(reg, btn);
@@ -124,14 +123,13 @@ TEST_CASE("game_state: game over button choice after delay", "[gamestate]") {
     game_state_system(reg, 0.016f);
 
     // Button tap sets choice AND transitions in same frame
-    CHECK(gs.transition_pending);
-    CHECK(gs.next_phase == GamePhase::LevelSelect);
+    CHECK(reg.ctx().contains<NextPhaseLevelSelectTag>());
 }
 
 TEST_CASE("game_state: game over keyboard confirm routes to restart", "[gamestate][input][regression]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
     gs.phase_timer = 0.5f;
 
     reg.ctx().get<entt::dispatcher>().enqueue<MenuPressEvent>(
@@ -139,14 +137,13 @@ TEST_CASE("game_state: game over keyboard confirm routes to restart", "[gamestat
 
     game_state_system(reg, 0.016f);
 
-    CHECK(gs.transition_pending);
-    CHECK(gs.next_phase == GamePhase::Playing);
+    CHECK(reg.ctx().contains<NextPhasePlayingTag>());
 }
 
 TEST_CASE("game_state: song complete keyboard confirm routes to restart", "[gamestate][input][regression]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::SongComplete);
+    set_test_phase<GamePhaseSongCompleteTag>(reg);
     gs.phase_timer = constants::SONG_COMPLETE_INPUT_DELAY + 0.1f;
 
     reg.ctx().get<entt::dispatcher>().enqueue<MenuPressEvent>(
@@ -154,15 +151,14 @@ TEST_CASE("game_state: song complete keyboard confirm routes to restart", "[game
 
     game_state_system(reg, 0.016f);
 
-    CHECK(gs.transition_pending);
-    CHECK(gs.next_phase == GamePhase::Playing);
+    CHECK(reg.ctx().contains<NextPhasePlayingTag>());
 }
 
 TEST_CASE("game_state: song complete keyboard confirm waits for button debounce",
           "[gamestate][input][regression]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::SongComplete);
+    set_test_phase<GamePhaseSongCompleteTag>(reg);
     gs.phase_timer = 0.45f;
 
     reg.ctx().get<entt::dispatcher>().enqueue<MenuPressEvent>(
@@ -170,7 +166,7 @@ TEST_CASE("game_state: song complete keyboard confirm waits for button debounce"
 
     game_state_system(reg, 0.0f);
 
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
     CHECK(reg.ctx().find<EndChoiceRestart>() == nullptr);
     CHECK(reg.ctx().find<EndChoiceLevelSelect>() == nullptr);
     CHECK(reg.ctx().find<EndChoiceMainMenu>() == nullptr);
@@ -179,20 +175,20 @@ TEST_CASE("game_state: song complete keyboard confirm waits for button debounce"
 TEST_CASE("game_state: game over ignores touch during delay", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::GameOver);
+    set_test_phase<GamePhaseGameOverTag>(reg);
     gs.phase_timer = 0.2f;  // within GAME_OVER_INPUT_DELAY
     auto btn = make_menu_button(reg, MenuActionKind::Confirm);
     press_button(reg, btn);
 
     game_state_system(reg, 0.016f);
 
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("game_state: paused menu input waits for entry debounce", "[gamestate][input]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::Paused);
+    set_test_phase<GamePhasePausedTag>(reg);
     gs.phase_timer = constants::UI_ENTRY_DEBOUNCE + 0.1f;
     gs.phase_timer = 0.1f;
 
@@ -201,13 +197,13 @@ TEST_CASE("game_state: paused menu input waits for entry debounce", "[gamestate]
 
     game_state_system(reg, 0.0f);
 
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("game_state: paused menu input resumes after entry debounce", "[gamestate][input]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::Paused);
+    set_test_phase<GamePhasePausedTag>(reg);
     gs.phase_timer = constants::UI_ENTRY_DEBOUNCE + 0.1f;
 
     reg.ctx().get<entt::dispatcher>().enqueue<MenuPressEvent>(
@@ -215,7 +211,7 @@ TEST_CASE("game_state: paused menu input resumes after entry debounce", "[gamest
 
     game_state_system(reg, 0.0f);
 
-    CHECK(gs.phase == GamePhase::Playing);
+    CHECK(reg.ctx().contains<GamePhasePlayingTag>());
     CHECK(gs.phase_timer == 0.0f);
 }
 
@@ -237,9 +233,7 @@ TEST_CASE("game_state: enter_playing clears entities and creates player", "[game
     reg.emplace<ObstacleTag>(junk);
     reg.emplace<WorldTransform>(junk, WorldTransform{{0.0f, 0.0f}});
 
-    auto& gs = reg.ctx().get<GameState>();
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::Playing;
+    request_phase_transition<NextPhasePlayingTag>(reg);
 
     game_state_system(reg, 0.016f);
 
@@ -253,7 +247,7 @@ TEST_CASE("game_state: enter_playing clears entities and creates player", "[game
     CHECK(player_count == 1);
 
     // Phase should be Playing
-    CHECK(gs.phase == GamePhase::Playing);
+    CHECK(reg.ctx().contains<GamePhasePlayingTag>());
 }
 
 TEST_CASE("game_state: enter_game_over updates high score", "[gamestate]") {
@@ -263,14 +257,12 @@ TEST_CASE("game_state: enter_game_over updates high score", "[gamestate]") {
     score.score = 5000;
     current.value = 3000;
 
-    auto& gs = reg.ctx().get<GameState>();
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::GameOver;
+    request_phase_transition<NextPhaseGameOverTag>(reg);
 
     game_state_system(reg, 0.016f);
 
     CHECK(current.value == 5000);
-    CHECK(gs.phase == GamePhase::GameOver);
+    CHECK(reg.ctx().contains<GamePhaseGameOverTag>());
     const auto& terminal = reg.ctx().get<TerminalResultState>();
     CHECK(terminal.new_best);
     CHECK(terminal.previous_best == 3000);
@@ -278,9 +270,7 @@ TEST_CASE("game_state: enter_game_over updates high score", "[gamestate]") {
 
 TEST_CASE("game_state: enter_game_over pushes Crash SFX", "[gamestate]") {
     auto reg = make_registry();
-    auto& gs = reg.ctx().get<GameState>();
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::GameOver;
+    request_phase_transition<NextPhaseGameOverTag>(reg);
 
     game_state_system(reg, 0.016f);
 
@@ -298,9 +288,7 @@ TEST_CASE("game_state: enter_game_over preserves high score if lower", "[gamesta
     score.score = 1000;
     current.value = 5000;
 
-    auto& gs = reg.ctx().get<GameState>();
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::GameOver;
+    request_phase_transition<NextPhaseGameOverTag>(reg);
 
     game_state_system(reg, 0.016f);
 
@@ -313,21 +301,21 @@ TEST_CASE("game_state: enter_game_over preserves high score if lower", "[gamesta
 TEST_CASE("game_state: paused to playing on touch", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::Paused);
+    set_test_phase<GamePhasePausedTag>(reg);
     gs.phase_timer = constants::UI_ENTRY_DEBOUNCE + 0.1f;
     auto btn = make_menu_button(reg, MenuActionKind::Confirm);
     press_button(reg, btn);
 
     game_state_system(reg, 0.016f);
 
-    CHECK(gs.phase == GamePhase::Playing);
+    CHECK(reg.ctx().contains<GamePhasePlayingTag>());
     CHECK(gs.phase_timer == 0.0f);
 }
 
 TEST_CASE("game_state: paused resume preserves active play session state", "[gamestate][regression]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::Paused);
+    set_test_phase<GamePhasePausedTag>(reg);
     gs.phase_timer = constants::UI_ENTRY_DEBOUNCE + 0.1f;
 
     auto player = make_player(reg);
@@ -352,7 +340,7 @@ TEST_CASE("game_state: paused resume preserves active play session state", "[gam
 
     game_state_system(reg, 0.016f);
 
-    CHECK(gs.phase == GamePhase::Playing);
+    CHECK(reg.ctx().contains<GamePhasePlayingTag>());
     CHECK(gs.phase_timer == 0.0f);
     CHECK(reg.valid(player));
     CHECK(reg.valid(obstacle));
@@ -373,51 +361,46 @@ TEST_CASE("game_state: paused resume preserves active play session state", "[gam
 
 TEST_CASE("game_state: title stays title without touch", "[gamestate]") {
     auto reg = make_registry();
-    auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::Title);
+    set_test_phase<GamePhaseTitleTag>(reg);
     // No press event in queue — no actions
 
     game_state_system(reg, 0.5f);
 
-    CHECK(gs.phase == GamePhase::Title);
-    CHECK_FALSE(gs.transition_pending);
+    CHECK(reg.ctx().contains<GamePhaseTitleTag>());
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("game_state: transition to Paused sets phase", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::Playing);
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::Paused;
+    set_test_phase<GamePhasePlayingTag>(reg);
+    request_phase_transition<NextPhasePausedTag>(reg);
 
     game_state_system(reg, 0.016f);
 
-    CHECK(gs.phase == GamePhase::Paused);
+    CHECK(reg.ctx().contains<GamePhasePausedTag>());
     CHECK(gs.phase_timer == 0.0f);
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("game_state: transition to Settings sets phase", "[gamestate]") {
     auto reg = make_registry();
     auto& gs = reg.ctx().get<GameState>();
-    set_test_phase(reg, GamePhase::Title);
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::Settings;
+    set_test_phase<GamePhaseTitleTag>(reg);
+    request_phase_transition<NextPhaseSettingsTag>(reg);
 
     game_state_system(reg, 0.016f);
 
-    CHECK(gs.phase == GamePhase::Settings);
+    CHECK(reg.ctx().contains<GamePhaseSettingsTag>());
     CHECK(gs.phase_timer == 0.0f);
-    CHECK_FALSE(gs.transition_pending);
+    CHECK_FALSE(is_phase_transition_pending(reg));
 }
 
 TEST_CASE("game_state: enter_playing resets score", "[gamestate]") {
     auto reg = make_registry();
     reg.ctx().get<ScoreState>().score = 9999;
 
-    auto& gs = reg.ctx().get<GameState>();
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::Playing;
+    request_phase_transition<NextPhasePlayingTag>(reg);
 
     game_state_system(reg, 0.016f);
 
@@ -428,7 +411,7 @@ TEST_CASE("game_state: enter_playing resets score", "[gamestate]") {
 
 TEST_CASE("scroll: no movement when not in Playing phase", "[scroll]") {
     auto reg = make_registry();
-    set_test_phase(reg, GamePhase::Title);
+    set_test_phase<GamePhaseTitleTag>(reg);
     auto e = reg.create();
     reg.emplace<WorldTransform>(e, WorldTransform{{100.0f, 200.0f}});
     reg.emplace<Vector2>(e, Vector2{10.0f, 20.0f});
@@ -441,7 +424,7 @@ TEST_CASE("scroll: no movement when not in Playing phase", "[scroll]") {
 
 TEST_CASE("motion: no movement when not in Playing phase", "[motion]") {
     auto reg = make_registry();
-    set_test_phase(reg, GamePhase::Title);
+    set_test_phase<GamePhaseTitleTag>(reg);
     auto e = reg.create();
     reg.emplace<WorldTransform>(e, WorldTransform{{100.0f, 200.0f}});
     reg.emplace<Vector2>(e, Vector2{10.0f, 20.0f});


### PR DESCRIPTION
Final PR in the #1202 GamePhase eradication chain. Builds on PRs A–F (#1264, #1265, #1266, #1267, #1269, #1270).

## What this PR removes

- `enum class GamePhase` (`app/components/game_state.h`)
- `GameState::phase` / `GameState::next_phase` / `GameState::transition_pending` (struct is now just `phase_timer`)
- Both `switch (phase)` helpers in `app/systems/game_phase_transition.cpp`
- `GamePhase` row from `app/.allowed-enums.txt`
- `GamePhase phase` parameter on `game_state_enter_terminal_phase()` (split into `_game_over` and `_song_complete`)

## New template-based API

In `app/systems/game_phase_transition.h` (all inline, header-only):

```cpp
template <typename PhaseTag>     void enter_phase(entt::registry& reg);
template <typename PhaseTag>     void sync_game_phase_tags(entt::registry& reg);
template <typename NextPhaseTag> void request_phase_transition(entt::registry& reg);
bool is_phase_transition_pending(const entt::registry& reg);
void clear_next_phase_tags(entt::registry& reg);  // unchanged
```

Dispatch happens at the call site via the template parameter — no runtime enum compare, no `switch`, no virtual dispatch. The compiler instantiates one transform per tag the program actually uses, exactly matching Fabian's "transform per row of the former enum table" mechanic.

`is_phase_transition_pending(reg)` ORs eight `ctx.contains<NextPhase*Tag>()` checks, replacing the `gs.transition_pending` boolean. `request_phase_transition<NextPhaseXTag>(reg)` replaces the `gs.transition_pending = true; gs.next_phase = X;` pair at every UI / input / system call site.

The canonical-allowlist matcher in `tests/test_phase_transition_canonical.cpp` now accepts the template syntax (`enter_phase<Tag>(`) in addition to the legacy enum form.

## Verification

- ✅ `cmake --build build --target shapeshifter shapeshifter_tests -j` — clean (`-Wall -Wextra -Werror`)
- ✅ `cmake --build build-no-unity --target shapeshifter shapeshifter_tests -j` — clean
- ✅ `./build/shapeshifter_tests` — **all 879 test cases / 2952 assertions pass**
- ✅ `./build-no-unity/shapeshifter_tests` — all pass
- ✅ `python3 tools/check_enum_allowlist.py` — ok, 9 enums allowlisted (GamePhase removed)

Refs #1202.
