### PR TITLE
Eradicate LevelSelectState::confirmed via LevelSelectConfirmedTag ctx singleton (refs #1194, #1203)

### DIFF
--- a/app/components/game_state.h
+++ b/app/components/game_state.h
@@ -59,8 +59,18 @@ struct EndChoiceMainMenu {};
 struct LevelSelectState {
     int selected_level      = 0;
     int selected_difficulty  = 1;  // default medium
-    bool confirmed          = false;
 };
+
+// ── Level-select confirmation latch (singleton ctx tag) ──────
+// Per Fabian's existential processing / relational normalization
+// (issues #1194, #1203): the former `LevelSelectState::confirmed` bool was a
+// one-shot latch with a different lifecycle than the selection bundle
+// (selection persists across phases; confirmation is a per-frame intent set
+// by UI on START and drained by game_state_system after the entry debounce).
+// Existence of this ctx tag is the data; absence is "not confirmed yet".
+// Matches the precedent set for `EndChoiceRestart` / `EndChoiceLevelSelect` /
+// `EndChoiceMainMenu` (player-choice latches on the end screens).
+struct LevelSelectConfirmedTag {};
 
 // ── Game-over cause (per-cause ctx tables) ──────────────────
 // Per Fabian's existential processing, each former DeathCause value is its

--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -143,8 +143,9 @@ void game_state_system(entt::registry& reg, float dt) {
         }
         if (ctx.contains<NextPhaseLevelSelectTag>()) {
             enter_phase<GamePhaseLevelSelectTag>(reg);
-            auto& lss = reg.ctx().get<LevelSelectState>();
-            lss.confirmed = false;
+            if (reg.ctx().find<LevelSelectConfirmedTag>()) {
+                reg.ctx().erase<LevelSelectConfirmedTag>();
+            }
         }
         if (ctx.contains<NextPhaseSettingsTag>()) {
             enter_phase<GamePhaseSettingsTag>(reg);
@@ -165,9 +166,8 @@ void game_state_system(entt::registry& reg, float dt) {
     // LevelSelect input handling
     if (reg.ctx().contains<GamePhaseLevelSelectTag>() &&
         gs.phase_timer > constants::UI_ENTRY_DEBOUNCE) {
-        auto& lss = reg.ctx().get<LevelSelectState>();
-        if (lss.confirmed) {
-            lss.confirmed = false;
+        if (reg.ctx().find<LevelSelectConfirmedTag>()) {
+            reg.ctx().erase<LevelSelectConfirmedTag>();
             const auto* settings_ptr = find_settings_state(reg);
             if (settings_ptr && !settings::ftue_complete(*settings_ptr)) {
                 request_phase_transition<NextPhaseTutorialTag>(reg);

--- a/app/systems/play_session.cpp
+++ b/app/systems/play_session.cpp
@@ -174,7 +174,7 @@ void setup_play_session(entt::registry& reg) {
         erase_ctx_if_exists<EndChoiceRestart>(reg);
         erase_ctx_if_exists<EndChoiceLevelSelect>(reg);
         erase_ctx_if_exists<EndChoiceMainMenu>(reg);
-        lss.confirmed = false;
+        erase_ctx_if_exists<LevelSelectConfirmedTag>(reg);
         enter_phase<GamePhaseLevelSelectTag>(reg);
         return;
     }

--- a/app/ui/level_select_controller.cpp
+++ b/app/ui/level_select_controller.cpp
@@ -27,7 +27,7 @@ void level_select_handle_press_menu(entt::registry& reg, const MenuPressEvent& e
 
     switch (evt.action) {
         case MenuActionKind::Confirm:
-            lss.confirmed = true;
+            reg.ctx().insert_or_assign(LevelSelectConfirmedTag{});
             break;
         case MenuActionKind::SelectLevel:
             if (content_config::is_valid_level_index(evt.index)) {

--- a/app/ui/screen_controllers/level_select_screen_controller.cpp
+++ b/app/ui/screen_controllers/level_select_screen_controller.cpp
@@ -164,5 +164,7 @@ void render_level_select_screen_ui(entt::registry& reg) {
     
     GuiSetStyle(DEFAULT, TEXT_SIZE, saved_text_size);
 
-    if (state.StartButtonPressed && gs.phase_timer > constants::UI_ENTRY_DEBOUNCE) lss.confirmed = true;
+    if (state.StartButtonPressed && gs.phase_timer > constants::UI_ENTRY_DEBOUNCE) {
+        reg.ctx().insert_or_assign(LevelSelectConfirmedTag{});
+    }
 }

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -177,22 +177,20 @@ TEST_CASE("game_state: song_complete ignores choice during delay", "[gamestate]"
 
 TEST_CASE("game_state: transition to LevelSelect resets confirmed", "[gamestate]") {
     auto reg = make_registry();
-    auto& lss = reg.ctx().get<LevelSelectState>();
-    lss.confirmed = true;
+    reg.ctx().insert_or_assign(LevelSelectConfirmedTag{});
 
     request_phase_transition<NextPhaseLevelSelectTag>(reg);
 
     game_state_system(reg, 0.016f);
 
     CHECK(reg.ctx().contains<GamePhaseLevelSelectTag>());
-    CHECK_FALSE(lss.confirmed);
+    CHECK_FALSE(reg.ctx().contains<LevelSelectConfirmedTag>());
 }
 
 TEST_CASE("game_state: terminal to LevelSelect hides stale world renderables",
           "[gamestate][render][regression][issue921]") {
     auto reg = make_registry();
-    auto& lss = reg.ctx().get<LevelSelectState>();
-    lss.confirmed = true;
+    reg.ctx().insert_or_assign(LevelSelectConfirmedTag{});
 
     auto stale = reg.create();
     reg.emplace<ModelTransform>(stale);
@@ -204,7 +202,7 @@ TEST_CASE("game_state: terminal to LevelSelect hides stale world renderables",
     game_state_system(reg, 0.016f);
 
     CHECK(reg.ctx().contains<GamePhaseLevelSelectTag>());
-    CHECK_FALSE(lss.confirmed);
+    CHECK_FALSE(reg.ctx().contains<LevelSelectConfirmedTag>());
     REQUIRE(reg.valid(stale));
     CHECK(reg.all_of<ModelTransform, TagWorldPass>(stale));
     CHECK_FALSE(game_render_should_draw_world_meshes(reg));
@@ -291,14 +289,13 @@ TEST_CASE("game_state: level select confirmed starts tutorial when FTUE is incom
     auto& gs = reg.ctx().get<GameState>();
     set_test_phase<GamePhaseLevelSelectTag>(reg);
     gs.phase_timer = 0.5f;  // past 0.2s guard
-    auto& lss = reg.ctx().get<LevelSelectState>();
-    lss.confirmed = true;
+    reg.ctx().insert_or_assign(LevelSelectConfirmedTag{});
     settings_state(reg).ftue_run_count = 0;
 
     game_state_system(reg, 0.016f);
 
     CHECK(reg.ctx().contains<NextPhaseTutorialTag>());
-    CHECK_FALSE(lss.confirmed);
+    CHECK_FALSE(reg.ctx().contains<LevelSelectConfirmedTag>());
 }
 
 TEST_CASE("game_state: level select confirmed triggers playing when FTUE is complete",
@@ -307,14 +304,13 @@ TEST_CASE("game_state: level select confirmed triggers playing when FTUE is comp
     auto& gs = reg.ctx().get<GameState>();
     set_test_phase<GamePhaseLevelSelectTag>(reg);
     gs.phase_timer = 0.5f;  // past 0.2s guard
-    auto& lss = reg.ctx().get<LevelSelectState>();
-    lss.confirmed = true;
+    reg.ctx().insert_or_assign(LevelSelectConfirmedTag{});
     settings_state(reg).ftue_run_count = 1;
 
     game_state_system(reg, 0.016f);
 
     CHECK(reg.ctx().contains<NextPhasePlayingTag>());
-    CHECK_FALSE(lss.confirmed);
+    CHECK_FALSE(reg.ctx().contains<LevelSelectConfirmedTag>());
 }
 
 TEST_CASE("tutorial: continue marks FTUE complete and requests gameplay",
@@ -367,13 +363,13 @@ TEST_CASE("game_state: level select ignores confirmed during delay", "[gamestate
     auto& gs = reg.ctx().get<GameState>();
     set_test_phase<GamePhaseLevelSelectTag>(reg);
     gs.phase_timer = 0.1f;  // within 0.2s delay
-    auto& lss = reg.ctx().get<LevelSelectState>();
-    lss.confirmed = true;
+    reg.ctx().insert_or_assign(LevelSelectConfirmedTag{});
 
     game_state_system(reg, 0.016f);
 
-    // confirmed still true, no transition yet
+    // confirmed still latched, no transition yet
     CHECK_FALSE(is_phase_transition_pending(reg));
+    CHECK(reg.ctx().contains<LevelSelectConfirmedTag>());
 }
 
 TEST_CASE("game_state: game_over restart button triggers playing", "[gamestate]") {

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -122,7 +122,7 @@ TEST_CASE("Play session: missing selected beatmap returns to level select withou
     high_score::set_score(high_scores, "1_stomper|medium", 4321);
     auto& session = reg.ctx().get<HighScoreSession>();
     session.key_hash = high_score::make_key_hash("1_stomper", "medium");
-    lss.confirmed = true;
+    reg.ctx().insert_or_assign(LevelSelectConfirmedTag{});
 
     reg.ctx().emplace<PlaySessionContentOverride>(
         PlaySessionContentOverride{"content/beatmaps/does_not_exist_835.json", "medium"});
@@ -130,7 +130,7 @@ TEST_CASE("Play session: missing selected beatmap returns to level select withou
     setup_play_session(reg);
 
     CHECK(reg.ctx().contains<GamePhaseLevelSelectTag>());
-    CHECK_FALSE(lss.confirmed);
+    CHECK_FALSE(reg.ctx().contains<LevelSelectConfirmedTag>());
     {
         const auto& bm = beat_map(reg);
         CHECK(beat_map_empty(bm));
@@ -143,7 +143,7 @@ TEST_CASE("Play session: missing selected beatmap returns to level select withou
     reg.ctx().erase<PlaySessionContentOverride>();
     lss.selected_level = content_config::DEFAULT_LEVEL_INDEX;
     lss.selected_difficulty = content_config::DEFAULT_DIFFICULTY_INDEX;
-    lss.confirmed = true;
+    reg.ctx().insert_or_assign(LevelSelectConfirmedTag{});
 
     REQUIRE_NOTHROW(setup_play_session(reg));
     CHECK(reg.ctx().find<SongState>() != nullptr);


### PR DESCRIPTION
## Why

`LevelSelectState` was the last god-class bullet in #1194's audit of `game_state.h` — it mixed two distinct lifecycles:

1. **Selection bundle** (`selected_level`, `selected_difficulty`) — persists across phases, always co-accessed by `play_session` / `test_player_session` / level-select UI.
2. **Confirmation latch** (`confirmed` bool) — per-frame intent set by UI on START or menu-Confirm and drained by `game_state_system` once the entry-debounce elapses (triggering Tutorial or Playing).

Per Fabian relational normalization (#1203), a flag whose meaning is "an intent transitioning between two states" with its own write/drain owners belongs in its own table, not as a bool column on an unrelated bundle. The companion principle (existential processing) prefers ctx-tag presence over bool fields for one-shot latches.

## What

- Add `struct LevelSelectConfirmedTag {};` ctx singleton in `app/components/game_state.h`. Existence = confirmed; absence = not confirmed yet. Documented next to the `EndChoiceRestart` / `EndChoiceLevelSelect` / `EndChoiceMainMenu` precedent (one-shot end-screen-choice latches, same shape).
- Remove the `confirmed` field from `LevelSelectState`. The struct now contains only the co-accessed selection bundle.
- **Writers** (was `lss.confirmed = true`) → `reg.ctx().insert_or_assign(LevelSelectConfirmedTag{})` in:
  - `app/ui/level_select_controller.cpp` (MenuPress Confirm action)
  - `app/ui/screen_controllers/level_select_screen_controller.cpp` (START button)
- **Drainers** (was `lss.confirmed = false`) → `if (find<>()) erase<>()` / `erase_ctx_if_exists<>()` in:
  - `app/systems/game_state_system.cpp` (two sites: NextPhaseLevelSelectTag entry, post-confirmation dispatch)
  - `app/systems/play_session.cpp` (failed-beatmap fallback path, alongside the existing EndChoice tag erases)
- **Readers** (was `if (lss.confirmed)`) → `ctx().find<LevelSelectConfirmedTag>()` in `game_state_system`; `ctx().contains<>()` in tests.
- Tests updated in `test_game_state_extended.cpp` (5 sites) and `test_high_score_integration.cpp` (2 sites).

## Audit-bullet ratchet

Closes the audit's bullet:

> SPLIT `game_state.h`: ... `LevelSelectState` mixes selection with a one-shot confirmation latch.

Last `game_state.h` SPLIT item in #1194. Remaining work in that audit folds into #1198 (wrapper-noise sweep).

## Diff size

7 files, +35/-27. Mechanical.

## Validation

- 880 Catch2 tests / 2956 assertions pass under unity AND non-unity Clang builds (`-Wall -Wextra -Werror`).
- One new assertion vs. baseline (the "ignores confirmed during delay" test now also asserts the latch *remains present* until the debounce elapses, since absence is now the source of truth).
- Zero warnings.

Refs #1194, #1203
