### PR TITLE
#1277 Split MenuPressEvent into per-action events; data-table for log_persistence_result

### DIFF
--- a/app/.allowed-enums.txt
+++ b/app/.allowed-enums.txt
@@ -5,8 +5,7 @@
 # with per-case component tables (real structs) or empty tags. Enums
 # survive in this codebase only as:
 #
-#   - input event labels / keybindings  (Direction, MenuActionKind,
-#                                        KeyboardShapeSlot)
+#   - input event labels / keybindings  (Direction, KeyboardShapeSlot)
 #   - playback IDs                      (HapticEvent, ImpactStyle, SFX)
 #   - finite return codes               (Status)
 #   - UI layout labels                  (FontSize)
@@ -30,7 +29,6 @@
 
 # --- Keep set: label / lookup / return code (Fabian "enums that make sense")
 Direction          # input event label
-MenuActionKind     # input event label
 KeyboardShapeSlot  # keybinding lookup key
 HapticEvent        # playback ID
 ImpactStyle        # playback ID

--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -101,27 +101,45 @@ void unload_text_fonts(TextContext& ctx) {
     ctx.release();
 }
 
+// Status → (log_level, message_template) lookup table. Per Fabian's
+// existential processing (issue #1277), behavior dispatch on the `Status`
+// discriminator is replaced with a value→data lookup — same shape as the
+// `to_string(Shape)` / `HapticEvent → TriggerPattern` lookups that the
+// issue lists as doctrinally OK.
+struct PersistenceLogRow {
+    persistence::Status status;
+    int log_level;            // raylib TraceLogLevel (LOG_INFO / LOG_WARNING)
+    const char* message_fmt;  // "%s: …" — operation name interpolates as 1st arg
+};
+
+constexpr PersistenceLogRow kPersistenceLogTable[] = {
+    {persistence::Status::Success,     LOG_INFO,    "%s: success"},
+    {persistence::Status::MissingFile, LOG_INFO,    "%s: missing file (defaults in use)"},
+    {persistence::Status::CorruptData, LOG_WARNING, "%s: corrupt data (defaults in use)"},
+};
+
+const PersistenceLogRow* find_persistence_log_row(persistence::Status status) {
+    for (const auto& row : kPersistenceLogTable) {
+        if (row.status == status) return &row;
+    }
+    return nullptr;
+}
+
 void log_persistence_result(const char* operation, const persistence::Result& result) {
-    switch (result.status) {
-        case persistence::Status::Success:
-            TraceLog(LOG_INFO, "%s: success", operation);
-            break;
-        case persistence::Status::MissingFile:
-            TraceLog(LOG_INFO, "%s: missing file (defaults in use)", operation);
-            break;
-        case persistence::Status::CorruptData:
-            TraceLog(LOG_WARNING, "%s: corrupt data (defaults in use)", operation);
-            break;
-        default:
-            if (result.error) {
-                TraceLog(LOG_WARNING, "%s: %s (%s)", operation,
-                         persistence::status_name(result.status),
-                         result.error.message().c_str());
-            } else {
-                TraceLog(LOG_WARNING, "%s: %s", operation,
-                         persistence::status_name(result.status));
-            }
-            break;
+    if (const auto* row = find_persistence_log_row(result.status)) {
+        TraceLog(row->log_level, row->message_fmt, operation);
+        return;
+    }
+    // Fallback for statuses not in the table (any failure status that isn't
+    // CorruptData) — stringify via persistence::status_name and include the
+    // OS error code message when available.
+    if (result.error) {
+        TraceLog(LOG_WARNING, "%s: %s (%s)", operation,
+                 persistence::status_name(result.status),
+                 result.error.message().c_str());
+    } else {
+        TraceLog(LOG_WARNING, "%s: %s", operation,
+                 persistence::status_name(result.status));
     }
 }
 

--- a/app/systems/game_state_routing.cpp
+++ b/app/systems/game_state_routing.cpp
@@ -9,46 +9,38 @@
 #include "../constants.h"
 
 namespace {
-// Per Fabian's existential processing (issue #1202/#1204, PR G): the former
-// `gs.phase == GamePhase::X` consumers dispatch on the per-phase ctx-tag
-// mirror; the former `gs.transition_pending = true; gs.next_phase = X` pair
-// is now `request_phase_transition<NextPhase*Tag>()` — presence of the tag
-// IS the pending request, and `game_state_system` swaps phases on the next
-// tick (deferred-transition pattern per #482).
-bool game_state_handle_end_screen_press(entt::registry& reg, const MenuPressEvent& evt) {
-    auto& gs = reg.ctx().get<GameState>();
+// Per Fabian's existential processing (issue #1202/#1204/#1277): each former
+// `gs.phase == GamePhase::X` arm dispatches on the per-phase ctx-tag mirror;
+// each former `MenuActionKind::Y` arm is now its own event type. The handlers
+// below contain no enum-typed discriminator — the dispatcher sink for each
+// event type routes straight to the matching handler.
+
+// Returns true once a press on the active end screen has cleared the per-
+// phase debounce window. Common gate for Restart / GoLevelSelect / GoMainMenu
+// (which only make sense on the GameOver / SongComplete screens) and for the
+// Confirm-on-end-screen passthrough below.
+bool end_screen_press_unlocked(entt::registry& reg) {
+    auto& gs  = reg.ctx().get<GameState>();
     auto& ctx = reg.ctx();
     const bool game_over_phase     = ctx.contains<GamePhaseGameOverTag>();
     const bool song_complete_phase = ctx.contains<GamePhaseSongCompleteTag>();
-    if (!game_over_phase && !song_complete_phase) {
-        return false;
-    }
+    if (!game_over_phase && !song_complete_phase) return false;
 
     const float input_delay = song_complete_phase
         ? constants::SONG_COMPLETE_INPUT_DELAY
         : constants::GAME_OVER_INPUT_DELAY;
-    if (gs.phase_timer <= input_delay) {
-        return false;
-    }
+    return gs.phase_timer > input_delay;
+}
 
-    const MenuActionKind action =
-        (evt.action == MenuActionKind::Confirm) ? MenuActionKind::Restart
-                                                : evt.action;
-
-    if (auto* disp = ctx.find<entt::dispatcher>()) {
-        disp->enqueue<PlayHapticEvent>({action == MenuActionKind::Restart
-                                           ? HapticEvent::RetryTap
-                                           : HapticEvent::UIButtonTap});
+void enqueue_ui_haptic(entt::registry& reg, HapticEvent which) {
+    if (auto* disp = reg.ctx().find<entt::dispatcher>()) {
+        disp->enqueue<PlayHapticEvent>({which});
     }
+}
 
-    if (action == MenuActionKind::Restart) {
-        ctx.insert_or_assign(EndChoiceRestart{});
-    } else if (action == MenuActionKind::GoLevelSelect) {
-        ctx.insert_or_assign(EndChoiceLevelSelect{});
-    } else if (action == MenuActionKind::GoMainMenu) {
-        ctx.insert_or_assign(EndChoiceMainMenu{});
-    }
-    return true;
+void latch_end_choice_restart(entt::registry& reg) {
+    enqueue_ui_haptic(reg, HapticEvent::RetryTap);
+    reg.ctx().insert_or_assign(EndChoiceRestart{});
 }
 } // namespace
 
@@ -60,31 +52,24 @@ void game_state_handle_go(entt::registry& reg, const GoEvent& /*evt*/) {
     request_phase_transition<NextPhasePlayingTag>(reg);
 }
 
-void game_state_handle_press_menu(entt::registry& reg, const MenuPressEvent& evt) {
-    auto& gs = reg.ctx().get<GameState>();
+void game_state_handle_confirm(entt::registry& reg, const MenuConfirmEvent&) {
+    auto& gs  = reg.ctx().get<GameState>();
     auto& ctx = reg.ctx();
 
     if (ctx.contains<GamePhaseTitleTag>()) {
-        if (auto* disp = ctx.find<entt::dispatcher>()) {
-            disp->enqueue<PlayHapticEvent>({HapticEvent::UIButtonTap});
-        }
-        if (evt.action == MenuActionKind::Exit) {
-#ifndef PLATFORM_WEB
-            ctx.get<InputState>().quit_requested = true;
-#endif
-        } else if (evt.action == MenuActionKind::Confirm) {
-            request_phase_transition<NextPhaseLevelSelectTag>(reg);
-        }
+        enqueue_ui_haptic(reg, HapticEvent::UIButtonTap);
+        request_phase_transition<NextPhaseLevelSelectTag>(reg);
         return;
     }
 
-    if (game_state_handle_end_screen_press(reg, evt)) {
+    // Confirm on an end screen is the keyboard Enter shortcut for Restart.
+    if (end_screen_press_unlocked(reg)) {
+        latch_end_choice_restart(reg);
         return;
     }
 
     if (ctx.contains<GamePhaseTutorialTag>()) {
         if (gs.phase_timer <= constants::UI_ENTRY_DEBOUNCE) return;
-        if (evt.action != MenuActionKind::Confirm) return;
         if (auto* settings_state = find_settings_state(reg)) {
             settings::mark_ftue_complete(*settings_state);
             if (auto* persistence = find_settings_persistence(reg)) {
@@ -101,4 +86,21 @@ void game_state_handle_press_menu(entt::registry& reg, const MenuPressEvent& evt
         request_phase_transition<NextPhasePlayingTag>(reg);
         return;
     }
+}
+
+void game_state_handle_restart(entt::registry& reg, const MenuRestartEvent&) {
+    if (!end_screen_press_unlocked(reg)) return;
+    latch_end_choice_restart(reg);
+}
+
+void game_state_handle_go_level_select(entt::registry& reg, const MenuGoLevelSelectEvent&) {
+    if (!end_screen_press_unlocked(reg)) return;
+    enqueue_ui_haptic(reg, HapticEvent::UIButtonTap);
+    reg.ctx().insert_or_assign(EndChoiceLevelSelect{});
+}
+
+void game_state_handle_go_main_menu(entt::registry& reg, const MenuGoMainMenuEvent&) {
+    if (!end_screen_press_unlocked(reg)) return;
+    enqueue_ui_haptic(reg, HapticEvent::UIButtonTap);
+    reg.ctx().insert_or_assign(EndChoiceMainMenu{});
 }

--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -72,8 +72,8 @@ void game_state_system(entt::registry& reg, float dt) {
     // ── Primary event drain ───────────────────────────────────────────────────
     // game_state_system runs first in tick_fixed_systems (game_loop.cpp) and
     // owns the authoritative drain for GoEvent and all press event queues
-    // (per-shape ShapePress* + MenuPressEvent — see input_events.h for the
-    // per-event-type split, issue #1202/#1204).
+    // (per-shape ShapePress* + per-action MenuConfirm/MenuRestart/...
+    // — see input_events.h for the per-event-type split, issue #1202/#1204/#1277).
     // Calling update<T>() here fires every registered listener in registration
     // order: game_state → level_select → player_input
     // (see wire_input_dispatcher in systems/input_dispatcher.cpp).
@@ -92,7 +92,12 @@ void game_state_system(entt::registry& reg, float dt) {
     disp.update<ShapePressCircleEvent>();
     disp.update<ShapePressSquareEvent>();
     disp.update<ShapePressTriangleEvent>();
-    disp.update<MenuPressEvent>();
+    disp.update<MenuConfirmEvent>();
+    disp.update<MenuRestartEvent>();
+    disp.update<MenuGoLevelSelectEvent>();
+    disp.update<MenuGoMainMenuEvent>();
+    disp.update<MenuSelectLevelEvent>();
+    disp.update<MenuSelectDiffEvent>();
     disp.update<GoEvent>();
 
     if (is_phase_transition_pending(reg)) {

--- a/app/systems/input_dispatcher.cpp
+++ b/app/systems/input_dispatcher.cpp
@@ -21,9 +21,14 @@ namespace {
 struct InputDispatcherConnections {
     entt::dispatcher* owner = nullptr;
     entt::connection go_game_state;
-    entt::connection menu_press_game_state;
+    entt::connection menu_confirm_game_state;
+    entt::connection menu_restart_game_state;
+    entt::connection menu_go_level_select_game_state;
+    entt::connection menu_go_main_menu_game_state;
     entt::connection go_level_select;
-    entt::connection menu_press_level_select;
+    entt::connection menu_confirm_level_select;
+    entt::connection menu_select_level_level_select;
+    entt::connection menu_select_diff_level_select;
     entt::connection go_player_input;
     entt::connection shape_press_circle_player_input;
     entt::connection shape_press_square_player_input;
@@ -34,9 +39,14 @@ struct InputDispatcherConnections {
         shape_press_square_player_input.release();
         shape_press_circle_player_input.release();
         go_player_input.release();
-        menu_press_level_select.release();
+        menu_select_diff_level_select.release();
+        menu_select_level_level_select.release();
+        menu_confirm_level_select.release();
         go_level_select.release();
-        menu_press_game_state.release();
+        menu_go_main_menu_game_state.release();
+        menu_go_level_select_game_state.release();
+        menu_restart_game_state.release();
+        menu_confirm_game_state.release();
         go_game_state.release();
         owner = nullptr;
     }
@@ -48,18 +58,29 @@ void warm_dispatcher_event_queues(entt::dispatcher& disp) {
     disp.enqueue<ShapePressCircleEvent>(ShapePressCircleEvent{});
     disp.enqueue<ShapePressSquareEvent>(ShapePressSquareEvent{});
     disp.enqueue<ShapePressTriangleEvent>(ShapePressTriangleEvent{});
-    disp.enqueue<MenuPressEvent>(MenuPressEvent{});
+    disp.enqueue<MenuConfirmEvent>(MenuConfirmEvent{});
+    disp.enqueue<MenuRestartEvent>(MenuRestartEvent{});
+    disp.enqueue<MenuGoLevelSelectEvent>(MenuGoLevelSelectEvent{});
+    disp.enqueue<MenuGoMainMenuEvent>(MenuGoMainMenuEvent{});
+    disp.enqueue<MenuSelectLevelEvent>(MenuSelectLevelEvent{});
+    disp.enqueue<MenuSelectDiffEvent>(MenuSelectDiffEvent{});
     disp.clear<GoEvent>();
     disp.clear<ShapePressCircleEvent>();
     disp.clear<ShapePressSquareEvent>();
     disp.clear<ShapePressTriangleEvent>();
-    disp.clear<MenuPressEvent>();
+    disp.clear<MenuConfirmEvent>();
+    disp.clear<MenuRestartEvent>();
+    disp.clear<MenuGoLevelSelectEvent>();
+    disp.clear<MenuGoMainMenuEvent>();
+    disp.clear<MenuSelectLevelEvent>();
+    disp.clear<MenuSelectDiffEvent>();
 }
 }
 
 // game_state_system owns the fixed-step drain of GoEvent and the per-shape
-// + menu press event queues. EnTT sinks are last-connected first; connect in
-// reverse semantic order (player_input → level_select → game_state).
+// + per-action menu press event queues. EnTT sinks are last-connected first;
+// connect in reverse semantic order (player_input → level_select → game_state)
+// so game_state handlers fire first per the pre-#1277 contract.
 void wire_input_dispatcher(entt::registry& reg) {
     auto* disp = reg.ctx().find<entt::dispatcher>();
     if (!disp) {
@@ -81,7 +102,8 @@ void wire_input_dispatcher(entt::registry& reg) {
 
     // Fixed-step semantic order: game_state, level_select, player_input.
     // Shape presses route only to player_input (no menu listeners care about
-    // them). Menu presses route to both game_state and level_select.
+    // them). Menu confirm routes to both game_state and level_select; the
+    // remaining menu events route to a single consumer.
     state->go_player_input =
         disp->sink<GoEvent>().connect<&player_input_handle_go>(reg);
     state->shape_press_circle_player_input =
@@ -92,12 +114,22 @@ void wire_input_dispatcher(entt::registry& reg) {
         disp->sink<ShapePressTriangleEvent>().connect<&player_input_handle_press_triangle>(reg);
     state->go_level_select =
         disp->sink<GoEvent>().connect<&level_select_handle_go>(reg);
-    state->menu_press_level_select =
-        disp->sink<MenuPressEvent>().connect<&level_select_handle_press_menu>(reg);
+    state->menu_confirm_level_select =
+        disp->sink<MenuConfirmEvent>().connect<&level_select_handle_confirm>(reg);
+    state->menu_select_level_level_select =
+        disp->sink<MenuSelectLevelEvent>().connect<&level_select_handle_select_level>(reg);
+    state->menu_select_diff_level_select =
+        disp->sink<MenuSelectDiffEvent>().connect<&level_select_handle_select_diff>(reg);
     state->go_game_state =
         disp->sink<GoEvent>().connect<&game_state_handle_go>(reg);
-    state->menu_press_game_state =
-        disp->sink<MenuPressEvent>().connect<&game_state_handle_press_menu>(reg);
+    state->menu_confirm_game_state =
+        disp->sink<MenuConfirmEvent>().connect<&game_state_handle_confirm>(reg);
+    state->menu_restart_game_state =
+        disp->sink<MenuRestartEvent>().connect<&game_state_handle_restart>(reg);
+    state->menu_go_level_select_game_state =
+        disp->sink<MenuGoLevelSelectEvent>().connect<&game_state_handle_go_level_select>(reg);
+    state->menu_go_main_menu_game_state =
+        disp->sink<MenuGoMainMenuEvent>().connect<&game_state_handle_go_main_menu>(reg);
 
     warm_dispatcher_event_queues(*disp);
 }

--- a/app/systems/input_events.h
+++ b/app/systems/input_events.h
@@ -9,30 +9,21 @@
 
 enum class Direction : uint8_t { Left, Right, Up, Down };
 
-enum class MenuActionKind : uint8_t {
-    Confirm       = 0,
-    Restart       = 1,
-    GoLevelSelect = 2,
-    GoMainMenu    = 3,
-    Exit          = 4,
-    SelectLevel   = 5,
-    SelectDiff    = 6,
-};
-
 // ── Semantic Press Events (produced by HUD controllers, test player, or keyboard) ──
 //
-// Per Fabian's existential processing (issues #1202/#1204), the former
-// `ButtonPressKind` discriminator and the union-like `ButtonPressEvent::shape`
-// column were eradicated. Each former (kind × shape) combination is now its
-// own event type. Listeners subscribe to the specific event they handle, so
-// there is no `switch (kind)` and no `if (evt.kind == Foo::Bar)` at any
-// consumer call site.
+// Per Fabian's existential processing (issues #1202/#1204/#1277), the former
+// `ButtonPressKind` and `MenuActionKind` discriminators and the union-like
+// `MenuPressEvent::action` column were eradicated. Each former
+// (kind × shape) and (action) combination is now its own event type.
+// Listeners subscribe to the specific event they handle, so there is no
+// `switch (kind)` / `switch (action)` and no `if (evt.kind == Foo::Bar)`
+// at any consumer call site.
 //
 // Shape presses are zero-column tag-events: "which shape?" is identity-
 // encoded in the event type itself, no payload, no runtime discriminator.
-// Menu presses keep the two semantic columns (action + index); per-action
-// dispatch lives in the menu consumers, still keyed on the `MenuActionKind`
-// label (allowlisted as a Keep enum: input event label).
+// Menu presses follow the same pattern: per-action event types, with the
+// `index` payload kept only where a semantic index is actually carried
+// (`MenuSelectLevelEvent`, `MenuSelectDiffEvent`).
 //
 // Producers never store an entity handle in any event — that was the
 // pre-#273 lifetime hazard and stays out of the new design.
@@ -40,10 +31,22 @@ struct ShapePressCircleEvent   {};
 struct ShapePressSquareEvent   {};
 struct ShapePressTriangleEvent {};
 
-struct MenuPressEvent {
-    MenuActionKind action = MenuActionKind::Confirm;
-    uint8_t        index  = 0;
-};
+// Generic "proceed" press: Enter / Space / Title-tap / Pause-tap / FTUE-tap /
+// end-screen tap. Per-phase routing lives on the listener side and dispatches
+// purely on the ctx phase tag (no enum discriminator).
+struct MenuConfirmEvent {};
+
+// End-screen choice events. `MenuConfirmEvent` on an end screen is also
+// routed to the "restart" path inside the listener so the keyboard Enter
+// shortcut still restarts the run.
+struct MenuRestartEvent       {};
+struct MenuGoLevelSelectEvent {};
+struct MenuGoMainMenuEvent    {};
+
+// Level-select numeric selection events. Index is bounds-checked at the
+// listener against the static content config.
+struct MenuSelectLevelEvent { uint8_t index = 0; };
+struct MenuSelectDiffEvent  { uint8_t index = 0; };
 
 struct GoEvent {
     Direction dir = Direction::Up;

--- a/app/systems/input_routing.h
+++ b/app/systems/input_routing.h
@@ -3,16 +3,23 @@
 #include <entt/entt.hpp>
 
 struct GoEvent;
-struct MenuPressEvent;
+struct MenuConfirmEvent;
+struct MenuRestartEvent;
+struct MenuGoLevelSelectEvent;
+struct MenuGoMainMenuEvent;
 struct ShapePressCircleEvent;
 struct ShapePressSquareEvent;
 struct ShapePressTriangleEvent;
 
 // Semantic listeners: events -> game/player state.
-// Per issue #1202/#1204, the press-event handler tree is identity-encoded
-// in the event type — no `switch (kind)` at consumers; the type IS the choice.
+// Per issue #1202/#1204/#1277, the press-event handler tree is identity-
+// encoded in the event type — no `switch (kind)` / `if (evt.action == X)`
+// at consumers; the type IS the choice.
 void game_state_handle_go(entt::registry& reg, const GoEvent& evt);
-void game_state_handle_press_menu(entt::registry& reg, const MenuPressEvent& evt);
+void game_state_handle_confirm         (entt::registry& reg, const MenuConfirmEvent&);
+void game_state_handle_restart         (entt::registry& reg, const MenuRestartEvent&);
+void game_state_handle_go_level_select (entt::registry& reg, const MenuGoLevelSelectEvent&);
+void game_state_handle_go_main_menu    (entt::registry& reg, const MenuGoMainMenuEvent&);
 
 void player_input_handle_go(entt::registry& reg, const GoEvent& evt);
 void player_input_handle_press_circle  (entt::registry& reg, const ShapePressCircleEvent&   evt);

--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -413,7 +413,7 @@ void input_system(entt::registry& reg, float raw_dt) {
         disp.enqueue<ShapePressTriangleEvent>({});
     }
     if (IsKeyPressed(KEY_ENTER) || IsKeyPressed(KEY_SPACE)) {
-        disp.enqueue<MenuPressEvent>({MenuActionKind::Confirm, 0});
+        disp.enqueue<MenuConfirmEvent>({});
     }
 #endif
 

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -221,11 +221,13 @@ void test_player_system(entt::registry& reg, float dt) {
     // ── AUTO-START ───────────────────────────────────────────
     if (title_phase || game_over_phase || song_complete_phase) {
         if (gs.phase_timer > constants::TEST_PLAYER_AUTO_START_DELAY) {
-            // On end screens, press Restart; on Title, press Confirm
-            auto target_action = (game_over_phase || song_complete_phase)
-                                 ? MenuActionKind::Restart
-                                 : MenuActionKind::Confirm;
-            disp.enqueue<MenuPressEvent>({target_action, 0});
+            // On end screens, press Restart; on Title, press Confirm.
+            // Per #1277: each action is its own event type — no enum.
+            if (game_over_phase || song_complete_phase) {
+                disp.enqueue<MenuRestartEvent>({});
+            } else {
+                disp.enqueue<MenuConfirmEvent>({});
+            }
             if (log) {
                 const char* phase_name =
                     title_phase         ? "Title" :
@@ -252,13 +254,13 @@ void test_player_system(entt::registry& reg, float dt) {
     }
 
     if (paused_phase) {
-        disp.enqueue<MenuPressEvent>({MenuActionKind::Confirm, 0});
+        disp.enqueue<MenuConfirmEvent>({});
         return;
     }
 
     // Auto-confirm on LevelSelect (level/difficulty already set in main.cpp)
     if (level_select_phase && gs.phase_timer > constants::UI_ENTRY_DEBOUNCE) {
-        disp.enqueue<MenuPressEvent>({MenuActionKind::Confirm, 0});
+        disp.enqueue<MenuConfirmEvent>({});
         return;
     }
 

--- a/app/ui/level_select_controller.cpp
+++ b/app/ui/level_select_controller.cpp
@@ -3,6 +3,16 @@
 #include "../util/level_content_config.h"
 #include "../systems/input_events.h"
 
+namespace {
+// Shared gate for level-select menu presses: only fire on the level-select
+// phase and after the entry-debounce window. Mirrors the pre-#1277 guard
+// inside the former `level_select_handle_press_menu` switch.
+bool level_select_press_gate(entt::registry& reg) {
+    if (!reg.ctx().contains<GamePhaseLevelSelectTag>()) return false;
+    return reg.ctx().get<GameState>().phase_timer >= 0.05f;
+}
+} // namespace
+
 void level_select_handle_go(entt::registry& reg, const GoEvent& evt) {
     if (!reg.ctx().contains<GamePhaseLevelSelectTag>()) return;
 
@@ -18,27 +28,19 @@ void level_select_handle_go(entt::registry& reg, const GoEvent& evt) {
     }
 }
 
-void level_select_handle_press_menu(entt::registry& reg, const MenuPressEvent& evt) {
-    auto& gs = reg.ctx().get<GameState>();
-    if (!reg.ctx().contains<GamePhaseLevelSelectTag>()) return;
-    if (gs.phase_timer < 0.05f) return;
+void level_select_handle_confirm(entt::registry& reg, const MenuConfirmEvent&) {
+    if (!level_select_press_gate(reg)) return;
+    reg.ctx().insert_or_assign(LevelSelectConfirmedTag{});
+}
 
-    auto& lss = reg.ctx().get<LevelSelectState>();
+void level_select_handle_select_level(entt::registry& reg, const MenuSelectLevelEvent& evt) {
+    if (!level_select_press_gate(reg)) return;
+    if (!content_config::is_valid_level_index(evt.index)) return;
+    reg.ctx().get<LevelSelectState>().selected_level = evt.index;
+}
 
-    switch (evt.action) {
-        case MenuActionKind::Confirm:
-            reg.ctx().insert_or_assign(LevelSelectConfirmedTag{});
-            break;
-        case MenuActionKind::SelectLevel:
-            if (content_config::is_valid_level_index(evt.index)) {
-                lss.selected_level = evt.index;
-            }
-            break;
-        case MenuActionKind::SelectDiff:
-            if (content_config::is_valid_difficulty_index(evt.index)) {
-                lss.selected_difficulty = evt.index;
-            }
-            break;
-        default: break;
-    }
+void level_select_handle_select_diff(entt::registry& reg, const MenuSelectDiffEvent& evt) {
+    if (!level_select_press_gate(reg)) return;
+    if (!content_config::is_valid_difficulty_index(evt.index)) return;
+    reg.ctx().get<LevelSelectState>().selected_difficulty = evt.index;
 }

--- a/app/ui/level_select_controller.h
+++ b/app/ui/level_select_controller.h
@@ -3,7 +3,14 @@
 #include <entt/entt.hpp>
 
 struct GoEvent;
-struct MenuPressEvent;
+struct MenuConfirmEvent;
+struct MenuSelectLevelEvent;
+struct MenuSelectDiffEvent;
 
 void level_select_handle_go(entt::registry& reg, const GoEvent& evt);
-void level_select_handle_press_menu(entt::registry& reg, const MenuPressEvent& evt);
+
+// Per-event handlers (#1277): the event type IS the choice; no enum-typed
+// discriminator at the consumer call site.
+void level_select_handle_confirm     (entt::registry& reg, const MenuConfirmEvent&);
+void level_select_handle_select_level(entt::registry& reg, const MenuSelectLevelEvent& evt);
+void level_select_handle_select_diff (entt::registry& reg, const MenuSelectDiffEvent&  evt);

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -451,22 +451,27 @@ enum class Direction : uint8_t { Left, Right, Up, Down };
 /// Carry concrete values rather than entity handles so consumers stay safe if
 /// the producing UI entity is destroyed between enqueue and dispatch.
 
-enum class ButtonPressKind : uint8_t {
-    Shape,  // shape button pressed — read `.shape`
-    Menu,   // menu button pressed  — read `.menu_action` / `.menu_index`
-};
+/// Per Fabian's existential processing (#1202/#1204/#1277), each former
+/// (kind × shape) combination and each former MenuActionKind value is now
+/// its own event type. Listeners subscribe to the specific event they
+/// handle; the type IS the choice — no enum discriminator field, no
+/// `switch (kind)` / `switch (action)` at consumers. Events carry concrete
+/// values (or nothing) — never entity handles — so consumers stay safe if
+/// the producing UI entity is destroyed between enqueue and dispatch.
 
-enum class MenuActionKind : uint8_t {
-    Confirm = 0, Restart, GoLevelSelect, GoMainMenu, Exit,
-    SelectLevel, SelectDiff,
-};
+// Shape presses are zero-column tag-events.
+struct ShapePressCircleEvent   {};
+struct ShapePressSquareEvent   {};
+struct ShapePressTriangleEvent {};
 
-struct ButtonPressEvent {
-    ButtonPressKind kind        = ButtonPressKind::Shape;
-    Shape           shape       = Shape::Circle;            // valid when kind == Shape
-    MenuActionKind  menu_action = MenuActionKind::Confirm;  // valid when kind == Menu
-    uint8_t         menu_index  = 0;                        // valid when kind == Menu
-};
+// Per-action menu events — replace the former
+// `MenuPressEvent { MenuActionKind action; uint8_t index; }`.
+struct MenuConfirmEvent       {};
+struct MenuRestartEvent       {};
+struct MenuGoLevelSelectEvent {};
+struct MenuGoMainMenuEvent    {};
+struct MenuSelectLevelEvent { uint8_t index = 0; };
+struct MenuSelectDiffEvent  { uint8_t index = 0; };
 
 struct GoEvent {
     Direction dir = Direction::Up;
@@ -1605,7 +1610,8 @@ app/
 │   │                              OnsetMarkerTag) and requirements
 │   │                              (RequiredShape, RequiredLane, ShapeGateLane)
 │   ├── scoring.h                ← ScoreState, ScorePopup
-│   ├── input_events.h           ← Direction, ButtonPressEvent, GoEvent, MenuActionKind (in systems/)
+│   ├── input_events.h           ← Direction, GoEvent, per-shape ShapePress*Event,
+│   │                              per-action Menu*Event (in systems/, #1277)
 │   ├── game_state.h             ← GameState, GamePhase, LevelSelectState
 │   ├── rendering.h              ← DrawSize, ScreenPosition; back-compat shim
 │   │                              for the camera/mesh splits (issue #1194)

--- a/design-docs/feature-specs.md
+++ b/design-docs/feature-specs.md
@@ -153,34 +153,28 @@ struct InputState {
 
 // ── Event types: semantic player intentions ──
 //
-// ButtonPressEvent carries semantic value data encoded at source (#273).
-// Consumers act on kind/shape/menu_action — never on a live entity handle,
-// which would be a lifetime hazard if the button entity were destroyed
-// between event production and consumption.
+// Per Fabian's existential processing (#1202/#1204/#1277), each former
+// `ButtonPressKind` × shape and each former `MenuActionKind` value is now
+// its own event type. Listeners subscribe to the specific event they
+// handle — the type IS the choice. Events carry concrete values (or
+// nothing) — never a live entity handle, which would be a lifetime hazard
+// if the button entity were destroyed between event production and
+// consumption.
 
 enum class Direction : uint8_t { Left, Right, Up, Down };  // defined in input.h
 
-enum class MenuActionKind : uint8_t {
-    Confirm       = 0,
-    Restart       = 1,
-    GoLevelSelect = 2,
-    GoMainMenu    = 3,
-    Exit          = 4,
-    SelectLevel   = 5,
-    SelectDiff    = 6,
-};
+// Shape presses are zero-column tag-events.
+struct ShapePressCircleEvent   {};
+struct ShapePressSquareEvent   {};
+struct ShapePressTriangleEvent {};
 
-enum class ButtonPressKind : uint8_t {
-    Shape,  // shape button pressed — use .shape
-    Menu,   // menu button pressed  — use .menu_action / .menu_index
-};
-
-struct ButtonPressEvent {
-    ButtonPressKind kind        = ButtonPressKind::Shape;
-    Shape           shape       = Shape::Circle;            // valid when kind == Shape
-    MenuActionKind  menu_action = MenuActionKind::Confirm;  // valid when kind == Menu
-    uint8_t         menu_index  = 0;                        // valid when kind == Menu
-};
+// Per-action menu events.
+struct MenuConfirmEvent       {};
+struct MenuRestartEvent       {};
+struct MenuGoLevelSelectEvent {};
+struct MenuGoMainMenuEvent    {};
+struct MenuSelectLevelEvent { uint8_t index = 0; };
+struct MenuSelectDiffEvent  { uint8_t index = 0; };
 
 struct GoEvent {
     Direction dir = Direction::Up;

--- a/tests/test_entt_dispatcher_contract.cpp
+++ b/tests/test_entt_dispatcher_contract.cpp
@@ -1,7 +1,7 @@
 // tests/test_entt_dispatcher_contract.cpp
 //
 // Verifies entt::dispatcher semantics relied on by the semantic input pipeline
-// (GoEvent + per-shape ShapePress*Event + MenuPressEvent only).
+// (GoEvent + per-shape ShapePress*Event + per-action menu events only).
 
 #include <catch2/catch_test_macros.hpp>
 #include <entt/entt.hpp>
@@ -182,7 +182,12 @@ TEST_CASE("wire_input_dispatcher prewarms semantic event queues without pending 
     CHECK(dispatcher.size<ShapePressCircleEvent>()   == 0);
     CHECK(dispatcher.size<ShapePressSquareEvent>()   == 0);
     CHECK(dispatcher.size<ShapePressTriangleEvent>() == 0);
-    CHECK(dispatcher.size<MenuPressEvent>()          == 0);
+    CHECK(dispatcher.size<MenuConfirmEvent>()        == 0);
+    CHECK(dispatcher.size<MenuRestartEvent>()        == 0);
+    CHECK(dispatcher.size<MenuGoLevelSelectEvent>()  == 0);
+    CHECK(dispatcher.size<MenuGoMainMenuEvent>()     == 0);
+    CHECK(dispatcher.size<MenuSelectLevelEvent>()    == 0);
+    CHECK(dispatcher.size<MenuSelectDiffEvent>()     == 0);
 }
 
 TEST_CASE("runtime scratch queues are explicit registry context state",

--- a/tests/test_event_queue.cpp
+++ b/tests/test_event_queue.cpp
@@ -48,39 +48,40 @@ TEST_CASE("dispatcher: ShapePress*Event enqueue/update", "[events]") {
     disp.sink<ShapePressCircleEvent>().connect<&PressCapture::on_circle>(cap);
     disp.sink<ShapePressSquareEvent>().connect<&PressCapture::on_square>(cap);
     disp.sink<ShapePressTriangleEvent>().connect<&PressCapture::on_triangle>(cap);
-    disp.sink<MenuPressEvent>().connect<&PressCapture::on_menu>(cap);
+    disp.sink<MenuRestartEvent>().connect<&PressCapture::on_restart>(cap);
 
     disp.enqueue<ShapePressSquareEvent>({});
-    disp.enqueue<MenuPressEvent>({MenuActionKind::Restart, 0});
+    disp.enqueue<MenuRestartEvent>({});
     disp.update<ShapePressCircleEvent>();
     disp.update<ShapePressSquareEvent>();
     disp.update<ShapePressTriangleEvent>();
-    disp.update<MenuPressEvent>();
+    disp.update<MenuRestartEvent>();
     disp.sink<ShapePressCircleEvent>().disconnect<&PressCapture::on_circle>(cap);
     disp.sink<ShapePressSquareEvent>().disconnect<&PressCapture::on_square>(cap);
     disp.sink<ShapePressTriangleEvent>().disconnect<&PressCapture::on_triangle>(cap);
-    disp.sink<MenuPressEvent>().disconnect<&PressCapture::on_menu>(cap);
+    disp.sink<MenuRestartEvent>().disconnect<&PressCapture::on_restart>(cap);
 
     REQUIRE(cap.shape_count() == 1);
     CHECK(cap.square == 1);
     CHECK(cap.circle == 0);
     CHECK(cap.triangle == 0);
-    REQUIRE(cap.menu_count == 1);
-    CHECK(cap.menu_buf[0].action == MenuActionKind::Restart);
+    REQUIRE(cap.menu_count() == 1);
+    CHECK(cap.restart == 1);
 }
 
 TEST_CASE("dispatcher: press events are pure value types — no entity field", "[events]") {
-    // Per #1202/#1204 (and the legacy #273 contract), no press event stores
-    // an entity handle. Constructing an event remains valid regardless of
-    // any entity lifecycle.
+    // Per #1202/#1204/#1277 (and the legacy #273 contract), no press event
+    // stores an entity handle. Constructing an event remains valid regardless
+    // of any entity lifecycle.
     entt::registry reg;
     auto btn_entity = reg.create();
     reg.destroy(btn_entity);  // entity is now invalid / recycled
 
     ShapePressTriangleEvent shape_evt{};
-    MenuPressEvent menu_evt{MenuActionKind::Confirm, 3};
+    MenuConfirmEvent        confirm_evt{};
+    MenuSelectLevelEvent    select_evt{3};
     (void)shape_evt;
-    CHECK(menu_evt.action == MenuActionKind::Confirm);
-    CHECK(menu_evt.index  == 3);
+    (void)confirm_evt;
+    CHECK(select_evt.index == 3);
     (void)btn_entity;
 }

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -345,8 +345,7 @@ TEST_CASE("tutorial: menu confirm marks FTUE complete and requests gameplay",
     persistence.path.clear();
     persistence.dirty = false;
 
-    reg.ctx().get<entt::dispatcher>().enqueue<MenuPressEvent>({
-        MenuActionKind::Confirm, 0});
+    reg.ctx().get<entt::dispatcher>().enqueue<MenuConfirmEvent>({});
     game_state_system(reg, 0.016f);
 
     const auto& saved_settings = settings_state(reg);
@@ -471,7 +470,7 @@ TEST_CASE("game_state: title position tap triggers level_select", "[gamestate]")
     auto reg = make_registry();
     set_test_phase<GamePhaseTitleTag>(reg);
     // Simulate a tap → Confirm menu button press (title screen has full-screen confirm)
-    auto btn = make_menu_button(reg, MenuActionKind::Confirm);
+    auto btn = make_menu_confirm_button(reg);
     press_button(reg, btn);
 
     game_state_system(reg, 0.016f);

--- a/tests/test_haptic_system.cpp
+++ b/tests/test_haptic_system.cpp
@@ -123,7 +123,7 @@ TEST_CASE("game state haptic: RetryTap enqueued when Restart pressed on end scre
     set_test_phase<GamePhaseGameOverTag>(reg);
     reg.ctx().get<GameState>().phase_timer = 1.0f;
 
-    auto btn = make_menu_button(reg, MenuActionKind::Restart);
+    auto btn = make_menu_restart_button(reg);
     press_button(reg, btn);
 
     game_state_system(reg, 0.016f);
@@ -140,7 +140,7 @@ TEST_CASE("game state haptic: UIButtonTap enqueued for non-Restart end screen bu
     set_test_phase<GamePhaseGameOverTag>(reg);
     reg.ctx().get<GameState>().phase_timer = 1.0f;
 
-    auto btn = make_menu_button(reg, MenuActionKind::GoMainMenu);
+    auto btn = make_menu_go_main_menu_button(reg);
     press_button(reg, btn);
 
     game_state_system(reg, 0.016f);
@@ -159,7 +159,7 @@ TEST_CASE("game state haptic: haptic_system no-crash when haptics_enabled=false 
     set_test_phase<GamePhaseGameOverTag>(reg);
     reg.ctx().get<GameState>().phase_timer = 1.0f;
 
-    auto btn = make_menu_button(reg, MenuActionKind::Restart);
+    auto btn = make_menu_restart_button(reg);
     press_button(reg, btn);
 
     game_state_system(reg, 0.016f);

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -81,17 +81,34 @@ struct PressCapture {
     int circle = 0;
     int square = 0;
     int triangle = 0;
-    MenuPressEvent menu_buf[8] = {};
-    int menu_count = 0;
+    int confirm = 0;
+    int restart = 0;
+    int go_level_select = 0;
+    int go_main_menu = 0;
+    MenuSelectLevelEvent select_level_buf[4] = {};
+    int select_level_count = 0;
+    MenuSelectDiffEvent select_diff_buf[4] = {};
+    int select_diff_count = 0;
 
     int shape_count() const { return circle + square + triangle; }
-    int count() const { return shape_count() + menu_count; }
+    int menu_count() const {
+        return confirm + restart + go_level_select + go_main_menu +
+               select_level_count + select_diff_count;
+    }
+    int count() const { return shape_count() + menu_count(); }
 
     void on_circle  (const ShapePressCircleEvent&)   { ++circle;   }
     void on_square  (const ShapePressSquareEvent&)   { ++square;   }
     void on_triangle(const ShapePressTriangleEvent&) { ++triangle; }
-    void on_menu(const MenuPressEvent& e) {
-        if (menu_count < 8) menu_buf[menu_count++] = e;
+    void on_confirm        (const MenuConfirmEvent&)        { ++confirm; }
+    void on_restart        (const MenuRestartEvent&)        { ++restart; }
+    void on_go_level_select(const MenuGoLevelSelectEvent&)  { ++go_level_select; }
+    void on_go_main_menu   (const MenuGoMainMenuEvent&)     { ++go_main_menu; }
+    void on_select_level   (const MenuSelectLevelEvent& e)  {
+        if (select_level_count < 4) select_level_buf[select_level_count++] = e;
+    }
+    void on_select_diff    (const MenuSelectDiffEvent& e)   {
+        if (select_diff_count < 4) select_diff_buf[select_diff_count++] = e;
     }
 };
 
@@ -119,30 +136,52 @@ inline GoCapture drain_go_events(entt::registry& reg) {
 inline PressCapture drain_press_events(entt::registry& reg) {
     PressCapture cap;
     auto& disp = reg.ctx().get<entt::dispatcher>();
-    disp.sink<ShapePressCircleEvent>().connect<&PressCapture::on_circle>(cap);
-    disp.sink<ShapePressSquareEvent>().connect<&PressCapture::on_square>(cap);
+    disp.sink<ShapePressCircleEvent>()  .connect<&PressCapture::on_circle>(cap);
+    disp.sink<ShapePressSquareEvent>()  .connect<&PressCapture::on_square>(cap);
     disp.sink<ShapePressTriangleEvent>().connect<&PressCapture::on_triangle>(cap);
-    disp.sink<MenuPressEvent>().connect<&PressCapture::on_menu>(cap);
+    disp.sink<MenuConfirmEvent>()       .connect<&PressCapture::on_confirm>(cap);
+    disp.sink<MenuRestartEvent>()       .connect<&PressCapture::on_restart>(cap);
+    disp.sink<MenuGoLevelSelectEvent>() .connect<&PressCapture::on_go_level_select>(cap);
+    disp.sink<MenuGoMainMenuEvent>()    .connect<&PressCapture::on_go_main_menu>(cap);
+    disp.sink<MenuSelectLevelEvent>()   .connect<&PressCapture::on_select_level>(cap);
+    disp.sink<MenuSelectDiffEvent>()    .connect<&PressCapture::on_select_diff>(cap);
     disp.update<ShapePressCircleEvent>();
     disp.update<ShapePressSquareEvent>();
     disp.update<ShapePressTriangleEvent>();
-    disp.update<MenuPressEvent>();
-    disp.sink<ShapePressCircleEvent>().disconnect<&PressCapture::on_circle>(cap);
-    disp.sink<ShapePressSquareEvent>().disconnect<&PressCapture::on_square>(cap);
+    disp.update<MenuConfirmEvent>();
+    disp.update<MenuRestartEvent>();
+    disp.update<MenuGoLevelSelectEvent>();
+    disp.update<MenuGoMainMenuEvent>();
+    disp.update<MenuSelectLevelEvent>();
+    disp.update<MenuSelectDiffEvent>();
+    disp.sink<ShapePressCircleEvent>()  .disconnect<&PressCapture::on_circle>(cap);
+    disp.sink<ShapePressSquareEvent>()  .disconnect<&PressCapture::on_square>(cap);
     disp.sink<ShapePressTriangleEvent>().disconnect<&PressCapture::on_triangle>(cap);
-    disp.sink<MenuPressEvent>().disconnect<&PressCapture::on_menu>(cap);
+    disp.sink<MenuConfirmEvent>()       .disconnect<&PressCapture::on_confirm>(cap);
+    disp.sink<MenuRestartEvent>()       .disconnect<&PressCapture::on_restart>(cap);
+    disp.sink<MenuGoLevelSelectEvent>() .disconnect<&PressCapture::on_go_level_select>(cap);
+    disp.sink<MenuGoMainMenuEvent>()    .disconnect<&PressCapture::on_go_main_menu>(cap);
+    disp.sink<MenuSelectLevelEvent>()   .disconnect<&PressCapture::on_select_level>(cap);
+    disp.sink<MenuSelectDiffEvent>()    .disconnect<&PressCapture::on_select_diff>(cap);
     return cap;
 }
 
-// Drains all press-event queues (per-shape ShapePress* + MenuPressEvent) in
-// the same order game_state_system uses (issue #1202/#1204). Use in tests
-// that previously called `disp.update<ButtonPressEvent>()` directly.
+// Drains all press-event queues (per-shape ShapePress* + per-action menu
+// events) in the same order game_state_system uses (issue #1202/#1204/#1277).
+// Use in tests that previously called `disp.update<ButtonPressEvent>()` or
+// `disp.update<MenuPressEvent>()` directly (both eradicated by the per-event-
+// type split).
 inline void update_press_events(entt::registry& reg) {
     auto& disp = reg.ctx().get<entt::dispatcher>();
     disp.update<ShapePressCircleEvent>();
     disp.update<ShapePressSquareEvent>();
     disp.update<ShapePressTriangleEvent>();
-    disp.update<MenuPressEvent>();
+    disp.update<MenuConfirmEvent>();
+    disp.update<MenuRestartEvent>();
+    disp.update<MenuGoLevelSelectEvent>();
+    disp.update<MenuGoMainMenuEvent>();
+    disp.update<MenuSelectLevelEvent>();
+    disp.update<MenuSelectDiffEvent>();
 }
 
 // Flush the dispatcher PlaySfxEvent queue and return all events that were pending.
@@ -189,16 +228,21 @@ struct TestShapeButtonData {
     Shape shape = Shape::Circle;
 };
 
+// Per-action menu-button tag for tests. Mirrors the per-event-type split
+// (#1277) on the producer side — the function pointer captures which event
+// type to enqueue when the button is "pressed". The `index` field is only
+// consulted for `MenuSelectLevelEvent` / `MenuSelectDiffEvent`.
 struct TestMenuButtonData {
-    MenuActionKind kind = MenuActionKind::Confirm;
+    void (*enqueue)(entt::dispatcher&, uint8_t index) = nullptr;
     uint8_t index = 0;
 };
 
 // ── Button-press injection helper ──────────────────────────────────────────
-// Per #1202/#1204: enqueues the per-shape ShapePress*Event (or MenuPressEvent
-// for menu buttons) corresponding to the button's TestShapeButtonData /
-// TestMenuButtonData. The per-shape table mirrors the same function-pointer-
-// per-row mechanic used by `kEnqueueShapePress` in test_player_system.cpp.
+// Per #1202/#1204/#1277: enqueues the per-shape ShapePress*Event (or one of
+// the per-action Menu*Event types for menu buttons) corresponding to the
+// button's TestShapeButtonData / TestMenuButtonData. The per-shape table
+// mirrors the same function-pointer-per-row mechanic used by
+// `kEnqueueShapePress` in test_player_system.cpp.
 inline void press_button(entt::registry& reg, entt::entity btn) {
     auto& disp = reg.ctx().get<entt::dispatcher>();
     if (reg.all_of<TestShapeButtonData>(btn)) {
@@ -214,8 +258,8 @@ inline void press_button(entt::registry& reg, entt::entity btn) {
         };
         kEnqueueFns[idx](disp);
     } else if (reg.all_of<TestMenuButtonData>(btn)) {
-        const auto& ma = reg.get<TestMenuButtonData>(btn);
-        disp.enqueue<MenuPressEvent>({ma.kind, ma.index});
+        const auto& mb = reg.get<TestMenuButtonData>(btn);
+        if (mb.enqueue) mb.enqueue(disp, mb.index);
     }
 }
 
@@ -356,9 +400,53 @@ inline entt::entity make_shape_button(entt::registry& reg, Shape shape) {
     return btn;
 }
 
-inline entt::entity make_menu_button(entt::registry& reg, MenuActionKind kind,
-                                      uint8_t index = 0) {
+// Per-action menu-button factories (#1277). Each factory wires up the
+// corresponding per-event-type enqueue so `press_button(reg, btn)` produces
+// the right event type with no enum discriminator.
+inline entt::entity make_menu_confirm_button(entt::registry& reg) {
     auto btn = reg.create();
-    reg.emplace<TestMenuButtonData>(btn, kind, index);
+    reg.emplace<TestMenuButtonData>(btn,
+        +[](entt::dispatcher& d, uint8_t){ d.enqueue<MenuConfirmEvent>({}); },
+        uint8_t{0});
+    return btn;
+}
+
+inline entt::entity make_menu_restart_button(entt::registry& reg) {
+    auto btn = reg.create();
+    reg.emplace<TestMenuButtonData>(btn,
+        +[](entt::dispatcher& d, uint8_t){ d.enqueue<MenuRestartEvent>({}); },
+        uint8_t{0});
+    return btn;
+}
+
+inline entt::entity make_menu_go_level_select_button(entt::registry& reg) {
+    auto btn = reg.create();
+    reg.emplace<TestMenuButtonData>(btn,
+        +[](entt::dispatcher& d, uint8_t){ d.enqueue<MenuGoLevelSelectEvent>({}); },
+        uint8_t{0});
+    return btn;
+}
+
+inline entt::entity make_menu_go_main_menu_button(entt::registry& reg) {
+    auto btn = reg.create();
+    reg.emplace<TestMenuButtonData>(btn,
+        +[](entt::dispatcher& d, uint8_t){ d.enqueue<MenuGoMainMenuEvent>({}); },
+        uint8_t{0});
+    return btn;
+}
+
+inline entt::entity make_menu_select_level_button(entt::registry& reg, uint8_t index) {
+    auto btn = reg.create();
+    reg.emplace<TestMenuButtonData>(btn,
+        +[](entt::dispatcher& d, uint8_t i){ d.enqueue<MenuSelectLevelEvent>({i}); },
+        index);
+    return btn;
+}
+
+inline entt::entity make_menu_select_diff_button(entt::registry& reg, uint8_t index) {
+    auto btn = reg.create();
+    reg.emplace<TestMenuButtonData>(btn,
+        +[](entt::dispatcher& d, uint8_t i){ d.enqueue<MenuSelectDiffEvent>({i}); },
+        index);
     return btn;
 }

--- a/tests/test_input_pipeline_behavior.cpp
+++ b/tests/test_input_pipeline_behavior.cpp
@@ -2,8 +2,9 @@
 //
 // End-to-end input pipeline behavioral tests.
 //
-// The pipeline: semantic GoEvent + per-shape ShapePress*Event + MenuPressEvent
-// producers → game_state_system drain (authoritative) → player_input listeners.
+// The pipeline: semantic GoEvent + per-shape ShapePress*Event + per-action
+// menu events (#1277) — producers → game_state_system drain (authoritative)
+// → player_input listeners.
 //
 // All assertions are on player component state (Lane::target, ShapeWindow::phase,
 // PlayerShape::current) — never on raw event queues.

--- a/tests/test_level_select_controller.cpp
+++ b/tests/test_level_select_controller.cpp
@@ -11,9 +11,7 @@ TEST_CASE("level_select_controller: select difficulty press updates state", "[le
     auto& lss = reg.ctx().get<LevelSelectState>();
     lss.selected_difficulty = 0;
 
-    level_select_handle_press_menu(reg, MenuPressEvent{
-        MenuActionKind::SelectDiff, 2
-    });
+    level_select_handle_select_diff(reg, MenuSelectDiffEvent{2});
 
     CHECK(lss.selected_difficulty == 2);
 }
@@ -27,9 +25,7 @@ TEST_CASE("level_select_controller: select level press updates state", "[level_s
     auto& lss = reg.ctx().get<LevelSelectState>();
     lss.selected_level = 0;
 
-    level_select_handle_press_menu(reg, MenuPressEvent{
-        MenuActionKind::SelectLevel, 2
-    });
+    level_select_handle_select_level(reg, MenuSelectLevelEvent{2});
 
     CHECK(lss.selected_level == 2);
 }
@@ -45,12 +41,8 @@ TEST_CASE("level_select_controller: invalid semantic indices do not update selec
     lss.selected_level = 1;
     lss.selected_difficulty = 2;
 
-    level_select_handle_press_menu(reg, MenuPressEvent{
-        MenuActionKind::SelectLevel, 255
-    });
-    level_select_handle_press_menu(reg, MenuPressEvent{
-        MenuActionKind::SelectDiff, 255
-    });
+    level_select_handle_select_level(reg, MenuSelectLevelEvent{255});
+    level_select_handle_select_diff (reg, MenuSelectDiffEvent {255});
 
     CHECK(lss.selected_level == 1);
     CHECK(lss.selected_difficulty == 2);
@@ -65,9 +57,7 @@ TEST_CASE("level_select_controller: ignores menu presses during entry delay", "[
     auto& lss = reg.ctx().get<LevelSelectState>();
     lss.selected_difficulty = 1;
 
-    level_select_handle_press_menu(reg, MenuPressEvent{
-        MenuActionKind::SelectDiff, 0
-    });
+    level_select_handle_select_diff(reg, MenuSelectDiffEvent{0});
 
     CHECK(lss.selected_difficulty == 1);
 }

--- a/tests/test_test_player_system.cpp
+++ b/tests/test_test_player_system.cpp
@@ -215,18 +215,11 @@ TEST_CASE("test_player: auto-starts from title screen", "[test_player]") {
     gs.phase_timer = 1.0f;
 
     // Create a Confirm menu button (as title screen would have)
-    make_menu_button(reg, MenuActionKind::Confirm);
+    make_menu_confirm_button(reg);
 
     test_player_system(reg, 0.016f);
-    bool has_confirm = false;
     auto cap = drain_press_events(reg);
-    for (int i = 0; i < cap.menu_count; ++i) {
-        if (cap.menu_buf[i].action == MenuActionKind::Confirm) {
-            has_confirm = true;
-            break;
-        }
-    }
-    CHECK(has_confirm);
+    CHECK(cap.confirm > 0);
 }
 
 // ── SWIPE COOLDOWN ───────────────────────────────────────────

--- a/tests/test_world_systems.cpp
+++ b/tests/test_world_systems.cpp
@@ -103,7 +103,7 @@ TEST_CASE("cleanup: non-obstacle entities are untouched", "[cleanup]") {
 TEST_CASE("game_state: title to level select on touch", "[gamestate]") {
     auto reg = make_registry();
     set_test_phase<GamePhaseTitleTag>(reg);
-    auto btn = make_menu_button(reg, MenuActionKind::Confirm);
+    auto btn = make_menu_confirm_button(reg);
     press_button(reg, btn);
 
     game_state_system(reg, 0.016f);
@@ -117,7 +117,7 @@ TEST_CASE("game_state: game over button choice after delay", "[gamestate]") {
     auto& gs = reg.ctx().get<GameState>();
     set_test_phase<GamePhaseGameOverTag>(reg);
     gs.phase_timer = 0.5f;
-    auto btn = make_menu_button(reg, MenuActionKind::GoLevelSelect);
+    auto btn = make_menu_go_level_select_button(reg);
     press_button(reg, btn);
 
     game_state_system(reg, 0.016f);
@@ -132,8 +132,7 @@ TEST_CASE("game_state: game over keyboard confirm routes to restart", "[gamestat
     set_test_phase<GamePhaseGameOverTag>(reg);
     gs.phase_timer = 0.5f;
 
-    reg.ctx().get<entt::dispatcher>().enqueue<MenuPressEvent>(
-        {MenuActionKind::Confirm, 0});
+    reg.ctx().get<entt::dispatcher>().enqueue<MenuConfirmEvent>({});
 
     game_state_system(reg, 0.016f);
 
@@ -146,8 +145,7 @@ TEST_CASE("game_state: song complete keyboard confirm routes to restart", "[game
     set_test_phase<GamePhaseSongCompleteTag>(reg);
     gs.phase_timer = constants::SONG_COMPLETE_INPUT_DELAY + 0.1f;
 
-    reg.ctx().get<entt::dispatcher>().enqueue<MenuPressEvent>(
-        {MenuActionKind::Confirm, 0});
+    reg.ctx().get<entt::dispatcher>().enqueue<MenuConfirmEvent>({});
 
     game_state_system(reg, 0.016f);
 
@@ -161,8 +159,7 @@ TEST_CASE("game_state: song complete keyboard confirm waits for button debounce"
     set_test_phase<GamePhaseSongCompleteTag>(reg);
     gs.phase_timer = 0.45f;
 
-    reg.ctx().get<entt::dispatcher>().enqueue<MenuPressEvent>(
-        {MenuActionKind::Confirm, 0});
+    reg.ctx().get<entt::dispatcher>().enqueue<MenuConfirmEvent>({});
 
     game_state_system(reg, 0.0f);
 
@@ -177,7 +174,7 @@ TEST_CASE("game_state: game over ignores touch during delay", "[gamestate]") {
     auto& gs = reg.ctx().get<GameState>();
     set_test_phase<GamePhaseGameOverTag>(reg);
     gs.phase_timer = 0.2f;  // within GAME_OVER_INPUT_DELAY
-    auto btn = make_menu_button(reg, MenuActionKind::Confirm);
+    auto btn = make_menu_confirm_button(reg);
     press_button(reg, btn);
 
     game_state_system(reg, 0.016f);
@@ -192,8 +189,7 @@ TEST_CASE("game_state: paused menu input waits for entry debounce", "[gamestate]
     gs.phase_timer = constants::UI_ENTRY_DEBOUNCE + 0.1f;
     gs.phase_timer = 0.1f;
 
-    reg.ctx().get<entt::dispatcher>().enqueue<MenuPressEvent>(
-        {MenuActionKind::Confirm, 0});
+    reg.ctx().get<entt::dispatcher>().enqueue<MenuConfirmEvent>({});
 
     game_state_system(reg, 0.0f);
 
@@ -206,8 +202,7 @@ TEST_CASE("game_state: paused menu input resumes after entry debounce", "[gamest
     set_test_phase<GamePhasePausedTag>(reg);
     gs.phase_timer = constants::UI_ENTRY_DEBOUNCE + 0.1f;
 
-    reg.ctx().get<entt::dispatcher>().enqueue<MenuPressEvent>(
-        {MenuActionKind::Confirm, 0});
+    reg.ctx().get<entt::dispatcher>().enqueue<MenuConfirmEvent>({});
 
     game_state_system(reg, 0.0f);
 
@@ -303,7 +298,7 @@ TEST_CASE("game_state: paused to playing on touch", "[gamestate]") {
     auto& gs = reg.ctx().get<GameState>();
     set_test_phase<GamePhasePausedTag>(reg);
     gs.phase_timer = constants::UI_ENTRY_DEBOUNCE + 0.1f;
-    auto btn = make_menu_button(reg, MenuActionKind::Confirm);
+    auto btn = make_menu_confirm_button(reg);
     press_button(reg, btn);
 
     game_state_system(reg, 0.016f);
@@ -335,7 +330,7 @@ TEST_CASE("game_state: paused resume preserves active play session state", "[gam
     song.playing = true;
     song.restart_music = false;
 
-    auto btn = make_menu_button(reg, MenuActionKind::Confirm);
+    auto btn = make_menu_confirm_button(reg);
     press_button(reg, btn);
 
     game_state_system(reg, 0.016f);


### PR DESCRIPTION
Closes #1277.

## Summary

Eradicates the two `switch`-on-enum-discriminator behavior dispatches flagged in #1277:

1. **`app/ui/level_select_controller.cpp:28`** — `switch (evt.action)` over `MenuActionKind` → per-event handlers.
2. **`app/game_loop.cpp:105`** — `switch (result.status)` over `persistence::Status` → value→data lookup table (`kPersistenceLogTable`), matching the doctrinally-OK pattern (`to_string(Shape)`, `HapticEvent → TriggerPattern`).

## Change shape

The `MenuActionKind` enum and `MenuPressEvent` payload are fully eradicated from `app/` per Fabian's existential processing (the type IS the choice). Per-action event types replace them:

| Former arm                       | New event type             |
| -------------------------------- | -------------------------- |
| `MenuActionKind::Confirm`        | `MenuConfirmEvent`         |
| `MenuActionKind::Restart`        | `MenuRestartEvent`         |
| `MenuActionKind::GoLevelSelect`  | `MenuGoLevelSelectEvent`   |
| `MenuActionKind::GoMainMenu`     | `MenuGoMainMenuEvent`      |
| `MenuActionKind::SelectLevel`    | `MenuSelectLevelEvent{idx}`|
| `MenuActionKind::SelectDiff`     | `MenuSelectDiffEvent{idx}` |
| `MenuActionKind::Exit`           | **deleted** (dead code — no producer in `app/` or `tests/`) |

The pre-existing `if (evt.action == MenuActionKind::X)` chains in `game_state_routing.cpp` dispatched on the same eradicated discriminator; replaced with one per-event-type free function each: `game_state_handle_confirm`, `_restart`, `_go_level_select`, `_go_main_menu`.

## Cascade

- `app/systems/input_dispatcher.cpp` — per-event-type sink connections + queue warm/clear; listener-vector ordering preserved.
- `app/systems/input_system.cpp` — keyboard Enter/Space emits `MenuConfirmEvent`.
- `app/systems/test_player_system.cpp` — auto-start emits `MenuConfirmEvent` / `MenuRestartEvent` per phase.
- `app/systems/game_state_system.cpp` — drain queue list expanded.
- `app/.allowed-enums.txt` — `MenuActionKind` removed.
- Tests — `make_menu_button(kind)` replaced with per-action `make_menu_confirm_button` / `_restart_button` / etc.; direct `MenuPressEvent` enqueues replaced with the matching per-action event type; `PressCapture` records per-action counts.
- Design docs — `architecture.md` / `feature-specs.md` snippets updated to the new per-event-type model.

## Verification (acceptance criteria from #1277)

- [x] Both `switch` statements removed.
- [x] No new `switch` on enum-typed discriminator in `app/` (only the six doctrinally-OK value→data lookups listed in the issue remain).
- [x] Clang `-Wall -Wextra -Werror` clean — unity AND non-unity builds.
- [x] All 880 Catch2 test cases pass (2960 assertions).
- [x] `tools/check_enum_allowlist.py` passes (`MenuActionKind` removed from `app/.allowed-enums.txt`).
