### PR TITLE
#1203 Eradicate `bool dirty` columns: SettingsDirtyTag / HighScoreDirtyTag

### DIFF
--- a/.squad/skills/settings-dirty-save-contract/SKILL.md
+++ b/.squad/skills/settings-dirty-save-contract/SKILL.md
@@ -5,15 +5,17 @@ Runtime settings mutate in UI but persistence state exists separately in registr
 
 ## Pattern
 Use a shared helper that owns persistence state transitions:
-1. Set `SettingsPersistence.dirty = true` before save attempt.
-2. If `path` is empty, set `last_save = PathUnavailable` and keep dirty.
+1. Emplace `SettingsDirtyTag` on the SettingsTag entity before save attempt.
+2. If `SettingsPersistence::path` is empty, set `last_save = PathUnavailable` and keep the tag.
 3. Otherwise call `settings::save_settings(...)`.
-4. Clear dirty only on success; keep dirty on failure for retry.
+4. Remove `SettingsDirtyTag` only on success; keep it on failure for retry.
+
+The former `bool dirty` column on `SettingsPersistence` / `HighScorePersistence` was eradicated per Fabian relational normalization (#1203): "needs save" is now expressed as the presence of an existence tag (`SettingsDirtyTag` on the SettingsTag entity, `HighScoreDirtyTag` on `registry.ctx()`).
 
 ## Integration Point
-Call the helper exactly where settings mutate (currently `settings_screen_controller`) so state is persisted at mutation time.
+Call `settings::mark_dirty_and_save(reg, state)` exactly where settings mutate (currently `settings_screen_controller`, `tutorial_screen_controller`, and `game_state_routing`) so state is persisted at mutation time.
 
 ## Regression Guard
 Keep tests that assert:
-- successful save clears dirty and round-trips settings values;
-- path-unavailable save keeps dirty and exposes `last_save.status`.
+- successful save removes `SettingsDirtyTag` and round-trips settings values;
+- path-unavailable save keeps `SettingsDirtyTag` and exposes `last_save.status`.

--- a/app/components/high_score.h
+++ b/app/components/high_score.h
@@ -35,9 +35,17 @@ struct HighScoreSession {
     entt::hashed_string::hash_type key_hash{0};
 };
 
+// Persistence I/O bookkeeping for the high-score file (path + last load/save
+// results). Lives as a ctx singleton; mutated by the terminal-phase
+// transition system.
+//
+// The former `bool dirty` column was eradicated per Fabian relational
+// normalization (issue #1203): "needs save" is now expressed as the
+// presence of `HighScoreDirtyTag` on `registry.ctx()` (see
+// app/tags/tags.h). The terminal-phase system is the canonical writer;
+// tests can emplace / erase the tag via `reg.ctx()` directly.
 struct HighScorePersistence {
     std::string path;
     persistence::Result last_load{};
     persistence::Result last_save{};
-    bool dirty{false};
 };

--- a/app/components/settings.h
+++ b/app/components/settings.h
@@ -33,11 +33,16 @@ struct SettingsState {
 };
 
 // Persistence I/O bookkeeping for the settings file (path + last load/save
-// results + dirty bit). Lives on the singleton settings entity alongside
-// SettingsState; mutated by systems/settings_system.
+// results). Lives on the singleton settings entity alongside SettingsState;
+// mutated by systems/settings_system.
+//
+// The former `bool dirty` column was eradicated per Fabian relational
+// normalization (issue #1203): "needs save" is now expressed as the
+// presence of `SettingsDirtyTag` on the same SettingsTag entity (see
+// app/tags/tags.h). `settings::mark_dirty_and_save()` is the canonical
+// writer; tests can emplace / remove the tag directly via the registry.
 struct SettingsPersistence {
     std::string path;
     persistence::Result last_load{};
     persistence::Result last_save{};
-    bool dirty{false};
 };

--- a/app/systems/game_state_routing.cpp
+++ b/app/systems/game_state_routing.cpp
@@ -83,9 +83,7 @@ void game_state_handle_confirm(entt::registry& reg, const MenuConfirmEvent&) {
         if (gs.phase_timer <= constants::UI_ENTRY_DEBOUNCE) return;
         if (auto* settings_state = find_settings_state(reg)) {
             settings::mark_ftue_complete(*settings_state);
-            if (auto* persistence = find_settings_persistence(reg)) {
-                settings::mark_dirty_and_save(*persistence, *settings_state);
-            }
+            settings::mark_dirty_and_save(reg, *settings_state);
         }
         request_phase_transition<NextPhasePlayingTag>(reg);
         return;

--- a/app/systems/game_state_terminal_phase_system.cpp
+++ b/app/systems/game_state_terminal_phase_system.cpp
@@ -2,6 +2,7 @@
 #include "game_phase_transition.h"
 #include "audio_events.h"
 #include "haptics.h"
+#include "tags/tags.h"
 #include "../components/high_score.h"
 #include "../components/rhythm.h"
 #include "../components/scoring.h"
@@ -9,8 +10,10 @@
 
 namespace {
 
-void persist_dirty_high_scores(const HighScoreState& high_scores, HighScorePersistence& persistence) {
-    if (!persistence.dirty) return;
+void persist_dirty_high_scores(entt::registry& reg,
+                               const HighScoreState& high_scores,
+                               HighScorePersistence& persistence) {
+    if (!reg.ctx().contains<HighScoreDirtyTag>()) return;
 
     if (persistence.path.empty()) {
         persistence.last_save = persistence::Result{persistence::Status::PathUnavailable, {}};
@@ -19,7 +22,7 @@ void persist_dirty_high_scores(const HighScoreState& high_scores, HighScorePersi
 
     persistence.last_save = high_score::save_high_scores(high_scores, persistence.path);
     if (persistence.last_save.ok()) {
-        persistence.dirty = false;
+        reg.ctx().erase<HighScoreDirtyTag>();
     }
 }
 
@@ -41,9 +44,9 @@ bool update_and_persist_high_score(entt::registry& reg) {
         }
         if (auto* hp = reg.ctx().find<HighScorePersistence>()) {
             if (score_exceeds_high_score && recorded_new_high_score && has_active_high_score_key) {
-                hp->dirty = true;
+                reg.ctx().emplace<HighScoreDirtyTag>();
             }
-            persist_dirty_high_scores(*hs, *hp);
+            persist_dirty_high_scores(reg, *hs, *hp);
         }
     } else if (score_exceeds_high_score) {
         current.value = score.score;

--- a/app/systems/play_session.cpp
+++ b/app/systems/play_session.cpp
@@ -1,4 +1,5 @@
 #include "play_session.h"
+#include "tags/tags.h"
 #include "../components/game_state.h"
 #include "../components/player.h"
 #include "../components/transform.h"
@@ -101,6 +102,11 @@ void setup_play_session(entt::registry& reg) {
     SettingsState settings = previous_settings ? *previous_settings : SettingsState{};
     SettingsPersistence settings_persistence =
         previous_settings_persistence ? *previous_settings_persistence : SettingsPersistence{};
+    bool settings_was_dirty = false;
+    if (restore_settings) {
+        auto dirty_view = reg.view<SettingsTag, SettingsDirtyTag>();
+        settings_was_dirty = dirty_view.begin() != dirty_view.end();
+    }
 
     reg.clear();
 
@@ -109,7 +115,11 @@ void setup_play_session(entt::registry& reg) {
     create_energy_bar_entity(reg);
     create_beat_map_entity(reg);
     if (restore_settings) {
-        create_settings_entity(reg, settings, settings_persistence);
+        const auto settings_entity =
+            create_settings_entity(reg, settings, settings_persistence);
+        if (settings_was_dirty) {
+            reg.emplace<SettingsDirtyTag>(settings_entity);
+        }
     }
 
     // Load beatmap from level selection. BeatMap is an entity singleton whose

--- a/app/systems/settings_system.cpp
+++ b/app/systems/settings_system.cpp
@@ -231,8 +231,16 @@ persistence::Result save_settings(const SettingsState& state, const std::filesys
     return persistence::flush_persistence_writes(path);
 }
 
-void mark_dirty_and_save(SettingsPersistence& persistence_state, const SettingsState& state) {
-    persistence_state.dirty = true;
+void mark_dirty_and_save(entt::registry& reg, const SettingsState& state) {
+    auto view = reg.view<SettingsTag, SettingsPersistence>();
+    auto it = view.begin();
+    if (it == view.end()) {
+        return;
+    }
+    const auto entity = *it;
+    auto& persistence_state = view.get<SettingsPersistence>(entity);
+
+    reg.emplace_or_replace<SettingsDirtyTag>(entity);
     if (persistence_state.path.empty()) {
         persistence_state.last_save = persistence::Result{persistence::Status::PathUnavailable, {}};
         return;
@@ -240,7 +248,7 @@ void mark_dirty_and_save(SettingsPersistence& persistence_state, const SettingsS
 
     persistence_state.last_save = save_settings(state, persistence_state.path);
     if (persistence_state.last_save.ok()) {
-        persistence_state.dirty = false;
+        reg.remove<SettingsDirtyTag>(entity);
     }
 }
 

--- a/app/systems/settings_system.h
+++ b/app/systems/settings_system.h
@@ -22,7 +22,11 @@ namespace settings {
 
 persistence::Result load_settings(SettingsState& state, const std::filesystem::path& path);
 persistence::Result save_settings(const SettingsState& state, const std::filesystem::path& path);
-void mark_dirty_and_save(SettingsPersistence& persistence_state, const SettingsState& state);
+// Mark the settings as needing a save and attempt persistence. On success
+// the SettingsDirtyTag is removed from the settings entity; on failure the
+// tag remains so a later call retries. The settings entity must exist
+// (created via create_settings_entity).
+void mark_dirty_and_save(entt::registry& reg, const SettingsState& state);
 persistence::Result get_settings_file_path(
     std::filesystem::path& out_path,
     const std::filesystem::path& root_override = {});

--- a/app/tags/tags.h
+++ b/app/tags/tags.h
@@ -139,6 +139,25 @@ struct TimingBadTag     {};
 struct BeatMapTag {};
 struct SettingsTag {};
 
+// ── Persistence dirty flags (existence = needs save) ─────────
+// Replaces the former `bool dirty` columns on `SettingsPersistence` and
+// `HighScorePersistence` per Fabian relational normalization (issue #1203
+// "Apply relational normalization to god-class component bundles"). A
+// "dirty" state-machine flag is a NULL-column in disguise: meaningful only
+// while a save is pending. Per Fabian's existential processing, that
+// pending-state is its own zero-column table; presence on the owning
+// entity / ctx is the entire signal.
+//
+// `SettingsDirtyTag` lives on the singleton SettingsTag entity (matches
+// the entity-level SettingsPersistence component).
+// `HighScoreDirtyTag` lives on `registry.ctx()` (matches the ctx-level
+// HighScorePersistence singleton).
+//
+// Writers: `settings::mark_dirty_and_save()`, `update_and_persist_high_score()`.
+// Test helpers: emplace / remove the tag directly via the registry / ctx.
+struct SettingsDirtyTag  {};
+struct HighScoreDirtyTag {};
+
 // ── Game phase (per-tag ctx tables; exactly one present at any time) ──
 // Per Fabian's existential processing (issue #1202/#1204), each former
 // GamePhase enum value gets its own zero-column table on `registry.ctx()`.

--- a/app/ui/screen_controllers/settings_screen_controller.cpp
+++ b/app/ui/screen_controllers/settings_screen_controller.cpp
@@ -132,9 +132,7 @@ void render_settings_screen_ui(entt::registry& reg) {
     }
 
     if (settings_changed) {
-        if (auto* persistence_state = find_settings_persistence(reg)) {
-            settings::mark_dirty_and_save(*persistence_state, *st);
-        }
+        settings::mark_dirty_and_save(reg, *st);
     }
 
     if (close_pressed) {

--- a/app/ui/screen_controllers/tutorial_screen_controller.cpp
+++ b/app/ui/screen_controllers/tutorial_screen_controller.cpp
@@ -56,9 +56,7 @@ void init_tutorial_screen_ui() {
 void tutorial_screen_continue(entt::registry& reg) {
     if (auto* settings_ptr = find_settings_state(reg)) {
         settings::mark_ftue_complete(*settings_ptr);
-        if (auto* persistence = find_settings_persistence(reg)) {
-            settings::mark_dirty_and_save(*persistence, *settings_ptr);
-        }
+        settings::mark_dirty_and_save(reg, *settings_ptr);
     }
 
     request_phase_transition<NextPhasePlayingTag>(reg);

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -2,6 +2,7 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include "systems/game_phase_transition.h"
 #include "systems/game_state_system.h"
+#include "tags/tags.h"
 #include "test_helpers.h"
 #include "ui/screen_controllers/tutorial_screen_controller.h"
 
@@ -322,12 +323,13 @@ TEST_CASE("tutorial: continue marks FTUE complete and requests gameplay",
     settings.ftue_run_count = 0;
     auto& persistence = settings_persistence(reg);
     persistence.path.clear();
-    persistence.dirty = false;
+    const auto settings_entity = *reg.view<SettingsTag>().begin();
+    reg.remove<SettingsDirtyTag>(settings_entity);
 
     tutorial_screen_continue(reg);
 
     CHECK(settings::ftue_complete(settings));
-    CHECK(persistence.dirty);
+    CHECK(reg.all_of<SettingsDirtyTag>(settings_entity));
     CHECK(persistence.last_save.status == persistence::Status::PathUnavailable);
     CHECK(reg.ctx().contains<NextPhasePlayingTag>());
 }
@@ -343,15 +345,17 @@ TEST_CASE("tutorial: menu confirm marks FTUE complete and requests gameplay",
     settings.ftue_run_count = 0;
     auto& persistence = settings_persistence(reg);
     persistence.path.clear();
-    persistence.dirty = false;
+    const auto settings_entity = *reg.view<SettingsTag>().begin();
+    reg.remove<SettingsDirtyTag>(settings_entity);
 
     reg.ctx().get<entt::dispatcher>().enqueue<MenuConfirmEvent>({});
     game_state_system(reg, 0.016f);
 
     const auto& saved_settings = settings_state(reg);
     const auto& saved_persistence = settings_persistence(reg);
+    const auto current_settings_entity = *reg.view<SettingsTag>().begin();
     CHECK(settings::ftue_complete(saved_settings));
-    CHECK(saved_persistence.dirty);
+    CHECK(reg.all_of<SettingsDirtyTag>(current_settings_entity));
     CHECK(saved_persistence.last_save.status == persistence::Status::PathUnavailable);
     CHECK_FALSE(is_phase_transition_pending(reg));
     CHECK(reg.ctx().contains<GamePhasePlayingTag>());

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -3,6 +3,7 @@
 #include <fstream>
 
 #include "components/high_score.h"
+#include "tags/tags.h"
 #include "util/level_content_config.h"
 #include "entities/camera_entity.h"
 #include "entities/obstacle_entity.h"
@@ -292,7 +293,7 @@ TEST_CASE("High score integration: missing active entry does not report new best
 
     CHECK(current.value == 1000);
     CHECK_FALSE(reg.ctx().get<TerminalResultState>().new_best);
-    CHECK_FALSE(reg.ctx().get<HighScorePersistence>().dirty);
+    CHECK_FALSE(reg.ctx().contains<HighScoreDirtyTag>());
     CHECK(high_score::get_score(high_scores, "overflow|hard") == 0);
 }
 
@@ -326,7 +327,7 @@ TEST_CASE("High score integration: failed save keeps dirty state for retry",
     game_state_system(reg, 0.016f);
 
     const auto& persistence_state = reg.ctx().get<HighScorePersistence>();
-    CHECK(persistence_state.dirty);
+    CHECK(reg.ctx().contains<HighScoreDirtyTag>());
     CHECK(persistence_state.last_save.status == persistence::Status::DirectoryCreateFailed);
 
     remove_path(root);
@@ -338,7 +339,7 @@ TEST_CASE("High score integration: failed save keeps dirty state for retry",
     game_state_system(reg, 0.016f);
 
     const auto& retried_persistence = reg.ctx().get<HighScorePersistence>();
-    CHECK_FALSE(retried_persistence.dirty);
+    CHECK_FALSE(reg.ctx().contains<HighScoreDirtyTag>());
     CHECK(retried_persistence.last_save.status == persistence::Status::Success);
 
     HighScoreState loaded;

--- a/tests/test_settings_persistence.cpp
+++ b/tests/test_settings_persistence.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include "entities/settings.h"
+#include "tags/tags.h"
 #include <filesystem>
 #include <fstream>
 #include <sstream>
@@ -280,12 +281,14 @@ TEST_CASE("Settings persistence runtime: mark_dirty_and_save persists and clears
     state.reduce_motion = true;
     state.ftue_run_count = 1;
 
-    SettingsPersistence persistence_state;
-    persistence_state.path = file.string();
+    entt::registry reg;
+    SettingsPersistence persistence;
+    persistence.path = file.string();
+    const auto entity = create_settings_entity(reg, state, std::move(persistence));
 
-    settings::mark_dirty_and_save(persistence_state, state);
-    CHECK_FALSE(persistence_state.dirty);
-    CHECK(persistence_state.last_save.status == persistence::Status::Success);
+    settings::mark_dirty_and_save(reg, state);
+    CHECK_FALSE(reg.all_of<SettingsDirtyTag>(entity));
+    CHECK(reg.get<SettingsPersistence>(entity).last_save.status == persistence::Status::Success);
     CHECK(std::filesystem::exists(file));
 
     SettingsState loaded;
@@ -301,12 +304,13 @@ TEST_CASE("Settings persistence runtime: mark_dirty_and_save persists and clears
 TEST_CASE("Settings persistence runtime: mark_dirty_and_save keeps dirty when path unavailable",
           "[settings][issue-303]") {
     SettingsState state;
-    SettingsPersistence persistence_state;
+    entt::registry reg;
+    const auto entity = create_settings_entity(reg, state);
 
-    settings::mark_dirty_and_save(persistence_state, state);
+    settings::mark_dirty_and_save(reg, state);
 
-    CHECK(persistence_state.dirty);
-    CHECK(persistence_state.last_save.status == persistence::Status::PathUnavailable);
+    CHECK(reg.all_of<SettingsDirtyTag>(entity));
+    CHECK(reg.get<SettingsPersistence>(entity).last_save.status == persistence::Status::PathUnavailable);
 }
 
 TEST_CASE("Persistence paths: one shared policy resolves both settings and high-score files", "[settings]") {


### PR DESCRIPTION
## Summary

Per Fabian relational normalization (#1203 'Apply relational normalization to god-class component bundles'), a state-machine column whose meaning is only "needs save / doesn't" is a NULL-column in disguise: meaningful only while a save is pending. Per existential processing, that pending-state is its own zero-column table; presence on the owning entity / ctx is the entire signal.

This PR completes one row of #1203's decomposition table — converting the `SettingsPersistence`/`HighScorePersistence` `bool dirty` columns into existence tags.

## Changes

- **Add** `SettingsDirtyTag` (entity-level) and `HighScoreDirtyTag` (ctx-level) to `app/tags/tags.h` (single-header convention).
- **Remove** `bool dirty` from `SettingsPersistence` and `HighScorePersistence`.
- **Signature change**: `settings::mark_dirty_and_save(SettingsPersistence&, …)` → `settings::mark_dirty_and_save(entt::registry&, const SettingsState&)`. It now finds the singleton settings entity internally and manipulates the tag on it. All three production callers (`tutorial_screen_controller`, `settings_screen_controller`, `game_state_routing`) updated to pass `reg`.
- **Update** `persist_dirty_high_scores` / `update_and_persist_high_score` in `game_state_terminal_phase_system` to emplace/erase `HighScoreDirtyTag` on `registry.ctx()`.
- **Carry** the dirty-tag state across `reg.clear()` in `setup_play_session` so retry semantics survive a session reset (matches the pre-refactor behaviour where the bool was carried in the `SettingsPersistence` snapshot).
- **Update** tests to query the tag instead of `.dirty` (and re-fetch the settings entity after session-reset paths).
- **Update** `.squad/skills/settings-dirty-save-contract/SKILL.md` to document the new contract.

## Verification

- `cmake --build build` → clean, zero warnings (`-Wall -Wextra -Werror`).
- `./build/shapeshifter_tests` → **880 cases / 2958 assertions all pass**.
- `./build/shapeshifter_startup_shutdown_smoke` → boots cleanly.

## Doctrine

This is a doctrinal sub-task of #1203 — it completes the dirty-flag row of the decomposition table:

> `SettingsValues` (data table), **`SettingsDirtyTag` (existence = needs save)**, `SettingsLoadedTag` (existence = loaded from disk). Persistence I/O moves to `systems/settings_system.cpp`.

The remaining doctrinal items in #1203's table (loaded-flag tags on `MusicContext`/`TextContext`/`SFXBank`, `BeatMap` per-event-kind decomposition into row entities) remain open for separate audit.

Refs: #1203