### PR TITLE
#1194 Rename WorldTransform → WorldPosition (final app/components/ audit bullet)

### DIFF
--- a/app/components/render_mesh.h
+++ b/app/components/render_mesh.h
@@ -36,7 +36,7 @@ struct MeshKindShape {
 struct MeshChild {
     entt::entity parent = entt::null;
     float x = 0.0f;             // absolute X position in game coords
-    float z_offset = 0.0f;      // offset from parent WorldTransform.position.y (scroll axis)
+    float z_offset = 0.0f;      // offset from parent WorldPosition.position.y (scroll axis)
     float width = 0.0f;         // slab width (game coords)
     float depth = 0.0f;         // slab depth (game coords)
     float height = 0.0f;        // slab height (game coords)

--- a/app/components/transform.h
+++ b/app/components/transform.h
@@ -2,14 +2,16 @@
 
 #include <raylib.h>
 
-// Authoritative world-space spatial state for moving/rendered world entities.
+// Authoritative world-space position for moving/rendered world entities.
 // New entity contracts should use this instead of adding new position structs.
-// Named WorldTransform to avoid colliding with raylib's global Transform type.
+// Named WorldPosition rather than a raw Vector2 because the per-entity
+// Vector2 component slot is reserved for "velocity" semantics (see below).
 //
-// Rotation and scale fields previously lived here but no runtime system read
-// them (only defaults were asserted in tests). Removed per issue #1194; if a
-// future entity needs rotation or scale, give it its own component table.
-struct WorldTransform {
+// Rotation and scale fields previously lived on a sibling WorldTransform
+// struct but no runtime system read them (only defaults were asserted in
+// tests). Removed per issue #1194; if a future entity needs rotation or
+// scale, give it its own component table rather than re-bundling here.
+struct WorldPosition {
     Vector2 position = {0.0f, 0.0f};
 };
 
@@ -17,7 +19,7 @@ struct WorldTransform {
 // position += velocity * dt. Raw Vector2 is used directly — the
 // MotionVelocity { Vector2 value } single-field wrapper was deleted
 // per issue #1198 (companion to the BlockedLanes → uint8_t unwrap in
-// PR #1240). motion_system queries view<WorldTransform, Vector2>;
+// PR #1240). motion_system queries view<WorldPosition, Vector2>;
 // existence of a Vector2 component on an entity is the ownership
 // marker for dt-integrated movement. Song-time-authoritative rhythm
 // obstacles intentionally omit Vector2 and carry BeatInfo instead.

--- a/app/entities/obstacle_entity.cpp
+++ b/app/entities/obstacle_entity.cpp
@@ -21,7 +21,7 @@ entt::entity create_shape_gate(entt::registry& reg, const ShapeGateSpawn& params
         throw std::logic_error("Invalid obstacle shape");
     }
     auto e = reg.create();
-    reg.emplace<WorldTransform>(e, WorldTransform{{params.x, params.y}});
+    reg.emplace<WorldPosition>(e, WorldPosition{{params.x, params.y}});
     reg.emplace<TagWorldPass>(e);
     reg.emplace<ShapeGateTag>(e);
     reg.emplace<Obstacle>(e, int16_t{constants::PTS_SHAPE_GATE});
@@ -41,7 +41,7 @@ entt::entity create_split_path(entt::registry& reg, const SplitPathSpawn& params
         throw std::logic_error("Invalid obstacle lane");
     }
     auto e = reg.create();
-    reg.emplace<WorldTransform>(e, WorldTransform{{params.x, params.y}});
+    reg.emplace<WorldPosition>(e, WorldPosition{{params.x, params.y}});
     reg.emplace<TagWorldPass>(e);
     reg.emplace<SplitPathTag>(e);
     reg.emplace<Obstacle>(e, int16_t{constants::PTS_SPLIT_PATH});
@@ -54,7 +54,7 @@ entt::entity create_split_path(entt::registry& reg, const SplitPathSpawn& params
 
 entt::entity create_onset_marker(entt::registry& reg, const OnsetMarkerSpawn& params) {
     auto e = reg.create();
-    reg.emplace<WorldTransform>(e, WorldTransform{{params.x, params.y}});
+    reg.emplace<WorldPosition>(e, WorldPosition{{params.x, params.y}});
     reg.emplace<TagWorldPass>(e);
     reg.emplace<OnsetMarkerTag>(e);
     reg.emplace<Obstacle>(e, int16_t{0});

--- a/app/entities/obstacle_render_entity.cpp
+++ b/app/entities/obstacle_render_entity.cpp
@@ -92,7 +92,7 @@ static entt::entity add_shape_child(entt::registry& reg, entt::entity parent,
 }
 
 void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical) {
-    const auto* wt_ptr = reg.try_get<WorldTransform>(logical);
+    const auto* wt_ptr = reg.try_get<WorldPosition>(logical);
     auto& col = reg.get<Color>(logical);
     auto& dsz = reg.get<DrawSize>(logical);
 

--- a/app/entities/player_entity.cpp
+++ b/app/entities/player_entity.cpp
@@ -14,7 +14,7 @@ entt::entity create_player_entity(entt::registry& reg) {
 
     auto player = reg.create();
     reg.emplace<PlayerTag>(player);
-    reg.emplace<WorldTransform>(player, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
+    reg.emplace<WorldPosition>(player, WorldPosition{{constants::LANE_X[1], constants::PLAYER_Y}});
     reg.emplace<PlayerShape>(player);
     // Player starts as Hexagon: presence of `ShapeHexagonTag` IS the data
     // (issue #1202/#1204 — see `app/util/shape_tag.h`).

--- a/app/entities/popup_entity.cpp
+++ b/app/entities/popup_entity.cpp
@@ -14,7 +14,7 @@ entt::entity create_popup_archetype(entt::registry& reg,
                                     float x, float y, int points,
                                     Color color) {
     auto popup = reg.create();
-    reg.emplace<WorldTransform>(popup, WorldTransform{{x, y - 40.0f}});
+    reg.emplace<WorldPosition>(popup, WorldPosition{{x, y - 40.0f}});
     reg.emplace<Vector2>(popup, Vector2{0.0f, -80.0f});
     reg.emplace<ScorePopup>(popup, ScorePopup{points,
                                               constants::POPUP_DURATION,

--- a/app/entities/popup_entity.h
+++ b/app/entities/popup_entity.h
@@ -25,7 +25,7 @@ void init_popup_display_ok     (PopupDisplay& pd, const Color& base);
 void init_popup_display_bad    (PopupDisplay& pd, const Color& base);
 
 // Per-tier popup spawn functions. Each emplaces the full popup archetype
-// (WorldTransform, Vector2 drift, ScorePopup, Color, TagHUDPass, PopupDisplay)
+// (WorldPosition, Vector2 drift, ScorePopup, Color, TagHUDPass, PopupDisplay)
 // plus the matching per-tier tag on the popup entity so renderers can identify
 // the popup's tier via tag presence (no enum lookup).
 //

--- a/app/systems/camera_system.cpp
+++ b/app/systems/camera_system.cpp
@@ -249,7 +249,7 @@ void game_camera_system(entt::registry& reg, [[maybe_unused]] float dt) {
 
         auto record_stale_or_compute_z = [&](entt::entity entity, const MeshChild& mc,
                                              float& out_z) -> bool {
-            auto* parent_wt = reg.try_get<WorldTransform>(mc.parent);
+            auto* parent_wt = reg.try_get<WorldPosition>(mc.parent);
             if (!parent_wt) {
                 if (stale_children.size() >= stale_children.capacity()) {
                     ++scratch->capacity_exceeded_count;
@@ -296,7 +296,7 @@ void game_camera_system(entt::registry& reg, [[maybe_unused]] float dt) {
 
     // 3. Player shape transform
     {
-        auto view = reg.view<PlayerTag, WorldTransform, PlayerShape, Color>();
+        auto view = reg.view<PlayerTag, WorldPosition, PlayerShape, Color>();
         for (auto [entity, transform, pshape, col] : view.each()) {
             (void)pshape;
             const auto* jump = reg.try_get<Jumping>(entity);
@@ -324,7 +324,7 @@ void game_camera_system(entt::registry& reg, [[maybe_unused]] float dt) {
 
     // 4. Particle transforms
     {
-        auto view = reg.view<ParticleTag, WorldTransform, ParticleData, Color>();
+        auto view = reg.view<ParticleTag, WorldPosition, ParticleData, Color>();
         for (auto [entity, transform, pdata, col] : view.each()) {
             float ratio = (pdata.max_time > 0.0f) ? (pdata.remaining / pdata.max_time) : 1.0f;
             float sz = pdata.size * ratio;
@@ -389,7 +389,7 @@ void ui_camera_system(entt::registry& reg, [[maybe_unused]] float dt) {
     // Popup screen-space projection
     {
         auto& cam = game_camera(reg).cam;
-        auto view = reg.view<ScorePopup, WorldTransform>();
+        auto view = reg.view<ScorePopup, WorldPosition>();
         for (auto [entity, popup, transform] : view.each()) {
             Vector3 world_pos = {transform.position.x, 5.0f, transform.position.y};
             Vector2 sp = GetWorldToScreenEx(world_pos, cam,

--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -67,12 +67,12 @@ bool shape_gate_lane_match(int8_t obstacle_lane, int player_lane) {
 }  // namespace
 
 void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
-    auto player_view = reg.view<PlayerTag, WorldTransform, PlayerShape, ShapeWindow, Lane>();
+    auto player_view = reg.view<PlayerTag, WorldPosition, PlayerShape, ShapeWindow, Lane>();
     if (player_view.begin() == player_view.end()) return;
 
     auto player_entity = *player_view.begin();
     auto [p_transform, p_shape, p_window, p_lane] =
-        player_view.get<WorldTransform, PlayerShape, ShapeWindow, Lane>(player_entity);
+        player_view.get<WorldPosition, PlayerShape, ShapeWindow, Lane>(player_entity);
     lane_utils::normalize(p_lane, &p_transform);
     (void)p_shape;
 
@@ -131,7 +131,7 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
     };
 
     auto resolve_shape_obstacle = [&](entt::entity entity,
-                                      const WorldTransform& wt,
+                                      const WorldPosition& wt,
                                       bool lane_ok,
                                       const BeatInfo* timing_info) {
         if (!lane_ok) {
@@ -158,7 +158,7 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
     // reservation in `app/components/obstacle.h` (issue #1198). SplitPath
     // entities are filtered out by absence of `ShapeGateTag`.
     {
-        auto rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, ShapeGateTag, int8_t, BeatInfo>(
+        auto rhythm_view = reg.view<ObstacleTag, Obstacle, WorldPosition, ShapeGateTag, int8_t, BeatInfo>(
             entt::exclude<ScoredTag, ResolvedObstacleTag>);
         for (auto [e, obstacle, wt, lane, info] : rhythm_view.each()) {
             (void)obstacle;
@@ -166,7 +166,7 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
             resolve_shape_obstacle(e, wt, lane_ok, &info);
         }
 
-        auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, ShapeGateTag, int8_t>(
+        auto view = reg.view<ObstacleTag, Obstacle, WorldPosition, ShapeGateTag, int8_t>(
             entt::exclude<ScoredTag, ResolvedObstacleTag, BeatInfo>);
         for (auto [e, obstacle, wt, lane] : view.each()) {
             (void)obstacle;
@@ -174,7 +174,7 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
             resolve_shape_obstacle(e, wt, lane_ok, nullptr);
         }
 
-        auto fallback_rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, ShapeGateTag, BeatInfo>(
+        auto fallback_rhythm_view = reg.view<ObstacleTag, Obstacle, WorldPosition, ShapeGateTag, BeatInfo>(
             entt::exclude<ScoredTag, ResolvedObstacleTag, int8_t>);
         for (auto [e, obstacle, wt, info] : fallback_rhythm_view.each()) {
             (void)obstacle;
@@ -182,7 +182,7 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
             resolve_shape_obstacle(e, wt, lane_ok, &info);
         }
 
-        auto fallback_view = reg.view<ObstacleTag, Obstacle, WorldTransform, ShapeGateTag>(
+        auto fallback_view = reg.view<ObstacleTag, Obstacle, WorldPosition, ShapeGateTag>(
             entt::exclude<ScoredTag, ResolvedObstacleTag, BeatInfo, int8_t>);
         for (auto [e, obstacle, wt] : fallback_view.each()) {
             (void)obstacle;
@@ -196,7 +196,7 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
     // reservation in `app/components/obstacle.h` (issue #1198). ShapeGate
     // entities are filtered out by absence of `SplitPathTag`.
     {
-        auto rhythm_view = reg.view<ObstacleTag, Obstacle, WorldTransform, SplitPathTag, int8_t, BeatInfo>(
+        auto rhythm_view = reg.view<ObstacleTag, Obstacle, WorldPosition, SplitPathTag, int8_t, BeatInfo>(
             entt::exclude<ScoredTag, ResolvedObstacleTag>);
         for (auto [e, obstacle, wt, rlane, info] : rhythm_view.each()) {
             (void)obstacle;
@@ -204,7 +204,7 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
             resolve_shape_obstacle(e, wt, lane_ok, &info);
         }
 
-        auto view = reg.view<ObstacleTag, Obstacle, WorldTransform, SplitPathTag, int8_t>(
+        auto view = reg.view<ObstacleTag, Obstacle, WorldPosition, SplitPathTag, int8_t>(
             entt::exclude<ScoredTag, ResolvedObstacleTag, BeatInfo>);
         for (auto [e, obstacle, wt, rlane] : view.each()) {
             (void)obstacle;

--- a/app/systems/miss_detection_system.cpp
+++ b/app/systems/miss_detection_system.cpp
@@ -8,7 +8,7 @@
 // Runs before scoring_system so that the MissTag is processed the same frame.
 // Energy drain and miss_count are handled exclusively by scoring_system's MissTag branch.
 void miss_detection_system(entt::registry& reg, [[maybe_unused]] float dt) {
-    auto view = reg.view<ObstacleTag, Obstacle, WorldTransform>(
+    auto view = reg.view<ObstacleTag, Obstacle, WorldPosition>(
         entt::exclude<ScoredTag, ResolvedObstacleTag, NonScorableTag>);
     for (auto [entity, obstacle, wt] : view.each()) {
         (void)obstacle;

--- a/app/systems/motion_system.cpp
+++ b/app/systems/motion_system.cpp
@@ -7,7 +7,7 @@ void motion_system(entt::registry& reg, float dt) {
     // A raw Vector2 component is the ownership marker for dt-integrated
     // movement (issue #1198: MotionVelocity wrapper unwrapped). Song-time-
     // authoritative rhythm obstacles have BeatInfo instead.
-    auto motion_view = reg.view<WorldTransform, Vector2>();
+    auto motion_view = reg.view<WorldPosition, Vector2>();
     for (auto [entity_id, transform, velocity] : motion_view.each()) {
         (void)entity_id;
         transform.position.x += velocity.x * dt;

--- a/app/systems/obstacle_despawn_system.cpp
+++ b/app/systems/obstacle_despawn_system.cpp
@@ -20,7 +20,7 @@ void obstacle_despawn_system(entt::registry& reg, [[maybe_unused]] float dt) {
     auto& to_destroy = despawn_scratch_for(reg).to_destroy;
     to_destroy.clear();
 
-    auto view = reg.view<ObstacleTag, WorldTransform>();
+    auto view = reg.view<ObstacleTag, WorldPosition>();
     for (auto [entity, wt] : view.each()) {
         if (wt.position.y > constants::DESTROY_Y) {
             auto& scratch = despawn_scratch_for(reg);

--- a/app/systems/player_movement_system.cpp
+++ b/app/systems/player_movement_system.cpp
@@ -53,7 +53,7 @@ void player_movement_system(entt::registry& reg, float dt) {
     auto* song = reg.ctx().find<SongState>();
     const bool rhythm_mode = (song != nullptr && (song->playing || song->finished));
 
-    auto view = reg.view<PlayerTag, WorldTransform, PlayerShape, Lane>();
+    auto view = reg.view<PlayerTag, WorldPosition, PlayerShape, Lane>();
     for (auto [entity, transform, pshape, lane] : view.each()) {
         lane_utils::normalize(lane, &transform);
 

--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -109,7 +109,7 @@ void spawn_score_particles(entt::registry& reg, const Vector2& position, Color c
         auto particle = reg.create();
         reg.emplace<ParticleTag>(particle);
         reg.emplace<ParticleData>(particle, kSize, kLifetime, kLifetime);
-        reg.emplace<WorldTransform>(particle, WorldTransform{position});
+        reg.emplace<WorldPosition>(particle, WorldPosition{position});
         reg.emplace<Vector2>(particle, Vector2Scale(dir, kSpeed));
         reg.emplace<Color>(particle, color);
         reg.emplace<TagEffectsPass>(particle);
@@ -136,7 +136,7 @@ void process_tier_hit_pass(entt::registry& reg,
     auto& hit_buf = scratch.hit_buf;
     hit_buf.clear();
 
-    auto view = reg.view<ObstacleTag, ScoredTag, Obstacle, WorldTransform, TimingGrade, TierTag>(
+    auto view = reg.view<ObstacleTag, ScoredTag, Obstacle, WorldPosition, TimingGrade, TierTag>(
         entt::exclude<MissTag, NonScorableTag>);
     for (auto [e, obs, wt, tg] : view.each()) {
         HitRecord r;
@@ -197,7 +197,7 @@ void process_ungraded_hit_pass(entt::registry& reg,
     auto& hit_buf = scratch.hit_buf;
     hit_buf.clear();
 
-    auto view = reg.view<ObstacleTag, ScoredTag, Obstacle, WorldTransform>(
+    auto view = reg.view<ObstacleTag, ScoredTag, Obstacle, WorldPosition>(
         entt::exclude<MissTag, NonScorableTag, TimingGrade>);
     for (auto [e, obs, wt] : view.each()) {
         HitRecord r;

--- a/app/systems/scroll_system.cpp
+++ b/app/systems/scroll_system.cpp
@@ -19,7 +19,7 @@ void scroll_system(entt::registry& reg, [[maybe_unused]] float dt) {
             return;
         }
 
-        auto beat_view = reg.view<ObstacleTag, WorldTransform, BeatInfo>();
+        auto beat_view = reg.view<ObstacleTag, WorldPosition, BeatInfo>();
         for (auto [entity, wt, info] : beat_view.each()) {
             (void)entity;
             wt.position.y = constants::SPAWN_Y

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -155,7 +155,7 @@ static TestPlayerAction determine_action(
         action.arrival_time = beat->arrival_time;
     } else {
         // Estimate from position + velocity
-        auto* wt  = reg.try_get<WorldTransform>(entity);
+        auto* wt  = reg.try_get<WorldPosition>(entity);
         auto* vel = reg.try_get<Vector2>(entity);
         if (wt && vel && vel->y > 0.0f) {
             action.arrival_time = song.song_time +
@@ -169,7 +169,7 @@ static TestPlayerAction determine_action(
 
         // ShapeGate: player must also be in the lane where the shape hole is.
         // The hole is at obs_pos.x — find which lane that corresponds to.
-        auto* obs_wt = reg.try_get<WorldTransform>(entity);
+        auto* obs_wt = reg.try_get<WorldPosition>(entity);
         if (obs_wt && !reg.all_of<SplitPathTag>(entity)) {
             for (int i = 0; i < constants::LANE_COUNT; ++i) {
                 if (!lane_centers_overlap(obs_wt->position.x, constants::LANE_X[i])) continue;
@@ -276,12 +276,12 @@ void test_player_system(entt::registry& reg, float dt) {
     const auto& cfg = test_player_config(*state);
 
     // ── Find player ──────────────────────────────────────────
-    auto player_view = reg.view<PlayerTag, WorldTransform, PlayerShape, ShapeWindow, Lane>();
+    auto player_view = reg.view<PlayerTag, WorldPosition, PlayerShape, ShapeWindow, Lane>();
     if (player_view.begin() == player_view.end()) return;
 
     auto player_entity = *player_view.begin();
     auto [p_transform, p_shape, p_window, p_lane] =
-        player_view.get<WorldTransform, PlayerShape, ShapeWindow, Lane>(player_entity);
+        player_view.get<WorldPosition, PlayerShape, ShapeWindow, Lane>(player_entity);
     lane_utils::normalize(p_lane, &p_transform);
 
     // Per-frame constant: player's vertical offset (Grounded/Sliding → 0,
@@ -301,7 +301,7 @@ void test_player_system(entt::registry& reg, float dt) {
         }
     }
 
-    auto obs_view = reg.view<ObstacleTag, WorldTransform, Obstacle>(
+    auto obs_view = reg.view<ObstacleTag, WorldPosition, Obstacle>(
         entt::exclude<ScoredTag, TestPlayerPlannedTag, NonScorableTag>);
     for (auto [entity, obs_wt, obs] : obs_view.each()) {
         (void)obs;
@@ -458,7 +458,7 @@ void test_player_system(entt::registry& reg, float dt) {
                                  && pending_shape_obstacle != action.obstacle);
         bool zone_blocked = false;
         {
-            auto zone_view = reg.view<ObstacleTag, Obstacle, WorldTransform>(
+            auto zone_view = reg.view<ObstacleTag, Obstacle, WorldPosition>(
                 entt::exclude<ScoredTag, NonScorableTag>);
             for (auto [ze, obstacle, zwt] : zone_view.each()) {
                 (void)obstacle;
@@ -480,7 +480,7 @@ void test_player_system(entt::registry& reg, float dt) {
             if (action.target_lane < next_lane) next_lane--;
             else if (action.target_lane > next_lane) next_lane++;
 
-            auto closer_view = reg.view<ObstacleTag, Obstacle, WorldTransform>(
+            auto closer_view = reg.view<ObstacleTag, Obstacle, WorldPosition>(
                 entt::exclude<ScoredTag, NonScorableTag>);
             for (auto [oe, obstacle, owt] : closer_view.each()) {
                 (void)obstacle;
@@ -545,7 +545,7 @@ void test_player_system(entt::registry& reg, float dt) {
                                       && pending_shape_obstacle != action.obstacle);
         bool vert_zone_blocked = false;
         {
-            auto zone_view = reg.view<ObstacleTag, Obstacle, WorldTransform>(
+            auto zone_view = reg.view<ObstacleTag, Obstacle, WorldPosition>(
                 entt::exclude<ScoredTag, NonScorableTag>);
             for (auto [ze, obstacle, zwt] : zone_view.each()) {
                 (void)obstacle;

--- a/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
+++ b/app/ui/screen_controllers/gameplay_hud_screen_controller.cpp
@@ -156,7 +156,7 @@ void render_shape_buttons(const entt::registry& reg,
 
     std::array<float, 4> nearest_dist = {-1.0f, -1.0f, -1.0f, -1.0f};
     for (auto [entity, obstacle, obstacle_pos] :
-         reg.view<ObstacleTag, Obstacle, WorldTransform>(entt::exclude<ScoredTag>).each()) {
+         reg.view<ObstacleTag, Obstacle, WorldPosition>(entt::exclude<ScoredTag>).each()) {
         (void)entity;
         (void)obstacle;
         if (!has_required_shape_tag(reg, entity)) continue;

--- a/app/util/lane_utils.h
+++ b/app/util/lane_utils.h
@@ -20,7 +20,7 @@ inline int8_t valid_or_default(int8_t lane) {
     return is_valid(lane) ? lane : kDefaultLane;
 }
 
-inline void snap_to_current_lane(const Lane& lane, WorldTransform& transform) {
+inline void snap_to_current_lane(const Lane& lane, WorldPosition& transform) {
     transform.position.x = constants::LANE_X[lane.current];
 }
 
@@ -39,7 +39,7 @@ inline int8_t nearest_lane_for_x(float x) {
     return nearest_lane;
 }
 
-inline bool normalize(Lane& lane, WorldTransform* transform = nullptr) {
+inline bool normalize(Lane& lane, WorldPosition* transform = nullptr) {
     if (!is_valid(lane.current)) {
         lane.current = kDefaultLane;
         lane.target = kNoTargetLane;

--- a/benchmarks/bench_systems.cpp
+++ b/benchmarks/bench_systems.cpp
@@ -39,7 +39,7 @@ static entt::registry make_bench_registry() {
 static entt::entity make_bench_player(entt::registry& reg) {
     auto p = reg.create();
     reg.emplace<PlayerTag>(p);
-    reg.emplace<WorldTransform>(p, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
+    reg.emplace<WorldPosition>(p, WorldPosition{{constants::LANE_X[1], constants::PLAYER_Y}});
     reg.emplace<PlayerShape>(p);
     reg.emplace<ShapeWindow>(p);
     reg.emplace<Lane>(p);
@@ -55,7 +55,7 @@ static void spawn_obstacles(entt::registry& reg, int count) {
         auto obs = reg.create();
         reg.emplace<ObstacleTag>(obs);
         float y = constants::SPAWN_Y + static_cast<float>(i) * 80.0f;
-        reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[i % 3], y}});
+        reg.emplace<WorldPosition>(obs, WorldPosition{{constants::LANE_X[i % 3], y}});
         reg.emplace<Vector2>(obs, Vector2{0.0f, song.scroll_speed});
         auto shape = static_cast<Shape>(i % 3);
         reg.emplace<Obstacle>(obs, int16_t{200});
@@ -66,27 +66,27 @@ static void spawn_obstacles(entt::registry& reg, int count) {
 }
 
 // Spawns obstacles with the production scroll_system archetype:
-// WorldTransform + Vector2 (freeplay non-beat path, exclude BeatInfo).
+// WorldPosition + Vector2 (freeplay non-beat path, exclude BeatInfo).
 static void spawn_scroll_obstacles(entt::registry& reg, int count) {
     const auto& song = reg.ctx().get<SongState>();
     for (int i = 0; i < count; ++i) {
         auto obs = reg.create();
         reg.emplace<ObstacleTag>(obs);
         float y = constants::SPAWN_Y + static_cast<float>(i) * 80.0f;
-        reg.emplace<WorldTransform>(obs, WorldTransform{{0.0f, y}});
+        reg.emplace<WorldPosition>(obs, WorldPosition{{0.0f, y}});
         reg.emplace<Vector2>(obs, Vector2{0.0f, song.scroll_speed});
         reg.emplace<Obstacle>(obs, int16_t{200});
     }
 }
 
-// Spawns particles using the production archetype: WorldTransform+Vector2.
+// Spawns particles using the production archetype: WorldPosition+Vector2.
 // These are processed by motion_system's motion_view and rendered
-// by camera_system via ParticleTag+WorldTransform.
+// by camera_system via ParticleTag+WorldPosition.
 static void spawn_particles(entt::registry& reg, int count) {
     for (int i = 0; i < count; ++i) {
         auto p = reg.create();
         reg.emplace<ParticleTag>(p);
-        reg.emplace<WorldTransform>(p, WorldTransform{{360.0f, 500.0f}});
+        reg.emplace<WorldPosition>(p, WorldPosition{{360.0f, 500.0f}});
         reg.emplace<Vector2>(p, Vector2{static_cast<float>(i % 50 - 25), -100.0f});
         reg.emplace<ParticleData>(p, 4.0f, 0.6f, 0.6f);
         reg.emplace<Color>(p, Color{255, 100, 50, 255});
@@ -121,7 +121,7 @@ TEST_CASE("Bench: collision_system", "[!benchmark][bench]") {
         make_bench_player(reg);
         auto obs = reg.create();
         reg.emplace<ObstacleTag>(obs);
-        reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
+        reg.emplace<WorldPosition>(obs, WorldPosition{{constants::LANE_X[1], constants::PLAYER_Y}});
         reg.emplace<Vector2>(obs, Vector2{0.0f, 400.0f});
         reg.emplace<Obstacle>(obs, int16_t{200});
         set_required_shape_tag(reg, obs, Shape::Circle);
@@ -155,7 +155,7 @@ TEST_CASE("Bench: scoring_system", "[!benchmark][bench]") {
         for (int i = 0; i < 5; ++i) {
             auto obs = reg.create();
             reg.emplace<ObstacleTag>(obs);
-            reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
+            reg.emplace<WorldPosition>(obs, WorldPosition{{constants::LANE_X[1], constants::PLAYER_Y}});
             reg.emplace<Vector2>(obs, Vector2{0.0f, 400.0f});
             reg.emplace<Obstacle>(obs, int16_t{200});
             reg.emplace<ScoredTag>(obs);

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -125,17 +125,15 @@ read infrequently or only by one system.
 ```cpp
 // components/transform.h
 
-/// Authoritative world-space spatial state for moving/rendered entities.
+/// Authoritative world-space position for moving/rendered entities.
 /// Iterated by: scroll_system, game_camera_system, ui_camera_system,
 ///              collision_system, obstacle_despawn_system
-struct WorldTransform {
+struct WorldPosition {
     Vector2 position = {0.0f, 0.0f};
-    float   rotation = 0.0f;
-    Vector2 scale    = {1.0f, 1.0f};
 };
 
 /// Movement vector in pixels/second for entities that integrate position.
-/// Iterated with WorldTransform by motion_system every frame.
+/// Iterated with WorldPosition by motion_system every frame.
 /// Rhythm obstacles use BeatInfo and are positioned by scroll_system instead.
 struct MotionVelocity {
     Vector2 value = {0.0f, 0.0f};
@@ -551,7 +549,7 @@ struct DrawSize {
 ```cpp
 // components/particle.h
 
-/// Particle-specific data (WorldTransform, MotionVelocity, Color are separate).
+/// Particle-specific data (WorldPosition, MotionVelocity, Color are separate).
 struct ParticleData {
     float size;            // base rendered size
     float remaining;       // seconds until destroy
@@ -602,7 +600,7 @@ struct AudioQueue {
 ```
 COMPONENT          BYTES   ACCESS     ITERATED BY
 ─────────────────────────────────────────────────────────────
-WorldTransform      20     HOT        motion, render, collision, despawn
+WorldPosition       8     HOT        motion, render, collision, despawn
 MotionVelocity       8     HOT        motion, particle effects
 ParticleData        12     HOT        particle expiry/render fade
 ScorePopup          16     HOT        popup expiry/render fade
@@ -713,7 +711,7 @@ system in the same frame (unidirectional data flow).
  │  │                           positions from SongState     │
  │  │                           song_time + BeatInfo.        │
  │  │                                                        │
- │  │     f. motion_system      For every (WorldTransform,   │
+ │  │     f. motion_system      For every (WorldPosition,   │
  │  │                           MotionVelocity):             │
  │  │                           position += velocity * dt.   │
  │  │                           Simple, tight inner loop.    │
@@ -783,7 +781,7 @@ system in the same frame (unidirectional data flow).
 systems. Fixed-lifetime effects no longer use a shared generic timer component:
 `particle_system` owns `ParticleData::remaining`, and `popup_display_system`
 owns `ScorePopup::remaining`. Obstacle destruction is handled by
-`obstacle_despawn_system`, which reads `WorldTransform` for obstacle position.
+`obstacle_despawn_system`, which reads `WorldPosition` for obstacle position.
 
 ---
 
@@ -862,7 +860,7 @@ In code, reusable construction lives in `app/entities/` factory functions
 ```
 ┌─ Player ──────────────────────────────────────────────────┐
 │ PlayerTag          (tag, 0 bytes)                         │
-│ WorldTransform     { position: {360.0, 920.0} }          │
+│ WorldPosition     { position: {360.0, 920.0} }          │
 │ PlayerShape        { current: Hexagon, morph_t: 1.0 }     │
 │ ShapeWindow        { target: Hexagon, phase: Idle, ... }  │
 │ Lane               { current: 1, target: -1, lerp_t: 1 } │
@@ -879,7 +877,7 @@ Total: ~97 bytes per entity (1 entity)
 ```
 ┌─ Shape Gate ──────────────────────────────────────────────┐
 │ ObstacleTag        (tag, 0 bytes)                         │
-│ WorldTransform     { position: {360.0, -120.0} }         │
+│ WorldPosition     { position: {360.0, -120.0} }         │
 │ MotionVelocity     { value: {0.0, 400.0} }               │
 │ Obstacle           { base_points: 200 }                    │
 │ RequiredShape      { shape: Triangle }                     │
@@ -910,7 +908,7 @@ LowBar/HighBar entity archetypes are historical only. The current runtime enum, 
 ```
 ┌─ Split Path ──────────────────────────────────────────────┐
 │ ObstacleTag        (tag, 0 bytes)                         │
-│ WorldTransform     { position: {360.0, -120.0} }         │
+│ WorldPosition     { position: {360.0, -120.0} }         │
 │ MotionVelocity     { value: {0.0, 400.0} }               │
 │ Obstacle           { base_points: 300 }                    │
 │ RequiredShape      { shape: Circle }                       │
@@ -927,7 +925,7 @@ Total: ~44 bytes per entity
 ```
 ┌─ Onset Marker ────────────────────────────────────────────┐
 │ ObstacleTag        (tag, 0 bytes)                         │
-│ WorldTransform     { position: {360.0, -120.0} }          │
+│ WorldPosition     { position: {360.0, -120.0} }          │
 │ MotionVelocity     { value: {0.0, 400.0} }                │
 │ Obstacle           { base_points: 0 }                      │
 │ OnsetMarkerTag     (tag, 0 bytes)                         │
@@ -952,7 +950,7 @@ during normal play.
 
 ```
 ┌─ Score Popup ─────────────────────────────────────────────┐
-│ WorldTransform     { position: {360.0, 900.0} }          │
+│ WorldPosition     { position: {360.0, 900.0} }          │
 │ MotionVelocity     { value: {0.0, -80.0} } (floats up)   │
 │ ScorePopup         { value: 600, tier: 3, remaining: 1.2 } │
 │ Color              { r: 255, g: 200, b: 50, a: 255 }     │
@@ -966,7 +964,7 @@ Total: ~33 bytes per entity (0–5 active)
 ```
 ┌─ Particle ────────────────────────────────────────────────┐
 │ ParticleTag        (tag, 0 bytes)                         │
-│ WorldTransform     { position: {360.0, 920.0} }          │
+│ WorldPosition     { position: {360.0, 920.0} }          │
 │ MotionVelocity     { value: {rand, rand} } (random burst) │
 │ ParticleData       { size: 4.0, remaining: 0.6, max_time: 0.6 } │
 │ Color              { r: 255, g: 100, b: 50, a: 255 }     │
@@ -1124,7 +1122,7 @@ int main(int argc, char* argv[]) {
     │ BeatMap      │                                             │ PlayerShape │
     │ SongState    │                                             │ Lane        │
     └──────┬───────┘                                             │ VertState   │
-           │ beat_scheduler_system                               │ WorldTransform │
+           │ beat_scheduler_system                               │ WorldPosition │
            │ creates note when spawn_time arrives                └──────┬──────┘
            ▼                                                            │
     ┌──────────────┐                                                    │
@@ -1323,7 +1321,7 @@ This entire game state fits in L1 cache (~32-64 KB).
   ACCESS FREQUENCY
   ▲
   │
-  │  ■ WorldTransform  (motion, render, collision, every frame, R+W)
+  │  ■ WorldPosition  (motion, render, collision, every frame, R+W)
   │  ■ MotionVelocity  (motion + particle, every frame, R+W)
   │  ■ ParticleData    (particle sys, every frame, R+W)
   │  ■ ScorePopup      (popup sys, every frame, R+W)
@@ -1350,22 +1348,22 @@ EnTT stores each component type in its own **sparse set** — effectively a
 `std::vector<T>` per component type with an indirection layer. This gives us:
 
 ```
-WorldTransform pool: [xf0] [xf1] [xf2] [xf3] ... [xfN]    contiguous in memory
+WorldPosition pool: [xf0] [xf1] [xf2] [xf3] ... [xfN]    contiguous in memory
 MotionVelocity pool: [vel0] [vel1] [vel2] ... [velN]      contiguous in memory
 Obstacle pool:   [obs0] [obs1] [obs2] ... [obsM]          contiguous in memory
 ```
 
 **For SHAPESHIFTER, AoS (EnTT default) is optimal because:**
 
-1. **Entity counts are tiny** (~71 peak). The whole `WorldTransform` pool is
+1. **Entity counts are tiny** (~71 peak). The whole `WorldPosition` pool is
    roughly 20 bytes × 71 = 1.4 KB. There is no cache pressure that SoA would
    alleviate.
 
 2. **Iteration patterns are simple**. The hottest loop (`motion_system`) reads
-   `WorldTransform` + `MotionVelocity` together — two tiny pools that are in L1
+   `WorldPosition` + `MotionVelocity` together — two tiny pools that are in L1
    after the first iteration.
 
-3. **SoA (splitting `WorldTransform::position` into x[] and y[])** would add
+3. **SoA (splitting `WorldPosition::position` into x[] and y[])** would add
    indirection overhead and code complexity for zero performance gain at these
    entity counts. SoA becomes beneficial at 10,000+ entities — we peak at 71.
 
@@ -1373,7 +1371,7 @@ The current implementation uses an EnTT view for the small dt-integrated set:
 
 ```cpp
 void motion_system(entt::registry& reg, float dt) {
-    auto motion_view = reg.view<WorldTransform, MotionVelocity>();
+    auto motion_view = reg.view<WorldPosition, MotionVelocity>();
     for (auto [entity, transform, velocity] : motion_view.each()) {
         transform.position.x += velocity.value.x * dt;
         transform.position.y += velocity.value.y * dt;
@@ -1413,7 +1411,7 @@ With only 5–15 obstacles on screen and 1 player, brute-force is optimal:
 ```cpp
 void collision_system(entt::registry& reg, float dt) {
     // Get player state (single entity)
-    auto player_view = reg.view<PlayerTag, WorldTransform, PlayerShape, Lane, VerticalState>();
+    auto player_view = reg.view<PlayerTag, WorldPosition, PlayerShape, Lane, VerticalState>();
     // Early-out: exactly one player
     auto [p_ent, p_pos, p_shape, p_lane, p_vstate] = *player_view.each().begin();
 
@@ -1421,10 +1419,10 @@ void collision_system(entt::registry& reg, float dt) {
     float player_y = p_pos.position.y + p_vstate.y_offset;
 
     // Linear scan of obstacles — 15 entities max
-    auto obs_view = reg.view<ObstacleTag, WorldTransform, Obstacle>(
+    auto obs_view = reg.view<ObstacleTag, WorldPosition, Obstacle>(
         entt::exclude<ScoredTag, ResolvedObstacleTag, NonScorableTag>);
     for (auto entity : obs_view) {
-        const auto& o_pos = obs_view.get<WorldTransform>(entity);
+        const auto& o_pos = obs_view.get<WorldPosition>(entity);
 
         // Broad phase: vertical proximity check
         float dy = o_pos.position.y - player_y;
@@ -1523,7 +1521,7 @@ void render_frame_pseudocode(entt::registry& reg, float alpha) {
 
         // Obstacles (5-15 entities — draw in pool order, no sort needed)
         {
-            auto view = reg.view<ObstacleTag, WorldTransform, Obstacle, Color, DrawSize>();
+            auto view = reg.view<ObstacleTag, WorldPosition, Obstacle, Color, DrawSize>();
             for (auto [e, pos, obs, col, sz] : view.each()) {
                 draw_obstacle(pos, obs, col, sz, reg, e);
             }
@@ -1531,7 +1529,7 @@ void render_frame_pseudocode(entt::registry& reg, float alpha) {
 
         // Player (1 entity)
         {
-            auto view = reg.view<PlayerTag, WorldTransform, PlayerShape,
+            auto view = reg.view<PlayerTag, WorldPosition, PlayerShape,
                                   Lane, VerticalState, Color, DrawSize>();
             for (auto [e, pos, shape, lane, vs, col, sz] : view.each()) {
                 // Interpolate position for smooth sub-frame rendering
@@ -1546,7 +1544,7 @@ void render_frame_pseudocode(entt::registry& reg, float alpha) {
     // ── Layer 2: Effects ──────────────────────────────
     // Particles
     {
-        auto view = reg.view<ParticleTag, WorldTransform, ParticleData, Color>();
+        auto view = reg.view<ParticleTag, WorldPosition, ParticleData, Color>();
         for (auto [e, transform, pd, col] : view.each()) {
             float t = pd.remaining / pd.max_time;
             uint8_t a = static_cast<uint8_t>(col.a * t);
@@ -1558,7 +1556,7 @@ void render_frame_pseudocode(entt::registry& reg, float alpha) {
 
     // Score popups
     {
-        auto view = reg.view<ScorePopup, WorldTransform>();
+        auto view = reg.view<ScorePopup, WorldPosition>();
         for (auto [e, popup, pos] : view.each()) {
             float t = popup.remaining / popup.max_time;
             draw_score_popup(pos.position.x, pos.position.y, popup.value, popup.tier, t);
@@ -1599,7 +1597,7 @@ app/
 ├── constants.h                  ← all tuning knobs (§1)
 │
 ├── components/                  ← all component structs
-│   ├── transform.h              ← WorldTransform, MotionVelocity
+│   ├── transform.h              ← WorldPosition, MotionVelocity
 │   ├── window_phase.h           ← WindowPhase (shared by player.h and rhythm.h)
 │   ├── player.h                 ← PlayerTag, PlayerShape, ShapeWindow, Lane, VerticalState
 │   ├── obstacle.h               ← obstacle tags (ScoredTag, MissTag,
@@ -1668,7 +1666,7 @@ float t = song.song_time;
 
 ```cpp
 // Multi-component view — O(n) where n = smallest pool
-auto view = reg.view<ObstacleTag, WorldTransform, Obstacle>();
+auto view = reg.view<ObstacleTag, WorldPosition, Obstacle>();
 for (auto [entity, pos, obs] : view.each()) {
     // ...
 }
@@ -1678,7 +1676,7 @@ for (auto [entity, pos, obs] : view.each()) {
 
 ```cpp
 // Used in motion_system for dt-integrated entities.
-auto motion_view = reg.view<WorldTransform, MotionVelocity>();
+auto motion_view = reg.view<WorldPosition, MotionVelocity>();
 for (auto [entity, transform, velocity] : motion_view.each()) {
     transform.position.x += velocity.value.x * dt;
     transform.position.y += velocity.value.y * dt;
@@ -1692,7 +1690,7 @@ entt::entity spawn_rhythm_shape_gate(entt::registry& reg, Shape required,
                                      int8_t lane, const BeatInfo& beat_info) {
     auto e = reg.create();
     reg.emplace<ObstacleTag>(e);
-    reg.emplace<WorldTransform>(e, WorldTransform{{constants::LANE_X[lane], constants::SPAWN_Y}});
+    reg.emplace<WorldPosition>(e, WorldPosition{{constants::LANE_X[lane], constants::SPAWN_Y}});
     reg.emplace<BeatInfo>(e, beat_info);
     reg.emplace<Obstacle>(e, int16_t{constants::PTS_SHAPE_GATE});
     reg.emplace<RequiredShape>(e, required);

--- a/design-docs/beatmap-integration.md
+++ b/design-docs/beatmap-integration.md
@@ -250,8 +250,8 @@ creates the standard runtime obstacle archetypes via `spawn_rhythm_obstacle()`.
   │  ✅ beat_log_system            (per-beat diagnostic log)        │
   │  ✅ beat_scheduler_system      (BeatMap → spawn entities)       │
   │  ✅ shape_window_activation_system (early MorphIn tick)         │
-  │  ✅ player_movement_system     (animate WorldTransform)         │
-  │  ✅ scroll_system              (WorldTransform += MotionVel·dt) │
+  │  ✅ player_movement_system     (animate WorldPosition)         │
+  │  ✅ scroll_system              (WorldPosition += MotionVel·dt) │
   │  ✅ motion_system              (additional motion components)   │
   │  ✅ collision_system           (player vs obstacles → ScoredTag)│
   │  ✅ shape_window_system        (runs AFTER collision — see #871)│

--- a/design-docs/isometric-perspective.md
+++ b/design-docs/isometric-perspective.md
@@ -565,7 +565,7 @@ entirely by `perspective::draw_shape()`.
 
 **No changes needed.**
 
-- Collision operates in logical space (`WorldTransform::position`) — unaffected.
+- Collision operates in logical space (`WorldPosition::position`) — unaffected.
 - HUD buttons are in viewport space — unaffected.
 - Swipe gestures are direction-based — unaffected.
 

--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -174,7 +174,7 @@ constexpr int32_t CHAIN_MULT_BONUS_STEPS_CAP = 20; // caps at 2.0x from chain 21
   ├──────────────────────────────────────────────────────────────┤
   │  PlayerShape       8B  ← current shape + morph progress     │
   │  ShapeWindow      24B  ← rhythm window timing state         │
-  │  WorldTransform    20B ← world position/rotation/scale      │
+  │  WorldPosition     8B ← world position (single Vector2)     │
   │  MotionVelocity     8B ← dx, dy                             │
   │  ObstacleTag        0B ← marker                             │
   │  RequiredShape      4B ← shape + lane                       │

--- a/design-docs/tester-personas-tech-spec.md
+++ b/design-docs/tester-personas-tech-spec.md
@@ -9,7 +9,7 @@
 
 > **Legacy transform naming note:** this older test-player spec still uses
 > `Position`/`Velocity` in diagrams and pseudocode. Current runtime transform
-> components are `WorldTransform` and `MotionVelocity`; treat the older names in
+> components are `WorldPosition` and `MotionVelocity`; treat the older names in
 > this document as historical aliases unless the text explicitly references
 > current component declarations.
 

--- a/tests/test_audio_offset_calibration.cpp
+++ b/tests/test_audio_offset_calibration.cpp
@@ -263,7 +263,7 @@ OffsetGameplayResult run_calibrated_on_arrival_hit(int16_t audio_offset_ms) {
     auto obstacle = *view.begin();
 
     auto& info = reg.get<BeatInfo>(obstacle);
-    auto& wt = reg.get<WorldTransform>(obstacle);
+    auto& wt = reg.get<WorldPosition>(obstacle);
     wt.position.y = constants::PLAYER_Y;
 
     sw.press_time = info.spawn_time + song.lead_time;

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -105,7 +105,7 @@ TEST_CASE("beat_scheduler: defaults invalid ShapeGate lane to center lane", "[be
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
-    auto view = reg.view<ObstacleTag, WorldTransform, ShapeGateTag, int8_t>();
+    auto view = reg.view<ObstacleTag, WorldPosition, ShapeGateTag, int8_t>();
     REQUIRE(view.size_hint() == 1);
     for (auto [e, wt, lane] : view.each()) {
         (void)e;
@@ -318,7 +318,7 @@ TEST_CASE("beat_scheduler: spawns OnsetMarker as visible non-scorable cue",
     beat_scheduler_system(reg, 0.016f);
 
     auto view = reg.view<ObstacleTag, OnsetMarkerTag, NonScorableTag, Obstacle,
-                         BeatInfo, WorldTransform, ObstacleChildren>();
+                         BeatInfo, WorldPosition, ObstacleChildren>();
     REQUIRE(view.size_hint() == 1);
 
     entt::entity cue = entt::null;
@@ -371,7 +371,7 @@ TEST_CASE("beat_scheduler: spawns SplitPath in authored lane", "[beat_scheduler]
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
 
-    auto view = reg.view<ObstacleTag, WorldTransform, SplitPathTag, int8_t>();
+    auto view = reg.view<ObstacleTag, WorldPosition, SplitPathTag, int8_t>();
     REQUIRE(view.size_hint() == 1);
     for (auto [e, wt, lane] : view.each()) {
         CHECK_THAT(wt.position.x, Catch::Matchers::WithinAbs(constants::LANE_X[2], 0.01f));
@@ -393,7 +393,7 @@ TEST_CASE("beat_scheduler: defaults invalid SplitPath lane to center lane", "[be
     song.next_onset_marker_idx = 0;
     CHECK_NOTHROW(beat_scheduler_system(reg, 0.016f));
 
-    auto view = reg.view<ObstacleTag, WorldTransform, SplitPathTag, int8_t, ObstacleChildren>();
+    auto view = reg.view<ObstacleTag, WorldPosition, SplitPathTag, int8_t, ObstacleChildren>();
     REQUIRE(view.size_hint() == 1);
     for (auto [e, wt, lane, children] : view.each()) {
         CHECK_THAT(wt.position.x, Catch::Matchers::WithinAbs(constants::LANE_X[1], 0.01f));
@@ -474,7 +474,7 @@ TEST_CASE("beat_scheduler: obstacles spawn with overshoot compensation", "[beat_
 
     // Obstacle should spawn below SPAWN_Y to compensate for late spawn.
     // start_y = SPAWN_Y + overshoot * scroll_speed
-    auto view = reg.view<ObstacleTag, WorldTransform>();
+    auto view = reg.view<ObstacleTag, WorldPosition>();
     for (auto [e, wt] : view.each()) {
         CHECK(wt.position.y > constants::SPAWN_Y);
     }
@@ -585,7 +585,7 @@ TEST_CASE("beat_scheduler: clamped late-spawn stores adjusted spawn_time in Beat
     float max_start_y = constants::PLAYER_Y;
 
     // Position must be clamped
-    auto pview = reg.view<ObstacleTag, WorldTransform>();
+    auto pview = reg.view<ObstacleTag, WorldPosition>();
     for (auto [e, wt] : pview.each()) {
         CHECK_THAT(wt.position.y, Catch::Matchers::WithinAbs(max_start_y, 0.01f));
     }

--- a/tests/test_collision_extended.cpp
+++ b/tests/test_collision_extended.cpp
@@ -77,7 +77,7 @@ TEST_CASE("collision: Hexagon fails even when matching gate shape", "[collision]
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
     reg.emplace<ShapeGateTag>(obs);
-    reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
+    reg.emplace<WorldPosition>(obs, WorldPosition{{constants::LANE_X[1], constants::PLAYER_Y}});
     reg.emplace<Vector2>(obs, Vector2{0.0f, 400.0f});
     reg.emplace<Obstacle>(obs, int16_t{200});
     set_required_shape_tag(reg, obs, Shape::Hexagon);
@@ -154,7 +154,7 @@ TEST_CASE("collision: on-beat shape press requires player hitbox to reach target
     song.song_time = 5.0f;
 
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
-    reg.get<WorldTransform>(obs).position.x = constants::LANE_X[0];
+    reg.get<WorldPosition>(obs).position.x = constants::LANE_X[0];
     reg.get<int8_t>(obs) = int8_t{0};
     reg.emplace<BeatInfo>(obs, 0, song.song_time, song.song_time - song.lead_time);
 
@@ -168,7 +168,7 @@ TEST_CASE("collision: on-beat shape press requires player hitbox to reach target
     song.song_time += song.morph_duration + 0.001f;
     shape_window_system(reg, song.morph_duration + 0.001f);
 
-    const auto& transform = reg.get<WorldTransform>(player);
+    const auto& transform = reg.get<WorldPosition>(player);
     REQUIRE(lane.current == 1);
     REQUIRE(lane.target == 0);
     REQUIRE(transform.position.x == constants::LANE_X[1]);
@@ -404,7 +404,7 @@ TEST_CASE("collision: split path succeeds with correct shape and lane", "[collis
     set_player_shape_tag(reg, p, Shape::Triangle);
     auto& lane = reg.get<Lane>(p);
     lane.current = 2;
-    reg.get<WorldTransform>(p).position.x = constants::LANE_X[2];
+    reg.get<WorldPosition>(p).position.x = constants::LANE_X[2];
 
     auto obs = make_split_path(reg, Shape::Triangle, 2, constants::PLAYER_Y);
 

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -44,7 +44,7 @@ TEST_CASE("collision: shape gate collision uses authored lane, not visual hitbox
         auto player = make_player(reg);
         auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
 
-        reg.get<WorldTransform>(obs).position.x = reg.get<WorldTransform>(player).position.x + tc.offset;
+        reg.get<WorldPosition>(obs).position.x = reg.get<WorldPosition>(player).position.x + tc.offset;
         collision_system(reg, 0.016f);
 
         CHECK(reg.all_of<ScoredTag>(obs));
@@ -59,7 +59,7 @@ TEST_CASE("collision: shape gate does not clear from target lane before strafe a
     auto& lane = reg.get<Lane>(player);
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
 
-    reg.get<WorldTransform>(obs).position.x = constants::LANE_X[0];
+    reg.get<WorldPosition>(obs).position.x = constants::LANE_X[0];
     reg.get<int8_t>(obs) = int8_t{0};
     lane.target = 0;
     lane.lerp_t = 0.0f;
@@ -76,7 +76,7 @@ TEST_CASE("collision: shape gate ignores visual lane drift from authored lane",
     make_player(reg);
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
 
-    reg.get<WorldTransform>(obs).position.x = constants::LANE_X[0];
+    reg.get<WorldPosition>(obs).position.x = constants::LANE_X[0];
 
     collision_system(reg, 0.016f);
 
@@ -91,9 +91,9 @@ TEST_CASE("collision: shape gate clears when interpolated player hitbox reaches 
     auto& lane = reg.get<Lane>(player);
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
 
-    reg.get<WorldTransform>(obs).position.x = constants::LANE_X[0];
+    reg.get<WorldPosition>(obs).position.x = constants::LANE_X[0];
     reg.get<int8_t>(obs) = int8_t{0};
-    reg.get<WorldTransform>(player).position.x = constants::LANE_X[0];
+    reg.get<WorldPosition>(player).position.x = constants::LANE_X[0];
     lane.target = 0;
     lane.lerp_t = 1.0f;
 
@@ -108,7 +108,7 @@ TEST_CASE("collision: split path uses interpolated player lane during transition
     auto reg = make_registry();
     auto player = make_player(reg);
     auto& lane = reg.get<Lane>(player);
-    auto& transform = reg.get<WorldTransform>(player);
+    auto& transform = reg.get<WorldPosition>(player);
     lane.current = 1;
     lane.target = 2;
     lane.lerp_t = 0.9f;
@@ -195,7 +195,7 @@ TEST_CASE("collision: visual obstacle leftovers without Obstacle payload are ign
 
     auto visual_leftover = reg.create();
     reg.emplace<ObstacleTag>(visual_leftover);
-    reg.emplace<WorldTransform>(visual_leftover, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
+    reg.emplace<WorldPosition>(visual_leftover, WorldPosition{{constants::LANE_X[1], constants::PLAYER_Y}});
     set_required_shape_tag(reg, visual_leftover, Shape::Triangle);
 
     collision_system(reg, 0.016f);

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -9,8 +9,8 @@
 
 // Verify component defaults and basic ECS operations
 
-TEST_CASE("components: WorldTransform defaults to origin position", "[components][transform]") {
-    WorldTransform transform{};
+TEST_CASE("components: WorldPosition defaults to origin position", "[components][transform]") {
+    WorldPosition transform{};
     CHECK(transform.position.x == 0.0f);
     CHECK(transform.position.y == 0.0f);
 }
@@ -231,7 +231,7 @@ TEST_CASE("ecs: make_player creates proper entity", "[ecs]") {
     auto p = make_player(reg);
 
     CHECK(reg.all_of<PlayerTag>(p));
-    CHECK(reg.all_of<WorldTransform>(p));
+    CHECK(reg.all_of<WorldPosition>(p));
     CHECK(reg.all_of<PlayerShape>(p));
     CHECK(reg.all_of<ShapeWindow>(p));
     CHECK(reg.all_of<Lane>(p));

--- a/tests/test_death_model_unified.cpp
+++ b/tests/test_death_model_unified.cpp
@@ -104,7 +104,7 @@ TEST_CASE("death_model: close hit banks points without instant GameOver", "[deat
     auto obstacle = reg.create();
     reg.emplace<ObstacleTag>(obstacle);
     reg.emplace<ShapeGateTag>(obstacle);
-    reg.emplace<WorldTransform>(obstacle, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
+    reg.emplace<WorldPosition>(obstacle, WorldPosition{{constants::LANE_X[1], constants::PLAYER_Y}});
     reg.emplace<Vector2>(obstacle, Vector2{0.0f, 0.0f});
     reg.emplace<Obstacle>(obstacle, int16_t{constants::PTS_SHAPE_GATE});
     set_required_shape_tag(reg, obstacle, Shape::Circle);
@@ -124,7 +124,7 @@ TEST_CASE("death_model: close miss drains energy instead of instant GameOver", "
     auto obstacle = reg.create();
     reg.emplace<ObstacleTag>(obstacle);
     reg.emplace<ShapeGateTag>(obstacle);
-    reg.emplace<WorldTransform>(obstacle, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
+    reg.emplace<WorldPosition>(obstacle, WorldPosition{{constants::LANE_X[1], constants::PLAYER_Y}});
     reg.emplace<Vector2>(obstacle, Vector2{0.0f, 0.0f});
     reg.emplace<Obstacle>(obstacle, int16_t{constants::PTS_SHAPE_GATE});
     set_required_shape_tag(reg, obstacle, Shape::Triangle);
@@ -169,7 +169,7 @@ TEST_CASE("death_model: scroll-past miss drains energy and requests GameOver", "
 
     auto obstacle = reg.create();
     reg.emplace<ObstacleTag>(obstacle);
-    reg.emplace<WorldTransform>(obstacle, WorldTransform{{0.0f, constants::DESTROY_Y + 10.0f}});
+    reg.emplace<WorldPosition>(obstacle, WorldPosition{{0.0f, constants::DESTROY_Y + 10.0f}});
     reg.emplace<Obstacle>(obstacle, int16_t{constants::PTS_SHAPE_GATE});
 
     // miss_detection_system tags; scoring_system drains.
@@ -203,7 +203,7 @@ TEST_CASE("death_model: scroll-past fatal miss triggers GameOver same frame", "[
 
     auto obstacle = reg.create();
     reg.emplace<ObstacleTag>(obstacle);
-    reg.emplace<WorldTransform>(obstacle, WorldTransform{{0.0f, constants::DESTROY_Y + 10.0f}});
+    reg.emplace<WorldPosition>(obstacle, WorldPosition{{0.0f, constants::DESTROY_Y + 10.0f}});
     reg.emplace<Obstacle>(obstacle, int16_t{constants::PTS_SHAPE_GATE});
 
     miss_detection_system(reg, 0.016f);
@@ -228,7 +228,7 @@ TEST_CASE("death_model: scroll-past miss does not double-drain", "[death_model]"
 
     auto obstacle = reg.create();
     reg.emplace<ObstacleTag>(obstacle);
-    reg.emplace<WorldTransform>(obstacle, WorldTransform{{0.0f, constants::DESTROY_Y + 10.0f}});
+    reg.emplace<WorldPosition>(obstacle, WorldPosition{{0.0f, constants::DESTROY_Y + 10.0f}});
     reg.emplace<Obstacle>(obstacle, int16_t{constants::PTS_SHAPE_GATE});
 
     miss_detection_system(reg, 0.016f);

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -46,7 +46,7 @@ TEST_CASE("game_state: song complete waits for obstacles to clear", "[gamestate]
     // Create an unscored obstacle
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
-    reg.emplace<WorldTransform>(obs, WorldTransform{{0.0f, 0.0f}});
+    reg.emplace<WorldPosition>(obs, WorldPosition{{0.0f, 0.0f}});
 
     game_state_system(reg, 0.016f);
 
@@ -82,7 +82,7 @@ TEST_CASE("game_state: song complete waits for scored obstacle to be destroyed",
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
     reg.emplace<ScoredTag>(obs);
-    reg.emplace<WorldTransform>(obs, WorldTransform{{0.0f, 0.0f}});
+    reg.emplace<WorldPosition>(obs, WorldPosition{{0.0f, 0.0f}});
 
     game_state_system(reg, 0.016f);
 
@@ -451,7 +451,7 @@ TEST_CASE("game_state: game_over restart enters fresh play session on next tick"
 
     auto stale = reg.create();
     reg.emplace<ObstacleTag>(stale);
-    reg.emplace<WorldTransform>(stale, WorldTransform{{0.0f, 0.0f}});
+    reg.emplace<WorldPosition>(stale, WorldPosition{{0.0f, 0.0f}});
     reg.ctx().get<ScoreState>().score = 3210;
 
     game_state_system(reg, 0.016f);

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -314,7 +314,7 @@ inline entt::registry make_rhythm_registry() {
 inline entt::entity make_player(entt::registry& reg) {
     auto player = reg.create();
     reg.emplace<PlayerTag>(player);
-    reg.emplace<WorldTransform>(player, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
+    reg.emplace<WorldPosition>(player, WorldPosition{{constants::LANE_X[1], constants::PLAYER_Y}});
     reg.emplace<PlayerShape>(player);
     // Default player shape is Circle (presence of `ShapeCircleTag`) — matches
     // the legacy `PlayerShape::current` default (enum first value).
@@ -391,7 +391,7 @@ inline entt::entity make_shape_gate(entt::registry& reg, Shape shape, float y) {
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
     reg.emplace<ShapeGateTag>(obs);
-    reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], y}});
+    reg.emplace<WorldPosition>(obs, WorldPosition{{constants::LANE_X[1], y}});
     reg.emplace<Vector2>(obs, Vector2{0.0f, song.scroll_speed});
     reg.emplace<Obstacle>(obs, int16_t{constants::PTS_SHAPE_GATE});
     set_required_shape_tag(reg, obs, shape);
@@ -408,7 +408,7 @@ inline entt::entity make_split_path(entt::registry& reg, Shape shape, int8_t lan
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
     reg.emplace<SplitPathTag>(obs);
-    reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], y}});
+    reg.emplace<WorldPosition>(obs, WorldPosition{{constants::LANE_X[1], y}});
     reg.emplace<Vector2>(obs, Vector2{0.0f, song.scroll_speed});
     reg.emplace<Obstacle>(obs, int16_t{constants::PTS_SPLIT_PATH});
     set_required_shape_tag(reg, obs, shape);

--- a/tests/test_miss_detection_regression.cpp
+++ b/tests/test_miss_detection_regression.cpp
@@ -13,13 +13,13 @@
 
 // ── helpers ─────────────────────────────────────────────────────────────────
 
-// Create a minimal expired obstacle: has ObstacleTag + Obstacle + WorldTransform past
+// Create a minimal expired obstacle: has ObstacleTag + Obstacle + WorldPosition past
 // DESTROY_Y, but no ScoredTag (miss_detection_system's precondition).
 static entt::entity make_expired_obstacle(entt::registry& reg) {
     auto e = reg.create();
     reg.emplace<ObstacleTag>(e);
     reg.emplace<Obstacle>(e, static_cast<int16_t>(constants::PTS_SHAPE_GATE));
-    reg.emplace<WorldTransform>(e, WorldTransform{{0.0f, constants::DESTROY_Y + 10.0f}});
+    reg.emplace<WorldPosition>(e, WorldPosition{{0.0f, constants::DESTROY_Y + 10.0f}});
     return e;
 }
 
@@ -102,7 +102,7 @@ TEST_CASE("miss_detection: obstacles above DESTROY_Y are not tagged",
     auto active = reg.create();
     reg.emplace<ObstacleTag>(active);
     reg.emplace<Obstacle>(active, static_cast<int16_t>(constants::PTS_SHAPE_GATE));
-    reg.emplace<WorldTransform>(active, WorldTransform{{0.0f, constants::PLAYER_Y - 100.0f}});
+    reg.emplace<WorldPosition>(active, WorldPosition{{0.0f, constants::PLAYER_Y - 100.0f}});
 
     miss_detection_system(reg, 0.016f);
 
@@ -157,8 +157,8 @@ TEST_CASE("miss_detection: visual obstacle leftovers without Obstacle payload ar
 
     auto visual_leftover = reg.create();
     reg.emplace<ObstacleTag>(visual_leftover);
-    reg.emplace<WorldTransform>(visual_leftover,
-                                WorldTransform{{0.0f, constants::DESTROY_Y + 10.0f}});
+    reg.emplace<WorldPosition>(visual_leftover,
+                                WorldPosition{{0.0f, constants::DESTROY_Y + 10.0f}});
 
     miss_detection_system(reg, 0.016f);
 

--- a/tests/test_obstacle_archetypes.cpp
+++ b/tests/test_obstacle_archetypes.cpp
@@ -33,7 +33,7 @@ int count_mesh_children(entt::registry& reg) {
 
 entt::entity make_mesh_factory_obstacle(entt::registry& reg) {
     auto parent = reg.create();
-    reg.emplace<WorldTransform>(parent, WorldTransform{{constants::LANE_X[1], -120.0f}});
+    reg.emplace<WorldPosition>(parent, WorldPosition{{constants::LANE_X[1], -120.0f}});
     reg.emplace<Obstacle>(parent, int16_t{0});
     reg.emplace<DrawSize>(parent, constants::SCREEN_W_F, 80.0f);
     reg.emplace<Color>(parent, Color{255, 255, 255, 255});
@@ -52,7 +52,7 @@ TEST_CASE("entity: ShapeGate Circle - correct components and color", "[archetype
     entt::registry reg;
     auto e = spawn_shape_gate_obstacle(reg, {360.0f, -120.0f, Shape::Circle});
 
-    REQUIRE(reg.all_of<ObstacleTag, Vector2, WorldTransform, Obstacle, int8_t, DrawSize, Color>(e));
+    REQUIRE(reg.all_of<ObstacleTag, Vector2, WorldPosition, Obstacle, int8_t, DrawSize, Color>(e));
     REQUIRE(has_required_shape_tag(reg, e));
     CHECK(!reg.all_of<uint8_t>(e));
     CHECK(!reg.all_of<SplitPathTag>(e));
@@ -60,8 +60,8 @@ TEST_CASE("entity: ShapeGate Circle - correct components and color", "[archetype
     CHECK(reg.get<Obstacle>(e).base_points == int16_t{constants::PTS_SHAPE_GATE});
     CHECK(current_required_shape(reg, e) == Shape::Circle);
     CHECK(reg.get<int8_t>(e) == int8_t{1});
-    CHECK(reg.get<WorldTransform>(e).position.x == 360.0f);
-    CHECK(reg.get<WorldTransform>(e).position.y == -120.0f);
+    CHECK(reg.get<WorldPosition>(e).position.x == 360.0f);
+    CHECK(reg.get<WorldPosition>(e).position.y == -120.0f);
 
     auto& c = reg.get<Color>(e);
     CHECK(c.r == 80); CHECK(c.g == 200); CHECK(c.b == 255);
@@ -97,7 +97,7 @@ TEST_CASE("entity: obstacle mesh overflow does not create orphan MeshChild", "[a
     entt::registry reg;
 
     auto parent = reg.create();
-    reg.emplace<WorldTransform>(parent, WorldTransform{{360.0f, -120.0f}});
+    reg.emplace<WorldPosition>(parent, WorldPosition{{360.0f, -120.0f}});
     reg.emplace<Obstacle>(parent, int16_t{constants::PTS_SHAPE_GATE});
     reg.emplace<DrawSize>(parent, constants::SCREEN_W_F, 80.0f);
     reg.emplace<Color>(parent, Color{80, 200, 255, 255});
@@ -194,7 +194,7 @@ TEST_CASE("entity: spawn_obstacle rejects invalid SplitPath lane before creating
                                                     Shape::Square, int8_t{3}}),
                     std::logic_error);
     CHECK(reg.view<ObstacleTag>().begin() == reg.view<ObstacleTag>().end());
-    CHECK(reg.view<WorldTransform>().begin() == reg.view<WorldTransform>().end());
+    CHECK(reg.view<WorldPosition>().begin() == reg.view<WorldPosition>().end());
     CHECK(count_mesh_children(reg) == 0);
 }
 
@@ -219,7 +219,7 @@ TEST_CASE("entity: SplitPath - required shape tag and required lane", "[archetyp
     auto e = spawn_split_path_obstacle(reg, {360.0f, -120.0f,
                                               Shape::Square, int8_t{2}});
 
-    REQUIRE(reg.all_of<ObstacleTag, Vector2, WorldTransform, Obstacle, int8_t, DrawSize, Color>(e));
+    REQUIRE(reg.all_of<ObstacleTag, Vector2, WorldPosition, Obstacle, int8_t, DrawSize, Color>(e));
     REQUIRE(has_required_shape_tag(reg, e));
     CHECK(!reg.all_of<uint8_t>(e));
 
@@ -233,7 +233,7 @@ TEST_CASE("entity: ShapeGate position x/y propagated from input", "[archetype]")
     entt::registry reg;
     auto e = spawn_shape_gate_obstacle(reg, {123.5f, 456.7f});
 
-    auto& transform = reg.get<WorldTransform>(e);
+    auto& transform = reg.get<WorldPosition>(e);
     CHECK(transform.position.x == 123.5f);
     CHECK(transform.position.y == 456.7f);
 }

--- a/tests/test_particle_system.cpp
+++ b/tests/test_particle_system.cpp
@@ -11,7 +11,7 @@ static entt::entity make_particle(entt::registry& reg, float size, float life_re
     reg.emplace<ParticleTag>(e);
     reg.emplace<ParticleData>(e, size, life_remaining, life_max);
     reg.emplace<Vector2>(e, Vector2{vx, vy});
-    reg.emplace<WorldTransform>(e, WorldTransform{{100.0f, 200.0f}});
+    reg.emplace<WorldPosition>(e, WorldPosition{{100.0f, 200.0f}});
     reg.emplace<TagEffectsPass>(e);
     return e;
 }

--- a/tests/test_perspective.cpp
+++ b/tests/test_perspective.cpp
@@ -120,7 +120,7 @@ TEST_CASE("game_camera_system drops stale MeshChild parents without crashing", "
     reg.ctx().emplace<ShapeMeshConfig>();
     reg.ctx().emplace<FloorParams>();
     auto parent = reg.create();
-    reg.emplace<WorldTransform>(parent, WorldTransform{{100.0f, 200.0f}});
+    reg.emplace<WorldPosition>(parent, WorldPosition{{100.0f, 200.0f}});
     auto child = reg.create();
     reg.emplace<MeshChild>(
         child,
@@ -160,7 +160,7 @@ TEST_CASE("game_camera_system rejects invalid MeshChild shape index", "[camera3d
     reg.ctx().emplace<ShapeMeshConfig>();
     reg.ctx().emplace<FloorParams>();
     auto parent = reg.create();
-    reg.emplace<WorldTransform>(parent, WorldTransform{{100.0f, 200.0f}});
+    reg.emplace<WorldPosition>(parent, WorldPosition{{100.0f, 200.0f}});
     auto child = reg.create();
     reg.emplace<MeshChild>(
         child,
@@ -195,7 +195,7 @@ TEST_CASE("game_camera_system: dense stale-parent cleanup stays within reserved 
     constexpr int dense_count = beat_capacity * ObstacleChildren::MAX;
     for (int i = 0; i < dense_count; ++i) {
         auto parent = reg.create();
-        reg.emplace<WorldTransform>(parent, WorldTransform{{static_cast<float>(i), 0.0f}});
+        reg.emplace<WorldPosition>(parent, WorldPosition{{static_cast<float>(i), 0.0f}});
         auto child = reg.create();
         reg.emplace<MeshChild>(
             child,

--- a/tests/test_phase_runner.cpp
+++ b/tests/test_phase_runner.cpp
@@ -26,7 +26,7 @@ TEST_CASE("tick_playing_systems: no-op when phase is Paused", "[phase_guard]") {
     // Expired obstacle that miss_detection would stamp if it ran.
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
-    reg.emplace<WorldTransform>(obs, WorldTransform{{0.0f, constants::DESTROY_Y + 1.0f}});
+    reg.emplace<WorldPosition>(obs, WorldPosition{{0.0f, constants::DESTROY_Y + 1.0f}});
 
     tick_playing_systems(reg, 0.016f);
 
@@ -43,7 +43,7 @@ TEST_CASE("tick_playing_systems: no-op when phase is GameOver", "[phase_guard]")
     // Expired obstacle to match Paused coverage (MissTag / ScoredTag guard).
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
-    reg.emplace<WorldTransform>(obs, WorldTransform{{0.0f, constants::DESTROY_Y + 1.0f}});
+    reg.emplace<WorldPosition>(obs, WorldPosition{{0.0f, constants::DESTROY_Y + 1.0f}});
 
     auto& score = reg.ctx().get<ScoreState>();
     auto& energy = reg.ctx().get<EnergyState>();
@@ -122,7 +122,7 @@ TEST_CASE("tick_playing_systems: shape window activates before collision", "[pha
 //
 // Why relative ordering between obstacle_despawn and popup_feedback does NOT
 // matter (Keaton-r14 finding): these two systems are commutative.
-//   obstacle_despawn reads ObstacleTag+WorldTransform → destroys entities
+//   obstacle_despawn reads ObstacleTag+WorldPosition → destroys entities
 //   popup_feedback  reads ScorePopupRequestQueue (ctx) → creates popup entities
 // Their data surfaces are disjoint; no observable state diff results from
 // swapping them.  The relative call order in fixed_tick_runner.cpp is a

--- a/tests/test_player_archetype.cpp
+++ b/tests/test_player_archetype.cpp
@@ -13,7 +13,7 @@ TEST_CASE("player_entity: canonical component set present", "[archetype][player]
     auto p = create_player_entity(reg);
 
     CHECK(reg.all_of<PlayerTag>(p));
-    CHECK(reg.all_of<WorldTransform>(p));
+    CHECK(reg.all_of<WorldPosition>(p));
     CHECK(reg.all_of<PlayerShape>(p));
     CHECK(reg.all_of<ShapeWindow>(p));
     CHECK(reg.all_of<Lane>(p));
@@ -28,7 +28,7 @@ TEST_CASE("player_entity: starts at center lane position", "[archetype][player]"
     auto reg = make_registry();
     auto p = create_player_entity(reg);
 
-    auto& transform = reg.get<WorldTransform>(p);
+    auto& transform = reg.get<WorldPosition>(p);
     CHECK(transform.position.x == constants::LANE_X[1]);
     CHECK(transform.position.y == constants::PLAYER_Y);
 }

--- a/tests/test_player_input_rhythm_extended.cpp
+++ b/tests/test_player_input_rhythm_extended.cpp
@@ -202,7 +202,7 @@ TEST_CASE("player_input_rhythm: circle press in lane 0 does not force mismatch b
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
     auto& lane = reg.get<Lane>(player);
-    auto& transform = reg.get<WorldTransform>(player);
+    auto& transform = reg.get<WorldPosition>(player);
 
     lane.current = 0;
     lane.target = -1;
@@ -212,7 +212,7 @@ TEST_CASE("player_input_rhythm: circle press in lane 0 does not force mismatch b
     set_player_shape_tag(reg, player, Shape::Hexagon);
 
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
-    reg.get<WorldTransform>(obs).position.x = constants::LANE_X[0];
+    reg.get<WorldPosition>(obs).position.x = constants::LANE_X[0];
     reg.get<int8_t>(obs) = int8_t{0};
 
     auto btn = make_shape_button(reg, Shape::Circle);

--- a/tests/test_player_systems.cpp
+++ b/tests/test_player_systems.cpp
@@ -188,10 +188,10 @@ TEST_CASE("player_movement: lane transition moves position", "[player]") {
     reg.get<Lane>(p).target = 0;
     reg.get<Lane>(p).lerp_t = 0.0f;
 
-    float initial_x = reg.get<WorldTransform>(p).position.x;
+    float initial_x = reg.get<WorldPosition>(p).position.x;
     player_movement_system(reg, 0.016f);
 
-    CHECK(reg.get<WorldTransform>(p).position.x < initial_x);
+    CHECK(reg.get<WorldPosition>(p).position.x < initial_x);
 }
 
 TEST_CASE("player_movement: lane transition completes", "[player]") {
@@ -207,14 +207,14 @@ TEST_CASE("player_movement: lane transition completes", "[player]") {
 
     CHECK(reg.get<Lane>(p).current == 2);
     CHECK(reg.get<Lane>(p).target == -1);
-    CHECK(reg.get<WorldTransform>(p).position.x == constants::LANE_X[2]);
+    CHECK(reg.get<WorldPosition>(p).position.x == constants::LANE_X[2]);
 }
 
 TEST_CASE("player_movement: clears stale lane target when target equals current", "[player]") {
     auto reg = make_registry();
     auto p = make_player(reg);
     auto& lane = reg.get<Lane>(p);
-    auto& transform = reg.get<WorldTransform>(p);
+    auto& transform = reg.get<WorldPosition>(p);
     lane.current = 1;
     lane.target = 1;
     lane.lerp_t = 0.0f;
@@ -231,7 +231,7 @@ TEST_CASE("player_movement: normalizes invalid current lane", "[player][issue900
     auto reg = make_registry();
     auto p = make_player(reg);
     auto& lane = reg.get<Lane>(p);
-    auto& transform = reg.get<WorldTransform>(p);
+    auto& transform = reg.get<WorldPosition>(p);
     lane.current = -1;
     lane.target = 0;
     lane.lerp_t = 0.0f;
@@ -249,7 +249,7 @@ TEST_CASE("player_movement: normalizes invalid target lane", "[player][issue900]
     auto reg = make_registry();
     auto p = make_player(reg);
     auto& lane = reg.get<Lane>(p);
-    auto& transform = reg.get<WorldTransform>(p);
+    auto& transform = reg.get<WorldPosition>(p);
     lane.current = 1;
     lane.target = constants::LANE_COUNT;
     lane.lerp_t = 0.0f;

--- a/tests/test_popup_display_system.cpp
+++ b/tests/test_popup_display_system.cpp
@@ -31,7 +31,7 @@
 #include "systems/popup_display_system.h"
 #include "components/text.h"      // FontSize
 #include "tags/tags.h"            // TimingPerfectTag / Good / Ok / Bad
-#include "components/transform.h" // WorldTransform, Vector2
+#include "components/transform.h" // WorldPosition, Vector2
 #include "entities/settings.h"    // SettingsState (reduce_motion)
 #include "systems/all_systems.h"  // popup_display_system declaration
 #include "entities/popup_entity.h"
@@ -273,7 +273,7 @@ TEST_CASE("spawn_score_popup_good: creates the full popup display archetype",
     auto e = spawn_score_popup_good(reg, 100.0f, 200.0f, 50);
 
     REQUIRE(reg.all_of<ScorePopup, PopupDisplay, Color, Vector2,
-                       WorldTransform, TagHUDPass>(e));
+                       WorldPosition, TagHUDPass>(e));
     CHECK(reg.all_of<TimingGoodTag>(e));
     CHECK(std::strcmp(reg.get<PopupDisplay>(e).text, "GOOD") == 0);
 }
@@ -315,13 +315,13 @@ TEST_CASE("init_popup_display_untimed: formats numeric value (#251)",
 // the full expected component bundle with correct values plus the matching
 // per-tier tag.
 
-TEST_CASE("spawn_score_popup_untimed: entity has WorldTransform at pos - 40",
+TEST_CASE("spawn_score_popup_untimed: entity has WorldPosition at pos - 40",
           "[popup_entity][issue349]") {
     entt::registry reg;
     auto e = spawn_score_popup_untimed(reg, 100.0f, 500.0f, 200);
 
-    REQUIRE(reg.all_of<WorldTransform>(e));
-    const auto& wt = reg.get<WorldTransform>(e);
+    REQUIRE(reg.all_of<WorldPosition>(e));
+    const auto& wt = reg.get<WorldPosition>(e);
     CHECK(wt.position.x == 100.0f);
     CHECK(wt.position.y == 460.0f);  // 500 - 40
 }

--- a/tests/test_redfoot_testflight_ui.cpp
+++ b/tests/test_redfoot_testflight_ui.cpp
@@ -89,7 +89,7 @@ namespace {
 void spawn_aligned_player(entt::registry& reg, float y) {
     auto p = reg.create();
     reg.emplace<PlayerTag>(p);
-    reg.emplace<WorldTransform>(p, WorldTransform{{constants::LANE_X[1], y}});
+    reg.emplace<WorldPosition>(p, WorldPosition{{constants::LANE_X[1], y}});
     PlayerShape ps;
     reg.emplace<PlayerShape>(p, ps);
     set_player_shape_tag(reg, p, Shape::Hexagon);
@@ -104,7 +104,7 @@ void spawn_aligned_player(entt::registry& reg, float y) {
 entt::entity spawn_obstacle(entt::registry& reg, float y) {
     auto e = reg.create();
     reg.emplace<ObstacleTag>(e);
-    reg.emplace<WorldTransform>(e, WorldTransform{{constants::LANE_X[1], y}});
+    reg.emplace<WorldPosition>(e, WorldPosition{{constants::LANE_X[1], y}});
     reg.emplace<Obstacle>(e, int16_t{0});
     return e;
 }

--- a/tests/test_rhythm_system.cpp
+++ b/tests/test_rhythm_system.cpp
@@ -667,7 +667,7 @@ TEST_CASE("scoring: timing_mult applied to scored obstacle", "[rhythm][scoring]"
     score.score = 0; score.chain_count = 0;
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
-    reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
+    reg.emplace<WorldPosition>(obs, WorldPosition{{constants::LANE_X[1], constants::PLAYER_Y}});
     reg.emplace<Obstacle>(obs, int16_t{200});
     reg.emplace<ScoredTag>(obs);
     emplace_timing_perfect(reg, obs, 1.0f);
@@ -874,7 +874,7 @@ TEST_CASE("integration: obstacle arrives on-beat within 1 frame", "[rhythm][inte
         beat_scheduler_system(reg, dt);
         scroll_system(reg, dt);
         frames++;
-        auto view = reg.view<ObstacleTag, WorldTransform>();
+        auto view = reg.view<ObstacleTag, WorldPosition>();
         for (auto [e, wt] : view.each()) {
             if (wt.position.y >= constants::PLAYER_Y) {
                 obstacle_at_player = true;

--- a/tests/test_scoring_extended.cpp
+++ b/tests/test_scoring_extended.cpp
@@ -21,7 +21,7 @@ int score_shape_gate_with_tier(entt::registry& reg, TierEmplace emplace_tag) {
 entt::entity make_zero_point_passive_obstacle(entt::registry& reg) {
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
-    reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
+    reg.emplace<WorldPosition>(obs, WorldPosition{{constants::LANE_X[1], constants::PLAYER_Y}});
     reg.emplace<Obstacle>(obs, int16_t{0});
     reg.emplace<ScoredTag>(obs);
     return obs;

--- a/tests/test_scoring_system.cpp
+++ b/tests/test_scoring_system.cpp
@@ -149,7 +149,7 @@ TEST_CASE("scoring: popup entity spawned on score", "[scoring]") {
     auto popup_view = reg.view<ScorePopup>();
     int popup_count = 0;
     for (auto e : popup_view) {
-        CHECK(reg.all_of<WorldTransform>(e));
+        CHECK(reg.all_of<WorldPosition>(e));
         CHECK(reg.all_of<Vector2>(e));
         CHECK(reg.all_of<TagHUDPass>(e));
         ++popup_count;
@@ -167,7 +167,7 @@ TEST_CASE("scoring: score feedback spawns effect particles", "[scoring][particle
 
     int particle_count = 0;
     auto particle_view =
-        reg.view<ParticleTag, ParticleData, WorldTransform, Vector2, Color, TagEffectsPass>();
+        reg.view<ParticleTag, ParticleData, WorldPosition, Vector2, Color, TagEffectsPass>();
     for (auto [entity, particle, transform, velocity, color] : particle_view.each()) {
         CHECK(reg.valid(entity));
         CHECK(particle.remaining > 0.0f);
@@ -358,7 +358,7 @@ TEST_CASE("scoring: popup entity has full factory contract", "[scoring][popup_en
     int count = 0;
     for (auto e : popup_view) {
         ++count;
-        CHECK(reg.all_of<WorldTransform>(e));
+        CHECK(reg.all_of<WorldPosition>(e));
         CHECK(reg.all_of<Vector2>(e));
         CHECK(reg.all_of<Color>(e));
         CHECK(reg.all_of<TagHUDPass>(e));
@@ -381,7 +381,7 @@ TEST_CASE("scoring: NonScorableTag entity cleared without scoring", "[scoring][n
 
     auto e = reg.create();
     reg.emplace<ObstacleTag>(e);
-    reg.emplace<WorldTransform>(e, WorldTransform{{300.0f, constants::PLAYER_Y}});
+    reg.emplace<WorldPosition>(e, WorldPosition{{300.0f, constants::PLAYER_Y}});
     reg.emplace<Obstacle>(e, int16_t{999});
     reg.emplace<NonScorableTag>(e);
     reg.emplace<ScoredTag>(e);
@@ -411,7 +411,7 @@ TEST_CASE("scoring: missed NonScorableTag entity is resolved without effects",
 
     auto e = reg.create();
     reg.emplace<ObstacleTag>(e);
-    reg.emplace<WorldTransform>(e, WorldTransform{{300.0f, constants::PLAYER_Y}});
+    reg.emplace<WorldPosition>(e, WorldPosition{{300.0f, constants::PLAYER_Y}});
     reg.emplace<Obstacle>(e, int16_t{0});
     reg.emplace<NonScorableTag>(e);
     reg.emplace<ScoredTag>(e);
@@ -439,7 +439,7 @@ TEST_CASE("scoring: missed obstacle drains energy without setting terminal death
 
     auto e = reg.create();
     reg.emplace<ObstacleTag>(e);
-    reg.emplace<WorldTransform>(e, WorldTransform{{300.0f, constants::PLAYER_Y}});
+    reg.emplace<WorldPosition>(e, WorldPosition{{300.0f, constants::PLAYER_Y}});
     reg.emplace<Obstacle>(e, int16_t{200});
     reg.emplace<ScoredTag>(e);
     reg.emplace<MissTag>(e);

--- a/tests/test_scroll_rhythm.cpp
+++ b/tests/test_scroll_rhythm.cpp
@@ -14,13 +14,13 @@ TEST_CASE("scroll: rhythm obstacles positioned from song_time and BeatInfo", "[s
 
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
-    reg.emplace<WorldTransform>(obs, WorldTransform{{0.0f, 0.0f}});
+    reg.emplace<WorldPosition>(obs, WorldPosition{{0.0f, 0.0f}});
     reg.emplace<BeatInfo>(obs, 0, 4.0f, 0.0f);
 
     scroll_system(reg, 0.016f);
 
     float expected_y = constants::SPAWN_Y + (song.song_time - 0.0f) * song.scroll_speed;
-    CHECK_THAT(reg.get<WorldTransform>(obs).position.y, Catch::Matchers::WithinAbs(expected_y, 0.1f));
+    CHECK_THAT(reg.get<WorldPosition>(obs).position.y, Catch::Matchers::WithinAbs(expected_y, 0.1f));
 }
 
 TEST_CASE("scroll: rhythm obstacles ignore Vector2 component", "[scroll][rhythm]") {
@@ -30,7 +30,7 @@ TEST_CASE("scroll: rhythm obstacles ignore Vector2 component", "[scroll][rhythm]
 
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
-    reg.emplace<WorldTransform>(obs, WorldTransform{{100.0f, 0.0f}});
+    reg.emplace<WorldPosition>(obs, WorldPosition{{100.0f, 0.0f}});
     reg.emplace<Vector2>(obs, Vector2{999.0f, 999.0f});
     reg.emplace<BeatInfo>(obs, 0, 3.0f, 0.0f);
 
@@ -38,22 +38,22 @@ TEST_CASE("scroll: rhythm obstacles ignore Vector2 component", "[scroll][rhythm]
 
     // X should not change (Vector2 is irrelevant for BeatInfo entities in rhythm mode)
     float expected_y = constants::SPAWN_Y + (1.0f - 0.0f) * song.scroll_speed;
-    CHECK_THAT(reg.get<WorldTransform>(obs).position.x, Catch::Matchers::WithinAbs(100.0f, 0.01f));
-    CHECK_THAT(reg.get<WorldTransform>(obs).position.y, Catch::Matchers::WithinAbs(expected_y, 0.1f));
+    CHECK_THAT(reg.get<WorldPosition>(obs).position.x, Catch::Matchers::WithinAbs(100.0f, 0.01f));
+    CHECK_THAT(reg.get<WorldPosition>(obs).position.y, Catch::Matchers::WithinAbs(expected_y, 0.1f));
 }
 
 TEST_CASE("motion: non-rhythm entities use dt-based movement", "[motion][rhythm]") {
     auto reg = make_rhythm_registry();
 
     auto particle = reg.create();
-    reg.emplace<WorldTransform>(particle, WorldTransform{{100.0f, 200.0f}});
+    reg.emplace<WorldPosition>(particle, WorldPosition{{100.0f, 200.0f}});
     reg.emplace<Vector2>(particle, Vector2{10.0f, 20.0f});
     // No BeatInfo → dt-based
 
     motion_system(reg, 0.5f);
 
-    CHECK_THAT(reg.get<WorldTransform>(particle).position.x, Catch::Matchers::WithinAbs(105.0f, 0.01f));
-    CHECK_THAT(reg.get<WorldTransform>(particle).position.y, Catch::Matchers::WithinAbs(210.0f, 0.01f));
+    CHECK_THAT(reg.get<WorldPosition>(particle).position.x, Catch::Matchers::WithinAbs(105.0f, 0.01f));
+    CHECK_THAT(reg.get<WorldPosition>(particle).position.y, Catch::Matchers::WithinAbs(210.0f, 0.01f));
 }
 
 TEST_CASE("scroll: BeatInfo position tracks song_time progression", "[scroll][rhythm]") {
@@ -62,18 +62,18 @@ TEST_CASE("scroll: BeatInfo position tracks song_time progression", "[scroll][rh
 
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
-    reg.emplace<WorldTransform>(obs, WorldTransform{{0.0f, 0.0f}});
+    reg.emplace<WorldPosition>(obs, WorldPosition{{0.0f, 0.0f}});
     reg.emplace<BeatInfo>(obs, 0, 4.0f, 1.0f);
 
     // Time 1: song_time=1.0
     song.song_time = 1.0f;
     scroll_system(reg, 0.016f);
-    float y1 = reg.get<WorldTransform>(obs).position.y;
+    float y1 = reg.get<WorldPosition>(obs).position.y;
 
     // Time 2: song_time=2.0
     song.song_time = 2.0f;
     scroll_system(reg, 0.016f);
-    float y2 = reg.get<WorldTransform>(obs).position.y;
+    float y2 = reg.get<WorldPosition>(obs).position.y;
 
     CHECK(y2 > y1);
     float delta = y2 - y1;
@@ -88,7 +88,7 @@ TEST_CASE("scroll: invalid scroll_speed preserves finite obstacle position", "[s
 
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
-    reg.emplace<WorldTransform>(obs, WorldTransform{{0.0f, 123.0f}});
+    reg.emplace<WorldPosition>(obs, WorldPosition{{0.0f, 123.0f}});
     reg.emplace<BeatInfo>(obs, 0, 4.0f, 0.0f);
 
     {
@@ -98,7 +98,7 @@ TEST_CASE("scroll: invalid scroll_speed preserves finite obstacle position", "[s
         scroll_system(reg, 0.016f);
     }
 
-    const auto& transform = reg.get<WorldTransform>(obs);
+    const auto& transform = reg.get<WorldPosition>(obs);
     CHECK(std::isfinite(transform.position.y));
     CHECK_THAT(transform.position.y, Catch::Matchers::WithinAbs(123.0f, 0.001f));
 }
@@ -111,7 +111,7 @@ TEST_CASE("scroll: non-positive scroll_speed skips position updates", "[scroll][
 
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
-    reg.emplace<WorldTransform>(obs, WorldTransform{{0.0f, 234.0f}});
+    reg.emplace<WorldPosition>(obs, WorldPosition{{0.0f, 234.0f}});
     reg.emplace<BeatInfo>(obs, 0, 4.0f, 0.0f);
 
     {
@@ -119,10 +119,10 @@ TEST_CASE("scroll: non-positive scroll_speed skips position updates", "[scroll][
         // scroll_speed; silence here so the test doesn't pollute stderr.
         ScopedTraceLogSilencer silence_warning;
         scroll_system(reg, 0.016f);
-        CHECK_THAT(reg.get<WorldTransform>(obs).position.y, Catch::Matchers::WithinAbs(234.0f, 0.001f));
+        CHECK_THAT(reg.get<WorldPosition>(obs).position.y, Catch::Matchers::WithinAbs(234.0f, 0.001f));
 
         song.scroll_speed = -100.0f;
         scroll_system(reg, 0.016f);
-        CHECK_THAT(reg.get<WorldTransform>(obs).position.y, Catch::Matchers::WithinAbs(234.0f, 0.001f));
+        CHECK_THAT(reg.get<WorldPosition>(obs).position.y, Catch::Matchers::WithinAbs(234.0f, 0.001f));
     }
 }

--- a/tests/test_song_playback_system.cpp
+++ b/tests/test_song_playback_system.cpp
@@ -203,7 +203,7 @@ TEST_CASE("song_playback: obstacles can clear after playback ends without soft-l
 
     auto obstacle = reg.create();
     reg.emplace<ObstacleTag>(obstacle);
-    reg.emplace<WorldTransform>(obstacle, WorldTransform{{constants::LANE_X[1], start_y}});
+    reg.emplace<WorldPosition>(obstacle, WorldPosition{{constants::LANE_X[1], start_y}});
     reg.emplace<BeatInfo>(obstacle, BeatInfo{0, song.song_time, spawn_time});
 
     tick_fixed_systems(reg, 0.1f);

--- a/tests/test_test_player_system.cpp
+++ b/tests/test_test_player_system.cpp
@@ -17,7 +17,7 @@ static entt::registry make_test_player_registry(SkillConfig skill = SKILL_PRO) {
 
 static entt::entity make_shape_gate_at_lane(entt::registry& reg, Shape shape, int8_t lane, float y) {
     auto obs = make_shape_gate(reg, shape, y);
-    reg.get<WorldTransform>(obs).position.x = constants::LANE_X[lane];
+    reg.get<WorldPosition>(obs).position.x = constants::LANE_X[lane];
     auto& song = reg.ctx().get<SongState>();
     float spawn_time = song.song_time - (y - constants::SPAWN_Y) / song.scroll_speed;
     float arrival = spawn_time + (constants::PLAYER_Y - constants::SPAWN_Y) / song.scroll_speed;
@@ -81,7 +81,7 @@ static entt::entity make_loggable_obstacle(entt::registry& reg) {
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
     reg.emplace<Obstacle>(obs, int16_t{constants::PTS_SHAPE_GATE});
-    reg.emplace<WorldTransform>(obs, WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y}});
+    reg.emplace<WorldPosition>(obs, WorldPosition{{constants::LANE_X[1], constants::PLAYER_Y}});
     reg.emplace<BeatInfo>(obs, 7, 2.0f, 0.0f);
     return obs;
 }
@@ -161,8 +161,8 @@ TEST_CASE("test_player: ignores visual obstacle leftovers without Obstacle paylo
 
     auto visual_leftover = reg.create();
     reg.emplace<ObstacleTag>(visual_leftover);
-    reg.emplace<WorldTransform>(visual_leftover,
-                                WorldTransform{{constants::LANE_X[1], constants::PLAYER_Y - 200.0f}});
+    reg.emplace<WorldPosition>(visual_leftover,
+                                WorldPosition{{constants::LANE_X[1], constants::PLAYER_Y - 200.0f}});
     set_required_shape_tag(reg, visual_leftover, Shape::Circle);
 
     test_player_system(reg, 0.016f);

--- a/tests/test_world_systems.cpp
+++ b/tests/test_world_systems.cpp
@@ -5,44 +5,44 @@
 // ── motion_system ────────────────────────────────────────────
 //
 // Single path after #349 migration:
-//   motion_view — WorldTransform+Vector2 (obstacles, popups, particles, player)
+//   motion_view — WorldPosition+Vector2 (obstacles, popups, particles, player)
 //                 also bridges to Position when both components are present.
 
-TEST_CASE("motion: WorldTransform+Vector2 moves by velocity * dt", "[motion]") {
+TEST_CASE("motion: WorldPosition+Vector2 moves by velocity * dt", "[motion]") {
     auto reg = make_registry();
     auto e = reg.create();
-    reg.emplace<WorldTransform>(e, WorldTransform{{100.0f, 200.0f}});
+    reg.emplace<WorldPosition>(e, WorldPosition{{100.0f, 200.0f}});
     reg.emplace<Vector2>(e, Vector2{10.0f, 20.0f});
 
     motion_system(reg, 1.0f);
 
-    CHECK(reg.get<WorldTransform>(e).position.x == 110.0f);
-    CHECK(reg.get<WorldTransform>(e).position.y == 220.0f);
+    CHECK(reg.get<WorldPosition>(e).position.x == 110.0f);
+    CHECK(reg.get<WorldPosition>(e).position.y == 220.0f);
 }
 
 TEST_CASE("motion: zero Vector2 means no movement", "[motion]") {
     auto reg = make_registry();
     auto e = reg.create();
-    reg.emplace<WorldTransform>(e, WorldTransform{{100.0f, 200.0f}});
+    reg.emplace<WorldPosition>(e, WorldPosition{{100.0f, 200.0f}});
     reg.emplace<Vector2>(e, Vector2{0.0f, 0.0f});
 
     motion_system(reg, 1.0f);
 
-    CHECK(reg.get<WorldTransform>(e).position.x == 100.0f);
-    CHECK(reg.get<WorldTransform>(e).position.y == 200.0f);
+    CHECK(reg.get<WorldPosition>(e).position.x == 100.0f);
+    CHECK(reg.get<WorldPosition>(e).position.y == 200.0f);
 }
 
-// ── motion_system: WorldTransform+Vector2 path (modern, issue #349 target) ──
+// ── motion_system: WorldPosition+Vector2 path (modern, issue #349 target) ──
 
-TEST_CASE("motion: WorldTransform+Vector2 entity moves by velocity * dt", "[motion]") {
+TEST_CASE("motion: WorldPosition+Vector2 entity moves by velocity * dt", "[motion]") {
     auto reg = make_registry();
     auto e = reg.create();
-    reg.emplace<WorldTransform>(e, WorldTransform{{100.0f, 200.0f}});
+    reg.emplace<WorldPosition>(e, WorldPosition{{100.0f, 200.0f}});
     reg.emplace<Vector2>(e, Vector2{10.0f, 20.0f});
 
     motion_system(reg, 1.0f);
 
-    const auto& wt = reg.get<WorldTransform>(e);
+    const auto& wt = reg.get<WorldPosition>(e);
     CHECK(wt.position.x == 110.0f);
     CHECK(wt.position.y == 220.0f);
 }
@@ -52,12 +52,12 @@ TEST_CASE("motion: BeatInfo alone does not make an entity movable", "[motion]") 
     // Vector2. BeatInfo by itself is ignored by motion_system.
     auto reg = make_registry();
     auto e = reg.create();
-    reg.emplace<WorldTransform>(e, WorldTransform{{100.0f, 200.0f}});
+    reg.emplace<WorldPosition>(e, WorldPosition{{100.0f, 200.0f}});
     reg.emplace<BeatInfo>(e, BeatInfo{0, 0.0f, 0.0f});  // marks entity as beat-authoritative
 
     motion_system(reg, 1.0f);
 
-    const auto& wt = reg.get<WorldTransform>(e);
+    const auto& wt = reg.get<WorldPosition>(e);
     CHECK(wt.position.x == 100.0f);
     CHECK(wt.position.y == 200.0f);
 }
@@ -69,7 +69,7 @@ TEST_CASE("cleanup: destroys obstacles past DESTROY_Y", "[cleanup]") {
     auto reg = make_registry();
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
-    reg.emplace<WorldTransform>(obs, WorldTransform{{0.0f, constants::DESTROY_Y + 10.0f}});
+    reg.emplace<WorldPosition>(obs, WorldPosition{{0.0f, constants::DESTROY_Y + 10.0f}});
 
     obstacle_despawn_system(reg, 0.016f);
 
@@ -80,7 +80,7 @@ TEST_CASE("cleanup: keeps obstacles above DESTROY_Y", "[cleanup]") {
     auto reg = make_registry();
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
-    reg.emplace<WorldTransform>(obs, WorldTransform{{0.0f, constants::DESTROY_Y - 10.0f}});
+    reg.emplace<WorldPosition>(obs, WorldPosition{{0.0f, constants::DESTROY_Y - 10.0f}});
 
     obstacle_despawn_system(reg, 0.016f);
 
@@ -90,7 +90,7 @@ TEST_CASE("cleanup: keeps obstacles above DESTROY_Y", "[cleanup]") {
 TEST_CASE("cleanup: non-obstacle entities are untouched", "[cleanup]") {
     auto reg = make_registry();
     auto e = reg.create();
-    reg.emplace<WorldTransform>(e, WorldTransform{{0.0f, constants::DESTROY_Y + 100.0f}});
+    reg.emplace<WorldPosition>(e, WorldPosition{{0.0f, constants::DESTROY_Y + 100.0f}});
     // No ObstacleTag
 
     obstacle_despawn_system(reg, 0.016f);
@@ -226,7 +226,7 @@ TEST_CASE("game_state: enter_playing clears entities and creates player", "[game
     // Create some entities that should be cleared
     auto junk = reg.create();
     reg.emplace<ObstacleTag>(junk);
-    reg.emplace<WorldTransform>(junk, WorldTransform{{0.0f, 0.0f}});
+    reg.emplace<WorldPosition>(junk, WorldPosition{{0.0f, 0.0f}});
 
     request_phase_transition<NextPhasePlayingTag>(reg);
 
@@ -316,7 +316,7 @@ TEST_CASE("game_state: paused resume preserves active play session state", "[gam
     auto player = make_player(reg);
     auto obstacle = reg.create();
     reg.emplace<ObstacleTag>(obstacle);
-    reg.emplace<WorldTransform>(obstacle, WorldTransform{{0.0f, 123.0f}});
+    reg.emplace<WorldPosition>(obstacle, WorldPosition{{0.0f, 123.0f}});
 
     auto& score = reg.ctx().get<ScoreState>();
     score.score = 4321;
@@ -408,26 +408,26 @@ TEST_CASE("scroll: no movement when not in Playing phase", "[scroll]") {
     auto reg = make_registry();
     set_test_phase<GamePhaseTitleTag>(reg);
     auto e = reg.create();
-    reg.emplace<WorldTransform>(e, WorldTransform{{100.0f, 200.0f}});
+    reg.emplace<WorldPosition>(e, WorldPosition{{100.0f, 200.0f}});
     reg.emplace<Vector2>(e, Vector2{10.0f, 20.0f});
 
     scroll_system(reg, 1.0f);
 
-    CHECK(reg.get<WorldTransform>(e).position.x == 100.0f);
-    CHECK(reg.get<WorldTransform>(e).position.y == 200.0f);
+    CHECK(reg.get<WorldPosition>(e).position.x == 100.0f);
+    CHECK(reg.get<WorldPosition>(e).position.y == 200.0f);
 }
 
 TEST_CASE("motion: no movement when not in Playing phase", "[motion]") {
     auto reg = make_registry();
     set_test_phase<GamePhaseTitleTag>(reg);
     auto e = reg.create();
-    reg.emplace<WorldTransform>(e, WorldTransform{{100.0f, 200.0f}});
+    reg.emplace<WorldPosition>(e, WorldPosition{{100.0f, 200.0f}});
     reg.emplace<Vector2>(e, Vector2{10.0f, 20.0f});
 
     tick_playing_systems(reg, 1.0f);
 
-    CHECK(reg.get<WorldTransform>(e).position.x == 100.0f);
-    CHECK(reg.get<WorldTransform>(e).position.y == 200.0f);
+    CHECK(reg.get<WorldPosition>(e).position.x == 100.0f);
+    CHECK(reg.get<WorldPosition>(e).position.y == 200.0f);
 }
 
 // ── cleanup: edge cases ─────────────────────────────────────
@@ -436,7 +436,7 @@ TEST_CASE("cleanup: obstacle at exactly DESTROY_Y is kept", "[cleanup]") {
     auto reg = make_registry();
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
-    reg.emplace<WorldTransform>(obs, WorldTransform{{0.0f, constants::DESTROY_Y}});
+    reg.emplace<WorldPosition>(obs, WorldPosition{{0.0f, constants::DESTROY_Y}});
 
     obstacle_despawn_system(reg, 0.016f);
 
@@ -452,7 +452,7 @@ TEST_CASE("cleanup: destroys multiple obstacles past DESTROY_Y in one pass", "[c
     for (int i = 0; i < N; ++i) {
         obs[i] = reg.create();
         reg.emplace<ObstacleTag>(obs[i]);
-        reg.emplace<WorldTransform>(obs[i], WorldTransform{{0.0f, constants::DESTROY_Y + static_cast<float>(i + 1) * 10.0f}});
+        reg.emplace<WorldPosition>(obs[i], WorldPosition{{0.0f, constants::DESTROY_Y + static_cast<float>(i + 1) * 10.0f}});
     }
 
     obstacle_despawn_system(reg, 0.016f);
@@ -475,8 +475,8 @@ TEST_CASE("cleanup: dense despawn burst stays within reserved capacity",
     for (int i = 0; i < dense_count; ++i) {
         auto obs = reg.create();
         reg.emplace<ObstacleTag>(obs);
-        reg.emplace<WorldTransform>(obs,
-            WorldTransform{{0.0f, constants::DESTROY_Y + static_cast<float>(i + 1) * 10.0f}});
+        reg.emplace<WorldPosition>(obs,
+            WorldPosition{{0.0f, constants::DESTROY_Y + static_cast<float>(i + 1) * 10.0f}});
     }
 
     obstacle_despawn_system(reg, 0.016f);
@@ -491,7 +491,7 @@ TEST_CASE("cleanup: does not emplace MissTag or ScoredTag on surviving obstacles
 
     auto survivor = reg.create();
     reg.emplace<ObstacleTag>(survivor);
-    reg.emplace<WorldTransform>(survivor, WorldTransform{{0.0f, constants::DESTROY_Y - 1.0f}});
+    reg.emplace<WorldPosition>(survivor, WorldPosition{{0.0f, constants::DESTROY_Y - 1.0f}});
 
     obstacle_despawn_system(reg, 0.016f);
 


### PR DESCRIPTION
Closes the last open item from the `app/components/` audit (#1194):

> Pick collision strategy / rename `WorldTransform`

## Why now

After PR #1235 stripped the dead `rotation`/`scale` fields, `WorldTransform` held only a single `Vector2 position`. The name no longer matched the data, and the header comment apologized for the workaround:

> Named WorldTransform to avoid colliding with raylib's global Transform type.

The slot-collision part of the audit bullet was already decided in #1198 (kept as a named wrapper because the per-entity `Vector2` slot is reserved for velocity semantics — same constraint as `ScreenPosition`/`DrawSize`). That left only the rename.

## What this PR does

| File group | Change |
|---|---|
| `app/components/transform.h` | `struct WorldTransform` → `struct WorldPosition`; header comment rewritten to explain the slot-reservation rationale (instead of the raylib-Transform workaround) |
| All 17 `app/` consumers | Mechanical rename: `WorldTransform` → `WorldPosition` |
| All 28 `tests/` consumers + `benchmarks/bench_systems.cpp` | Mechanical rename |
| `design-docs/architecture.md`, `design-docs/beatmap-integration.md`, `design-docs/isometric-perspective.md`, `design-docs/rhythm-spec.md`, `design-docs/tester-personas-tech-spec.md` | Mechanical rename + opportunistic doc-drift cleanup (struct snippets and component summary tables no longer show the `rotation`/`scale` fields deleted in PR #1235) |

## Out of scope (intentional)

- **File name** `app/components/transform.h` kept as-is — renaming the file would touch every `#include` site for cosmetic gain; deferred.
- **`.squad/decisions.md` / archive / agent histories / round reports / session logs** left untouched as immutable historical record.
- **`MotionVelocity` row in architecture.md component summary** — unrelated stale entry from #1198 (MotionVelocity wrapper was deleted in PR #1241); not touching since it's a separate concern.

## Validation

- ✅ 880 Catch2 test cases / 2958 assertions pass on macOS
- ✅ Unity Clang `-Wall -Wextra -Werror` build clean
- ✅ Non-unity Clang `-Wall -Wextra -Werror` build clean
- ✅ Zero warnings
- ✅ Diff stat: 49 files changed, 223 insertions(+), 223 deletions(-)

Refs #1194. Companion to the closed wrapper-noise sweep #1198.