### PR TITLE
#1312 Scrub stale VMode/VerticalState/GamePhase-enum/screen_controllers refs from design-docs

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -204,19 +204,36 @@ struct Lane {
     float    lerp_t;       // 0.0..1.0 transition progress
 };
 
-/// Vertical movement (jump / slide / grounded). 12 bytes.
-/// Hot: read by collision_system, game_camera_system.
-enum class VMode : uint8_t {
-    Grounded = 0,
-    Jumping  = 1,
-    Sliding  = 2
+// Per-state vertical motion tables (issue #1202/#1204; Fabian existential
+// processing). Each former `VMode` value is its own zero/one-column
+// component on the player entity — absence of both means grounded
+// (no data needed). The old `VerticalState` god-struct and the `VMode`
+// enum were eradicated by these issues; see `app/components/player.h:68-88`
+// for the in-code rationale comment.
+//
+//   `Jumping` present  → entity is mid-jump  (timer + parabolic y_offset).
+//   `Sliding` present  → entity is mid-slide (timer; y_offset stays 0,
+//                        visual squash handled by the render system).
+//
+// Read by: collision_system (`try_get<Jumping>` for y_offset),
+//          game_camera_system, player_movement_system.
+
+struct Jumping {
+    float timer    = 0.0f;   // seconds remaining in the jump
+    float y_offset = 0.0f;   // visual offset from PLAYER_Y (negative = up)
 };
 
-struct VerticalState {
-    VMode    mode;
-    float    timer;        // time remaining in jump/slide
-    float    y_offset;     // visual offset from PLAYER_Y (negative = up)
+struct Sliding {
+    float timer = 0.0f;      // seconds remaining in the slide
 };
+
+// State transitions are component-table operations — no enum compare,
+// no `switch`:
+//   start jump:  reg.emplace<Jumping>(player, Jumping{JUMP_DURATION, 0.0f});
+//   end jump:    reg.remove<Jumping>(player);
+// `player_movement_system` runs one transform per table (one over the
+// `Jumping` view, one over the `Sliding` view); grounded entities have
+// neither row and are skipped without a discriminator check.
 ```
 
 ### 2.3 — HOT: Obstacle Core (iterated every frame for scroll + collision)
@@ -476,23 +493,27 @@ struct GoRightEvent {};
 ```cpp
 // components/game_state.h
 
-enum class GamePhase : uint8_t {
-    Title        = 0,
-    LevelSelect  = 1,
-    Playing      = 2,
-    Paused       = 3,
-    GameOver     = 4,
-    SongComplete = 5,
-    Settings     = 6,
-    Tutorial     = 7
-};
+// Per Fabian's existential processing (issue #1202/#1204), the former
+// `GamePhase` enum and the `GameState::phase` / `transition_pending` /
+// `next_phase` mirror fields have been eradicated. Each former enum value
+// is now a zero-column ctx tag in `app/tags/tags.h`:
+//
+//   GamePhaseTitleTag        GamePhaseLevelSelectTag
+//   GamePhasePlayingTag      GamePhasePausedTag
+//   GamePhaseGameOverTag     GamePhaseSongCompleteTag
+//   GamePhaseSettingsTag     GamePhaseTutorialTag
+//
+// The active phase is the lone present `GamePhase*Tag` on `reg.ctx()`
+// (exactly one at any time). Pending transitions use the parallel
+// `NextPhase*Tag` set; `app/systems/game_phase_transition.h` exposes
+// `enter_phase<...>()`, `request_phase_transition<...>()`, and
+// `is_phase_transition_pending()` — all dispatched on the tag type at
+// the *call site* (no runtime enum compare, no `switch`).
 
-/// Singleton: governs which systems run and screen transitions.
+/// Singleton: per-phase elapsed timer. Phase identity itself lives on the
+/// active `GamePhase*Tag` ctx slot (see above) — not on a field here.
 struct GameState {
-    GamePhase  phase;
-    float      phase_timer;          // seconds in current phase
-    bool       transition_pending;   // set to request a phase change
-    GamePhase  next_phase;           // destination of pending transition
+    float phase_timer = 0.0f;   // seconds in current phase
 };
 
 // End-screen menu choice — per-choice zero-column tables on registry.ctx().
@@ -502,18 +523,18 @@ struct EndChoiceLevelSelect {};
 struct EndChoiceMainMenu {};
 ```
 
-Active phase responsibilities:
+Active-phase responsibilities (the `GamePhase*Tag` whose presence selects the row):
 
-| Phase | Purpose |
+| Phase tag | Purpose |
 | --- | --- |
-| `Title` | Default boot/menu entry point. Routes to level select, settings, tutorial, or exit. |
-| `LevelSelect` | Lets the player choose level and difficulty before `setup_play_session`. |
-| `Playing` | Runs song playback, beat scheduling, player input, collision, scoring, energy, and HUD systems. |
-| `Paused` | Freezes gameplay update while preserving the current play session for resume. |
-| `GameOver` | Terminal failure screen after energy depletion/crash; freezes world and offers restart, level select, or main menu. |
-| `SongComplete` | Terminal success/results screen after the song finishes; offers restart, level select, or main menu. |
-| `Settings` | Menu phase for runtime settings such as audio/haptics/calibration. |
-| `Tutorial` | First-time/user-training phase that teaches controls and basic rhythm rules. |
+| `GamePhaseTitleTag` | Default boot/menu entry point. Routes to level select, settings, tutorial, or exit. |
+| `GamePhaseLevelSelectTag` | Lets the player choose level and difficulty before `setup_play_session`. |
+| `GamePhasePlayingTag` | Runs song playback, beat scheduling, player input, collision, scoring, energy, and HUD systems. |
+| `GamePhasePausedTag` | Freezes gameplay update while preserving the current play session for resume. |
+| `GamePhaseGameOverTag` | Terminal failure screen after energy depletion/crash; freezes world and offers restart, level select, or main menu. |
+| `GamePhaseSongCompleteTag` | Terminal success/results screen after the song finishes; offers restart, level select, or main menu. |
+| `GamePhaseSettingsTag` | Menu phase for runtime settings such as audio/haptics/calibration. |
+| `GamePhaseTutorialTag` | First-time/user-training phase that teaches controls and basic rhythm rules. |
 
 ### 2.9 — Legacy: Difficulty (removed)
 
@@ -608,7 +629,8 @@ PlayerTag            0     HOT        collision/filter
 PlayerShape          8     HOT        shape_window, collision, render, player_action
 ShapeWindow         24     HOT        shape_window, input dispatcher, collision
 Lane                 8     HOT        collision, render, player_action
-VerticalState       12     HOT        collision, render, player_action
+Jumping              8     HOT        present when mid-jump; collision (y_offset), camera, movement
+Sliding              4     HOT        present when mid-slide; movement, render
 ObstacleTag          0     HOT        scroll, collision, cleanup
 Obstacle             4     WARM       collision, miss_detection, scoring
 RequiredShape        1     WARM       collision, scoring
@@ -632,7 +654,9 @@ SINGLETONS (ctx)
 InputState          var    per-frame  input_system internal touch/mouse state
 entt::dispatcher    var    per-frame  input/UI/test-player enqueue semantic events, game_state drains
 ButtonPress/Go      var    per-frame  dispatcher payloads handled by game_state/player input listeners
-GameState           12     per-frame  game_state_system
+GameState            4     per-frame  game_state_system (phase_timer only; phase identity is a `GamePhase*Tag` on ctx)
+GamePhase*Tag        0     per-frame  active-phase mirror; one present at a time (see `app/tags/tags.h`)
+NextPhase*Tag        0     per-frame  pending-transition mirror; drained by `clear_next_phase_tags`
 BeatMap             var    session    setup_play_session (write), beat_scheduler (read)
 SongState           48     per-frame  song_playback/beat_scheduler
 EnergyState         12     per-frame  energy_system (write), ui_render (read)
@@ -811,20 +835,23 @@ owns `ScorePopup::remaining`. Obstacle destruction is handled by
      End screens can restart, return to LEVEL_SELECT, or return to TITLE.
 ```
 
-`GameState::transition_pending` and `next_phase` are the canonical transition
-queue. UI controllers and input handlers request a phase by setting those
-fields; `game_state_system` drains the request, clears stale pointer state, and
-then enters the requested phase. `enter_phase` updates `phase` and
-`phase_timer`.
+The `NextPhase*Tag` ctx slots are the canonical transition queue (per
+issue #1202/#1204; they replace the former `GameState::transition_pending`
+boolean and `GameState::next_phase` enum field). UI controllers and input
+handlers request a phase by calling
+`request_phase_transition<NextPhase*Tag>(reg)`; `game_state_system` drains
+the request via `is_phase_transition_pending(reg)`, clears stale pointer
+state, and then enters the requested phase. `enter_phase<PhaseTag>(reg)`
+swaps the active `GamePhase*Tag` and resets `GameState::phase_timer`.
 
-`Tutorial` is a defined phase with a controller, but current shipped screens do
+`Tutorial` is a defined phase tag with a screen, but current shipped screens do
 not route into it. Its continue action transitions to `Playing`.
 
 ### Transition Summary
 
 | From | To | Trigger / owner | Notes |
 |------|----|-----------------|-------|
-| Title | LevelSelect | Title screen body/start action | Defers through `transition_pending`. |
+| Title | LevelSelect | Title screen body/start action | Defers through `request_phase_transition<NextPhaseLevelSelectTag>`. |
 | Title | Settings | Title screen gear action | Settings exits back to Title. |
 | LevelSelect | Playing | `LevelSelectState::confirmed` | `setup_play_session` loads the selected level/difficulty. |
 | Playing | Paused | HUD pause, keyboard pause, or app background | Gameplay entities remain intact. |
@@ -864,7 +891,7 @@ In code, reusable construction lives in `app/entities/` factory functions
 │ PlayerShape        { current: Hexagon, morph_t: 1.0 }     │
 │ ShapeWindow        { target: Hexagon, phase: Idle, ... }  │
 │ Lane               { current: 1, target: -1, lerp_t: 1 } │
-│ VerticalState      { mode: Grounded, timer: 0, y_off: 0 }│
+│ (Jumping/Sliding absent → grounded; rows added on demand) │
 │ Color              { r: 80, g: 180, b: 255, a: 255 }     │
 │ DrawSize           { w: 64, h: 64 }                       │
 │ TagWorldPass       (tag, 0 bytes)                         │
@@ -1008,12 +1035,8 @@ int main(int argc, char* argv[]) {
     reg.ctx().emplace<InputState>();
     reg.ctx().emplace<entt::dispatcher>();
     wire_input_dispatcher(reg);
-    reg.ctx().emplace<GameState>(GameState{
-        .phase = GamePhase::Title,
-        .phase_timer = 0.0f,
-        .transition_pending = false,
-        .next_phase = GamePhase::Title
-    });
+    reg.ctx().emplace<GameState>(GameState{ .phase_timer = 0.0f });
+    enter_phase<GamePhaseTitleTag>(reg);   // emplaces the active-phase tag
     reg.ctx().emplace<AudioQueue>();
 
     // Load audio assets, textures, fonts into ctx()...
@@ -1254,10 +1277,10 @@ int main(int argc, char* argv[]) {
     │       }                                                │      lerp_t: 0.0 }
     │   }                                                    │
     │   player_input_handle_go_up(GoUpEvent) {               │
-    │       if (VertState.mode == Grounded) {                │──▶ VerticalState
-    │           VertState.mode  = Jumping;                   │    { mode: Jumping,
-    │           VertState.timer = JUMP_DURATION;             │      timer: 0.45,
-    │       }                                                │      y_offset: 0.0 }
+    │       if (!reg.all_of<Jumping, Sliding>(player)) {     │──▶ Jumping (new row)
+    │           reg.emplace<Jumping>(player,                 │    { timer: 0.45,
+    │              Jumping{JUMP_DURATION, 0.0f});            │      y_offset: 0.0 }
+    │       }                                                │
     │   }                                                    │
     │   // ... GoRightEvent, GoDownEvent handlers similar ...│
     │   }                                                    │
@@ -1328,7 +1351,7 @@ This entire game state fits in L1 cache (~32-64 KB).
   │
   │  □ PlayerShape     (shape window + collision + render, every frame, R)
   │  □ Lane            (collision + render, every frame, R)
-  │  □ VerticalState   (collision + render, every frame, R)
+  │  □ Jumping/Sliding (present only when mid-jump/slide; movement + camera + collision, R+W)
   │  □ Obstacle        (collision + scoring, every frame, R)
   │
   │  ○ RequiredShape   (collision + scoring, per-obstacle, R)
@@ -1411,12 +1434,15 @@ With only 5–15 obstacles on screen and 1 player, brute-force is optimal:
 ```cpp
 void collision_system(entt::registry& reg, float dt) {
     // Get player state (single entity)
-    auto player_view = reg.view<PlayerTag, WorldPosition, PlayerShape, Lane, VerticalState>();
+    auto player_view = reg.view<PlayerTag, WorldPosition, PlayerShape, Lane>();
     // Early-out: exactly one player
-    auto [p_ent, p_pos, p_shape, p_lane, p_vstate] = *player_view.each().begin();
+    auto [p_ent, p_pos, p_shape, p_lane] = *player_view.each().begin();
 
+    // Grounded entities have neither Jumping nor Sliding; only Jumping
+    // carries a y_offset (Sliding leaves it at 0). No enum compare.
+    const auto* p_jump = reg.try_get<Jumping>(p_ent);
     float player_x = p_pos.position.x;
-    float player_y = p_pos.position.y + p_vstate.y_offset;
+    float player_y = p_pos.position.y + (p_jump ? p_jump->y_offset : 0.0f);
 
     // Linear scan of obstacles — 15 entities max
     auto obs_view = reg.view<ObstacleTag, WorldPosition, Obstacle>(
@@ -1434,10 +1460,10 @@ void collision_system(entt::registry& reg, float dt) {
             reg.emplace<ScoredTag>(entity);
             // scoring_system will pick this up next
         } else if (dy >= 0.0f) {
-            // Obstacle has reached player and shape doesn't match → CRASH
-            auto& gs = reg.ctx().get<GameState>();
-            gs.transition_pending = true;
-            gs.next_phase = GamePhase::GameOver;
+            // Obstacle has reached player and shape doesn't match → CRASH.
+            // Deferred per #482: request the swap; game_state_system
+            // performs it on the next tick.
+            request_phase_transition<NextPhaseGameOverTag>(reg);
             return;  // stop checking — game over
         }
     }
@@ -1509,15 +1535,17 @@ functions above.
 void render_frame_pseudocode(entt::registry& reg, float alpha) {
     ClearBackground({18, 18, 24, 255});
 
-    auto phase = reg.ctx().get<GameState>().phase;
+    const auto& ctx = reg.ctx();
 
     // ── Layer 0: Background ───────────────────────────
     draw_background();
     draw_lane_lines();
 
     // ── Layer 1: Game entities ────────────────────────
-    if (phase == GamePhase::Playing || phase == GamePhase::Paused
-        || phase == GamePhase::GameOver) {
+    // Per-tag world-pass gating — no enum compare, no `switch`.
+    if (ctx.contains<GamePhasePlayingTag>()
+        || ctx.contains<GamePhasePausedTag>()
+        || ctx.contains<GamePhaseGameOverTag>()) {
 
         // Obstacles (5-15 entities — draw in pool order, no sort needed)
         {
@@ -1530,11 +1558,13 @@ void render_frame_pseudocode(entt::registry& reg, float alpha) {
         // Player (1 entity)
         {
             auto view = reg.view<PlayerTag, WorldPosition, PlayerShape,
-                                  Lane, VerticalState, Color, DrawSize>();
-            for (auto [e, pos, shape, lane, vs, col, sz] : view.each()) {
-                // Interpolate position for smooth sub-frame rendering
+                                  Lane, Color, DrawSize>();
+            for (auto [e, pos, shape, lane, col, sz] : view.each()) {
+                // Interpolate position for smooth sub-frame rendering.
+                // Only Jumping carries a y_offset; absence = grounded.
+                const auto* jump = reg.try_get<Jumping>(e);
                 float render_x = pos.position.x;  // lane lerp already applied
-                float render_y = pos.position.y + vs.y_offset;
+                float render_y = pos.position.y + (jump ? jump->y_offset : 0.0f);
                 draw_player_shape(render_x, render_y,
                                   shape, col, sz);
             }
@@ -1564,7 +1594,7 @@ void render_frame_pseudocode(entt::registry& reg, float alpha) {
     }
 
     // ── Layer 3: HUD ──────────────────────────────────
-    if (phase == GamePhase::Playing || phase == GamePhase::Paused) {
+    if (ctx.contains<GamePhasePlayingTag>() || ctx.contains<GamePhasePausedTag>()) {
         auto& score  = reg.ctx().get<ScoreState>();
         auto& energy = reg.ctx().get<EnergyState>();
         draw_hud_score(score);
@@ -1574,12 +1604,16 @@ void render_frame_pseudocode(entt::registry& reg, float alpha) {
     }
 
     // ── Overlays ──────────────────────────────────────
-    if (phase == GamePhase::Title) {
+    // Each per-phase overlay is its own ctx.contains<> check — same
+    // existential-table dispatch as the world-pass gate above.
+    if (ctx.contains<GamePhaseTitleTag>()) {
         draw_title_screen(reg);
-    } else if (phase == GamePhase::Paused) {
+    }
+    if (ctx.contains<GamePhasePausedTag>()) {
         draw_pause_overlay();
-    } else if (phase == GamePhase::GameOver) {
-        auto& gs = reg.ctx().get<GameState>();
+    }
+    if (ctx.contains<GamePhaseGameOverTag>()) {
+        const auto& gs = reg.ctx().get<GameState>();
         draw_game_over(reg, gs.phase_timer);
     }
 
@@ -1599,7 +1633,9 @@ app/
 ├── components/                  ← all component structs
 │   ├── transform.h              ← WorldPosition, MotionVelocity
 │   ├── window_phase.h           ← WindowPhase (shared by player.h and rhythm.h)
-│   ├── player.h                 ← PlayerTag, PlayerShape, ShapeWindow, Lane, VerticalState
+│   ├── player.h                 ← PlayerTag, PlayerShape, ShapeWindow, Lane,
+│   │                              Jumping, Sliding (per-state vertical motion tables;
+│   │                              absence of both = grounded)
 │   ├── obstacle.h               ← obstacle tags (ScoredTag, MissTag,
 │   │                              ResolvedObstacleTag, NonScorableTag,
 │   │                              OnsetMarkerTag) and requirements
@@ -1608,7 +1644,9 @@ app/
 │   ├── input_events.h           ← per-shape ShapePress*Event, per-action
 │   │                              Menu*Event, per-direction Go*Event
 │   │                              (in systems/, #1277/#1278/#1279)
-│   ├── game_state.h             ← GameState, GamePhase, LevelSelectState
+│   ├── game_state.h             ← GameState (phase_timer only), LevelSelectState,
+│   │                              TerminalResultState. Phase identity lives on
+│   │                              `GamePhase*Tag` ctx slots in `app/tags/tags.h`.
 │   ├── rendering.h              ← DrawSize, ScreenPosition; back-compat shim
 │   │                              for the camera/mesh splits (issue #1194)
 │   ├── particle.h               ← ParticleData, ParticleTag

--- a/design-docs/game-flow.md
+++ b/design-docs/game-flow.md
@@ -39,10 +39,17 @@
 
 ## 1. MASTER SCREEN FLOW MAP
 
-> **Source of truth:** `app/components/game_state.h` defines the
-> `GamePhase` enum; `app/ui/screen_controllers/*` and
-> `app/systems/game_state_system.cpp` define the actual transitions.
-> The diagram below mirrors shipped routing as of Round 6 audit.
+> **Source of truth:** the active phase is carried by per-phase ctx tags
+> (`GamePhaseTitleTag` / `GamePhaseLevelSelectTag` / `GamePhasePlayingTag` /
+> `GamePhasePausedTag` / `GamePhaseGameOverTag` / `GamePhaseSongCompleteTag` /
+> `GamePhaseSettingsTag` / `GamePhaseTutorialTag` per `app/tags/tags.h`);
+> the active phase is the lone present `GamePhase*Tag` on the registry
+> ctx. Transitions live in `app/systems/game_state_routing.cpp` (per-event
+> handlers that call `request_phase_transition<NextPhase*Tag>`),
+> `app/systems/game_phase_transition.{h,cpp}` (the swap mechanic), and
+> `app/systems/screen_lifecycle_system.{h,cpp}` (per-tag spawn/despawn
+> dispatch into `app/ui/generated/screen_spawners.h`).
+> The diagram below mirrors current shipped routing.
 
 ```
                           ┌─────────────────┐
@@ -104,44 +111,54 @@
                           (back to Title)
 ```
 
-> **Tutorial phase.** `GamePhase::Tutorial` is reached from Level Select
+> **Tutorial phase.** `GamePhaseTutorialTag` is reached from Level Select
 > when `SettingsState::ftue_run_count == 0`. Pressing START on the
 > tutorial marks FTUE complete, persists settings, and starts gameplay.
 > Completed FTUE profiles skip Tutorial and go directly to Playing.
 
 ### State Enumeration (for ECS implementation)
 
-> **Source of truth:** `app/components/game_state.h:6-15`. If this list
-> drifts from the header, the header wins.
+> **Source of truth:** `app/tags/tags.h` § "Game phase mirrors"
+> (`GamePhase*Tag` set). If this list drifts from the header, the
+> header wins.
 
+```cpp
+struct GamePhaseTitleTag        {};   // main menu
+struct GamePhaseLevelSelectTag  {};   // song/difficulty selection
+struct GamePhasePlayingTag      {};   // core gameplay
+struct GamePhasePausedTag       {};   // overlay on gameplay
+struct GamePhaseGameOverTag     {};   // results screen
+struct GamePhaseSongCompleteTag {};   // song finished successfully
+struct GamePhaseSettingsTag     {};   // settings screen (entered from Title gear)
+struct GamePhaseTutorialTag     {};   // FTUE/tutorial run before first gameplay
 ```
-  enum class GamePhase : uint8_t {
-      Title        = 0,   // main menu
-      LevelSelect  = 1,   // song/difficulty selection
-      Playing      = 2,   // core gameplay
-      Paused       = 3,   // overlay on gameplay
-      GameOver     = 4,   // results screen
-      SongComplete = 5,   // song finished successfully
-      Settings     = 6,   // settings screen (entered from Title gear)
-      Tutorial     = 7    // FTUE/tutorial run before first gameplay
-  };
+
+The active phase is the lone `GamePhase*Tag` present on `reg.ctx()` —
+exactly one is present at any time. A parallel `NextPhase*Tag` set (same
+names with `NextPhase` prefix) holds the pending-transition target; see
+`app/systems/game_phase_transition.h` for the `enter_phase<...>()` /
+`request_phase_transition<...>()` / `is_phase_transition_pending()` API.
 ```
 
-Shipped transitions, by controller, as of Round 6 audit:
+Shipped transitions (input events flow through dispatcher sinks in
+`app/systems/game_state_routing.cpp`, which call
+`request_phase_transition<NextPhase*Tag>`; the actual swap runs in
+`game_state_system` on the next tick per the deferred-transition
+pattern of issue #482):
 
-- `Title → LevelSelect` — body tap (`title_screen_controller.cpp:62-72`).
-- `Title → Settings` — gear-icon tap (same controller).
-- `Settings → Title` — back action (`settings_screen_controller.cpp:101-104` and `:141-144`).
+- `Title → LevelSelect` — confirm/body tap (`game_state_handle_confirm`).
+- `Title → Settings` — gear-icon tap (settings entrypoint event).
+- `Settings → Title` — back action.
 - `LevelSelect → Tutorial` — song selection when FTUE is incomplete.
 - `LevelSelect → Playing` — song selection after FTUE is complete.
-- `Playing ↔ Paused` — pause button / resume.
+- `Playing ↔ Paused` — pause button / resume (any direction unpauses).
 - `Paused → Title` — quit action.
-- `Playing → GameOver` — energy reaches zero.
-- `Playing → SongComplete` — song reaches end.
-- `GameOver | SongComplete → Playing` — restart action.
-- `GameOver | SongComplete → LevelSelect` — level-select action.
-- `GameOver | SongComplete → Title` — main-menu action.
-- `Tutorial → Playing` — START marks FTUE complete and begins the run.
+- `Playing → GameOver` — energy reaches zero (`energy_system` requests it).
+- `Playing → SongComplete` — song reaches end (`game_state_terminal_phase_system`).
+- `GameOver | SongComplete → Playing` — restart end-screen choice.
+- `GameOver | SongComplete → LevelSelect` — level-select end-screen choice.
+- `GameOver | SongComplete → Title` — main-menu end-screen choice.
+- `Tutorial → Playing` — `game_state_handle_confirm` marks FTUE complete and begins the run.
 
 ---
 
@@ -179,10 +196,10 @@ and screen width (W) for portrait mode (9:16 aspect ratio target).
 ### 2a-bis. LEVEL SELECT SCREEN
 
 After tapping "start" on the title screen, the player is taken to the
-**LevelSelect** screen (`GamePhase::LevelSelect`). This screen presents
-a list of available songs and difficulty options. The layout is defined in
-`content/ui/screens/level_select.rgl`. Confirming a selection transitions
-to `GamePhase::Playing`.
+**LevelSelect** screen (active `GamePhaseLevelSelectTag`). This screen
+presents a list of available songs and difficulty options. The layout
+is defined in `content/ui/screens/level_select.rgl`. Confirming a
+selection transitions to `GamePhasePlayingTag`.
 
 ---
 
@@ -562,7 +579,7 @@ Terminal split:
 ## 3. FIRST-TIME USER EXPERIENCE (FTUE)
 
 > **Implementation status:** the shipped tutorial is the single-screen
-> **Quick Start** flow (`GamePhase::Tutorial`, `content/ui/screens/tutorial.rgl`).
+> **Quick Start** flow (active `GamePhaseTutorialTag`, `content/ui/screens/tutorial.rgl`).
 > The five-run adaptive FTUE design below is aspirational/archived and is not
 > routed by the current controllers.
 


### PR DESCRIPTION
## Summary

Scrubs `design-docs/architecture.md` and `design-docs/game-flow.md` of references to architecture that #1202/#1204 (Fabian existential processing) and #1308 (delete `app/ui/screen_controllers/`) explicitly rejected. Closes #1312.

The README pins these two files as "source of truth — check here before implementing any feature", so leaving them describing the old `VMode`/`VerticalState` god-struct, the `GamePhase` enum + `GameState::{phase, transition_pending, next_phase}` god-struct, and the deleted `screen_controllers/` folder is a contributor trap.

## What changed

**`architecture.md`**

- **§2.2** — Replaced `enum class VMode` + `struct VerticalState` with the per-state `Jumping` / `Sliding` component tables (absence of both = grounded). Shows the `emplace`/`remove` transition mechanic, the read-set for each system, and cites `app/components/player.h:68-88` + #1202/#1204 per AC bullet 1.
- **§2.8** — Replaced `enum class GamePhase` + `struct GameState { GamePhase phase; bool transition_pending; GamePhase next_phase; ... }` with the per-tag `GamePhase*Tag` / `NextPhase*Tag` ctx model and the minimal `struct GameState { float phase_timer; }`. Rewrote the phase-responsibility table to key on the tag name.
- **Downstream sweeps** — Component summary table (`Jumping`/`Sliding` rows, `GameState` width updated, `GamePhase*Tag`/`NextPhase*Tag` rows added), §5.1 archetype block, hot/cold classification chart, main-loop registry init (`enter_phase<GamePhaseTitleTag>` instead of the four-field god-struct literal), GoUp input handler pseudocode (`reg.emplace<Jumping>(player, {…})` instead of the VMode mutation), §8.5 `collision_system` pseudocode (player view drops `VerticalState`, uses `try_get<Jumping>` for `y_offset`, replaces `gs.transition_pending = true; gs.next_phase = GamePhase::GameOver` with `request_phase_transition<NextPhaseGameOverTag>(reg)`), §8.6 render-frame pseudocode (`ctx.contains<GamePhaseXTag>()` instead of `phase == GamePhase::X`), §8.7 directory listing (`player.h` adds `Jumping`/`Sliding`; `game_state.h` drops `GamePhase`), and the Transition Summary table prose.

**`game-flow.md`**

- **§1 preamble** — Per AC bullet 2: `GamePhase` enum → `GamePhase*Tag` set (with the full eight-tag list and `app/tags/tags.h` citation); `app/ui/screen_controllers/*` → `app/systems/game_state_routing.cpp` + `app/systems/game_phase_transition.{h,cpp}` + `app/systems/screen_lifecycle_system.{h,cpp}` + reference to `app/ui/generated/screen_spawners.h`; dropped the stale "Round 6 audit" qualifier.
- **State Enumeration block** — Replaced the `enum class GamePhase` definition with the `GamePhase*Tag` struct list keyed off the `app/tags/tags.h` "Game phase mirrors" section.
- **Shipped transitions list** — Re-routed through `game_state_routing.cpp` event sinks (`game_state_handle_confirm`, `game_state_handle_restart`, etc.) and `game_state_terminal_phase_system` instead of the deleted `*_screen_controller.cpp` files.
- **LevelSelect prose & Quick Start FTUE caption** — `GamePhase::LevelSelect` / `GamePhase::Playing` / `GamePhase::Tutorial` → corresponding `GamePhase*Tag`.

## Verification

```
$ rg -n 'VMode|VerticalState|screen_controllers|GamePhase::|enum class GamePhase|gs\.next_phase|gs\.transition_pending' design-docs/architecture.md design-docs/game-flow.md
design-docs/architecture.md:208:// processing). Each former `VMode` value is its own zero/one-column
design-docs/architecture.md:210:// (no data needed). The old `VerticalState` god-struct and the `VMode`
```

Only the two surviving mentions are inside the §2.2 migration-note block — which AC bullet 1 explicitly requires for the #1202/#1204 citation ("the former VMode enum and VerticalState god-struct were eradicated by these issues"). All other sections of both files are clean per AC bullet 3.

Build + tests: green (`cmake --build build` + `./build/shapeshifter_tests` → `All tests passed (3140 assertions in 934 test cases)`).

## References

- Closes #1312
- #1202 / #1204 — Migrate control-flow enums to tag-based existential processing
- #1308 — Delete `app/ui/screen_controllers/`
- `.squad/decisions.md` § "DoD source-text grounding (Fabian)" Principles 1 + 3
