### PR TITLE
#1198 Unwrap ShapeGateLane / RequiredLane wrappers to raw int8_t

### DIFF
--- a/app/components/obstacle.h
+++ b/app/components/obstacle.h
@@ -21,13 +21,21 @@ struct Obstacle {
 // emplace it, and `current_required_shape()` / `has_required_shape_tag()`
 // to read it back.
 
-struct ShapeGateLane {
-    int8_t lane = 0;
-};
-
-struct RequiredLane {
-    int8_t lane = 0;
-};
+// The former `ShapeGateLane { int8_t lane }` and `RequiredLane { int8_t lane }`
+// single-field wrappers were deleted per issue #1198 (companion to the
+// `BlockedLanes` → `uint8_t` unwrap in PR #1240 and the `MotionVelocity`
+// → `Vector2` unwrap in PR #1241). The per-entity lane index is now stored
+// as a raw `int8_t` component.
+//
+// Slot reservation: the per-entity `int8_t` component is the *lane index*
+// for an obstacle entity. Its semantics is determined by the obstacle's
+// kind tag (per `app/tags/tags.h`):
+//   - `ShapeGateTag`  → positional lane (where the shape hole is)
+//   - `SplitPathTag`  → required dodge lane (where the player must be)
+// ShapeGate and SplitPath archetypes never coexist on the same entity, so
+// the shared `int8_t` slot has no collision. Onset markers and any other
+// future obstacle archetype must not emplace a raw `int8_t` on the same
+// entity — give them their own per-archetype component table instead.
 
 // Owned mesh children for a logical obstacle entity. destroy_obstacle_with_children
 // in app/entities/obstacle_render_entity.cpp cleans up in O(count). Relocated out

--- a/app/entities/obstacle_entity.cpp
+++ b/app/entities/obstacle_entity.cpp
@@ -26,7 +26,7 @@ entt::entity create_shape_gate(entt::registry& reg, const ShapeGateSpawn& params
     reg.emplace<ShapeGateTag>(e);
     reg.emplace<Obstacle>(e, int16_t{constants::PTS_SHAPE_GATE});
     set_required_shape_tag(reg, e, params.shape);
-    reg.emplace<ShapeGateLane>(
+    reg.emplace<int8_t>(
         e, static_cast<int8_t>(lane_utils::nearest_lane_for_x(params.x)));
     reg.emplace<DrawSize>(e, constants::SCREEN_W_F, 80.0f);
     reg.emplace<Color>(e, constants::SHAPE_COLORS[shape_index(params.shape)]);
@@ -46,7 +46,7 @@ entt::entity create_split_path(entt::registry& reg, const SplitPathSpawn& params
     reg.emplace<SplitPathTag>(e);
     reg.emplace<Obstacle>(e, int16_t{constants::PTS_SPLIT_PATH});
     set_required_shape_tag(reg, e, params.shape);
-    reg.emplace<RequiredLane>(e, params.req_lane);
+    reg.emplace<int8_t>(e, params.req_lane);
     reg.emplace<DrawSize>(e, constants::SCREEN_W_F, 80.0f);
     reg.emplace<Color>(e, Color{255, 215, 0, 255});
     return e;

--- a/app/entities/obstacle_entity.h
+++ b/app/entities/obstacle_entity.h
@@ -10,8 +10,9 @@
 //   - `SplitPathSpawn`: shape + required dodge lane
 //   - `OnsetMarkerSpawn`: position + speed only
 // `req_lane` for ShapeGate is computed at spawn-time from x via
-// `nearest_lane_for_x()` and stored in `ShapeGateLane`. SplitPath uses
-// `req_lane` directly to set `RequiredLane`.
+// `nearest_lane_for_x()` and stored as the entity's raw `int8_t`
+// lane component. SplitPath uses `req_lane` directly. See the slot-
+// reservation note in `app/components/obstacle.h`.
 struct ShapeGateSpawn {
     float  x      = 0.0f;
     float  y      = 0.0f;

--- a/app/entities/obstacle_render_entity.cpp
+++ b/app/entities/obstacle_render_entity.cpp
@@ -18,7 +18,7 @@ uint8_t checked_shape_mesh_index(Shape shape) {
 int checked_lane_index(int8_t lane) {
     const int lane_index = static_cast<int>(lane);
     if (lane_index < 0 || lane_index >= constants::LANE_COUNT) {
-        throw std::logic_error("Invalid RequiredLane lane");
+        throw std::logic_error("Invalid required lane index");
     }
     return lane_index;
 }
@@ -114,10 +114,10 @@ void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical) {
         return;
     }
     if (reg.all_of<SplitPathTag>(logical)) {
-        auto* rlane = reg.try_get<RequiredLane>(logical);
+        auto* rlane = reg.try_get<int8_t>(logical);
         int lane_index = 0;
         if (rlane) {
-            lane_index = checked_lane_index(rlane->lane);
+            lane_index = checked_lane_index(*rlane);
         }
         const bool has_req = has_required_shape_tag(reg, logical);
         uint8_t mesh_index = 0;

--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -153,26 +153,29 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
     // so the views below filter on `ShapeGateTag` / `SplitPathTag` and the
     // resolver dispatches per-shape via `player_matches_required_shape`.
 
-    // ShapeGate: ShapeGateTag (carries RequiredShape*Tag, no RequiredLane)
+    // ShapeGate: ShapeGateTag (carries RequiredShape*Tag + raw int8_t lane).
+    // The raw int8_t component is the ShapeGate positional lane per the slot
+    // reservation in `app/components/obstacle.h` (issue #1198). SplitPath
+    // entities are filtered out by absence of `ShapeGateTag`.
     {
-        auto rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, ShapeGateTag, ShapeGateLane, BeatInfo>(
-            entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredLane>);
+        auto rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, ShapeGateTag, int8_t, BeatInfo>(
+            entt::exclude<ScoredTag, ResolvedObstacleTag>);
         for (auto [e, obstacle, wt, lane, info] : rhythm_view.each()) {
             (void)obstacle;
-            const bool lane_ok = shape_gate_lane_match(lane.lane, player_lane);
+            const bool lane_ok = shape_gate_lane_match(lane, player_lane);
             resolve_shape_obstacle(e, wt, lane_ok, &info);
         }
 
-        auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, ShapeGateTag, ShapeGateLane>(
-            entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredLane, BeatInfo>);
+        auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, ShapeGateTag, int8_t>(
+            entt::exclude<ScoredTag, ResolvedObstacleTag, BeatInfo>);
         for (auto [e, obstacle, wt, lane] : view.each()) {
             (void)obstacle;
-            const bool lane_ok = shape_gate_lane_match(lane.lane, player_lane);
+            const bool lane_ok = shape_gate_lane_match(lane, player_lane);
             resolve_shape_obstacle(e, wt, lane_ok, nullptr);
         }
 
         auto fallback_rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, ShapeGateTag, BeatInfo>(
-            entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredLane, ShapeGateLane>);
+            entt::exclude<ScoredTag, ResolvedObstacleTag, int8_t>);
         for (auto [e, obstacle, wt, info] : fallback_rhythm_view.each()) {
             (void)obstacle;
             const bool lane_ok = lane_utils::nearest_lane_for_x(wt.position.x) == player_lane;
@@ -180,7 +183,7 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
         }
 
         auto fallback_view = reg.view<ObstacleTag, Obstacle, WorldTransform, ShapeGateTag>(
-            entt::exclude<ScoredTag, ResolvedObstacleTag, RequiredLane, BeatInfo, ShapeGateLane>);
+            entt::exclude<ScoredTag, ResolvedObstacleTag, BeatInfo, int8_t>);
         for (auto [e, obstacle, wt] : fallback_view.each()) {
             (void)obstacle;
             const bool lane_ok = lane_utils::nearest_lane_for_x(wt.position.x) == player_lane;
@@ -188,21 +191,24 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
         }
     }
 
-    // SplitPath: SplitPathTag (carries RequiredShape*Tag + RequiredLane)
+    // SplitPath: SplitPathTag (carries RequiredShape*Tag + raw int8_t lane).
+    // The raw int8_t component is the required dodge lane per the slot
+    // reservation in `app/components/obstacle.h` (issue #1198). ShapeGate
+    // entities are filtered out by absence of `SplitPathTag`.
     {
-        auto rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, SplitPathTag, RequiredLane, BeatInfo>(
+        auto rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, SplitPathTag, int8_t, BeatInfo>(
             entt::exclude<ScoredTag, ResolvedObstacleTag>);
         for (auto [e, obstacle, wt, rlane, info] : rhythm_view.each()) {
             (void)obstacle;
-            const bool lane_ok = player_lane == rlane.lane;
+            const bool lane_ok = player_lane == rlane;
             resolve_shape_obstacle(e, wt, lane_ok, &info);
         }
 
-        auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, SplitPathTag, RequiredLane>(
+        auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, SplitPathTag, int8_t>(
             entt::exclude<ScoredTag, ResolvedObstacleTag, BeatInfo>);
         for (auto [e, obstacle, wt, rlane] : view.each()) {
             (void)obstacle;
-            const bool lane_ok = player_lane == rlane.lane;
+            const bool lane_ok = player_lane == rlane;
             resolve_shape_obstacle(e, wt, lane_ok, nullptr);
         }
     }

--- a/app/systems/session_logger_system.cpp
+++ b/app/systems/session_logger_system.cpp
@@ -120,8 +120,9 @@ void session_log_on_obstacle_spawn(entt::registry& reg, entt::entity entity) {
     const bool has_req = has_required_shape_tag(reg, entity);
 
     int8_t lane = 1;
-    auto* rlane = reg.try_get<RequiredLane>(entity);
-    if (rlane) lane = rlane->lane;
+    if (reg.all_of<SplitPathTag>(entity)) {
+        if (auto* rlane = reg.try_get<int8_t>(entity)) lane = *rlane;
+    }
 
     float arrival = beat ? beat->arrival_time : 0.0f;
     const std::string_view kind_name = obstacle_kind_label(reg, entity);

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -170,7 +170,7 @@ static TestPlayerAction determine_action(
         // ShapeGate: player must also be in the lane where the shape hole is.
         // The hole is at obs_pos.x — find which lane that corresponds to.
         auto* obs_wt = reg.try_get<WorldTransform>(entity);
-        if (obs_wt && !reg.all_of<RequiredLane>(entity)) {
+        if (obs_wt && !reg.all_of<SplitPathTag>(entity)) {
             for (int i = 0; i < constants::LANE_COUNT; ++i) {
                 if (!lane_centers_overlap(obs_wt->position.x, constants::LANE_X[i])) continue;
                 if (i != player_lane) {
@@ -181,10 +181,13 @@ static TestPlayerAction determine_action(
         }
     }
 
-    // Lane requirement (RequiredLane — exact lane)
-    auto* req_lane = reg.try_get<RequiredLane>(entity);
-    if (req_lane && lane_utils::is_valid(req_lane->lane) && req_lane->lane != player_lane) {
-        action.target_lane = req_lane->lane;
+    // Lane requirement (SplitPath: exact lane stored as raw int8_t per
+    // issue #1198 / the slot-reservation note in app/components/obstacle.h).
+    if (reg.all_of<SplitPathTag>(entity)) {
+        if (auto* req_lane = reg.try_get<int8_t>(entity);
+            req_lane && lane_utils::is_valid(*req_lane) && *req_lane != player_lane) {
+            action.target_lane = *req_lane;
+        }
     }
 
     return action;

--- a/app/tags/tags.h
+++ b/app/tags/tags.h
@@ -70,8 +70,11 @@ struct RequiredShapeHexagonTag  {};
 // Replaces the former ObstacleKind enum (issue #1202/#1204). Each
 // former enum value is its own per-kind table:
 //   - ShapeGateTag / SplitPathTag  → zero-column tag; the per-instance
-//     data (`RequiredShape*Tag`, `RequiredLane`, `ShapeGateLane`) lives in
-//     its own component table per the schema-per-kind mechanic in #1204.
+//     data (`RequiredShape*Tag` for shape, raw `int8_t` for lane index)
+//     lives in its own component table per the schema-per-kind mechanic
+//     in #1204. The lane wrappers `ShapeGateLane` / `RequiredLane` were
+//     unwrapped to raw `int8_t` per #1198; see `app/components/obstacle.h`
+//     for the slot-reservation note.
 //   - OnsetMarkerTag → zero-column tag (no per-instance data).
 // Spawn helpers in `entities/obstacle_entity.h` emplace exactly one
 // kind tag; renderer / logger / test-player systems dispatch via

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -83,13 +83,13 @@ TEST_CASE("beat_scheduler: spawns ShapeGate when time passes spawn_time", "[beat
     CHECK(count == 1);
 
     // Verify it's a ShapeGate with correct components
-    auto view = reg.view<ObstacleTag, Obstacle, ShapeGateLane>();
+    auto view = reg.view<ObstacleTag, Obstacle, ShapeGateTag, int8_t>();
     for (auto [e, obs, lane] : view.each()) {
         (void)obs;
         CHECK_FALSE(reg.all_of<uint8_t>(e));
-        CHECK_FALSE(reg.all_of<RequiredLane>(e));
+        CHECK_FALSE(reg.all_of<SplitPathTag>(e));
         CHECK(current_required_shape(reg, e) == Shape::Circle);
-        CHECK(lane.lane == int8_t{1});
+        CHECK(lane == int8_t{1});
     }
 }
 
@@ -105,12 +105,12 @@ TEST_CASE("beat_scheduler: defaults invalid ShapeGate lane to center lane", "[be
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
-    auto view = reg.view<ObstacleTag, WorldTransform, ShapeGateLane>();
+    auto view = reg.view<ObstacleTag, WorldTransform, ShapeGateTag, int8_t>();
     REQUIRE(view.size_hint() == 1);
     for (auto [e, wt, lane] : view.each()) {
         (void)e;
         CHECK_THAT(wt.position.x, Catch::Matchers::WithinAbs(constants::LANE_X[1], 0.01f));
-        CHECK(lane.lane == int8_t{1});
+        CHECK(lane == int8_t{1});
     }
 }
 
@@ -328,7 +328,7 @@ TEST_CASE("beat_scheduler: spawns OnsetMarker as visible non-scorable cue",
         CHECK(obstacle.base_points == int16_t{0});
         CHECK_FALSE(has_required_shape_tag(reg, e));
         CHECK_FALSE(reg.all_of<uint8_t>(e));
-        CHECK_FALSE(reg.all_of<RequiredLane>(e));
+        CHECK_FALSE(reg.all_of<SplitPathTag>(e));
         REQUIRE(children.count == 1);
         const auto child = children.children[0];
         REQUIRE(reg.valid(child));
@@ -371,12 +371,12 @@ TEST_CASE("beat_scheduler: spawns SplitPath in authored lane", "[beat_scheduler]
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
-    auto view = reg.view<ObstacleTag, WorldTransform, RequiredLane>();
+    auto view = reg.view<ObstacleTag, WorldTransform, SplitPathTag, int8_t>();
     REQUIRE(view.size_hint() == 1);
     for (auto [e, wt, lane] : view.each()) {
         CHECK_THAT(wt.position.x, Catch::Matchers::WithinAbs(constants::LANE_X[2], 0.01f));
         CHECK(current_required_shape(reg, e) == Shape::Triangle);
-        CHECK(lane.lane == 2);
+        CHECK(lane == 2);
     }
     CHECK(song.next_split_path_triangle_idx == 1);
 }
@@ -393,12 +393,12 @@ TEST_CASE("beat_scheduler: defaults invalid SplitPath lane to center lane", "[be
     song.next_onset_marker_idx = 0;
     CHECK_NOTHROW(beat_scheduler_system(reg, 0.016f));
 
-    auto view = reg.view<ObstacleTag, WorldTransform, RequiredLane, ObstacleChildren>();
+    auto view = reg.view<ObstacleTag, WorldTransform, SplitPathTag, int8_t, ObstacleChildren>();
     REQUIRE(view.size_hint() == 1);
     for (auto [e, wt, lane, children] : view.each()) {
         CHECK_THAT(wt.position.x, Catch::Matchers::WithinAbs(constants::LANE_X[1], 0.01f));
         CHECK(current_required_shape(reg, e) == Shape::Square);
-        CHECK(lane.lane == int8_t{1});
+        CHECK(lane == int8_t{1});
         REQUIRE(children.count == 3);
         for (int i = 0; i < children.count; ++i) {
             REQUIRE(reg.valid(children.children[i]));

--- a/tests/test_collision_extended.cpp
+++ b/tests/test_collision_extended.cpp
@@ -155,7 +155,7 @@ TEST_CASE("collision: on-beat shape press requires player hitbox to reach target
 
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.get<WorldTransform>(obs).position.x = constants::LANE_X[0];
-    reg.get<ShapeGateLane>(obs).lane = int8_t{0};
+    reg.get<int8_t>(obs) = int8_t{0};
     reg.emplace<BeatInfo>(obs, 0, song.song_time, song.song_time - song.lead_time);
 
     auto& lane = reg.get<Lane>(player);

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -60,7 +60,7 @@ TEST_CASE("collision: shape gate does not clear from target lane before strafe a
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
 
     reg.get<WorldTransform>(obs).position.x = constants::LANE_X[0];
-    reg.get<ShapeGateLane>(obs).lane = int8_t{0};
+    reg.get<int8_t>(obs) = int8_t{0};
     lane.target = 0;
     lane.lerp_t = 0.0f;
 
@@ -92,7 +92,7 @@ TEST_CASE("collision: shape gate clears when interpolated player hitbox reaches 
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
 
     reg.get<WorldTransform>(obs).position.x = constants::LANE_X[0];
-    reg.get<ShapeGateLane>(obs).lane = int8_t{0};
+    reg.get<int8_t>(obs) = int8_t{0};
     reg.get<WorldTransform>(player).position.x = constants::LANE_X[0];
     lane.target = 0;
     lane.lerp_t = 1.0f;

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -279,11 +279,11 @@ TEST_CASE("ecs: make_split_path creates proper entity", "[ecs]") {
     CHECK(reg.all_of<ObstacleTag>(obs));
     CHECK(reg.all_of<Obstacle>(obs));
     CHECK(has_required_shape_tag(reg, obs));
-    CHECK(reg.all_of<RequiredLane>(obs));
+    CHECK(reg.all_of<int8_t>(obs));
     CHECK(reg.all_of<SplitPathTag>(obs));
     CHECK(!reg.all_of<ShapeGateTag>(obs));
     CHECK(current_required_shape(reg, obs) == Shape::Triangle);
-    CHECK(reg.get<RequiredLane>(obs).lane == 2);
+    CHECK(reg.get<int8_t>(obs) == 2);
 }
 
 namespace {

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -323,7 +323,7 @@ inline entt::entity make_shape_gate(entt::registry& reg, Shape shape, float y) {
     reg.emplace<Vector2>(obs, Vector2{0.0f, song.scroll_speed});
     reg.emplace<Obstacle>(obs, int16_t{constants::PTS_SHAPE_GATE});
     set_required_shape_tag(reg, obs, shape);
-    reg.emplace<ShapeGateLane>(obs, int8_t{1});
+    reg.emplace<int8_t>(obs, int8_t{1});
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);
     reg.emplace<TagWorldPass>(obs);
     reg.emplace<Color>(obs, Color{255, 255, 255, 255});
@@ -340,7 +340,7 @@ inline entt::entity make_split_path(entt::registry& reg, Shape shape, int8_t lan
     reg.emplace<Vector2>(obs, Vector2{0.0f, song.scroll_speed});
     reg.emplace<Obstacle>(obs, int16_t{constants::PTS_SPLIT_PATH});
     set_required_shape_tag(reg, obs, shape);
-    reg.emplace<RequiredLane>(obs, lane);
+    reg.emplace<int8_t>(obs, lane);
     reg.emplace<DrawSize>(obs, float(constants::SCREEN_W), 80.0f);
     reg.emplace<TagWorldPass>(obs);
     reg.emplace<Color>(obs, Color{255, 215, 0, 255});

--- a/tests/test_obstacle_archetypes.cpp
+++ b/tests/test_obstacle_archetypes.cpp
@@ -52,14 +52,14 @@ TEST_CASE("entity: ShapeGate Circle - correct components and color", "[archetype
     entt::registry reg;
     auto e = spawn_shape_gate_obstacle(reg, {360.0f, -120.0f, Shape::Circle});
 
-    REQUIRE(reg.all_of<ObstacleTag, Vector2, WorldTransform, Obstacle, ShapeGateLane, DrawSize, Color>(e));
+    REQUIRE(reg.all_of<ObstacleTag, Vector2, WorldTransform, Obstacle, int8_t, DrawSize, Color>(e));
     REQUIRE(has_required_shape_tag(reg, e));
     CHECK(!reg.all_of<uint8_t>(e));
-    CHECK(!reg.all_of<RequiredLane>(e));
+    CHECK(!reg.all_of<SplitPathTag>(e));
 
     CHECK(reg.get<Obstacle>(e).base_points == int16_t{constants::PTS_SHAPE_GATE});
     CHECK(current_required_shape(reg, e) == Shape::Circle);
-    CHECK(reg.get<ShapeGateLane>(e).lane == int8_t{1});
+    CHECK(reg.get<int8_t>(e) == int8_t{1});
     CHECK(reg.get<WorldTransform>(e).position.x == 360.0f);
     CHECK(reg.get<WorldTransform>(e).position.y == -120.0f);
 
@@ -152,12 +152,12 @@ TEST_CASE("entity: direct mesh factory cleanup does not depend on ObstacleTag or
     CHECK(count_mesh_children(reg) == 0);
 }
 
-TEST_CASE("entity: mesh factory rejects invalid RequiredLane before children", "[archetype][render][validation]") {
+TEST_CASE("entity: mesh factory rejects invalid required lane before children", "[archetype][render][validation]") {
     SECTION("negative lane") {
         entt::registry reg;
         auto parent = make_mesh_factory_obstacle(reg);
         set_required_shape_tag(reg, parent, Shape::Square);
-        reg.emplace<RequiredLane>(parent, int8_t{-1});
+        reg.emplace<int8_t>(parent, int8_t{-1});
         reg.emplace<SplitPathTag>(parent);
 
         CHECK_THROWS_AS(spawn_obstacle_meshes(reg, parent), std::logic_error);
@@ -168,7 +168,7 @@ TEST_CASE("entity: mesh factory rejects invalid RequiredLane before children", "
         entt::registry reg;
         auto parent = make_mesh_factory_obstacle(reg);
         set_required_shape_tag(reg, parent, Shape::Square);
-        reg.emplace<RequiredLane>(parent, int8_t{3});
+        reg.emplace<int8_t>(parent, int8_t{3});
         reg.emplace<SplitPathTag>(parent);
 
         CHECK_THROWS_AS(spawn_obstacle_meshes(reg, parent), std::logic_error);
@@ -214,18 +214,18 @@ TEST_CASE("entity: ShapeGate Triangle - green color", "[archetype]") {
     CHECK(c.r == 100); CHECK(c.g == 255); CHECK(c.b == 100);
 }
 
-TEST_CASE("entity: SplitPath - RequiredShape and RequiredLane", "[archetype]") {
+TEST_CASE("entity: SplitPath - required shape tag and required lane", "[archetype]") {
     entt::registry reg;
     auto e = spawn_split_path_obstacle(reg, {360.0f, -120.0f,
                                               Shape::Square, int8_t{2}});
 
-    REQUIRE(reg.all_of<ObstacleTag, Vector2, WorldTransform, Obstacle, RequiredLane, DrawSize, Color>(e));
+    REQUIRE(reg.all_of<ObstacleTag, Vector2, WorldTransform, Obstacle, int8_t, DrawSize, Color>(e));
     REQUIRE(has_required_shape_tag(reg, e));
     CHECK(!reg.all_of<uint8_t>(e));
 
     CHECK(reg.get<Obstacle>(e).base_points == int16_t{constants::PTS_SPLIT_PATH});
     CHECK(current_required_shape(reg, e) == Shape::Square);
-    CHECK(reg.get<RequiredLane>(e).lane == int8_t{2});
+    CHECK(reg.get<int8_t>(e) == int8_t{2});
 }
 
 

--- a/tests/test_player_input_rhythm_extended.cpp
+++ b/tests/test_player_input_rhythm_extended.cpp
@@ -213,7 +213,7 @@ TEST_CASE("player_input_rhythm: circle press in lane 0 does not force mismatch b
 
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.get<WorldTransform>(obs).position.x = constants::LANE_X[0];
-    reg.get<ShapeGateLane>(obs).lane = int8_t{0};
+    reg.get<int8_t>(obs) = int8_t{0};
 
     auto btn = make_shape_button(reg, Shape::Circle);
     press_button(reg, btn);


### PR DESCRIPTION
## Summary

Resolves the final two open bullets on #1198's wrapper-noise checklist by
unwrapping `ShapeGateLane { int8_t lane }` and `RequiredLane { int8_t lane }`
to raw `int8_t`.

## Per-archetype audit (cycle 2026-05-16)

| Archetype | Carries | Never carries |
|---|---|---|
| ShapeGate (`ShapeGateTag`) | `ShapeGateLane` | `RequiredLane` (excluded by every `collision_system` view) |
| SplitPath (`SplitPathTag`) | `RequiredLane` | `ShapeGateLane` |

The two wrappers are mutually exclusive on production archetypes, so unwrapping
both to raw `int8_t` collapses them into one per-entity slot with no collision.

`int8_t` has no other `emplace<>` site in `app/`, `tests/`, or `benchmarks/`
(`grep -E 'emplace<int8_t>'` -> no matches), so the slot is unambiguous.

## Semantics now live on the tag

The lane value's semantics (positional vs required-dodge) is now determined
entirely by the entity's kind tag (`ShapeGateTag` / `SplitPathTag`), matching
the tag-based dispatch already used by `collision_system`,
`obstacle_render_entity`, `session_logger_system`, and `test_player_system`.

The slot-reservation contract is documented in `app/components/obstacle.h` so
a future `emplace<int8_t>` regression is caught at review.

## Side cleanups required by the swap

- `collision_system`: drop the now-contradictory `exclude<RequiredLane>`
  filters on ShapeGate views (a view requiring `int8_t` cannot also exclude
  `int8_t`) and dedupe the fallback `exclude<int8_t>` list. The views still
  require `ShapeGateTag` / `SplitPathTag` for archetype discrimination.
- `test_player_system`: `!all_of<RequiredLane>` -> `!all_of<SplitPathTag>`
  (semantic upgrade -- tag-based dispatch is the proper ECS pattern).
- `session_logger_system`: gate the `try_get<int8_t>` lookup on
  `all_of<SplitPathTag>` to preserve "lane=N only for SplitPath" log
  semantics.

## Validation

- Clang `-Wall -Wextra -Werror` clean on macOS, unity AND non-unity.
- 2956 assertions / 880 Catch2 test cases pass on both builds.

## Wrapper-deletion checklist after this PR

- 2-float wrappers -> `Vector2`
  - [x] `UIPosition` (deleted as dead -- PR #1239)
  - [x] `MotionVelocity` (unwrapped -- PR #1241)
  - [ ] `ScreenPosition` -- stays as wrapper (Vector2 slot reserved for velocity)
  - [ ] `DrawSize` -- stays as wrapper (same constraint; also `{w, h}` extent)
- Single-int / single-enum wrappers
  - [x] `DrawLayer` (deleted as dead -- PR #1242)
  - [x] `RequiredShape` (eradicated via per-shape tags -- #1202/#1204)
  - [x] **`ShapeGateLane`** (unwrapped to raw `int8_t` -- this PR)
  - [x] **`RequiredLane`** (unwrapped to raw `int8_t` -- this PR)
  - [x] `BlockedLanes` (unwrapped -- PR #1240)

With this PR landed, #1198 has only the two slot-reserved 2-float wrappers
remaining (`ScreenPosition`, `DrawSize`), which are documented to stay as
named structs.

Closes #1198 (after merge, pending final checklist confirmation in issue).
