### PR TITLE
Drop magic_enum dependency (#1204 bonus cleanup)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,6 @@ configure_file(
 # nlohmann-json: JSON parsing for beat map loading (vcpkg on all platforms).
 
 find_package(EnTT CONFIG REQUIRED)
-find_package(magic_enum CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(raylib CONFIG REQUIRED)
 find_path(RAYGUI_INCLUDE_DIR raygui.h REQUIRED)
@@ -98,7 +97,7 @@ target_compile_options(shapeshifter_warnings INTERFACE
 
 # Mark third-party include directories as SYSTEM so warnings from their
 # headers are suppressed and cannot be promoted to errors by -Werror.
-set(_system_deps EnTT::EnTT magic_enum::magic_enum raylib nlohmann_json::nlohmann_json)
+set(_system_deps EnTT::EnTT raylib nlohmann_json::nlohmann_json)
 if(BUILD_TESTING)
     list(APPEND _system_deps Catch2::Catch2 Catch2::Catch2WithMain)
 endif()
@@ -183,7 +182,6 @@ target_include_directories(shapeshifter_lib SYSTEM PUBLIC
 )
 target_link_libraries(shapeshifter_lib PUBLIC
     EnTT::EnTT
-    magic_enum::magic_enum
     nlohmann_json::nlohmann_json
 )
 target_link_libraries(shapeshifter_lib PUBLIC raylib)

--- a/app/.allowed-enums.txt
+++ b/app/.allowed-enums.txt
@@ -48,3 +48,11 @@ Shape              # lookup key — perfect-hash index into per-shape function-p
 # Each row below is a control-flow enum awaiting migration to per-case tags
 # or component tables. Removing a row here = the migration landed.
 # Adding a row here would be drift; eradicate instead.
+#
+# Status (post-#1271): the pending set is now EMPTY — every former
+# control-flow enum (Shape, GamePhase, GamePhaseBit, ObstacleKind,
+# WindowPhase, MeshType, Layer, TimingTier, VMode, EndScreenChoice,
+# TestPlayerSkill, ActionDoneBit, DeathCause) has been eradicated or
+# (Shape only) promoted to the Keep set above. New enums in `app/` are
+# rejected by `tools/check_enum_allowlist.py`; any future entry must
+# either justify the Keep set or open an eradication issue.

--- a/app/components/audio.h
+++ b/app/components/audio.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <cstdint>
-#include <magic_enum/magic_enum.hpp>
 #include <raylib.h>
 
+// `Count` is a sentinel (always last); `static_cast<int>(SFX::Count)` replaces
+// the former `magic_enum::enum_count<SFX>()` lookup (issue #1204 bonus).
 enum class SFX : uint8_t {
     ShapeShift = 0,
     Crash,
@@ -11,18 +12,19 @@ enum class SFX : uint8_t {
     ChainBonus,
     ScorePopup,
     GameStart,
+    Count,
 };
 
 // Compile-time guard: SFX values must be contiguous and zero-based so that
 // static arrays indexed by static_cast<int>(sfx) are always in-bounds.
-static_assert(magic_enum::enum_count<SFX>() == 6,
+static_assert(static_cast<int>(SFX::Count) == 6,
               "SFX enum changed — update systems/sfx_bank.cpp SFX_SPECS and this guard");
 static_assert(static_cast<int>(SFX::ShapeShift) == 0,
               "SFX enum must be zero-based for array indexing");
 
 // Resident sound bank initialised by sfx_bank_init (app/systems/sfx_bank.cpp).
 struct SFXBank {
-    static constexpr int SFX_COUNT = static_cast<int>(magic_enum::enum_count<SFX>());
+    static constexpr int SFX_COUNT = static_cast<int>(SFX::Count);
     Sound sounds[SFX_COUNT]       = {};
     bool  sound_loaded[SFX_COUNT] = {};
     bool  loaded                  = false;

--- a/app/components/player.h
+++ b/app/components/player.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string_view>
 #include "tags/tags.h"
 
 enum class Shape : uint8_t {
@@ -9,6 +10,20 @@ enum class Shape : uint8_t {
     Triangle,
     Hexagon,
 };
+
+// Stringification for trace/log lines. Pure label lookup, doctrinally fine
+// per Fabian's Existential Processing chapter (see issue #1204 — "Bonus:
+// drop the magic_enum dependency"). Replaces the former
+// `magic_enum::enum_name(Shape)` lookup used by the session logger and tests.
+constexpr std::string_view to_string(Shape shape) noexcept {
+    switch (shape) {
+        case Shape::Circle:   return "Circle";
+        case Shape::Square:   return "Square";
+        case Shape::Triangle: return "Triangle";
+        case Shape::Hexagon:  return "Hexagon";
+    }
+    return {};
+}
 
 // Hot render data — read by game_camera_system, player_movement_system every frame.
 // The player's current shape identity lives as one of `ShapeCircleTag` /

--- a/app/systems/haptics.h
+++ b/app/systems/haptics.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string_view>
 
 // Haptic feedback events — sourced from design-docs/game-flow.md Appendix B.
 // All haptics are opt-out (enabled by default).
@@ -14,3 +15,21 @@ enum class HapticEvent : uint8_t {
     RetryTap,         // Crisp tap       — end-screen Restart pressed
     UIButtonTap,      // Ultra-light tap — any UI menu button pressed
 };
+
+// Stringification for trace/log lines. Pure label lookup (no control-flow
+// dispatch on the enum's value beyond the symbolic name), so the switch is
+// doctrinally fine per Fabian's Existential Processing chapter (see issue
+// #1204 — "Bonus: drop the magic_enum dependency"). Replaces the former
+// `magic_enum::enum_name(HapticEvent)` call site in haptics_backend.cpp.
+constexpr std::string_view to_string(HapticEvent event) noexcept {
+    switch (event) {
+        case HapticEvent::ShapeShift:   return "ShapeShift";
+        case HapticEvent::LaneSwitch:   return "LaneSwitch";
+        case HapticEvent::JumpLand:     return "JumpLand";
+        case HapticEvent::DeathCrash:   return "DeathCrash";
+        case HapticEvent::NewHighScore: return "NewHighScore";
+        case HapticEvent::RetryTap:     return "RetryTap";
+        case HapticEvent::UIButtonTap:  return "UIButtonTap";
+    }
+    return {};
+}

--- a/app/systems/haptics_backend.cpp
+++ b/app/systems/haptics_backend.cpp
@@ -2,7 +2,6 @@
 
 #include "haptics_ios_bridge.h"
 
-#include <magic_enum/magic_enum.hpp>
 #include <raylib.h>
 
 namespace platform::haptics {
@@ -15,7 +14,7 @@ struct HapticsRuntimeState {
 #endif
 
 void trace_haptic_event(const char* prefix, HapticEvent event) {
-    const auto event_name = magic_enum::enum_name(event);
+    const auto event_name = to_string(event);
     if (event_name.empty()) {
         TraceLog(LOG_DEBUG, "%sUnknown", prefix);
         return;

--- a/app/systems/session_logger_system.cpp
+++ b/app/systems/session_logger_system.cpp
@@ -126,7 +126,7 @@ void session_log_on_obstacle_spawn(entt::registry& reg, entt::entity entity) {
     float arrival = beat ? beat->arrival_time : 0.0f;
     const std::string_view kind_name = obstacle_kind_label(reg, entity);
     const std::string_view shape_name =
-        has_req ? enum_name_or_unknown(current_required_shape(reg, entity))
+        has_req ? to_string(current_required_shape(reg, entity))
                 : std::string_view{"-"};
 
     session_log_write(*log, t, "GAME",

--- a/app/systems/session_logger_system.h
+++ b/app/systems/session_logger_system.h
@@ -1,21 +1,11 @@
 #pragma once
 
 #include <entt/entt.hpp>
-#include <magic_enum/magic_enum.hpp>
 #include <cstddef>
 #include <cstdio>
 #include <cstdint>
 #include <string>
 #include <string_view>
-
-// Returns the enum name as a string_view, or "???" when magic_enum cannot
-// resolve the value (out-of-range / non-reflective). Intended for log lines
-// where an enum should print symbolically without aborting on bad data.
-template <typename E>
-std::string_view enum_name_or_unknown(E value) {
-    const std::string_view name = magic_enum::enum_name(value);
-    return name.empty() ? std::string_view{"???"} : name;
-}
 
 // Per-tag obstacle-kind label for log lines. Replaces the former
 // `enum_name(ObstacleKind)` lookup with a tag-presence dispatch

--- a/app/systems/sfx_bank.cpp
+++ b/app/systems/sfx_bank.cpp
@@ -7,7 +7,6 @@
 #include <array>
 #include <cmath>
 #include <cstdint>
-#include <magic_enum/magic_enum.hpp>
 #include <vector>
 
 namespace {
@@ -26,7 +25,7 @@ struct SfxSpec {
 
 constexpr float kPi = 3.14159265358979323846f;
 constexpr int SAMPLE_RATE = 44100;
-constexpr int SFX_COUNT = static_cast<int>(magic_enum::enum_count<SFX>());
+constexpr int SFX_COUNT = static_cast<int>(SFX::Count);
 
 float next_noise(std::uint32_t& state) {
     state = state * 1664525u + 1013904223u;
@@ -53,7 +52,7 @@ constexpr std::array<SfxSpec, SFX_COUNT> SFX_SPECS{{
     {587.0f, 0.180f, 0.35f, sample_sine,  10u},      // GameStart
 }};
 
-static_assert(SFX_SPECS.size() == magic_enum::enum_count<SFX>(),
+static_assert(SFX_SPECS.size() == static_cast<std::size_t>(SFX::Count),
               "SFX_SPECS entry count must match SFX enum count");
 
 float envelope_at(int frame, int frame_count) {

--- a/tests/test_helpers_and_functions.cpp
+++ b/tests/test_helpers_and_functions.cpp
@@ -1,6 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
-#include <magic_enum/magic_enum.hpp>
 #include "test_helpers.h"
 #include "ui/screen_controllers/screen_controller_base.h"
 #include "util/rhythm_math.h"
@@ -138,10 +137,10 @@ TEST_CASE("song_state_derived: fixed window independent of song BPM", "[song_sta
 // ── enum name helpers ────────────────────────────────────────
 
 TEST_CASE("ToString: Shape covers all shapes", "[ToString]") {
-    CHECK(magic_enum::enum_name(Shape::Circle)   == "Circle");
-    CHECK(magic_enum::enum_name(Shape::Square)   == "Square");
-    CHECK(magic_enum::enum_name(Shape::Triangle) == "Triangle");
-    CHECK(magic_enum::enum_name(Shape::Hexagon)  == "Hexagon");
+    CHECK(to_string(Shape::Circle)   == "Circle");
+    CHECK(to_string(Shape::Square)   == "Square");
+    CHECK(to_string(Shape::Triangle) == "Triangle");
+    CHECK(to_string(Shape::Hexagon)  == "Hexagon");
 }
 
 // ObstacleKind enum was eradicated in issue #1202/#1204 (per Fabian's

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,7 +5,6 @@
   "description": "Endless runner with shape-shifting and burnout scoring",
   "dependencies": [
     "entt",
-    "magic-enum",
     "raylib",
     "raygui",
     "nlohmann-json",


### PR DESCRIPTION
Closes the final open work item on #1204 — the Bonus appendix's path to removing the `magic_enum` runtime dependency now that all eradicate-set enums are gone.

## What landed

1. **`SFX::Count` sentinel** — added as the last enum value of `SFX`. Replaces the four `magic_enum::enum_count<SFX>()` sites in `app/components/audio.h` and `app/systems/sfx_bank.cpp` with `static_cast<int>(SFX::Count)`. The existing loops iterate `0..SFX_COUNT-1` so the sentinel is never treated as a real SFX value.

2. **Hand-rolled `to_string()` for Kept enums** — `constexpr std::string_view to_string(HapticEvent)` in `app/systems/haptics.h` and `to_string(Shape)` in `app/components/player.h`. Replaces `magic_enum::enum_name` in `haptics_backend.cpp:18` and `session_logger_system.cpp:129`. Pure label lookup — stringification-only switches are doctrinally fine per Fabian (Existential Processing, quoted in #1204).

3. **Deleted `enum_name_or_unknown` template** from `session_logger_system.h` (now unused; magic_enum include removed). The `"???"` fallback was only reachable on out-of-range enum values; `current_required_shape` always returns a valid Shape, so the inline `to_string(...)` call is total-by-construction.

4. **Updated `tests/test_helpers_and_functions.cpp`** — the `ToString: Shape covers all shapes` test now exercises the hand-rolled helper.

5. **CMakeLists.txt + vcpkg.json** — dropped `find_package(magic_enum CONFIG REQUIRED)`, the `magic_enum::magic_enum` entries in `_system_deps` and the `shapeshifter_lib` link, and the `magic-enum` dependency in `vcpkg.json`.

6. **Documented in `app/.allowed-enums.txt`** that the Pending eradication set is now empty (every former control-flow enum is gone). The Keep set is unchanged (9 enums).

## Verification

| check | result |
|---|---|
| `cmake --build build` (Clang `-Wall -Wextra -Werror`) | clean, zero warnings |
| `./build/shapeshifter_tests '~[bench]'` | 880 cases / 2955 assertions pass |
| `ctest --test-dir build` (native, excluding wasm + node-only) | 891/891 pass |
| `python3 tools/check_enum_allowlist.py` | `ok: 9 enum(s) in app/, all allowlisted` |
| `python3 -m unittest discover -s tools -p 'test_*.py'` | 214 tests pass |
| `grep -rn magic_enum app/ tests/ tools/ CMakeLists.txt vcpkg.json` | only doc comments explaining what was replaced |

## Acceptance criteria mapping (final block of #1204)

- ✅ `magic_enum` removed from `CMakeLists.txt` and `vcpkg.json`.
- ✅ No `#include <magic_enum/...>` anywhere in `app/`, `tests/`, or `tools/`.
- ✅ `SFX::Count` sentinel pattern used for the SFX array-size assertion.
- ✅ Hand-written `to_string()` for `HapticEvent` and `Shape` (both Kept enums in the allowlist).

With this PR, #1204's body acceptance + Bonus appendix are both complete; the issue can be closed once this lands.

Refs #1204.