### PR TITLE
#1313 Add to_string(HapticEvent) test coverage symmetric to Shape

### DIFF
--- a/tests/test_helpers_and_functions.cpp
+++ b/tests/test_helpers_and_functions.cpp
@@ -142,6 +142,16 @@ TEST_CASE("ToString: Shape covers all shapes", "[ToString]") {
     CHECK(to_string(Shape::Hexagon)  == "Hexagon");
 }
 
+TEST_CASE("ToString: HapticEvent covers all events", "[ToString]") {
+    CHECK(to_string(HapticEvent::ShapeShift)   == "ShapeShift");
+    CHECK(to_string(HapticEvent::LaneSwitch)   == "LaneSwitch");
+    CHECK(to_string(HapticEvent::JumpLand)     == "JumpLand");
+    CHECK(to_string(HapticEvent::DeathCrash)   == "DeathCrash");
+    CHECK(to_string(HapticEvent::NewHighScore) == "NewHighScore");
+    CHECK(to_string(HapticEvent::RetryTap)     == "RetryTap");
+    CHECK(to_string(HapticEvent::UIButtonTap)  == "UIButtonTap");
+}
+
 // ObstacleKind enum was eradicated in issue #1202/#1204 (per Fabian's
 // existential processing); each former value is now a zero-column tag
 // (ShapeGateTag/SplitPathTag/OnsetMarkerTag) and the magic_enum


### PR DESCRIPTION
Closes #1313.

## Summary

Adds the missing `to_string(HapticEvent)` per-enumerator test, symmetric to the existing `to_string(Shape)` test that has lived next to it since #1204. #1311 converted both helpers to `constexpr std::array<std::string_view, N>` lookups; the `static_assert` in each pins the table size, but the row contents can still drift silently on rename or reorder. The `Shape` test already protects against that drift — this PR brings `HapticEvent` to parity.

## Changes

`tests/test_helpers_and_functions.cpp` — one new `TEST_CASE` placed directly after `"ToString: Shape covers all shapes"`, one `CHECK` per `HapticEvent` enumerator:

```cpp
TEST_CASE("ToString: HapticEvent covers all events", "[ToString]") {
    CHECK(to_string(HapticEvent::ShapeShift)   == "ShapeShift");
    CHECK(to_string(HapticEvent::LaneSwitch)   == "LaneSwitch");
    CHECK(to_string(HapticEvent::JumpLand)     == "JumpLand");
    CHECK(to_string(HapticEvent::DeathCrash)   == "DeathCrash");
    CHECK(to_string(HapticEvent::NewHighScore) == "NewHighScore");
    CHECK(to_string(HapticEvent::RetryTap)     == "RetryTap");
    CHECK(to_string(HapticEvent::UIButtonTap)  == "UIButtonTap");
}
```

`HapticEvent` is already available transitively via `tests/test_helpers.h:15` (`#include "systems/haptics.h"`), so no new include lines are needed.

No production-code changes.

## Acceptance criteria (from #1313)

- [x] New `TEST_CASE("ToString: HapticEvent covers all events", "[ToString]")` added after the `Shape` block.
- [x] One `CHECK` per enumerator: `ShapeShift`, `LaneSwitch`, `JumpLand`, `DeathCrash`, `NewHighScore`, `RetryTap`, `UIButtonTap` (7 total — matches `kNameByEvent.size()` pinned by `static_assert`).
- [x] All tests pass: 933 → 934 test cases, 3133 → 3140 assertions.
- [x] Zero new warnings under `-Wall -Wextra -Werror`.
- [x] No change to `app/systems/haptics.h`.

## Validation

```
$ ./build.sh Release   # zero warnings
$ ./build/shapeshifter_tests --reporter=compact
All tests passed (3140 assertions in 934 test cases)
```

## References

- #1311 — converted `to_string(HapticEvent)` to a constexpr table lookup
- #1288 — original `pattern_for_event(HapticEvent)` table lookup precedent
- `tests/test_helpers_and_functions.cpp:138-143` — sibling `to_string(Shape)` test
