### PR TITLE
#1295 Migrate Settings screen to entity-driven UI (refs #1287, #1193 OoS-A)

### DIFF
--- a/app/components/ui.h
+++ b/app/components/ui.h
@@ -68,3 +68,13 @@ inline void ui_label_set(UiLabel& label, const char* src) noexcept {
 struct OnPress {
     ActionId action = ActionId::None;
 };
+
+// Two-state toggle data for buttons carrying `UiToggleTag` (Settings
+// screen, issue #1295). The bind system (e.g.
+// `settings_screen_bind_system`) writes the current ON/OFF state each
+// frame from the underlying domain data (`SettingsState::haptics_enabled`,
+// `!SettingsState::reduce_motion`, …). `ui_render_system` reads it to
+// pick the two-cue colour + icon-prefix row.
+struct UiToggleState {
+    bool on = false;
+};

--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -31,6 +31,7 @@
 #include "systems/screen_lifecycle_system.h"
 #include "systems/game_over_scoreboard_bind_system.h"
 #include "systems/song_complete_scoreboard_bind_system.h"
+#include "systems/settings_screen_bind_system.h"
 #include "systems/title_start_tap_system.h"
 #include "systems/tutorial_dodge_hint_bind_system.h"
 #include "systems/ui_update_system.h"
@@ -305,6 +306,7 @@ void game_loop_frame(entt::registry& reg, float& accumulator) {
     tutorial_dodge_hint_bind_system(reg);
     song_complete_scoreboard_bind_system(reg);
     game_over_scoreboard_bind_system(reg);
+    settings_screen_bind_system(reg);
 
     // Camera runs after gameplay systems so transforms reflect current frame
     game_camera_system(reg, raw_dt);

--- a/app/systems/screen_lifecycle_system.cpp
+++ b/app/systems/screen_lifecycle_system.cpp
@@ -39,8 +39,8 @@ bool entities_alive_probe(entt::registry& reg) noexcept {
 }
 
 // Pilot (#1287): Paused. Tutorial (#1291), Song Complete (#1292), Game
-// Over (#1293), Title (#1294). Each subsequent per-screen migration
-// sub-issue extends this table by one row.
+// Over (#1293), Title (#1294), Settings (#1295). Each subsequent
+// per-screen migration sub-issue extends this table by one row.
 constexpr ScreenLifecycleRow kLifecycleRows[] = {
     {
         &phase_active_probe<GamePhasePausedTag>,
@@ -71,6 +71,12 @@ constexpr ScreenLifecycleRow kLifecycleRows[] = {
         &entities_alive_probe<TitleScreenTag>,
         &spawn_title_screen,
         &despawn_title_screen,
+    },
+    {
+        &phase_active_probe<GamePhaseSettingsTag>,
+        &entities_alive_probe<SettingsScreenTag>,
+        &spawn_settings_screen,
+        &despawn_settings_screen,
     },
 };
 

--- a/app/systems/screen_lifecycle_system.h
+++ b/app/systems/screen_lifecycle_system.h
@@ -21,5 +21,5 @@
 // this system. See #1287 for the per-screen sub-issue ladder.
 //
 // Migrated so far: Paused (#1290 pilot), Tutorial (#1291), Song Complete (#1292),
-// Game Over (#1293), Title (#1294).
+// Game Over (#1293), Title (#1294), Settings (#1295).
 void screen_lifecycle_system(entt::registry& reg);

--- a/app/systems/settings_screen_bind_system.cpp
+++ b/app/systems/settings_screen_bind_system.cpp
@@ -1,0 +1,69 @@
+#include "settings_screen_bind_system.h"
+
+#include "../components/settings.h"
+#include "../components/ui.h"
+#include "../tags/tags.h"
+#include "settings_system.h"
+
+#include <array>
+#include <cstdio>
+
+namespace {
+
+// Canonical slot positions from `content/ui/screens/settings.rgl`. Position-
+// keyed identification matches the convention established for the
+// SongComplete / Tutorial / GameOver binders — codegen bakes these into
+// the spawn block, so a layout edit that moves a slot will visibly break
+// placement before any bind ever misses silently.
+constexpr float kAudioOffsetDisplayX = 252.0f;
+constexpr float kAudioOffsetDisplayY = 560.0f;
+constexpr float kHapticsToggleX      = 152.0f;
+constexpr float kHapticsToggleY      = 720.0f;
+constexpr float kReduceMotionToggleX = 152.0f;
+constexpr float kReduceMotionToggleY = 880.0f;
+
+void format_offset(int16_t offset_ms, UiLabel& label) {
+    char buf[16];
+    std::snprintf(buf, sizeof(buf), "%+d ms", static_cast<int>(offset_ms));
+    ui_label_set(label, buf);
+}
+
+void format_toggle(UiLabel& label, const char* name, bool on) {
+    // Two-cue ON/OFF (issue #390): icon-prefix `[X]` vs `[ ]` plus the
+    // explicit ON/OFF suffix. The colour cue lives in `ui_render_system`
+    // (`UiToggleTag` view selects the green/grey row).
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "[%s] %s: %s",
+                  on ? "X" : " ", name, on ? "ON" : "OFF");
+    ui_label_set(label, buf);
+}
+
+}  // namespace
+
+void settings_screen_bind_system(entt::registry& reg) {
+    auto view = reg.view<SettingsScreenTag, UiPosition, UiBounds, UiLabel>();
+    if (view.begin() == view.end()) return;
+
+    const auto* state = find_settings_state(reg);
+    if (state == nullptr) return;
+
+    const bool haptics_on = state->haptics_enabled;
+    // Display-side inversion: the visible toggle reads "MOTION: ON" when
+    // motion is NOT reduced. Matches the legacy controller (#1295 spec).
+    const bool motion_on  = !state->reduce_motion;
+
+    for (auto entity : view) {
+        const auto& pos = view.get<UiPosition>(entity);
+        auto& label = view.get<UiLabel>(entity);
+
+        if (pos.x == kAudioOffsetDisplayX && pos.y == kAudioOffsetDisplayY) {
+            format_offset(state->audio_offset_ms, label);
+        } else if (pos.x == kHapticsToggleX && pos.y == kHapticsToggleY) {
+            format_toggle(label, "HAPTICS", haptics_on);
+            reg.emplace_or_replace<UiToggleState>(entity, UiToggleState{haptics_on});
+        } else if (pos.x == kReduceMotionToggleX && pos.y == kReduceMotionToggleY) {
+            format_toggle(label, "MOTION", motion_on);
+            reg.emplace_or_replace<UiToggleState>(entity, UiToggleState{motion_on});
+        }
+    }
+}

--- a/app/systems/settings_screen_bind_system.h
+++ b/app/systems/settings_screen_bind_system.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <entt/entt.hpp>
+
+// Settings screen dynamic-text + toggle-state binder
+// (issue #1295, refs #1287, #1193 OoS-A).
+//
+// Writes per-frame Settings UI data into the entities spawned by
+// `spawn_settings_screen()` (codegen, see
+// `app/ui/generated/settings_screen.cpp`):
+//
+//   * AudioOffsetDisplay label  → "%+d ms" from `SettingsState::audio_offset_ms`
+//   * HapticsToggle      label  → "[X] HAPTICS: ON" / "[ ] HAPTICS: OFF"
+//   * HapticsToggle      toggle → `UiToggleState{haptics_enabled}`
+//   * ReduceMotionToggle label  → "[X] MOTION: ON" / "[ ] MOTION: OFF"
+//                                 (display is inverted — MOTION ON when
+//                                  `reduce_motion` is false)
+//   * ReduceMotionToggle toggle → `UiToggleState{!reduce_motion}`
+//
+// Slot entities are identified by their canonical (x, y) position baked
+// from `content/ui/screens/settings.rgl`; the bind table is per-slot
+// rows of (x, y, write fn) — no `switch` over a discriminator.
+//
+// Runs after `screen_lifecycle_system` so the Settings entity set is
+// guaranteed to exist whenever `GamePhaseSettingsTag` is the active
+// phase; trivially no-ops on every other phase (the view is empty).
+void settings_screen_bind_system(entt::registry& reg);

--- a/app/systems/ui_render_system.cpp
+++ b/app/systems/ui_render_system.cpp
@@ -13,7 +13,6 @@
 #include "../tags/tags.h"
 #include "../util/shape_draw_2d.h"
 
-#include "../ui/screen_controllers/settings_screen_controller.h"
 #include "../ui/screen_controllers/level_select_screen_controller.h"
 #include "../ui/screen_controllers/gameplay_hud_screen_controller.h"
 #include <raygui.h>
@@ -93,15 +92,74 @@ void render_ui_entities(entt::registry& reg) {
     // `ui_update_system`; ignoring the return value keeps that path the
     // single source of truth for button activation.
     //
-    // `UiHiddenOnWebTag` entities (Title-screen ExitButton on Web per #511)
-    // are skipped to keep the button invisible on Web — their bounds still
-    // act as a tap-anywhere dead-zone via `title_start_tap_system`.
+    // Toggle buttons (`UiToggleTag`, Settings screen #1295) need two-cue
+    // ON/OFF styling per A11Y issue #390: green border + dim green fill
+    // when on, grey border + dark fill when off (the icon-prefix cue is
+    // baked into `UiLabel::text` by `settings_screen_bind_system`).
+    // Plain (non-toggle) buttons render in a second pass with the default
+    // raygui style. `UiHiddenOnWebTag` entities (Title-screen ExitButton
+    // on Web per #511) are skipped to keep the button invisible on Web —
+    // their bounds still act as a tap-anywhere dead-zone via
+    // `title_start_tap_system`.
     {
         GuiSetStyle(DEFAULT, TEXT_SIZE, kEntityButtonTextSize);
-        auto view = reg.view<UiPosition, UiBounds, UiLabel, UiButtonTag>(
+
+        // ── Pass A: toggle buttons (per-entity colour override) ───
+        constexpr int kToggleStyleProps[] = {
+            BORDER_COLOR_NORMAL, BASE_COLOR_NORMAL, TEXT_COLOR_NORMAL,
+            BORDER_COLOR_FOCUSED, BASE_COLOR_FOCUSED, TEXT_COLOR_FOCUSED,
+        };
+        constexpr std::size_t kToggleStylePropCount =
+            sizeof(kToggleStyleProps) / sizeof(kToggleStyleProps[0]);
+        int saved_button_style[kToggleStylePropCount];
+        for (std::size_t i = 0; i < kToggleStylePropCount; ++i) {
+            saved_button_style[i] = GuiGetStyle(BUTTON, kToggleStyleProps[i]);
+        }
+
+        constexpr Color kToggleOnBorder  {  64, 200, 110, 255 };
+        constexpr Color kToggleOnBase    {  20,  64,  36, 255 };
+        constexpr Color kToggleOffBorder { 130, 130, 130, 255 };
+        constexpr Color kToggleOffBase   {  36,  36,  36, 255 };
+        constexpr Color kToggleTextColor { 230, 230, 230, 255 };
+
+        auto toggle_view = reg.view<UiPosition, UiBounds, UiLabel,
+                                    UiButtonTag, UiToggleTag>(
 #ifdef PLATFORM_WEB
             entt::exclude<UiHiddenOnWebTag>
 #endif
+        );
+        for (auto entity : toggle_view) {
+            const auto& pos = toggle_view.template get<UiPosition>(entity);
+            const auto& sz  = toggle_view.template get<UiBounds>(entity);
+            const auto& lbl = toggle_view.template get<UiLabel>(entity);
+            // `UiToggleState` is written each frame by the per-screen bind
+            // system; if missing (frame 0 race before the bind runs) treat
+            // as OFF — safe default, harmless visual flicker.
+            const auto* state = reg.try_get<UiToggleState>(entity);
+            const bool on = (state != nullptr) && state->on;
+
+            const Color border = on ? kToggleOnBorder : kToggleOffBorder;
+            const Color base   = on ? kToggleOnBase   : kToggleOffBase;
+            GuiSetStyle(BUTTON, BORDER_COLOR_NORMAL,  ColorToInt(border));
+            GuiSetStyle(BUTTON, BORDER_COLOR_FOCUSED, ColorToInt(border));
+            GuiSetStyle(BUTTON, BASE_COLOR_NORMAL,    ColorToInt(base));
+            GuiSetStyle(BUTTON, BASE_COLOR_FOCUSED,   ColorToInt(base));
+            GuiSetStyle(BUTTON, TEXT_COLOR_NORMAL,    ColorToInt(kToggleTextColor));
+            GuiSetStyle(BUTTON, TEXT_COLOR_FOCUSED,   ColorToInt(kToggleTextColor));
+            (void)GuiButton(Rectangle{pos.x, pos.y, sz.w, sz.h}, lbl.text.data());
+        }
+
+        for (std::size_t i = 0; i < kToggleStylePropCount; ++i) {
+            GuiSetStyle(BUTTON, kToggleStyleProps[i], saved_button_style[i]);
+        }
+
+        // ── Pass B: plain (non-toggle) buttons, default raygui style ──
+        auto view = reg.view<UiPosition, UiBounds, UiLabel, UiButtonTag>(
+            entt::exclude<UiToggleTag
+#ifdef PLATFORM_WEB
+                          , UiHiddenOnWebTag
+#endif
+                          >
         );
         for (auto [e, pos, sz, label] : view.each()) {
             (void)e;
@@ -215,12 +273,12 @@ void ui_render_system(entt::registry& reg, float /*alpha*/) {
     //
     // Paused was migrated to the entity-driven path (#1287 pilot);
     // Tutorial migrated in #1291; Song Complete migrated in #1292; Game
-    // Over migrated in #1293; Title migrated in #1294. The remaining three
-    // screens migrate in follow-up sub-issues — see #1287.
+    // Over migrated in #1293; Title migrated in #1294; Settings migrated
+    // in #1295. The remaining two screens migrate in follow-up sub-issues
+    // — see #1287.
     const auto& ctx = reg.ctx();
     if (ctx.contains<GamePhaseLevelSelectTag>())  { render_level_select_screen_ui(reg); }
     if (ctx.contains<GamePhasePlayingTag>())      { render_gameplay_hud_screen_ui(reg); }
-    if (ctx.contains<GamePhaseSettingsTag>())     { render_settings_screen_ui(reg); }
 
     // Restore raw mouse transform for non-UI systems in subsequent frames.
     SetMouseOffset(0, 0);

--- a/app/systems/ui_update_system.cpp
+++ b/app/systems/ui_update_system.cpp
@@ -2,11 +2,14 @@
 
 #include "../components/actions.h"
 #include "../components/game_state.h"
+#include "../components/settings.h"
 #include "../components/ui.h"
 #include "../constants.h"
 #include "../tags/tags.h"
 #include "game_phase_transition.h"
+#include "haptics_backend.h"
 #include "input.h"
+#include "settings_system.h"
 
 #include <array>
 #include <cstddef>
@@ -112,6 +115,61 @@ void settings_button_action(entt::registry& reg, entt::entity /*entity*/) {
     request_phase_transition<NextPhaseSettingsTag>(reg);
 }
 
+// Settings screen actions (issue #1295).
+//
+// AudioOffsetMinus / AudioOffsetPlus step `SettingsState::audio_offset_ms`
+// by `AUDIO_OFFSET_STEP_MS` and clamp to [MIN, MAX]. CloseButton routes
+// back to Title (no other screen currently emits ActionId::CloseButton).
+// HapticsToggle / ReduceMotionToggle flip their respective bool and
+// persist via `settings::mark_dirty_and_save`. Enabling haptics also
+// warms up the platform backend (latency-sensitive first vibration,
+// matches legacy controller).
+
+void audio_offset_step_action(entt::registry& reg, int delta) {
+    auto* st = find_settings_state(reg);
+    if (st == nullptr) return;
+    const auto before = st->audio_offset_ms;
+    const int candidate = static_cast<int>(st->audio_offset_ms) + delta;
+    const int clamped = (candidate < SettingsState::MIN_AUDIO_OFFSET_MS)
+                      ? SettingsState::MIN_AUDIO_OFFSET_MS
+                      : ((candidate > SettingsState::MAX_AUDIO_OFFSET_MS)
+                         ? SettingsState::MAX_AUDIO_OFFSET_MS
+                         : candidate);
+    st->audio_offset_ms = static_cast<int16_t>(clamped);
+    if (st->audio_offset_ms != before) {
+        settings::mark_dirty_and_save(reg, *st);
+    }
+}
+
+void audio_offset_minus_action(entt::registry& reg, entt::entity /*entity*/) {
+    audio_offset_step_action(reg, -SettingsState::AUDIO_OFFSET_STEP_MS);
+}
+
+void audio_offset_plus_action(entt::registry& reg, entt::entity /*entity*/) {
+    audio_offset_step_action(reg, +SettingsState::AUDIO_OFFSET_STEP_MS);
+}
+
+void close_button_action(entt::registry& reg, entt::entity /*entity*/) {
+    request_phase_transition<NextPhaseTitleTag>(reg);
+}
+
+void haptics_toggle_action(entt::registry& reg, entt::entity /*entity*/) {
+    auto* st = find_settings_state(reg);
+    if (st == nullptr) return;
+    st->haptics_enabled = !st->haptics_enabled;
+    settings::mark_dirty_and_save(reg, *st);
+    if (st->haptics_enabled) {
+        platform::haptics::warmup(reg);
+    }
+}
+
+void reduce_motion_toggle_action(entt::registry& reg, entt::entity /*entity*/) {
+    auto* st = find_settings_state(reg);
+    if (st == nullptr) return;
+    st->reduce_motion = !st->reduce_motion;
+    settings::mark_dirty_and_save(reg, *st);
+}
+
 // ── Dispatch table ──────────────────────────────────────────────────
 //
 // Order must match the `ActionId` enumerator order in
@@ -120,19 +178,19 @@ void settings_button_action(entt::registry& reg, entt::entity /*entity*/) {
 
 constexpr std::array<ActionHandler, 17> kActionHandlers = {
     /* None                 */ &noop_action_handler,
-    /* AudioOffsetMinus     */ &noop_action_handler,
-    /* AudioOffsetPlus      */ &noop_action_handler,
-    /* CloseButton          */ &noop_action_handler,
+    /* AudioOffsetMinus     */ &audio_offset_minus_action,
+    /* AudioOffsetPlus      */ &audio_offset_plus_action,
+    /* CloseButton          */ &close_button_action,
     /* ContinueButton       */ &continue_button_action,
     /* DifficultyEasy       */ &noop_action_handler,
     /* DifficultyHard       */ &noop_action_handler,
     /* DifficultyMedium     */ &noop_action_handler,
     /* ExitButton           */ &exit_button_action,
-    /* HapticsToggle        */ &noop_action_handler,
+    /* HapticsToggle        */ &haptics_toggle_action,
     /* LevelSelectButton    */ &level_select_button_action,
     /* MenuButton           */ &menu_button_action,
     /* PauseButton          */ &noop_action_handler,
-    /* ReduceMotionToggle   */ &noop_action_handler,
+    /* ReduceMotionToggle   */ &reduce_motion_toggle_action,
     /* RestartButton        */ &restart_button_action,
     /* ResumeButton         */ &resume_button_action,
     /* SettingsButton       */ &settings_button_action,

--- a/app/tags/tags.h
+++ b/app/tags/tags.h
@@ -277,3 +277,13 @@ struct UiShapeIconHexagonTag  {};
 // Codegen attaches this tag to `.rgl` entities whose name is in the
 // NAME_EXTRA_TAGS web-hidden list (`tools/rguilayout/codegen.py`).
 struct UiHiddenOnWebTag {};
+
+// ── UI toggle kind (per-kind specialization of UiButtonTag) ──────────
+// Per Fabian's existential processing, "is this button a two-state
+// toggle?" is presence of this tag rather than a `UiButtonKind` enum
+// field. Toggle buttons (#1295) render with green ON / grey OFF colors
+// + an `[X] / [ ]` icon prefix per the two-cue A11Y requirement (#390);
+// `ui_render_system` reads the sibling `UiToggleState` component to pick
+// the row. Codegen attaches this tag to `.rgl` button controls whose
+// name is in the NAME_EXTRA_TAGS toggle list (`tools/rguilayout/codegen.py`).
+struct UiToggleTag {};

--- a/app/ui/generated/settings_screen.cpp
+++ b/app/ui/generated/settings_screen.cpp
@@ -69,6 +69,7 @@ void spawn_settings_screen(entt::registry& reg) {
         auto e = reg.create();
         reg.emplace<SettingsScreenTag>(e);
         reg.emplace<UiButtonTag>(e);
+        reg.emplace<UiToggleTag>(e);
         reg.emplace<UiPosition>(e, 152.0f, 720.0f);
         reg.emplace<UiBounds>(e, 416.0f, 100.0f);
         auto& label = reg.emplace<UiLabel>(e);
@@ -90,6 +91,7 @@ void spawn_settings_screen(entt::registry& reg) {
         auto e = reg.create();
         reg.emplace<SettingsScreenTag>(e);
         reg.emplace<UiButtonTag>(e);
+        reg.emplace<UiToggleTag>(e);
         reg.emplace<UiPosition>(e, 152.0f, 880.0f);
         reg.emplace<UiBounds>(e, 416.0f, 100.0f);
         auto& label = reg.emplace<UiLabel>(e);

--- a/app/ui/screen_controllers/settings_screen_controller.cpp
+++ b/app/ui/screen_controllers/settings_screen_controller.cpp
@@ -1,13 +1,11 @@
-// Settings screen controller - renders raygui layout with dynamic toggle labels
-// and dispatches settings mutations and back-navigation to game state.
+// Settings screen controller — kept in tree per #1287 OoS-B pattern (legacy
+// controllers are deleted in a single sweep after every screen migrates).
+// The render path is no longer called from `ui_render_system.cpp`; entity
+// dispatch flows through the codegen spawner + `settings_screen_bind_system`
+// + `ui_update_system` action handlers (issue #1295). The implementations
+// below remain only to preserve the symbol shape until the bulk deletion.
 
-#include "../../components/game_state.h"
-#include "../../systems/game_phase_transition.h"
-#include "../../entities/settings.h"
-#include "../../systems/haptics_backend.h"
 #include "screen_controller_base.h"
-#include <algorithm>
-#include <cstdio>
 #include <entt/entt.hpp>
 
 #include <raygui.h>
@@ -26,116 +24,9 @@ void init_settings_screen_ui() {
 }
 
 void render_settings_screen_ui(entt::registry& reg) {
+    // No-op since #1295 — entity-driven render path runs in
+    // `ui_render_system::render_ui_entities` plus
+    // `settings_screen_bind_system`.
     auto& controller = screen_controller<SettingsController>(reg);
-    auto* st = find_settings_state(reg);
-
-    // Static controls: heading, audio offset label, +/- buttons, back button
-    controller.render();
-
-    // Audio offset value display (centre slot between - and + buttons)
-    if (st) {
-        char offset_buf[16];
-        std::snprintf(offset_buf, sizeof(offset_buf), "%+d ms", static_cast<int>(st->audio_offset_ms));
-        GuiLabel(offset_rect(controller.state().Anchor01, 252, 560, 216, 77), offset_buf);
-    }
-
-    // Dynamic toggle buttons with live labels.
-    // Issue #390: encode ON/OFF state with both an icon prefix and a colored
-    // border/background so color-blind players can read state without relying
-    // on the trailing text alone.
-    auto draw_toggle = [](Rectangle bounds, const char* name, bool on) -> bool {
-        constexpr int kProps[] = {
-            BORDER_COLOR_NORMAL, BASE_COLOR_NORMAL, TEXT_COLOR_NORMAL,
-            BORDER_COLOR_FOCUSED, BASE_COLOR_FOCUSED, TEXT_COLOR_FOCUSED,
-        };
-        int saved[sizeof(kProps) / sizeof(kProps[0])] = {0};
-        for (int i = 0; i < (int)(sizeof(kProps) / sizeof(kProps[0])); ++i) {
-            saved[i] = GuiGetStyle(BUTTON, kProps[i]);
-        }
-
-        // ON  → green border + dim green fill
-        // OFF → grey border + dark fill
-        const Color on_border  = {  64, 200, 110, 255 };
-        const Color on_base    = {  20,  64,  36, 255 };
-        const Color off_border = { 130, 130, 130, 255 };
-        const Color off_base   = {  36,  36,  36, 255 };
-        const Color text_color = { 230, 230, 230, 255 };
-
-        const Color border = on ? on_border : off_border;
-        const Color base   = on ? on_base   : off_base;
-        GuiSetStyle(BUTTON, BORDER_COLOR_NORMAL,  ColorToInt(border));
-        GuiSetStyle(BUTTON, BORDER_COLOR_FOCUSED, ColorToInt(border));
-        GuiSetStyle(BUTTON, BASE_COLOR_NORMAL,    ColorToInt(base));
-        GuiSetStyle(BUTTON, BASE_COLOR_FOCUSED,   ColorToInt(base));
-        GuiSetStyle(BUTTON, TEXT_COLOR_NORMAL,    ColorToInt(text_color));
-        GuiSetStyle(BUTTON, TEXT_COLOR_FOCUSED,   ColorToInt(text_color));
-
-        char label[32];
-        std::snprintf(label, sizeof(label), "[%s] %s: %s",
-                      on ? "X" : " ", name, on ? "ON" : "OFF");
-        bool pressed = GuiButton(bounds, label);
-
-        for (int i = 0; i < (int)(sizeof(kProps) / sizeof(kProps[0])); ++i) {
-            GuiSetStyle(BUTTON, kProps[i], saved[i]);
-        }
-        return pressed;
-    };
-
-    {
-        bool haptics_on = !st || st->haptics_enabled;
-        controller.state().HapticsTogglePressed = draw_toggle(
-            offset_rect(controller.state().Anchor01, 152, 720, 416, 100),
-            "HAPTICS", haptics_on);
-    }
-    {
-        // Reduce-motion semantics: the visible toggle reads "MOTION ON" when
-        // motion is NOT reduced. We therefore invert reduce_motion for display.
-        bool motion_on = !st || !st->reduce_motion;
-        controller.state().ReduceMotionTogglePressed = draw_toggle(
-            offset_rect(controller.state().Anchor01, 152, 880, 416, 100),
-            "MOTION", motion_on);
-    }
-
-    // Dispatch actions
-    const bool close_pressed = controller.state().CloseButtonPressed;
-    if (!st && close_pressed) {
-        request_phase_transition<NextPhaseTitleTag>(reg);
-        return;
-    }
-    if (!st) return;
-
-    bool settings_changed = false;
-    if (controller.state().AudioOffsetMinusPressed) {
-        const auto before = st->audio_offset_ms;
-        st->audio_offset_ms = static_cast<int16_t>(
-            std::max(static_cast<int>(SettingsState::MIN_AUDIO_OFFSET_MS),
-                     static_cast<int>(st->audio_offset_ms) - SettingsState::AUDIO_OFFSET_STEP_MS));
-        settings_changed = settings_changed || (st->audio_offset_ms != before);
-    }
-    if (controller.state().AudioOffsetPlusPressed) {
-        const auto before = st->audio_offset_ms;
-        st->audio_offset_ms = static_cast<int16_t>(
-            std::min(static_cast<int>(SettingsState::MAX_AUDIO_OFFSET_MS),
-                     static_cast<int>(st->audio_offset_ms) + SettingsState::AUDIO_OFFSET_STEP_MS));
-        settings_changed = settings_changed || (st->audio_offset_ms != before);
-    }
-    if (controller.state().HapticsTogglePressed) {
-        st->haptics_enabled = !st->haptics_enabled;
-        settings_changed = true;
-        if (st->haptics_enabled) {
-            platform::haptics::warmup(reg);
-        }
-    }
-    if (controller.state().ReduceMotionTogglePressed) {
-        st->reduce_motion = !st->reduce_motion;
-        settings_changed = true;
-    }
-
-    if (settings_changed) {
-        settings::mark_dirty_and_save(reg, *st);
-    }
-
-    if (close_pressed) {
-        request_phase_transition<NextPhaseTitleTag>(reg);
-    }
+    (void)controller;
 }

--- a/tests/test_ui_update_system.cpp
+++ b/tests/test_ui_update_system.cpp
@@ -32,6 +32,7 @@
 #include "systems/screen_lifecycle_system.h"
 #include "systems/settings_system.h"
 #include "systems/song_complete_scoreboard_bind_system.h"
+#include "systems/settings_screen_bind_system.h"
 #include "systems/title_start_tap_system.h"
 #include "systems/tutorial_dodge_hint_bind_system.h"
 #include "systems/ui_update_system.h"
@@ -884,3 +885,301 @@ TEST_CASE("ui_update_system: PLATFORM_WEB skips UiHiddenOnWebTag entities (#511,
     CHECK_FALSE(any_next_phase_pending(reg));
 }
 #endif
+
+// ── Settings screen migration (#1295) ────────────────────────────────────
+
+namespace {
+
+void prime_settings_entry(entt::registry& reg) {
+    sync_game_phase_tags<GamePhaseSettingsTag>(reg);
+    spawn_settings_screen(reg);
+    reg.ctx().get<GameState>().phase_timer = constants::UI_ENTRY_DEBOUNCE + 0.05f;
+    clear_next_phase_tags(reg);
+}
+
+}  // namespace
+
+TEST_CASE("screen_lifecycle_system: spawns Settings entities on phase entry, "
+          "despawns on exit",
+          "[ui][screen_lifecycle_system][issue1295]") {
+    entt::registry reg = make_registry();
+    clear_next_phase_tags(reg);
+
+    // Pre-condition: not on Settings.
+    sync_game_phase_tags<GamePhaseTitleTag>(reg);
+    screen_lifecycle_system(reg);
+    CHECK(reg.view<SettingsScreenTag>().size() == 0);
+
+    sync_game_phase_tags<GamePhaseSettingsTag>(reg);
+    screen_lifecycle_system(reg);
+    CHECK(reg.view<SettingsScreenTag>().size() > 0);
+
+    // Idempotent — second tick on the same phase does not double-spawn.
+    const auto count_after_first_spawn = reg.view<SettingsScreenTag>().size();
+    screen_lifecycle_system(reg);
+    CHECK(reg.view<SettingsScreenTag>().size() == count_after_first_spawn);
+
+    sync_game_phase_tags<GamePhaseTitleTag>(reg);
+    screen_lifecycle_system(reg);
+    CHECK(reg.view<SettingsScreenTag>().size() == 0);
+}
+
+TEST_CASE("Settings toggle buttons carry UiToggleTag (issue #1295)",
+          "[ui][settings][codegen][issue1295]") {
+    entt::registry reg;
+    spawn_settings_screen(reg);
+
+    // Exactly two toggle buttons: HapticsToggle + ReduceMotionToggle.
+    auto toggles = reg.view<UiToggleTag, UiButtonTag, SettingsScreenTag>();
+    CHECK(toggles.size_hint() == 2);
+
+    int haptics = 0, motion = 0, other = 0;
+    auto with_action = reg.view<UiToggleTag, OnPress>();
+    for (auto [e, on_press] : with_action.each()) {
+        (void)e;
+        if (on_press.action == ActionId::HapticsToggle) ++haptics;
+        else if (on_press.action == ActionId::ReduceMotionToggle) ++motion;
+        else ++other;
+    }
+    CHECK(haptics == 1);
+    CHECK(motion == 1);
+    CHECK(other == 0);
+
+    // Non-toggle Settings buttons (audio +/- and CloseButton) must NOT
+    // carry the toggle tag — otherwise the render system would apply
+    // the green/grey style to them.
+    auto non_toggle_btns = reg.view<UiButtonTag, SettingsScreenTag>(
+        entt::exclude<UiToggleTag>);
+    int non_toggle_count = 0;
+    for (auto e : non_toggle_btns) { (void)e; ++non_toggle_count; }
+    CHECK(non_toggle_count == 3);
+}
+
+TEST_CASE("ui_update_system: Settings audio offset minus decrements and persists",
+          "[ui][ui_update_system][issue1295]") {
+    entt::registry reg = make_registry();
+    prime_settings_entry(reg);
+
+    auto& settings = settings_state(reg);
+    settings.audio_offset_ms = 50;
+    const auto settings_entity = *reg.view<SettingsTag>().begin();
+    reg.remove<SettingsDirtyTag>(settings_entity);
+
+    auto& input = reg.ctx().get<InputState>();
+    // AudioOffsetMinus bounds from settings.rgl: (180, 560, 72, 77).
+    click_at(input, 216.0f, 600.0f);
+
+    ui_update_system(reg);
+
+    CHECK(settings_state(reg).audio_offset_ms ==
+          50 - SettingsState::AUDIO_OFFSET_STEP_MS);
+    const auto settings_entity_after = *reg.view<SettingsTag>().begin();
+    CHECK(reg.all_of<SettingsDirtyTag>(settings_entity_after));
+    CHECK_FALSE(any_next_phase_pending(reg));
+}
+
+TEST_CASE("ui_update_system: Settings audio offset plus increments and persists",
+          "[ui][ui_update_system][issue1295]") {
+    entt::registry reg = make_registry();
+    prime_settings_entry(reg);
+
+    auto& settings = settings_state(reg);
+    settings.audio_offset_ms = -50;
+    const auto settings_entity = *reg.view<SettingsTag>().begin();
+    reg.remove<SettingsDirtyTag>(settings_entity);
+
+    auto& input = reg.ctx().get<InputState>();
+    // AudioOffsetPlus bounds from settings.rgl: (468, 560, 72, 77).
+    click_at(input, 504.0f, 600.0f);
+
+    ui_update_system(reg);
+
+    CHECK(settings_state(reg).audio_offset_ms ==
+          -50 + SettingsState::AUDIO_OFFSET_STEP_MS);
+    const auto settings_entity_after = *reg.view<SettingsTag>().begin();
+    CHECK(reg.all_of<SettingsDirtyTag>(settings_entity_after));
+}
+
+TEST_CASE("ui_update_system: Settings audio offset clamps at MIN/MAX",
+          "[ui][ui_update_system][issue1295]") {
+    entt::registry reg = make_registry();
+    prime_settings_entry(reg);
+
+    auto& input = reg.ctx().get<InputState>();
+
+    // Clamp at min.
+    settings_state(reg).audio_offset_ms = SettingsState::MIN_AUDIO_OFFSET_MS;
+    click_at(input, 216.0f, 600.0f);  // minus
+    ui_update_system(reg);
+    CHECK(settings_state(reg).audio_offset_ms ==
+          SettingsState::MIN_AUDIO_OFFSET_MS);
+
+    // Clamp at max.
+    settings_state(reg).audio_offset_ms = SettingsState::MAX_AUDIO_OFFSET_MS;
+    click_at(input, 504.0f, 600.0f);  // plus
+    ui_update_system(reg);
+    CHECK(settings_state(reg).audio_offset_ms ==
+          SettingsState::MAX_AUDIO_OFFSET_MS);
+}
+
+TEST_CASE("ui_update_system: Settings close button requests Title phase",
+          "[ui][ui_update_system][issue1295]") {
+    entt::registry reg = make_registry();
+    prime_settings_entry(reg);
+
+    auto& input = reg.ctx().get<InputState>();
+    // CloseButton bounds from settings.rgl: (260, 1040, 200, 100).
+    click_at(input, 360.0f, 1090.0f);
+
+    ui_update_system(reg);
+
+    CHECK(reg.ctx().contains<NextPhaseTitleTag>());
+}
+
+TEST_CASE("ui_update_system: Settings haptics toggle flips haptics_enabled and persists",
+          "[ui][ui_update_system][issue1295]") {
+    entt::registry reg = make_registry();
+    prime_settings_entry(reg);
+
+    settings_state(reg).haptics_enabled = true;
+    const auto settings_entity = *reg.view<SettingsTag>().begin();
+    reg.remove<SettingsDirtyTag>(settings_entity);
+
+    auto& input = reg.ctx().get<InputState>();
+    // HapticsToggle bounds from settings.rgl: (152, 720, 416, 100).
+    click_at(input, 360.0f, 770.0f);
+
+    ui_update_system(reg);
+
+    CHECK_FALSE(settings_state(reg).haptics_enabled);
+    const auto settings_entity_after = *reg.view<SettingsTag>().begin();
+    CHECK(reg.all_of<SettingsDirtyTag>(settings_entity_after));
+}
+
+TEST_CASE("ui_update_system: Settings reduce motion toggle flips reduce_motion",
+          "[ui][ui_update_system][issue1295]") {
+    entt::registry reg = make_registry();
+    prime_settings_entry(reg);
+
+    settings_state(reg).reduce_motion = false;
+    const auto settings_entity = *reg.view<SettingsTag>().begin();
+    reg.remove<SettingsDirtyTag>(settings_entity);
+
+    auto& input = reg.ctx().get<InputState>();
+    // ReduceMotionToggle bounds from settings.rgl: (152, 880, 416, 100).
+    click_at(input, 360.0f, 930.0f);
+
+    ui_update_system(reg);
+
+    CHECK(settings_state(reg).reduce_motion);
+    const auto settings_entity_after = *reg.view<SettingsTag>().begin();
+    CHECK(reg.all_of<SettingsDirtyTag>(settings_entity_after));
+}
+
+TEST_CASE("ui_update_system: Settings click before debounce ignored (issue #1295)",
+          "[ui][ui_update_system][issue1295]") {
+    entt::registry reg = make_registry();
+    sync_game_phase_tags<GamePhaseSettingsTag>(reg);
+    spawn_settings_screen(reg);
+    reg.ctx().get<GameState>().phase_timer = 0.0f;
+    clear_next_phase_tags(reg);
+
+    const auto offset_before = settings_state(reg).audio_offset_ms;
+
+    auto& input = reg.ctx().get<InputState>();
+    click_at(input, 216.0f, 600.0f);  // AudioOffsetMinus centre
+
+    ui_update_system(reg);
+
+    CHECK(settings_state(reg).audio_offset_ms == offset_before);
+}
+
+TEST_CASE("settings_screen_bind_system: writes formatted audio offset text",
+          "[ui][settings_screen_bind_system][issue1295]") {
+    entt::registry reg = make_registry();
+    prime_settings_entry(reg);
+
+    settings_state(reg).audio_offset_ms = -40;
+    settings_screen_bind_system(reg);
+
+    // AudioOffsetDisplay at (252, 560) — see settings.rgl.
+    auto view = reg.view<SettingsScreenTag, UiPosition, UiLabel>();
+    bool found = false;
+    for (auto [e, pos, label] : view.each()) {
+        (void)e;
+        if (pos.x == 252.0f && pos.y == 560.0f) {
+            CHECK(std::string(label.text.data()) == "-40 ms");
+            found = true;
+            break;
+        }
+    }
+    CHECK(found);
+
+    // Positive offset gets a `+` prefix.
+    settings_state(reg).audio_offset_ms = 70;
+    settings_screen_bind_system(reg);
+    for (auto [e, pos, label] : view.each()) {
+        (void)e;
+        if (pos.x == 252.0f && pos.y == 560.0f) {
+            CHECK(std::string(label.text.data()) == "+70 ms");
+            break;
+        }
+    }
+}
+
+TEST_CASE("settings_screen_bind_system: writes toggle labels and UiToggleState",
+          "[ui][settings_screen_bind_system][issue1295]") {
+    entt::registry reg = make_registry();
+    prime_settings_entry(reg);
+
+    settings_state(reg).haptics_enabled = true;
+    settings_state(reg).reduce_motion = false;
+    settings_screen_bind_system(reg);
+
+    auto view = reg.view<SettingsScreenTag, UiToggleTag, UiPosition, UiLabel,
+                         UiToggleState>();
+    int haptics_match = 0;
+    int motion_match = 0;
+    for (auto entity : view) {
+        const auto& pos = view.get<UiPosition>(entity);
+        const auto& label = view.get<UiLabel>(entity);
+        const auto& state = view.get<UiToggleState>(entity);
+        if (pos.x == 152.0f && pos.y == 720.0f) {
+            CHECK(std::string(label.text.data()) == "[X] HAPTICS: ON");
+            CHECK(state.on);
+            ++haptics_match;
+        } else if (pos.x == 152.0f && pos.y == 880.0f) {
+            // motion_on = !reduce_motion → true → label shows MOTION: ON
+            CHECK(std::string(label.text.data()) == "[X] MOTION: ON");
+            CHECK(state.on);
+            ++motion_match;
+        }
+    }
+    CHECK(haptics_match == 1);
+    CHECK(motion_match == 1);
+
+    // Flip both — verify off-state cue.
+    settings_state(reg).haptics_enabled = false;
+    settings_state(reg).reduce_motion = true;
+    settings_screen_bind_system(reg);
+    for (auto entity : view) {
+        const auto& pos = view.get<UiPosition>(entity);
+        const auto& label = view.get<UiLabel>(entity);
+        const auto& state = view.get<UiToggleState>(entity);
+        if (pos.x == 152.0f && pos.y == 720.0f) {
+            CHECK(std::string(label.text.data()) == "[ ] HAPTICS: OFF");
+            CHECK_FALSE(state.on);
+        } else if (pos.x == 152.0f && pos.y == 880.0f) {
+            CHECK(std::string(label.text.data()) == "[ ] MOTION: OFF");
+            CHECK_FALSE(state.on);
+        }
+    }
+}
+
+TEST_CASE("settings_screen_bind_system: no-op when Settings entities absent",
+          "[ui][settings_screen_bind_system][issue1295]") {
+    entt::registry reg = make_registry();
+    // No spawn_settings_screen call — the bind must short-circuit.
+    settings_screen_bind_system(reg);
+    SUCCEED("bind ran without spawning Settings entities");
+}

--- a/tools/rguilayout/codegen.py
+++ b/tools/rguilayout/codegen.py
@@ -76,6 +76,12 @@ NAME_EXTRA_TAGS: Dict[str, Tuple[str, ...]] = {
     # PLATFORM_WEB; `title_start_tap_system` keeps treating their bounds
     # as a dead-zone (defense-in-depth).
     "ExitButton":    ("UiHiddenOnWebTag",),
+    # Settings screen toggle buttons (#1295). `UiToggleTag` selects the
+    # two-cue ON/OFF render row in `ui_render_system`; the sibling
+    # `UiToggleState` is written each frame by `settings_screen_bind_system`
+    # from `SettingsState`.
+    "HapticsToggle":      ("UiToggleTag",),
+    "ReduceMotionToggle": ("UiToggleTag",),
 }
 
 

--- a/tools/test_rguilayout_codegen.py
+++ b/tools/test_rguilayout_codegen.py
@@ -87,6 +87,38 @@ class EmitterTests(unittest.TestCase):
             self.assertNotIn("UiKind::", out, f"{rgl} introduced UiKind enum")
             self.assertNotIn("LayoutState", out, f"{rgl} mentions LayoutState")
 
+    def test_emit_attaches_toggle_tag_to_settings_toggles(self):
+        # Settings migration (#1295): HapticsToggle and ReduceMotionToggle
+        # must carry UiToggleTag so ui_render_system applies the two-cue
+        # ON/OFF style.
+        layout = codegen.parse_rgl(RGL_DIR / "settings.rgl")
+        out = codegen.emit_spawner_cpp(layout, RGL_DIR / "settings.rgl")
+        self.assertRegex(
+            out,
+            re.compile(
+                r"// HapticsToggle.*?UiToggleTag",
+                re.DOTALL,
+            ),
+        )
+        self.assertRegex(
+            out,
+            re.compile(
+                r"// ReduceMotionToggle.*?UiToggleTag",
+                re.DOTALL,
+            ),
+        )
+        # Non-toggle Settings buttons (AudioOffsetMinus / AudioOffsetPlus /
+        # CloseButton) must NOT receive UiToggleTag.
+        for name in ("AudioOffsetMinus", "AudioOffsetPlus", "CloseButton"):
+            block_re = re.compile(
+                r"// " + name + r".*?(?=\n\s*\{|\Z)",
+                re.DOTALL,
+            )
+            m = block_re.search(out)
+            self.assertIsNotNone(m, f"{name} block not found")
+            self.assertNotIn("UiToggleTag", m.group(0),
+                             f"{name} should not carry UiToggleTag")
+
     def test_emit_is_deterministic(self):
         layout = codegen.parse_rgl(RGL_DIR / "settings.rgl")
         first = codegen.emit_spawner_cpp(layout, RGL_DIR / "settings.rgl")


### PR DESCRIPTION
Migrate the Settings screen off the legacy `screen_controllers/*` render path. Sixth screen after Paused (#1290), Tutorial (#1291), Song Complete (#1292), Game Over (#1293), and Title (#1294). Closes #1295. Refs #1287, #1193.

## Per-screen changes

- **Lifecycle row** added to `screen_lifecycle_system` for `GamePhaseSettingsTag` / `SettingsScreenTag`.
- **Five action handlers** wired in `kActionHandlers`:
  - `audio_offset_minus_action` / `audio_offset_plus_action` — step `SettingsState::audio_offset_ms` by `AUDIO_OFFSET_STEP_MS`, clamp to `[MIN_AUDIO_OFFSET_MS, MAX_AUDIO_OFFSET_MS]`, mark dirty + save only when the value actually changed.
  - `close_button_action` → `NextPhaseTitleTag` (no other screen emits `ActionId::CloseButton`).
  - `haptics_toggle_action` — flip `haptics_enabled`, persist, warmup haptics on enable.
  - `reduce_motion_toggle_action` — flip `reduce_motion`, persist.
- **`render_settings_screen_ui` call removed** from `ui_render_system.cpp`; controller .cpp stays in tree (stubbed to a no-op) until OoS-B deletes every `screen_controllers/*` file in one PR.

## New: `UiToggleTag` + `UiToggleState`

Two-cue ON/OFF rendering per A11Y issue #390 — green border + dim green fill when on, grey border + dark fill when off, plus an icon-prefix `[X]`/`[ ]` baked into `UiLabel::text`. Per Fabian's existential processing, "is this button a two-state toggle?" is presence of `UiToggleTag` (zero-column table) rather than a `UiButtonKind` enum field.

- `app/tags/tags.h` — `UiToggleTag {}`.
- `app/components/ui.h` — `UiToggleState { bool on }`.
- `tools/rguilayout/codegen.py` — `NAME_EXTRA_TAGS` maps `HapticsToggle` and `ReduceMotionToggle` to `UiToggleTag`.
- `app/systems/ui_render_system.cpp` — button render splits into Pass A (toggle, per-entity color override + restore) and Pass B (plain). Style props saved/restored per pass so neighbouring screens are unaffected.

## New: `settings_screen_bind_system`

Position-keyed writes from `SettingsState` into the spawned entity labels each frame:

| Slot | Position | Label format | UiToggleState |
|------|----------|--------------|----------------|
| AudioOffsetDisplay  | (252, 560) | `"%+d ms"` | — |
| HapticsToggle       | (152, 720) | `"[X|·] HAPTICS: ON|OFF"` | `haptics_enabled` |
| ReduceMotionToggle  | (152, 880) | `"[X|·] MOTION: ON|OFF"` | `!reduce_motion` |

Display-side inversion for motion preserves the legacy semantic ("MOTION ON when motion is NOT reduced"). View-empty short-circuit makes the system a trivial no-op on every other phase.

Wired in `game_loop_frame` after `game_over_scoreboard_bind_system`, before `ui_render_system`.

## Tests

- **`tests/test_ui_update_system.cpp`**: 12 new test cases — lifecycle spawn/despawn, codegen attaches `UiToggleTag` to the right two buttons (and not the rest), audio offset minus/plus increment + persist, audio offset clamp at MIN/MAX, close button → Title, haptics + reduce_motion flips persist via `SettingsDirtyTag`, debounce-window click ignored, bind system writes formatted offset / toggle labels / `UiToggleState`, bind no-op when no Settings entities present.
- **`tools/test_rguilayout_codegen.py`**: new test verifies `HapticsToggle` / `ReduceMotionToggle` blocks carry `UiToggleTag` and the non-toggle Settings buttons (`AudioOffsetMinus` / `AudioOffsetPlus` / `CloseButton`) do not.

## Verification

| Check | Result |
|---|---|
| `cmake --build build` (macOS, Clang, `-Wall -Wextra -Werror`) | clean |
| `./build/shapeshifter_tests` | **925 / 925** (was 913 baseline, +12 new) |
| `./build/shapeshifter_startup_shutdown_smoke` | clean |
| `python3 tools/check_enum_allowlist.py` | clean (8 enums) |
| `python3 -m unittest tools.test_rguilayout_codegen` | **13 / 13** clean |

## AC progress (issue #1295)

- [x] `screen_lifecycle_system` row added for `GamePhaseSettingsTag` / `SettingsScreenTag`.
- [x] All 5 action handlers wired (minus / plus / close / haptics-toggle / reduce-motion-toggle).
- [x] Two-cue ON/OFF rendering preserved (border colour via `UiToggleState` + icon prefix in `UiLabel::text`).
- [x] Audio offset clamp logic preserved; persistence preserved (`settings::mark_dirty_and_save`).
- [x] Haptics warmup on enable preserved.
- [x] `render_settings_screen_ui` call removed from `ui_render_system.cpp`.
- [x] Build passes `-Wall -Wextra -Werror`; all settings tests pass.
