### PR TITLE
#1309 Replace remaining label→value switches with constexpr table lookups

### DIFF
--- a/app/components/player.h
+++ b/app/components/player.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <array>
+#include <cstddef>
 #include <cstdint>
 #include <string_view>
 #include "tags/tags.h"
@@ -11,18 +13,26 @@ enum class Shape : uint8_t {
     Hexagon,
 };
 
-// Stringification for trace/log lines. Pure label lookup, doctrinally fine
-// per Fabian's Existential Processing chapter (see issue #1204 — "Bonus:
-// drop the magic_enum dependency"). Replaces the former
+// Stringification for trace/log lines. Replaces the former
 // `magic_enum::enum_name(Shape)` lookup used by the session logger and tests.
+//
+// Fabian Principle 1 / issue #1309: enum-as-lookup-key into a static table.
+// Row order must match the `Shape` declaration above; the `static_assert`
+// pins the table size to the trailing enumerator (`Hexagon`).
 constexpr std::string_view to_string(Shape shape) noexcept {
-    switch (shape) {
-        case Shape::Circle:   return "Circle";
-        case Shape::Square:   return "Square";
-        case Shape::Triangle: return "Triangle";
-        case Shape::Hexagon:  return "Hexagon";
-    }
-    return {};
+    constexpr std::array<std::string_view, 4> kNameByShape{{
+        /* Circle   */ "Circle",
+        /* Square   */ "Square",
+        /* Triangle */ "Triangle",
+        /* Hexagon  */ "Hexagon",
+    }};
+    static_assert(kNameByShape.size() ==
+                  static_cast<std::size_t>(Shape::Hexagon) + 1,
+                  "kNameByShape must cover every Shape enumerator");
+
+    const auto idx = static_cast<std::size_t>(shape);
+    if (idx >= kNameByShape.size()) return {};
+    return kNameByShape[idx];
 }
 
 // Hot render data — read by game_camera_system, player_movement_system every frame.

--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -112,8 +112,8 @@ void unload_text_fonts(TextContext& ctx) {
 // Status → (log_level, message_template) lookup table. Per Fabian's
 // existential processing (issue #1277), behavior dispatch on the `Status`
 // discriminator is replaced with a value→data lookup — same shape as the
-// `to_string(Shape)` / `HapticEvent → TriggerPattern` lookups that the
-// issue lists as doctrinally OK.
+// `to_string(Shape)` / `HapticEvent → TriggerPattern` lookups (issue #1309
+// converted these label→value mappings to constexpr table indexing).
 struct PersistenceLogRow {
     persistence::Status status;
     int log_level;            // raylib TraceLogLevel (LOG_INFO / LOG_WARNING)

--- a/app/systems/haptics.h
+++ b/app/systems/haptics.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <array>
+#include <cstddef>
 #include <cstdint>
 #include <string_view>
 
@@ -16,20 +18,28 @@ enum class HapticEvent : uint8_t {
     UIButtonTap,      // Ultra-light tap — any UI menu button pressed
 };
 
-// Stringification for trace/log lines. Pure label lookup (no control-flow
-// dispatch on the enum's value beyond the symbolic name), so the switch is
-// doctrinally fine per Fabian's Existential Processing chapter (see issue
-// #1204 — "Bonus: drop the magic_enum dependency"). Replaces the former
+// Stringification for trace/log lines. Replaces the former
 // `magic_enum::enum_name(HapticEvent)` call site in haptics_backend.cpp.
+//
+// Fabian Principle 1 / issue #1309: enum-as-lookup-key into a static table.
+// Row order must match the `HapticEvent` declaration above; the
+// `static_assert` pins the table size to the trailing enumerator
+// (`UIButtonTap`).
 constexpr std::string_view to_string(HapticEvent event) noexcept {
-    switch (event) {
-        case HapticEvent::ShapeShift:   return "ShapeShift";
-        case HapticEvent::LaneSwitch:   return "LaneSwitch";
-        case HapticEvent::JumpLand:     return "JumpLand";
-        case HapticEvent::DeathCrash:   return "DeathCrash";
-        case HapticEvent::NewHighScore: return "NewHighScore";
-        case HapticEvent::RetryTap:     return "RetryTap";
-        case HapticEvent::UIButtonTap:  return "UIButtonTap";
-    }
-    return {};
+    constexpr std::array<std::string_view, 7> kNameByEvent{{
+        /* ShapeShift   */ "ShapeShift",
+        /* LaneSwitch   */ "LaneSwitch",
+        /* JumpLand     */ "JumpLand",
+        /* DeathCrash   */ "DeathCrash",
+        /* NewHighScore */ "NewHighScore",
+        /* RetryTap     */ "RetryTap",
+        /* UIButtonTap  */ "UIButtonTap",
+    }};
+    static_assert(kNameByEvent.size() ==
+                  static_cast<std::size_t>(HapticEvent::UIButtonTap) + 1,
+                  "kNameByEvent must cover every HapticEvent enumerator");
+
+    const auto idx = static_cast<std::size_t>(event);
+    if (idx >= kNameByEvent.size()) return {};
+    return kNameByEvent[idx];
 }

--- a/app/util/keyboard_shape_mapping.h
+++ b/app/util/keyboard_shape_mapping.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <array>
+#include <cstddef>
 #include <cstdint>
 #include "../components/player.h"
 
@@ -10,12 +12,22 @@ enum class KeyboardShapeSlot : uint8_t {
 };
 
 inline constexpr Shape shape_for_keyboard_slot(KeyboardShapeSlot slot) noexcept {
-    switch (slot) {
-        case KeyboardShapeSlot::Left:   return Shape::Circle;
-        case KeyboardShapeSlot::Center: return Shape::Square;
-        case KeyboardShapeSlot::Right:  return Shape::Triangle;
-    }
-    return Shape::Square;
+    // Fabian Principle 1 / issue #1309: enum-as-lookup-key into a static
+    // table. Row order must match the `KeyboardShapeSlot` declaration above;
+    // the `static_assert` pins the table size to the trailing enumerator
+    // (`Right`).
+    constexpr std::array<Shape, 3> kShapeBySlot{{
+        /* Left   */ Shape::Circle,
+        /* Center */ Shape::Square,
+        /* Right  */ Shape::Triangle,
+    }};
+    static_assert(kShapeBySlot.size() ==
+                  static_cast<std::size_t>(KeyboardShapeSlot::Right) + 1,
+                  "kShapeBySlot must cover every KeyboardShapeSlot enumerator");
+
+    const auto idx = static_cast<std::size_t>(slot);
+    if (idx >= kShapeBySlot.size()) return Shape::Square;
+    return kShapeBySlot[idx];
 }
 
 inline constexpr Shape kKeyboardShapeLeft = shape_for_keyboard_slot(KeyboardShapeSlot::Left);


### PR DESCRIPTION
Closes #1309.

## Summary

Three remaining enum-as-lookup-key `switch` statements in `app/` (called out by #1309) are exact analogues of the cases fixed in #1307 (post-#1306 `popup_font_for_size` / `status_name`) and #1288 (original `pattern_for_event`). All three are converted to `constexpr std::array<…>` lookups indexed by `static_cast<std::size_t>(enum_value)`.

## Changes

| File | Symbol | Before | After |
| --- | --- | --- | --- |
| `app/util/keyboard_shape_mapping.h` | `shape_for_keyboard_slot(KeyboardShapeSlot)` | `switch (slot)` over 3 cases | `constexpr std::array<Shape, 3>` indexed by ordinal |
| `app/components/player.h` | `to_string(Shape)` | `switch (shape)` over 4 cases | `constexpr std::array<std::string_view, 4>` indexed by ordinal |
| `app/systems/haptics.h` | `to_string(HapticEvent)` | `switch (event)` over 7 cases | `constexpr std::array<std::string_view, 7>` indexed by ordinal |

Each table pins its size with a `static_assert` against the trailing enumerator (`Right` / `Hexagon` / `UIButtonTap`), so adding an enum case becomes a compile-time failure instead of a silent default-return fallback. The shape, mechanism, and bounds-check fallback (`if (idx >= table.size()) return {default};`) match the pattern established by `pattern_for_event` in `haptics_backend.cpp`.

### Stale-comment removal

The "the switch is doctrinally fine per Fabian's Existential Processing chapter" comments on `to_string(Shape)` and `to_string(HapticEvent)` predate #1306/#1307 and #1288; the precedent established by those PRs is that the table lookup IS the canonical shape for label→value mappings, not the switch. Replaced with the same comment style used in #1307 (citing #1309 / Principle 1 and noting the static_assert pin).

The `game_loop.cpp` comment that referenced these as "doctrinally OK" was also updated to reflect that the referenced lookups are now table-based.

### Enum allowlist

`KeyboardShapeSlot`, `Shape`, and `HapticEvent` all remain in `app/.allowed-enums.txt` as legitimate Keep-set entries (input event label / lookup key / playback ID). Only the dispatch shape changes; the enums themselves are unaffected. `tools/check_enum_allowlist.py` still passes (8 enums, all allowlisted).

## Acceptance criteria (from #1309)

- [x] `shape_for_keyboard_slot` replaced with `constexpr std::array<Shape, 3>` lookup; no `switch (slot)`
- [x] `to_string(Shape)` replaced with `constexpr std::array<std::string_view, 4>`; no `switch (shape)`
- [x] `to_string(HapticEvent)` replaced with `constexpr std::array<std::string_view, 7>`; no `switch (event)`
- [x] Each table pinned with `static_assert(kTable.size() == static_cast<size_t>(LastEnumerator) + 1)`
- [x] Cyclomatic ratchet trends down: `switch (` count in `app/` drops by 3 (11 → 8 total occurrences; the 8 remaining are 6 comment references and 2 platform-specific iOS framework dispatches in `haptics_ios_bridge_ios.mm`, out of scope)
- [x] All three call sites in tests/other systems unchanged (`tests/test_input_pipeline_behavior.cpp` and `tests/test_helpers_and_functions.cpp` still pass against the same return values)
- [x] Zero new warnings under `-Wall -Wextra -Werror`
- [x] All 933 C++ tests pass (3133 assertions) — local baseline matches; #1309's "934" cited baseline is one ahead, no regression observed

## Validation

```
$ ./build.sh Release   # zero warnings
$ ./build/shapeshifter_tests --reporter=compact
All tests passed (3133 assertions in 933 test cases)
$ python3 tools/check_enum_allowlist.py
ok: 8 enum(s) in app/, all allowlisted
```

## References

- #1306 / #1307 — immediate precedent (FontSize / persistence::Status)
- #1288 — original pattern (HapticEvent → TriggerPattern table)
- `.squad/decisions.md` § "DoD source-text grounding (Fabian) Principle 1"
