### PR TITLE
#1288 haptics: replace pattern_for_event switch with constexpr lookup table

### DIFF
--- a/app/systems/haptics_backend.cpp
+++ b/app/systems/haptics_backend.cpp
@@ -4,6 +4,9 @@
 
 #include <raylib.h>
 
+#include <array>
+#include <cstddef>
+
 namespace platform::haptics {
 namespace {
 
@@ -42,21 +45,30 @@ platform::ios::HapticsIOSState* ensure_ios_state(HapticsRuntimeState& state) {
 }  // namespace
 
 TriggerPattern pattern_for_event(HapticEvent event) noexcept {
-    switch (event) {
-        case HapticEvent::LaneSwitch:
-        case HapticEvent::UIButtonTap:
-            return {ImpactStyle::Light, 1};
-        case HapticEvent::ShapeShift:
-        case HapticEvent::JumpLand:
-        case HapticEvent::RetryTap:
-            return {ImpactStyle::Light, 1};
-        case HapticEvent::NewHighScore:
-            return {ImpactStyle::Medium, 1};
-        case HapticEvent::DeathCrash:
-            return {ImpactStyle::Heavy, 2};
-        default:
-            return {ImpactStyle::Light, 1};
-    }
+    // Fabian Principle 1 / issue #1288: enum-as-lookup-key into a static
+    // table. The former `switch` mapped each `HapticEvent` value to per-row
+    // data; that data table is now indexed by the enum ordinal directly so
+    // there is no central switch on the discriminator.
+    //
+    // Row order must match the `HapticEvent` declaration in
+    // `app/systems/haptics.h`; a static_assert below pins the table size to
+    // the trailing enumerator (`UIButtonTap`).
+    constexpr std::array<TriggerPattern, 7> kPatternByEvent{{
+        /* ShapeShift   */ TriggerPattern{ImpactStyle::Light,  1},
+        /* LaneSwitch   */ TriggerPattern{ImpactStyle::Light,  1},
+        /* JumpLand     */ TriggerPattern{ImpactStyle::Light,  1},
+        /* DeathCrash   */ TriggerPattern{ImpactStyle::Heavy,  2},
+        /* NewHighScore */ TriggerPattern{ImpactStyle::Medium, 1},
+        /* RetryTap     */ TriggerPattern{ImpactStyle::Light,  1},
+        /* UIButtonTap  */ TriggerPattern{ImpactStyle::Light,  1},
+    }};
+    static_assert(kPatternByEvent.size() ==
+                  static_cast<std::size_t>(HapticEvent::UIButtonTap) + 1,
+                  "kPatternByEvent must cover every HapticEvent enumerator");
+
+    const auto idx = static_cast<std::size_t>(event);
+    if (idx >= kPatternByEvent.size()) return TriggerPattern{ImpactStyle::Light, 1};
+    return kPatternByEvent[idx];
 }
 
 void warmup(entt::registry& reg) noexcept {


### PR DESCRIPTION
Fabian drift fix per Principle 1 (Existential Processing). The per-event `switch (HapticEvent)` in `pattern_for_event` was the only remaining central dispatch on this enum's value — every other site treats `HapticEvent` as either a label (`to_string`) or a lookup key.

## Change

Replace the switch with a `constexpr std::array<TriggerPattern, 7>` indexed by `static_cast<size_t>(event)`. Row order matches the `HapticEvent` declaration in `app/systems/haptics.h`:

| Ordinal | Event          | Style  | Pulses |
|---------|----------------|--------|--------|
| 0       | `ShapeShift`   | Light  | 1      |
| 1       | `LaneSwitch`   | Light  | 1      |
| 2       | `JumpLand`     | Light  | 1      |
| 3       | `DeathCrash`   | Heavy  | 2      |
| 4       | `NewHighScore` | Medium | 1      |
| 5       | `RetryTap`     | Light  | 1      |
| 6       | `UIButtonTap`  | Light  | 1      |

A `static_assert` pins the array length to `static_cast<std::size_t>(HapticEvent::UIButtonTap) + 1` so that adding a new enumerator without extending the table is a compile error rather than a silent fallthrough.

## Why this is correct under Principle 1

The enum survives as a **lookup-table index**, not as a discriminator that drives control flow. The function is now one straight-line memory load — no branches, no per-case behaviour. New events become new rows; no `pattern_for_event` change required beyond the table.

## Verification

- All 905 tests pass — including `tests/test_haptics_backend.cpp` which asserts the exact mapping (`DeathCrash` = Heavy/2, `LaneSwitch` = Light/1, `NewHighScore` = Medium/1, etc.).
- Native build clean under `-Wall -Wextra -Werror`.
- `python3 tools/check_enum_allowlist.py` clean.

Closes #1288.
Refs #1202, #1204.
