### PR TITLE
#1287 Migrate Paused screen to entity-driven UI (pilot slice, refs #1193 OoS-A)

### DIFF
--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -28,6 +28,8 @@
 #include "components/high_score.h"
 #include "systems/high_score_system.h"
 #include "systems/haptics_backend.h"
+#include "systems/screen_lifecycle_system.h"
+#include "systems/ui_update_system.h"
 
 #include <raylib.h>
 #include <algorithm>
@@ -277,6 +279,7 @@ void game_loop_frame(entt::registry& reg, float& accumulator) {
 
     compute_screen_transform(reg);
     input_system(reg, raw_dt);
+    ui_update_system(reg);
     gameplay_hud_process_button_input(reg);
     test_player_system(reg, raw_dt);
 
@@ -284,6 +287,12 @@ void game_loop_frame(entt::registry& reg, float& accumulator) {
         tick_fixed_systems(reg, FIXED_DT);
         accumulator -= FIXED_DT;
     }
+
+    // Screen entity lifecycle: spawn/despawn per-screen UI entities to
+    // match the active `GamePhase*Tag` produced by the fixed tick. Must
+    // run before render so this frame's UI reflects the post-transition
+    // phase. Issue #1287.
+    screen_lifecycle_system(reg);
 
     // Camera runs after gameplay systems so transforms reflect current frame
     game_camera_system(reg, raw_dt);

--- a/app/systems/screen_lifecycle_system.cpp
+++ b/app/systems/screen_lifecycle_system.cpp
@@ -1,0 +1,64 @@
+#include "screen_lifecycle_system.h"
+
+#include "../components/game_state.h"
+#include "../tags/tags.h"
+#include "../ui/generated/screen_spawners.h"
+
+// Per Fabian existential processing (#1202/#1204): the mapping
+// "active phase tag → which screen entity set must exist" is itself a
+// table, indexed by row (one row per migrated screen). Each row references
+// the matching phase tag, screen entity tag, and the spawn/despawn pair
+// emitted by codegen. Convergence runs once per frame and short-circuits
+// when the entity-set membership already matches the phase tag presence.
+//
+// Adding a new screen to the migration: append one row below. No `switch`,
+// no `if`-ladder over phase, no virtual dispatch.
+
+namespace {
+
+using SpawnFn   = void (*)(entt::registry&);
+using DespawnFn = void (*)(entt::registry&);
+using PhaseProbeFn  = bool (*)(const entt::registry&);
+using EntityProbeFn = bool (*)(entt::registry&);
+
+struct ScreenLifecycleRow {
+    PhaseProbeFn  phase_active;   // is the matching GamePhase*Tag present?
+    EntityProbeFn entities_alive; // is the matching screen-tag view non-empty?
+    SpawnFn       spawn;
+    DespawnFn     despawn;
+};
+
+template <typename PhaseTag>
+bool phase_active_probe(const entt::registry& reg) noexcept {
+    return reg.ctx().contains<PhaseTag>();
+}
+
+template <typename ScreenTag>
+bool entities_alive_probe(entt::registry& reg) noexcept {
+    return reg.view<ScreenTag>().size() > 0;
+}
+
+// Pilot (#1287): Paused only. Each per-screen migration sub-issue extends
+// this table by one row.
+constexpr ScreenLifecycleRow kLifecycleRows[] = {
+    {
+        &phase_active_probe<GamePhasePausedTag>,
+        &entities_alive_probe<PausedScreenTag>,
+        &spawn_paused_screen,
+        &despawn_paused_screen,
+    },
+};
+
+}  // namespace
+
+void screen_lifecycle_system(entt::registry& reg) {
+    for (const auto& row : kLifecycleRows) {
+        const bool want = row.phase_active(reg);
+        const bool have = row.entities_alive(reg);
+        if (want && !have) {
+            row.spawn(reg);
+        } else if (!want && have) {
+            row.despawn(reg);
+        }
+    }
+}

--- a/app/systems/screen_lifecycle_system.h
+++ b/app/systems/screen_lifecycle_system.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <entt/entt.hpp>
+
+// Keeps per-screen UI entity sets in sync with the active `GamePhase*Tag`
+// ctx mirror (issue #1287, refs #1193 OoS-A).
+//
+// Per Fabian's existential processing, the membership "which entities
+// belong to which screen" lives in tag presence — not in an enum field,
+// not in a god-struct. Each `.rgl` produces a `spawn_<screen>_screen()` +
+// `despawn_<screen>_screen()` pair (codegen, see
+// `app/ui/generated/screen_spawners.h`). This system converges the entity
+// set toward whatever `GamePhase*Tag` is currently in `reg.ctx()`: if the
+// matching screen-tag has no entities and the phase tag is present, spawn;
+// if the phase tag is absent and entities still exist, despawn.
+//
+// Migration boundary: screens are migrated from
+// `app/ui/screen_controllers/*` one at a time. Until every screen migrates,
+// only the screens explicitly handled here participate; un-migrated screens
+// continue to render via their legacy controller and stay invisible to
+// this system. See #1287 for the per-screen sub-issue ladder.
+//
+// Pilot (this cycle): Paused only.
+void screen_lifecycle_system(entt::registry& reg);

--- a/app/systems/ui_render_system.cpp
+++ b/app/systems/ui_render_system.cpp
@@ -1,5 +1,6 @@
 #include "all_systems.h"
 #include "camera_system.h"
+#include "../components/actions.h"
 #include "../components/player.h"
 #include "../components/rendering.h"
 #include "../components/scoring.h"
@@ -7,16 +8,18 @@
 #include "../components/game_state.h"
 #include "../components/song_state.h"
 #include "../components/text_resources.h"
+#include "../components/ui.h"
 #include "../constants.h"
+#include "../tags/tags.h"
 
 #include "../ui/screen_controllers/title_screen_controller.h"
-#include "../ui/screen_controllers/paused_screen_controller.h"
 #include "../ui/screen_controllers/game_over_screen_controller.h"
 #include "../ui/screen_controllers/song_complete_screen_controller.h"
 #include "../ui/screen_controllers/settings_screen_controller.h"
 #include "../ui/screen_controllers/tutorial_screen_controller.h"
 #include "../ui/screen_controllers/level_select_screen_controller.h"
 #include "../ui/screen_controllers/gameplay_hud_screen_controller.h"
+#include <raygui.h>
 #include <raylib.h>
 #include <raymath.h>
 #include <cmath>
@@ -37,6 +40,72 @@ const Font& popup_font_for_size(const TextContext& ctx, FontSize font_size) {
         case FontSize::Large:  return ctx.font_large;
     }
     return ctx.font_medium;
+}
+
+// ── Entity-driven UI render (issue #1287) ──────────────────────────────────
+//
+// Iterates the per-kind tag views populated by the rguilayout codegen
+// (`spawn_<screen>_screen()`, see `app/ui/generated/`). Per-screen membership
+// is the per-screen tag on each entity; the screen lifecycle system
+// (`app/systems/screen_lifecycle_system.h`) keeps the entity set in sync
+// with the active `GamePhase*Tag`, so this pass only sees the active
+// screen's entities and trivially partitions by tag.
+//
+// Per-screen visual specifics (font size, alignment, label vs centered
+// label, button colour overrides) currently match the legacy raygui
+// defaults; per-screen visual tweaks migrate row-by-row as their screen
+// migrates off the legacy controller path. See #1287 for the per-screen
+// sub-issue ladder.
+//
+// Migration boundary: a button press dispatch lives in
+// `app/systems/ui_update_system.cpp` — that system hit-tests against
+// `view<UiPosition, UiBounds, OnPress, UiButtonTag>()`. The GuiButton call
+// here renders only; its return value is ignored.
+
+constexpr int kEntityLabelTextSize  = 24;
+constexpr int kEntityButtonTextSize = 28;
+// Paused overlay headline ("PAUSED") needs a larger size than the default
+// raygui DEFAULT::TEXT_SIZE; matched against the legacy
+// `paused_layout.h` constant.
+constexpr float kPausedHeadlineHeight = 80.0f;
+constexpr int   kPausedHeadlineSize   = 56;
+
+void render_ui_entities(entt::registry& reg) {
+    const int saved_text_size       = GuiGetStyle(DEFAULT, TEXT_SIZE);
+    const int saved_label_alignment = GuiGetStyle(LABEL, TEXT_ALIGNMENT);
+
+    GuiSetStyle(LABEL, TEXT_ALIGNMENT, TEXT_ALIGN_CENTER);
+
+    // Labels (and dummy-rec slots that carry text). Both kinds use GuiLabel
+    // rendering with center alignment; the kind distinction is for hit-test
+    // exclusion in `ui_update_system` and future visual specialization.
+    {
+        auto view = reg.view<UiPosition, UiBounds, UiLabel, UiLabelTag>();
+        for (auto [e, pos, sz, label] : view.each()) {
+            (void)e;
+            if (label.text[0] == '\0') continue;
+            const int text_size = (sz.h >= kPausedHeadlineHeight)
+                                ? kPausedHeadlineSize
+                                : kEntityLabelTextSize;
+            GuiSetStyle(DEFAULT, TEXT_SIZE, text_size);
+            GuiLabel(Rectangle{pos.x, pos.y, sz.w, sz.h}, label.text.data());
+        }
+    }
+
+    // Buttons — rendered with GuiButton. Press dispatch lives in
+    // `ui_update_system`; ignoring the return value keeps that path the
+    // single source of truth for button activation.
+    {
+        GuiSetStyle(DEFAULT, TEXT_SIZE, kEntityButtonTextSize);
+        auto view = reg.view<UiPosition, UiBounds, UiLabel, UiButtonTag>();
+        for (auto [e, pos, sz, label] : view.each()) {
+            (void)e;
+            (void)GuiButton(Rectangle{pos.x, pos.y, sz.w, sz.h}, label.text.data());
+        }
+    }
+
+    GuiSetStyle(LABEL, TEXT_ALIGNMENT, saved_label_alignment);
+    GuiSetStyle(DEFAULT, TEXT_SIZE, saved_text_size);
 }
 
 } // namespace
@@ -79,7 +148,10 @@ void ui_render_system(entt::registry& reg, float /*alpha*/) {
                          {0, 0, 0, 160});
     }
 
-    // UI rendering is handled exclusively by rguilayout screen controllers.
+    // UI rendering is handled by the entity-driven `render_ui_entities`
+    // call below (issue #1287). Screens still on the legacy controller
+    // path render via the per-phase dispatch further down; each will be
+    // migrated off in a follow-up sub-issue.
 
     // Make raygui hit-testing use virtual-space coordinates even when the
     // window is letterboxed/scaled relative to the fixed 720x1280 UI space.
@@ -90,20 +162,30 @@ void ui_render_system(entt::registry& reg, float /*alpha*/) {
         SetMouseScale(inv_scale, inv_scale);
     }
 
+    // Entity-driven render pass — issue #1287. Iterates every spawned UI
+    // entity for the active screen (the screen lifecycle system already
+    // partitions by `GamePhase*Tag`, so this pass is screen-agnostic).
+    // Per #1287 the legacy `render_<screen>_screen_ui` calls below are
+    // removed one at a time as each screen migrates off the
+    // `screen_controllers/*` path. Paused is the pilot.
+    render_ui_entities(reg);
+
     // Dynamic screens that still need specialized rendering.
     //
     // Per Fabian's existential processing (issue #1202/#1204, PR D): each
     // former `case GamePhase::X` is its own per-tag transform on the ctx-tag
     // mirror seeded by `enter_phase<...>()`. The mirror
     // invariant pinned by `tests/test_game_phase_tags.cpp` guarantees that
-    // exactly one `GamePhase*Tag` is present at any time, so these eight
-    // `if` blocks are mutually exclusive even without `else` chaining and
+    // exactly one `GamePhase*Tag` is present at any time, so these `if`
+    // blocks are mutually exclusive even without `else` chaining and
     // dispatch on tag presence rather than on an enum compare.
+    //
+    // Paused was migrated to the entity-driven path (#1287 pilot); the
+    // other seven screens migrate in follow-up sub-issues — see #1287.
     const auto& ctx = reg.ctx();
     if (ctx.contains<GamePhaseTitleTag>())        { render_title_screen_ui(reg); }
     if (ctx.contains<GamePhaseLevelSelectTag>())  { render_level_select_screen_ui(reg); }
     if (ctx.contains<GamePhasePlayingTag>())      { render_gameplay_hud_screen_ui(reg); }
-    if (ctx.contains<GamePhasePausedTag>())       { render_paused_screen_ui(reg); }
     if (ctx.contains<GamePhaseGameOverTag>())     { render_game_over_screen_ui(reg); }
     if (ctx.contains<GamePhaseSongCompleteTag>()) { render_song_complete_screen_ui(reg); }
     if (ctx.contains<GamePhaseSettingsTag>())     { render_settings_screen_ui(reg); }

--- a/app/systems/ui_update_system.cpp
+++ b/app/systems/ui_update_system.cpp
@@ -1,0 +1,114 @@
+#include "ui_update_system.h"
+
+#include "../components/actions.h"
+#include "../components/game_state.h"
+#include "../components/ui.h"
+#include "../constants.h"
+#include "../tags/tags.h"
+#include "game_phase_transition.h"
+#include "input.h"
+
+#include <array>
+#include <cstddef>
+
+#include <raylib.h>  // CheckCollisionPointRec, Rectangle, Vector2
+
+// ── ActionId dispatch table ─────────────────────────────────────────────────
+//
+// Per Fabian Principle 1 (and the explicit Keep-set rationale for
+// `ActionId` in `app/.allowed-enums.txt`), the enum value is a perfect-hash
+// index into a per-action function-pointer column. Each row owns the
+// effect of "the user pressed this button". No central switch.
+//
+// Adding a new action: append the enumerator to `ActionId` (alphabetically),
+// then add a row below. Codegen + the table-size assertion below catch
+// mismatches at build time.
+
+namespace {
+
+using ActionHandler = void (*)(entt::registry&, entt::entity);
+
+// ── Per-action handlers ─────────────────────────────────────────────
+//
+// `noop_action_handler` covers actions that have no consumer yet (e.g. the
+// 6 screens still on the legacy controller path). The legacy controller
+// renders the button and reads the press flag itself, so a no-op here
+// avoids double dispatch. Migrating a screen means replacing its row's
+// handler from `noop_action_handler` to the real per-action transform.
+
+void noop_action_handler(entt::registry& /*reg*/, entt::entity /*entity*/) {
+    // No consumer for this action yet — the owning screen has not migrated
+    // off the legacy `screen_controllers/*` path. See #1287.
+}
+
+// Paused screen actions (migrated this cycle).
+void resume_button_action(entt::registry& reg, entt::entity /*entity*/) {
+    request_phase_transition<NextPhasePlayingTag>(reg);
+}
+
+void menu_button_action(entt::registry& reg, entt::entity /*entity*/) {
+    request_phase_transition<NextPhaseTitleTag>(reg);
+}
+
+// ── Dispatch table ──────────────────────────────────────────────────
+//
+// Order must match the `ActionId` enumerator order in
+// `app/components/actions.h`. A compile-time check at the bottom verifies
+// the count.
+
+constexpr std::array<ActionHandler, 17> kActionHandlers = {
+    /* None                 */ &noop_action_handler,
+    /* AudioOffsetMinus     */ &noop_action_handler,
+    /* AudioOffsetPlus      */ &noop_action_handler,
+    /* CloseButton          */ &noop_action_handler,
+    /* ContinueButton       */ &noop_action_handler,
+    /* DifficultyEasy       */ &noop_action_handler,
+    /* DifficultyHard       */ &noop_action_handler,
+    /* DifficultyMedium     */ &noop_action_handler,
+    /* ExitButton           */ &noop_action_handler,
+    /* HapticsToggle        */ &noop_action_handler,
+    /* LevelSelectButton    */ &noop_action_handler,
+    /* MenuButton           */ &menu_button_action,
+    /* PauseButton          */ &noop_action_handler,
+    /* ReduceMotionToggle   */ &noop_action_handler,
+    /* RestartButton        */ &noop_action_handler,
+    /* ResumeButton         */ &resume_button_action,
+    /* SettingsButton       */ &noop_action_handler,
+};
+
+// Bumping ActionId without bumping kActionHandlers (or vice versa) is a
+// build-time error.
+static_assert(kActionHandlers.size() ==
+              static_cast<std::size_t>(ActionId::SettingsButton) + 1,
+              "kActionHandlers size must match ActionId enumerator count");
+
+void dispatch_action(entt::registry& reg, ActionId action, entt::entity entity) {
+    const auto idx = static_cast<std::size_t>(action);
+    if (idx >= kActionHandlers.size()) return;
+    kActionHandlers[idx](reg, entity);
+}
+
+}  // namespace
+
+void ui_update_system(entt::registry& reg) {
+    const auto& input = reg.ctx().get<InputState>();
+    if (!(input.click || input.touch_up)) return;
+
+    // Debounce: ignore button presses inside the first UI_ENTRY_DEBOUNCE
+    // seconds of the active phase so a click that opened the phase does
+    // not also dismiss it (matches legacy controller behaviour, e.g.
+    // `paused_screen_controller.cpp`).
+    const auto& gs = reg.ctx().get<GameState>();
+    if (gs.phase_timer <= constants::UI_ENTRY_DEBOUNCE) return;
+
+    const Vector2 pointer = {input.end_x, input.end_y};
+
+    // First-hit wins, matching raygui's GuiButton dispatch order.
+    auto view = reg.view<UiPosition, UiBounds, OnPress, UiButtonTag>();
+    for (auto [e, pos, sz, on_press] : view.each()) {
+        const Rectangle rect{pos.x, pos.y, sz.w, sz.h};
+        if (!CheckCollisionPointRec(pointer, rect)) continue;
+        dispatch_action(reg, on_press.action, e);
+        return;
+    }
+}

--- a/app/systems/ui_update_system.h
+++ b/app/systems/ui_update_system.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <entt/entt.hpp>
+
+// Entity-driven UI input system (issue #1287, refs #1193 OoS-A).
+//
+// Hit-tests `view<UiPosition, UiBounds, OnPress, UiButtonTag>` against the
+// frame's pointer-release event read from `InputState` (mouse click or
+// touch lift). On a hit, dispatches the entity's `OnPress::action` through
+// a per-`ActionId` function-pointer table — no `switch` on the
+// discriminator (Fabian Principle 1; `ActionId` is in the enum allowlist
+// specifically as a lookup-key index).
+//
+// Migration boundary: until all 8 screens migrate to the entity-driven
+// path, only screens whose buttons are actually spawned participate;
+// un-migrated screens continue to dispatch via their legacy
+// `screen_controllers/*` cpp. See #1287 for the per-screen sub-issue
+// ladder.
+//
+// Honours the `gs.phase_timer > UI_ENTRY_DEBOUNCE` debounce that legacy
+// controllers apply so a click on the previous phase's button does not
+// fire on the entry frame of the new phase.
+void ui_update_system(entt::registry& reg);

--- a/app/ui/generated/screen_spawners.h
+++ b/app/ui/generated/screen_spawners.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <entt/entt.hpp>
+
+// Forward declarations of the per-screen entity-spawner functions emitted by
+// `tools/rguilayout/codegen.py` (one pair per `.rgl` in
+// `content/ui/screens/`). Per #1193: each call creates one entity per
+// control row in its `.rgl`, carrying atomic `UiPosition` / `UiBounds` /
+// `UiLabel` (+ `OnPress` for buttons) plus a per-screen tag (e.g.
+// `PausedScreenTag`) and a per-kind tag (`UiLabelTag` / `UiButtonTag` /
+// `UiDummyRecTag`) — see `app/components/ui.h` and `app/tags/tags.h`.
+//
+// `despawn_<screen>_screen` queries `view<<ScreenTag>>()` and destroys every
+// matched entity; the per-screen tag IS the membership.
+//
+// Wired by `screen_lifecycle_system` (`app/systems/screen_lifecycle_system.h`),
+// which keeps the entity set in sync with the active `GamePhase*Tag` ctx
+// mirror seeded by `enter_phase<...>()`. Per #1287, individual screens
+// migrate from `app/ui/screen_controllers/*` to the entity-driven path one
+// at a time; until all eight migrate, only the screens explicitly handled
+// by `screen_lifecycle_system` participate (others stay on the legacy
+// controller render path).
+
+void spawn_title_screen(entt::registry& reg);
+void despawn_title_screen(entt::registry& reg);
+
+void spawn_level_select_screen(entt::registry& reg);
+void despawn_level_select_screen(entt::registry& reg);
+
+void spawn_tutorial_screen(entt::registry& reg);
+void despawn_tutorial_screen(entt::registry& reg);
+
+void spawn_gameplay_screen(entt::registry& reg);
+void despawn_gameplay_screen(entt::registry& reg);
+
+void spawn_paused_screen(entt::registry& reg);
+void despawn_paused_screen(entt::registry& reg);
+
+void spawn_game_over_screen(entt::registry& reg);
+void despawn_game_over_screen(entt::registry& reg);
+
+void spawn_song_complete_screen(entt::registry& reg);
+void despawn_song_complete_screen(entt::registry& reg);
+
+void spawn_settings_screen(entt::registry& reg);
+void despawn_settings_screen(entt::registry& reg);

--- a/tests/test_ui_update_system.cpp
+++ b/tests/test_ui_update_system.cpp
@@ -1,0 +1,177 @@
+// Tests for the entity-driven UI update system (issue #1287 / refs #1193 OoS-A).
+//
+// `ui_update_system` hit-tests `view<UiPosition, UiBounds, OnPress,
+// UiButtonTag>` against the frame's pointer-release event and dispatches the
+// matching `ActionId` via a per-action function-pointer table. These tests
+// pin the dispatch semantics for the Paused-screen pilot:
+//
+//   * pointer hit on Resume button → `NextPhasePlayingTag` requested
+//   * pointer hit on Menu button   → `NextPhaseTitleTag`   requested
+//   * pointer miss                 → no transition requested
+//   * click before UI_ENTRY_DEBOUNCE elapses → ignored (debounce honored)
+//   * un-pressed frame (no click / no touch_up) → ignored (no spurious fire)
+//
+// The pilot wires only PausedScreenTag through the lifecycle system, so
+// other-screen buttons have no spawned entities to hit-test and the system
+// is trivially a no-op there.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "test_helpers.h"
+
+#include "components/actions.h"
+#include "components/game_state.h"
+#include "components/ui.h"
+#include "constants.h"
+#include "systems/game_phase_transition.h"
+#include "systems/input.h"
+#include "systems/screen_lifecycle_system.h"
+#include "systems/ui_update_system.h"
+#include "tags/tags.h"
+#include "ui/generated/screen_spawners.h"
+
+namespace {
+
+void prime_paused_entry(entt::registry& reg) {
+    sync_game_phase_tags<GamePhasePausedTag>(reg);
+    spawn_paused_screen(reg);
+    // Step the phase timer past the entry debounce so clicks register.
+    reg.ctx().get<GameState>().phase_timer = constants::UI_ENTRY_DEBOUNCE + 0.05f;
+    // Clear any prior next-phase tag noise.
+    clear_next_phase_tags(reg);
+}
+
+void click_at(InputState& input, float x, float y) {
+    input.click = true;
+    input.touch_up = false;
+    input.end_x = x;
+    input.end_y = y;
+}
+
+bool any_next_phase_pending(entt::registry& reg) {
+    return is_phase_transition_pending(reg);
+}
+
+}  // namespace
+
+TEST_CASE("ui_update_system: Paused resume hit dispatches NextPhasePlayingTag",
+          "[ui][ui_update_system]") {
+    entt::registry reg = make_registry();
+    prime_paused_entry(reg);
+
+    auto& input = reg.ctx().get<InputState>();
+    // Resume button bounds from paused.rgl: (160, 620, 400, 100).
+    click_at(input, 360.0f, 670.0f);
+
+    ui_update_system(reg);
+
+    CHECK(reg.ctx().contains<NextPhasePlayingTag>());
+    CHECK_FALSE(reg.ctx().contains<NextPhaseTitleTag>());
+}
+
+TEST_CASE("ui_update_system: Paused menu hit dispatches NextPhaseTitleTag",
+          "[ui][ui_update_system]") {
+    entt::registry reg = make_registry();
+    prime_paused_entry(reg);
+
+    auto& input = reg.ctx().get<InputState>();
+    // Menu button bounds from paused.rgl: (160, 820, 400, 100).
+    click_at(input, 360.0f, 870.0f);
+
+    ui_update_system(reg);
+
+    CHECK(reg.ctx().contains<NextPhaseTitleTag>());
+    CHECK_FALSE(reg.ctx().contains<NextPhasePlayingTag>());
+}
+
+TEST_CASE("ui_update_system: pointer miss requests no transition",
+          "[ui][ui_update_system]") {
+    entt::registry reg = make_registry();
+    prime_paused_entry(reg);
+
+    auto& input = reg.ctx().get<InputState>();
+    // Click in a gap region between the two paused buttons.
+    click_at(input, 360.0f, 770.0f);
+
+    ui_update_system(reg);
+
+    CHECK_FALSE(any_next_phase_pending(reg));
+}
+
+TEST_CASE("ui_update_system: click before debounce is ignored",
+          "[ui][ui_update_system]") {
+    entt::registry reg = make_registry();
+    sync_game_phase_tags<GamePhasePausedTag>(reg);
+    spawn_paused_screen(reg);
+    // Phase entered this tick — timer at 0, debounce active.
+    reg.ctx().get<GameState>().phase_timer = 0.0f;
+    clear_next_phase_tags(reg);
+
+    auto& input = reg.ctx().get<InputState>();
+    click_at(input, 360.0f, 670.0f);  // resume hit
+
+    ui_update_system(reg);
+
+    CHECK_FALSE(any_next_phase_pending(reg));
+}
+
+TEST_CASE("ui_update_system: no click/touch_up flag means no dispatch",
+          "[ui][ui_update_system]") {
+    entt::registry reg = make_registry();
+    prime_paused_entry(reg);
+
+    auto& input = reg.ctx().get<InputState>();
+    // Pointer in resume bounds but neither click nor touch_up set —
+    // matches a still-held / mid-drag state, no release event.
+    input.click = false;
+    input.touch_up = false;
+    input.end_x = 360.0f;
+    input.end_y = 670.0f;
+
+    ui_update_system(reg);
+
+    CHECK_FALSE(any_next_phase_pending(reg));
+}
+
+TEST_CASE("ui_update_system: touch_up release on resume dispatches transition",
+          "[ui][ui_update_system]") {
+    entt::registry reg = make_registry();
+    prime_paused_entry(reg);
+
+    auto& input = reg.ctx().get<InputState>();
+    input.click = false;
+    input.touch_up = true;
+    input.end_x = 360.0f;
+    input.end_y = 670.0f;
+
+    ui_update_system(reg);
+
+    CHECK(reg.ctx().contains<NextPhasePlayingTag>());
+}
+
+TEST_CASE("screen_lifecycle_system: spawns Paused entities when phase entered, "
+          "despawns on exit",
+          "[ui][screen_lifecycle_system]") {
+    entt::registry reg = make_registry();
+    clear_next_phase_tags(reg);
+
+    // Pre-condition: no PausedScreenTag entities, no GamePhasePausedTag.
+    sync_game_phase_tags<GamePhaseTitleTag>(reg);
+    screen_lifecycle_system(reg);
+    CHECK(reg.view<PausedScreenTag>().size() == 0);
+
+    // Transition into Paused — lifecycle should spawn entities.
+    sync_game_phase_tags<GamePhasePausedTag>(reg);
+    screen_lifecycle_system(reg);
+    CHECK(reg.view<PausedScreenTag>().size() > 0);
+
+    // A second call must be idempotent — no duplicate spawn.
+    const auto count_after_first_spawn = reg.view<PausedScreenTag>().size();
+    screen_lifecycle_system(reg);
+    CHECK(reg.view<PausedScreenTag>().size() == count_after_first_spawn);
+
+    // Transition out — lifecycle despawns.
+    sync_game_phase_tags<GamePhasePlayingTag>(reg);
+    screen_lifecycle_system(reg);
+    CHECK(reg.view<PausedScreenTag>().size() == 0);
+}


### PR DESCRIPTION
#1287 Migrate Paused screen to entity-driven UI (pilot slice, refs #1193 OoS-A)

First per-screen slice of #1287. Lays down the shared infrastructure for
entity-driven UI input + rendering and migrates the Paused screen off the
legacy `screen_controllers/paused_screen_controller.cpp` path as a proof.
The other seven screens remain on the legacy controller path; per-screen
follow-up issues track each remaining migration.

## What's new

- `app/systems/ui_update_system.{h,cpp}` — Hit-tests
  `view<UiPosition, UiBounds, OnPress, UiButtonTag>()` against the frame's
  pointer-release event from `InputState`. Dispatches the entity's
  `OnPress::action` through a `constexpr std::array<fn, N>` indexed by
  `static_cast<size_t>(ActionId)` — no `switch` on the discriminator
  (Fabian Principle 1; `ActionId` is in the enum allowlist specifically
  as a lookup-key index, same mechanic as `kShapeFlatDrawFns`).
  Honours the `UI_ENTRY_DEBOUNCE` debounce so a click that entered the
  phase does not also dismiss it.

- `app/systems/screen_lifecycle_system.{h,cpp}` — Converges per-screen
  entity sets toward the active `GamePhase*Tag` ctx mirror. Each migrated
  screen appends one row to `kLifecycleRows`; no `switch`, no `if`-ladder
  over phase, no virtual dispatch. Pilot scope wires Paused only.

- `app/ui/generated/screen_spawners.h` — Forward declarations of all 8
  `spawn_<screen>_screen()` / `despawn_<screen>_screen()` pairs emitted
  by the rguilayout codegen. Hand-written for now; codegen ownership can
  come in a future cycle once all screens migrate.

- `app/systems/ui_render_system.cpp::render_ui_entities()` — New
  entity-driven render pass iterating per-kind tag views
  (`UiLabelTag`, `UiButtonTag`). `GuiButton` return values are ignored:
  the press dispatch lives in `ui_update_system`. The legacy
  `render_paused_screen_ui(reg)` call is removed; the seven remaining
  screens continue dispatching through the existing per-tag if-block.

- `app/game_loop.cpp` — Wires `ui_update_system` after `input_system`
  and `screen_lifecycle_system` after the fixed tick so the entity set
  reflects this frame's phase before rendering.

- `tests/test_ui_update_system.cpp` — Seven tests pinning the dispatch
  semantics: resume hit / menu hit / pointer miss / pre-debounce click /
  no-pointer-release / touch_up release / lifecycle spawn+despawn
  idempotence. 887 total tests pass (up from 880 baseline).

## What stays

- `app/ui/screen_controllers/paused_screen_controller.{cpp,h}` are
  intentionally left in tree — per #1287, deletion is OoS-B, deferred
  until all 8 screens migrate. The function is never called now, but
  keeping it compiled avoids a deletion churn that would conflict with
  the in-flight per-screen migrations.

- The seven non-Paused per-tag dispatches in `ui_render_system.cpp`
  remain. Each will be removed by its per-screen migration sub-issue.

## Verification

- `cmake --build build` — clean under `-Wall -Wextra -Werror` on macOS.
- `./build/shapeshifter_tests` — 887 / 887 passing (7 new).
- `python3 -m unittest tools.test_rguilayout_codegen tools.test_check_enum_allowlist` — pass.
- `tools/check_enum_allowlist.py` — clean.

## Why pilot, not full migration

Full AC for #1287 requires migrating ~2200 LOC of controllers including
the 477-LOC `gameplay_hud_screen_controller` (lane buttons, approach
rings, energy bar), title dead-zone hit testing, settings dynamic
toggle styling, game-over scoreboard hooks (with test hooks), and
level-select dynamic level cards. Not landable in one cycle while keeping
the build warning-free and all 880+ tests green. Per-screen migration is
the natural slice — #1287 stays open as the parent until the seven
follow-up sub-issues all land.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
