### PR TITLE
#1268 Fix dispatcher connection teardown SIGSEGV (scoped_connection → connection)

### DIFF
--- a/app/systems/audio_dispatcher.cpp
+++ b/app/systems/audio_dispatcher.cpp
@@ -5,10 +5,24 @@
 
 namespace {
 
+// Raw `entt::connection` (not `scoped_connection`) on purpose: see issue #1268.
+// Same rationale as `input_dispatcher.cpp` — `reg.ctx()` is a `dense_map` whose
+// packed `std::vector` destruction order is unspecified across standard
+// libraries (libc++ reverse, libstdc++ forward). A `scoped_connection` whose
+// destructor fires after the dispatcher is freed would dereference a dead
+// `sigh` and SIGSEGV in test teardown. Registry teardown is now a no-op for
+// these handles; explicit release happens through `release_all()` only when
+// the dispatcher is known to still be alive.
 struct AudioHapticDispatcherConnections {
     entt::dispatcher* owner = nullptr;
-    entt::scoped_connection sfx;
-    entt::scoped_connection haptic;
+    entt::connection sfx;
+    entt::connection haptic;
+
+    void release_all() noexcept {
+        haptic.release();
+        sfx.release();
+        owner = nullptr;
+    }
 };
 
 void warm_audio_haptic_dispatcher(entt::dispatcher& disp) {
@@ -36,19 +50,19 @@ void wire_audio_haptic_dispatcher(entt::registry& reg) {
     if (state->owner == disp) {
         return;
     }
-    *state = AudioHapticDispatcherConnections{};
+    state->release_all();
     state->owner = disp;
 
-    state->sfx    = entt::scoped_connection{
-        disp->sink<PlaySfxEvent>().connect<&audio_handle_play_sfx>(reg)};
-    state->haptic = entt::scoped_connection{
-        disp->sink<PlayHapticEvent>().connect<&haptic_handle_play>(reg)};
+    state->sfx =
+        disp->sink<PlaySfxEvent>().connect<&audio_handle_play_sfx>(reg);
+    state->haptic =
+        disp->sink<PlayHapticEvent>().connect<&haptic_handle_play>(reg);
 
     warm_audio_haptic_dispatcher(*disp);
 }
 
 void unwire_audio_haptic_dispatcher(entt::registry& reg) {
     if (auto* state = reg.ctx().find<AudioHapticDispatcherConnections>()) {
-        *state = AudioHapticDispatcherConnections{};
+        state->release_all();
     }
 }

--- a/app/systems/input_dispatcher.cpp
+++ b/app/systems/input_dispatcher.cpp
@@ -5,16 +5,41 @@
 #include <stdexcept>
 
 namespace {
+// Raw `entt::connection` (not `scoped_connection`) on purpose: see issue #1268.
+// These live alongside the `entt::dispatcher` in `reg.ctx()`, which is a
+// `dense_map<id_type, basic_any>` whose packed std::vector destruction order
+// is unspecified across standard libraries (libc++ destroys in reverse,
+// libstdc++ in forward order). A `scoped_connection` whose destructor fires
+// after the dispatcher has already been destroyed would dereference a freed
+// `sigh` and SIGSEGV in test teardown.
+//
+// With raw connections, registry teardown is a no-op for these handles: the
+// listener vectors die with the dispatcher's `sigh`s, so there is nothing
+// to disconnect. The `unwire_input_dispatcher()` path still has to release
+// the listeners explicitly while the dispatcher is alive — see
+// `release_all()` below — to honour "unwire preserves external listeners".
 struct InputDispatcherConnections {
     entt::dispatcher* owner = nullptr;
-    entt::scoped_connection go_game_state;
-    entt::scoped_connection menu_press_game_state;
-    entt::scoped_connection go_level_select;
-    entt::scoped_connection menu_press_level_select;
-    entt::scoped_connection go_player_input;
-    entt::scoped_connection shape_press_circle_player_input;
-    entt::scoped_connection shape_press_square_player_input;
-    entt::scoped_connection shape_press_triangle_player_input;
+    entt::connection go_game_state;
+    entt::connection menu_press_game_state;
+    entt::connection go_level_select;
+    entt::connection menu_press_level_select;
+    entt::connection go_player_input;
+    entt::connection shape_press_circle_player_input;
+    entt::connection shape_press_square_player_input;
+    entt::connection shape_press_triangle_player_input;
+
+    void release_all() noexcept {
+        shape_press_triangle_player_input.release();
+        shape_press_square_player_input.release();
+        shape_press_circle_player_input.release();
+        go_player_input.release();
+        menu_press_level_select.release();
+        go_level_select.release();
+        menu_press_game_state.release();
+        go_game_state.release();
+        owner = nullptr;
+    }
 };
 
 void warm_dispatcher_event_queues(entt::dispatcher& disp) {
@@ -48,34 +73,37 @@ void wire_input_dispatcher(entt::registry& reg) {
     if (state->owner == disp) {
         return;
     }
-    *state = InputDispatcherConnections{};
+    // Re-wire onto a different dispatcher: release any previously-wired
+    // listeners on the previous dispatcher (assumed still alive — same
+    // assumption the prior `scoped_connection` assignment relied on).
+    state->release_all();
     state->owner = disp;
 
     // Fixed-step semantic order: game_state, level_select, player_input.
     // Shape presses route only to player_input (no menu listeners care about
     // them). Menu presses route to both game_state and level_select.
-    state->go_player_input = entt::scoped_connection{
-        disp->sink<GoEvent>().connect<&player_input_handle_go>(reg)};
-    state->shape_press_circle_player_input = entt::scoped_connection{
-        disp->sink<ShapePressCircleEvent>().connect<&player_input_handle_press_circle>(reg)};
-    state->shape_press_square_player_input = entt::scoped_connection{
-        disp->sink<ShapePressSquareEvent>().connect<&player_input_handle_press_square>(reg)};
-    state->shape_press_triangle_player_input = entt::scoped_connection{
-        disp->sink<ShapePressTriangleEvent>().connect<&player_input_handle_press_triangle>(reg)};
-    state->go_level_select = entt::scoped_connection{
-        disp->sink<GoEvent>().connect<&level_select_handle_go>(reg)};
-    state->menu_press_level_select = entt::scoped_connection{
-        disp->sink<MenuPressEvent>().connect<&level_select_handle_press_menu>(reg)};
-    state->go_game_state = entt::scoped_connection{
-        disp->sink<GoEvent>().connect<&game_state_handle_go>(reg)};
-    state->menu_press_game_state = entt::scoped_connection{
-        disp->sink<MenuPressEvent>().connect<&game_state_handle_press_menu>(reg)};
+    state->go_player_input =
+        disp->sink<GoEvent>().connect<&player_input_handle_go>(reg);
+    state->shape_press_circle_player_input =
+        disp->sink<ShapePressCircleEvent>().connect<&player_input_handle_press_circle>(reg);
+    state->shape_press_square_player_input =
+        disp->sink<ShapePressSquareEvent>().connect<&player_input_handle_press_square>(reg);
+    state->shape_press_triangle_player_input =
+        disp->sink<ShapePressTriangleEvent>().connect<&player_input_handle_press_triangle>(reg);
+    state->go_level_select =
+        disp->sink<GoEvent>().connect<&level_select_handle_go>(reg);
+    state->menu_press_level_select =
+        disp->sink<MenuPressEvent>().connect<&level_select_handle_press_menu>(reg);
+    state->go_game_state =
+        disp->sink<GoEvent>().connect<&game_state_handle_go>(reg);
+    state->menu_press_game_state =
+        disp->sink<MenuPressEvent>().connect<&game_state_handle_press_menu>(reg);
 
     warm_dispatcher_event_queues(*disp);
 }
 
 void unwire_input_dispatcher(entt::registry& reg) {
     if (auto* state = reg.ctx().find<InputDispatcherConnections>()) {
-        *state = InputDispatcherConnections{};
+        state->release_all();
     }
 }

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -338,6 +338,38 @@ TEST_CASE("ecs: repeated unwire_input_dispatcher is idempotent before rewire",
     CHECK(drain_sfx_events(reg).count == 1);
 }
 
+// Issue #1268: dispatcher connections must NOT auto-release on registry
+// teardown. EnTT's `ctx` is a `dense_map` whose packed `std::vector`
+// destruction order is unspecified (libc++ destroys in reverse, libstdc++
+// in forward). With `scoped_connection`, libstdc++ would destruct the
+// dispatcher first and the connection-holder's destructor would then call
+// `release()` on a freed `sigh` — SIGSEGV in teardown. The fix is to use
+// raw `entt::connection` so destruction is a no-op; release happens only
+// through `unwire_*_dispatcher()` while the dispatcher is still alive.
+TEST_CASE("ecs: registry teardown without unwire_* is safe (no UAF)",
+          "[ecs][dispatcher][shutdown][regression]") {
+    // Constructing then dropping a registry without ever calling
+    // `unwire_*_dispatcher()` must not crash. Every TEST_CASE that does
+    // `auto reg = make_registry();` exercises the same teardown path at
+    // scope-exit; this case makes the intent explicit, drains a wired
+    // listener so the dispatcher's `sigh` has real bookkeeping, and
+    // then lets the inner block destruct the registry.
+    {
+        auto reg = make_rhythm_registry();
+        auto player = make_rhythm_player(reg);
+        REQUIRE(window_phase_is_idle(reg, player));
+
+        auto& disp = reg.ctx().get<entt::dispatcher>();
+        disp.enqueue<GoEvent>(GoEvent{Direction::Right});
+        disp.update<GoEvent>();
+        CHECK(reg.get<Lane>(player).target == 2);
+        // Inner-block exit destroys the registry. With `scoped_connection`,
+        // libstdc++ would SIGSEGV here because the dispatcher's `sigh` is
+        // destroyed before the holder's auto-release runs.
+    }
+    SUCCEED("registry teardown completed without crash");
+}
+
 TEST_CASE("collision: SongState ctx singleton identity is stable across collision ticks",
           "[collision][song_state][regression]") {
     auto reg = make_registry();


### PR DESCRIPTION
Fixes the Catch2 random-ordering flake reported in #1268 (`Unknown expression after the reported line` → SIGSEGV in registry teardown on Linux and Windows-Clang under specific seeds).

## Root cause

Both `InputDispatcherConnections` and `AudioHapticDispatcherConnections` live in `reg.ctx()` alongside the `entt::dispatcher`. `registry::ctx` is internally a `dense_map<id_type, basic_any>` whose packed `std::vector` destruction order is **unspecified across standard libraries**:

| stdlib | vector element destruction | dispatcher vs holders | result |
|---|---|---|---|
| libc++ (macOS / iOS) | reverse (back-to-front) | holders die first | `scoped_connection::release()` against still-live `sigh` — safe |
| libstdc++ (Linux) | forward (front-to-back) | dispatcher dies first | `scoped_connection::~scoped_connection()` dereferences a freed `sigh` — **UB → SIGSEGV** |

Catch2's random test order rotates which TEST_CASE happens to be the one to hit this path, producing the seed-dependent flake on Linux and Windows-Clang while macOS / WASM stayed green.

## Fix

Switch the eight input + two audio/haptic handles from `entt::scoped_connection` to raw `entt::connection`. Add an explicit `release_all()` helper on each holder, and call it from `unwire_input_dispatcher` / `unwire_audio_haptic_dispatcher` while the dispatcher is still alive.

Net effect:

- **Registry teardown is now a no-op for these handles.** The listener vectors die with the dispatcher's `sigh`s, leaving nothing to disconnect. No dependency on ctx destruction order.
- **`unwire_*_dispatcher` still releases listeners explicitly** while the dispatcher is alive, preserving the existing `ecs: unwire_input_dispatcher preserves external listeners` contract.
- **Re-wire path** (`state->owner != disp`) now calls `release_all()` instead of relying on `*state = DefaultConstructed{}` to release scoped_connections.

## Regression test

New `[ecs][dispatcher][shutdown][regression]` TEST_CASE in `tests/test_components.cpp` that constructs, drives the dispatcher to give its `sigh`s real bookkeeping, then drops the registry without calling `unwire_*`. This is the exact pattern the original flake exercised; it would SIGSEGV on libstdc++ under the previous code and is now safe on both stdlibs.

## Verification

- `cmake --build build --target shapeshifter shapeshifter_tests -j` — clean (`-Wall -Wextra -Werror`)
- `cmake --build build-no-unity --target shapeshifter shapeshifter_tests -j` — clean
- `./build/shapeshifter_tests "~[bench]"` — **880 cases / 2955 assertions pass**
- `./build-no-unity/shapeshifter_tests "~[bench]"` — all pass
- Replayed the three known-failing CI seeds locally (`617283530`, `761056933`, `768111768`) — all green
- `python3 tools/check_enum_allowlist.py` — ok (9 enums)

Refs #1268. Refs PR chain #1267 / #1269 / #1270 / #1271 where the flake surfaced.