### PR TITLE
#1318 Scrub stale screen_controllers/ refs from 4 remaining design-docs (follow-up to #1315)

### DIFF
--- a/design-docs/feature-specs.md
+++ b/design-docs/feature-specs.md
@@ -204,11 +204,12 @@ void wire_input_dispatcher(entt::registry& reg);
 // Entity-driven UI dispatch (issue #1287, completed in #1297): each
 // migrated screen — including the gameplay HUD — relies on
 // `ui_update_system` to hit-test `UiPosition`/`UiBounds`/`OnPress`
-// entities and dispatch the matching action. The legacy
-// `screen_controllers/*_screen_controller.cpp` raygui producers are
-// being removed in lockstep. Gameplay HUD lane buttons (Circle /
-// Square / Triangle) emit `ShapePress*Event`s through this same
-// system; the Pause button enqueues a `NextPhasePausedTag` phase
+// entities and dispatch the matching action. The screen-spawner
+// functions in `app/ui/generated/<screen>_screen.cpp` (codegen output)
+// emplace those entities at phase entry; the prior per-screen raygui
+// producer layer was deleted in #1308. Gameplay HUD lane buttons
+// (Circle / Square / Triangle) emit `ShapePress*Event`s through this
+// same system; the Pause button enqueues a `NextPhasePausedTag` phase
 // transition.
 void ui_update_system(entt::registry& reg);
 

--- a/design-docs/raygui-rguilayout-ui-spec.md
+++ b/design-docs/raygui-rguilayout-ui-spec.md
@@ -2,39 +2,38 @@
 
 ## Status
 
-Implemented. All migration phases described below have shipped; this spec now documents the as-built rguilayout / raygui screen-controller architecture.
+Implemented. All migration phases described below have shipped; this spec now documents the as-built rguilayout / raygui entity-spawner UI architecture.
 
-This spec replaced the legacy JSON-driven UI layout path with raygui controls and rguilayout-authored/generated layout files. The current implementation lives under `app/ui/generated/`, `app/ui/screen_controllers/`, and `app/systems/ui_render_system.cpp` (raygui screen-controller dispatch + render-pass glue).
+This spec replaced the legacy JSON-driven UI layout path with raygui controls and rguilayout-authored/generated layout files. The current implementation lives under `app/ui/generated/<screen>_screen.cpp` (per-screen spawner functions emitted by `tools/rguilayout/` codegen), `app/systems/screen_lifecycle_system.{h,cpp}` (per-tag spawn/despawn dispatch), `app/systems/ui_render_system.cpp` (single render pass over `UiLabelTag` / `UiButtonTag` / `UiDummyRecTag` entities), and `app/systems/ui_update_system.cpp` (button-action dispatch). An intermediate per-screen render-callback folder used during migration was deleted in #1308 once #1287 (entity-driven UI) completed.
 
-Current runtime note: proximity rings are active HUD timing feedback in
-`gameplay_hud_screen_controller.cpp` and are specified by
+Current runtime note: proximity rings are active HUD timing feedback driven by `app/systems/approach_ring_envelope_system.cpp` (which writes per-button `ApproachRing` components consumed by `app/systems/ui_render_system.cpp`) and are specified by
 `design-docs/rhythm-spec.md`. The migration preserved this behavior; the
 historical `approach_ring` JSON layout fields (which lived in the now-removed
 `content/ui/screens/gameplay.json`) were intentionally not ported and are not
 the active C++ proximity-ring behavior.
 
-Current directive: the rguilayout application is vendored under `tools/rguilayout/`; `.rgl` files have replaced the legacy `content/ui` JSON layout sources; exported `.h` files live under `app/ui/generated/` (the export pattern in use today is header-only — no `.c` exports are committed); the headers are compiled in via the screen-controller `.cpp` files under `app/ui/screen_controllers/`.
+Current directive: the rguilayout application is vendored under `tools/rguilayout/`; `.rgl` files have replaced the legacy `content/ui` JSON layout sources; codegen runs at CMake configure time and writes per-screen entity-spawner `.cpp` files plus `screen_spawners.h` declarations under `app/ui/generated/`; the screen spawners are linked into `shapeshifter_lib` and called by `screen_lifecycle_system` whenever the active `GamePhase*Tag` mirror changes.
 
 The Excalidraw tool currently returns an empty scene, so Excalidraw is not a usable source of truth for this spec. If Excalidraw is restored later, it should be used as visual reference only; rguilayout `.rgl` files remain the authoring source for compiled UI layout.
 
 ## Goals
 
-1. Replace hand-authored runtime JSON UI layout files with rguilayout `.rgl` authoring files and generated header exports compiled in via screen controllers.
+1. Replace hand-authored runtime JSON UI layout files with rguilayout `.rgl` authoring files and codegen-emitted entity-spawner sources linked into `shapeshifter_lib`.
 2. Use raygui for menu, overlay, settings, pause, and HUD UI controls where appropriate.
-3. Keep layout geometry contained in rguilayout exported files. Do not mirror exported rectangles, anchors, widget IDs, or hit targets into ECS components, ECS entities, or `reg.ctx()` layout caches.
-4. Preserve existing `GamePhase`-driven screen-controller dispatch and dispatcher-driven game commands.
+3. Keep layout geometry contained in rguilayout exported files. Do not mirror exported rectangles, anchors, widget IDs, or hit targets into hand-written ECS layout caches; the rguilayout codegen IS the entity-spawner contract.
+4. Preserve `GamePhase*Tag`-driven screen lifecycle (active tag → matching entity set) and dispatcher-driven game commands (UI button presses → semantic events).
 5. Keep UI geometry contained in generated rguilayout exports. The legacy duplicators (`ui_layout_cache.h`, `ui_button_spawner.h`, and the `UIElementTag` / `UIText` / `UIButton` / `UIShape` widget components) have already been removed; do not re-introduce equivalent project-owned layout structures.
 
 ## Non-goals
 
 - Do not change gameplay scoring, energy, input semantics, level selection rules, or song result computation.
 - Do not re-introduce the stale `approach_ring` layout data that lived in the removed `content/ui/screens/gameplay.json`. Preserve the active C++ proximity-ring HUD behavior unless a separate gameplay/design decision removes it.
-- Do not create custom ECS layout components/entities to represent rguilayout data.
-- Do not require rguilayout to be installed in CI or at runtime (CI does not run the authoring tool).
+- Do not create hand-written ECS layout components/entities to represent rguilayout data; the codegen-emitted spawner is the single producer of UI entities.
+- Do not require rguilayout to be installed in CI or at runtime (CI does not run the authoring tool — codegen output is committed).
 
 ## Core decision: exported files own layout data
 
-The rguilayout export is the runtime boundary for UI layout data. Generated headers are committed under `app/ui/generated/` and consumed by screen controllers under `app/ui/screen_controllers/`.
+The rguilayout export is the runtime boundary for UI layout data. Generated headers and per-screen entity-spawner sources are committed under `app/ui/generated/` and called by `app/systems/screen_lifecycle_system.cpp`.
 
 The rguilayout tool itself lives in:
 
@@ -47,70 +46,75 @@ For each migrated screen, commit:
 | File | Role | Runtime behavior |
 |---|---|---|
 | `content/ui/screens/<screen>.rgl` | Editable rguilayout source replacing `content/ui/screens/<screen>.json` | Not compiled |
-| `app/ui/generated/<screen>_layout.h` (e.g. `title_layout.h`) | Generated C/C++ header with `GuiLayout_*` symbols, anchors, and a `<Screen>LayoutState` struct | Header-only; included by the matching screen controller `.cpp` and compiled in transitively |
+| `app/ui/generated/<screen>_screen.cpp` (e.g. `title_screen.cpp`) | Codegen-emitted C++ source defining `spawn_<screen>_screen(reg)` / `despawn_<screen>_screen(reg)`. Each spawner emplaces one entity per control row from the `.rgl`, carrying atomic `UiPosition` / `UiBounds` / `UiLabel` (+ `OnPress` for buttons) plus a per-screen tag and per-kind tag (`UiLabelTag` / `UiButtonTag` / `UiDummyRecTag`). | Linked into `shapeshifter_lib`; called by `screen_lifecycle_system` when the active `GamePhase*Tag` ctx mirror changes |
+| `app/ui/generated/screen_spawners.h` | Forward declarations of every `spawn_*` / `despawn_*` pair emitted by codegen, plus the consuming-system contract comment. | Single header included by `screen_lifecycle_system.cpp` |
 
-The current export pattern is header-only — there are no committed generated `.c` files. The screen controller TU that includes the layout header acts as the implementation owner.
+The codegen pattern is source-emitting — there are no separate per-screen layout `.h` files. The spawner `.cpp` files compile as ordinary translation units and own their literal rectangles, anchors, and label strings directly.
 
 Recommendation: keep screen layouts under `content/ui/screens/*.rgl` because the existing split already stores screen JSON in `content/ui/screens/` and keeps `content/ui/routes.json` at the root. Use root-level `content/ui/*.rgl` only if a future non-screen/global layout source is introduced. Route data is not layout geometry; do not replace `routes.json` with an `.rgl` unless routing is moved to another non-layout source.
 
-The generated headers contain the runtime layout geometry and generated `GuiLayout_*`-style APIs. Hand-written code may call generated APIs and pass dynamic state/text into them, but it must not copy generated rectangles into project-owned structs or ECS storage.
+The generated spawners produce the runtime UI entity set — one entity per control. Hand-written code may mutate those entities' atomic components (e.g. `UiLabel.text` for dynamic score text via per-system bind passes such as `gameplay_hud_bind_system`), but it must not create or destroy UI entities outside the spawner contract.
 
 Disallowed:
 
-- `RaguiAnchors<ScreenTag>` or similar ECS/ctx anchor structs.
+- `RaguiAnchors<ScreenTag>` or similar hand-written ECS/ctx anchor structs.
 - Rebuilding `HudLayout`, `LevelSelectLayout`, or `OverlayLayout` from rguilayout constants.
-- `UIElementTag`-style entities for generated widgets.
+- Hand-written widget-entity spawners outside `app/ui/generated/`.
 - Legacy UI hit-test entities whose only purpose is raygui widget hit testing.
 - Hand-written normalized-coordinate tables that duplicate `.rgl` data.
 
 Allowed:
 
 - Existing game/menu state in ECS or ctx: active phase/screen, score, high score, energy, selected song, selected difficulty, settings values, dispatcher/services.
-- Thin non-ECS screen controllers that include generated headers, call generated layout APIs, bind runtime text/state, apply platform guards, and translate raygui return values into existing events.
-- Custom raygui-style controls implemented as drawing/input functions, provided their placement comes from generated rguilayout exports and not duplicated ECS layout state.
+- Per-screen bind systems that read game state and write into the spawner-emitted entities' `UiLabel` / `UiBounds` / per-button colour overrides (see `gameplay_hud_bind_system`, `game_over_scoreboard_bind_system`).
+- Custom raygui-style draw functions invoked from `ui_render_system` for non-text controls (e.g. shape buttons, energy bar), provided their placement comes from the spawner-emitted `UiPosition` / `UiBounds` on each entity and not duplicated layout state.
 
 ## Runtime architecture
 
 ```text
 tools/rguilayout/
         |
-        | author/edit/export on developer machine
+        | author/edit on developer machine
         v
 content/ui/screens/<screen>.rgl
         |
-        | export generated code
+        | codegen.py emits per-screen spawner source
+        | (runs at CMake configure time)
         v
-app/ui/generated/<screen>_layout.h
+app/ui/generated/<screen>_screen.cpp + screen_spawners.h
         |
-        | included by the matching screen controller TU
+        | linked into shapeshifter_lib
         v
-app/ui/screen_controllers/<screen>_screen_controller.cpp
+screen_lifecycle_system (app/systems/screen_lifecycle_system.cpp)
         |
-        | called by UI render path
+        | invokes spawn_<screen>_screen(reg) when the matching
+        | GamePhase*Tag becomes active; despawn_<screen>_screen(reg)
+        | when it deactivates
         v
-ui_render_system()
+UiLabelTag / UiButtonTag / UiDummyRecTag entities in the registry
         |
-        | raygui return values become existing ButtonPressEvent / navigation actions
+        | per-frame
         v
-existing dispatcher + game state systems
+ui_render_system (single render pass over UI entities)
+ui_update_system (touch → OnPress dispatch → game commands)
 ```
 
-Screen controllers and `ui_render_system` are responsible for screen dispatch and widget interaction. They do not load JSON, spawn widget entities, or populate layout caches for rguilayout screens.
+The screen-lifecycle table in `screen_lifecycle_system.cpp` maps each `GamePhase*Tag` to one `(spawn, despawn)` row. There is no central `switch (phase)`; convergence runs once per frame and short-circuits when the entity-set membership already matches the active tag.
 
-`ui_render_system` switches on the active screen and calls the relevant screen controller. The controller calls generated layout functions directly. If the generated header exposes named controls, slots, or rectangles, the controller may use those generated symbols directly; the key rule is that the values stay in generated files and are not persisted into ECS or copied into hand-written layout tables.
+`ui_render_system` queries `UiLabelTag` / `UiButtonTag` / `UiDummyRecTag` entities directly — it does not know about screens. Per-screen tags (e.g. `PausedScreenTag`) exist on each entity for despawn membership, not for render dispatch. Custom raygui-style controls (shape buttons, energy bar) are emitted as ordinary entities whose draw callback is selected via the per-button kind tag.
 
 ## Screen migration scope
 
 | Screen | Migration target | Notes |
 |---|---|---|
-| Title | Generated layout + raygui screen controller | Preserve start/confirm behavior. Exit stays platform-gated off web. |
-| Tutorial | Generated layout + screen controller | Runtime demo shapes may be drawn by custom functions into generated slots. |
-| Level Select | Generated layout + screen controller | Song list may remain data-driven, but card placement must come from generated layout or generated list slots, not `LevelSelectLayout`. |
-| Gameplay HUD | Generated layout + screen controller / custom controls | HUD is in scope. Use generated placement for score, high score, pause, energy, lane divider, and shape buttons. |
-| Paused | Generated layout + screen controller | Preserve dim overlay behavior; overlay geometry/color must not come from JSON caches. |
-| Game Over | Generated layout + screen controller | Dynamic score/high score/death reason is bound at render time. |
-| Song Complete | Generated layout + screen controller | Dynamic score/high score/stat table is bound at render time. |
-| Settings | Generated layout + screen controller | Wire only when `GamePhase::Settings` / route support exists; runtime toggle text is state-derived. |
+| Title | Generated entity spawner | Preserve start/confirm behavior. Exit stays platform-gated off web. |
+| Tutorial | Generated entity spawner + `tutorial_screen_continue` action handler in `ui_update_system.cpp` | Runtime demo shapes drawn by custom draw callbacks during render. |
+| Level Select | Generated entity spawner + `level_select_dynamic_spawn_system` for per-song cards | Song list remains data-driven; static frame comes from `.rgl`, per-card entities are spawned by the dynamic spawn system and carry `LevelSelectScreenTag` so the codegen-emitted `despawn_level_select_screen` reaps them in one query. |
+| Gameplay HUD | Generated entity spawner + custom-control draw callbacks | HUD placement comes from generated `UiPosition` / `UiBounds` per entity. Shape buttons and the energy bar are raygui-style custom immediate-mode draw functions selected by per-entity kind tag. |
+| Paused | Generated entity spawner | Preserve dim overlay behavior; overlay rectangle comes from `.rgl`. |
+| Game Over | Generated entity spawner + `game_over_scoreboard_bind_system` for dynamic score/high score/death-reason text | Bind system mutates `UiLabel.text` per frame on spawner-emitted entities. |
+| Song Complete | Generated entity spawner + per-frame bind for stat-table text | Same bind pattern as Game Over. |
+| Settings | Generated entity spawner + per-toggle bind for label text and toggle state | Routed via the dedicated `GamePhaseSettingsTag` phase. |
 
 ## HUD treatment
 
@@ -118,108 +122,115 @@ The HUD is part of this refactor. Stale JSON `approach_ring` layout fields are
 out of scope, but the active proximity-ring timing cue is in scope for behavior
 parity and should remain driven by gameplay state.
 
-HUD controls should be implemented as raygui or raygui-style immediate-mode functions, with layout placement supplied by generated rguilayout exports:
+HUD controls should be implemented as raygui or raygui-style immediate-mode draw functions invoked from `ui_render_system`, with layout placement supplied by the spawner-emitted `UiPosition` / `UiBounds` on each entity:
 
 | HUD element | Implementation |
 |---|---|
-| Score / high score | `GuiLabel` or existing text draw called from the HUD screen controller using generated slots. |
-| Pause button | Stock `GuiButton` is acceptable. |
-| Energy bar | `GuiProgressBar` or project `GuiEnergyBar(...)` custom control. LOW blink/text/border behavior stays dynamic, but bounds come from generated layout. |
-| Shape buttons | Project `GuiShapeButton(...)` custom controls are acceptable for circular hit testing, colorblind glyphs, and shape-specific drawing. Placement comes from generated layout. |
-| Lane divider | Custom draw using generated layout position. |
-| Proximity rings | Preserve active timing-cue behavior; do not port stale JSON `approach_ring` layout data. |
+| Score / high score | `UiLabelTag` entity with `UiLabel.text` written per frame by `gameplay_hud_bind_system`. |
+| Pause button | `UiButtonTag` entity with `OnPress` carrying the action that enqueues `NextPhasePausedTag`. |
+| Energy bar | `EnergyBarTag` entity; custom raygui-style draw selected by tag in `ui_render_system`. LOW blink/text/border behavior stays dynamic, but bounds come from the spawner-emitted `UiBounds`. |
+| Shape buttons | `LaneButtonTag` entities. Custom raygui-style draw selected by tag in `ui_render_system` handles circular hit testing, colorblind glyphs, and shape-specific drawing. Placement comes from the spawner-emitted `UiPosition` / `UiBounds`. |
+| Lane divider | `UiDummyRecTag` entity; rectangle from `.rgl`. |
+| Proximity rings | Per-`LaneButtonTag` `ApproachRing` component, written every frame by `approach_ring_envelope_system` (which uses `gameplay_hud_ring_cue()` from `app/util/gameplay_hud_ring.{h,cpp}`); rendered as the active timing-cue overlay. Stale JSON `approach_ring` layout data is not used. |
 
-Custom controls are not ECS entities. They are immediate-mode UI functions called during rendering. They may read game state and return clicks/commands, but they do not own persistent layout data.
+Custom controls are not lifecycle-owning systems. They are immediate-mode draw functions called during the single `ui_render_system` pass, selected by the entity's per-kind tag. They may read game state and call into the dispatcher, but they do not own persistent layout data.
 
-## Screen controller boundary
+## Producer / consumer boundary
 
-Screen controllers live under:
+The UI runtime has three responsibility layers; each consumes the previous one:
 
 ```text
-app/ui/screen_controllers/
-  title_screen_controller.cpp/.h
-  tutorial_screen_controller.cpp/.h
-  level_select_screen_controller.cpp/.h
-  gameplay_hud_screen_controller.cpp/.h
-  paused_screen_controller.cpp/.h
-  game_over_screen_controller.cpp/.h
-  song_complete_screen_controller.cpp/.h
-  settings_screen_controller.cpp/.h
+app/ui/generated/<screen>_screen.cpp + screen_spawners.h   (Producer)
+   - spawn_<screen>_screen(reg)   → emplace UI entities for one screen
+   - despawn_<screen>_screen(reg) → destroy every entity carrying <screen>Tag
+
+app/systems/screen_lifecycle_system.cpp                    (Coordinator)
+   - one row per migrated screen mapping GamePhase*Tag → (spawn, despawn)
+   - converges entity-set membership against the active phase tag
+
+app/systems/ui_render_system.cpp                           (Renderer)
+   - single pass over UiLabelTag / UiButtonTag / UiDummyRecTag /
+     LaneButtonTag / EnergyBarTag entities
+   - selects custom draw via per-kind tag
+
+app/systems/ui_update_system.cpp                           (Input dispatch)
+   - hit-tests touch / mouse against UiButtonTag entities
+   - reads OnPress and invokes the bound action function
 ```
 
-A shared `app/ui/screen_controllers/screen_controller_base.h` provides the common dispatch surface used by `ui_render_system`. One screen controller TU also acts as the `RAYGUI_IMPLEMENTATION` owner (currently `title_screen_controller.cpp`).
+The single producer is the codegen output under `app/ui/generated/`. Hand-written code never creates UI entities outside this contract; bind systems (`gameplay_hud_bind_system`, `game_over_scoreboard_bind_system`, etc.) only **mutate** atomic component data on spawner-emitted entities. An intermediate per-screen render-callback folder was the staging shape during migration and was deleted in #1308 once #1287 (entity-driven UI) shipped.
 
-Screen controllers may contain:
+Spawner sources may contain:
 
-- `extern "C"` / C++ include boundaries for generated headers.
-- Calls to generated `GuiLayout_*` functions or generated control symbols.
-- Runtime text binding via existing state/resolvers.
-- Platform guards such as web-only/desktop-only visibility.
-- Viewport transform setup/reset if generated coordinates need virtual-screen mapping.
-- Dispatcher/event glue translating UI clicks into existing commands.
-- Short-lived stack-local state required by raygui/generated APIs.
+- Literal `Rectangle` / anchor / colour constants exported by codegen from the `.rgl`.
+- One `registry.emplace<...>` per control row, with the per-screen tag and per-kind tag attached.
+- One `registry.create` per button carrying an `OnPress { action_fn }` payload.
 
-Screen controllers must not contain:
+Spawner sources must not contain:
 
-- Copied `Rectangle` constants from generated files.
-- Normalized coordinate constants duplicated from `.rgl`.
-- Rebuilt `HudLayout`, `LevelSelectLayout`, `OverlayLayout`, or equivalent layout structs.
-- `reg.ctx()` layout caches.
-- ECS components/entities for widgets or hit targets.
-- Persistent widget state that is not actual menu/game state.
+- Hand-written rectangles outside the codegen output (regenerate from `.rgl` instead).
+- Game-state reads (those belong in bind systems consuming the spawner-emitted entities).
+- Conditional control creation (the spawner is a flat list — visibility is a bind-system or render-pass concern).
+
+Bind systems and custom-draw callbacks may contain:
+
+- Reads of game state / ctx singletons to compute label text, colour overrides, energy bar fill, etc.
+- Writes to `UiLabel.text`, per-entity colour override components, `ApproachRing` ratio, etc.
+- Platform guards such as web-only / desktop-only visibility (by toggling per-entity visibility components rather than recreating entities).
+- Dispatcher/event glue translating `OnPress` activations into the same semantic events the rest of the game consumes.
 
 ## Dynamic text and state binding
 
-Dynamic UI values stay runtime-driven:
+Dynamic UI values stay runtime-driven via per-screen bind systems:
 
-- Score / high score.
-- Energy value and LOW cue.
-- Current shape and selected shape.
-- Selected song and difficulty.
-- Game-over reason.
-- Song-complete timing/stat table.
-- Settings toggle labels and audio offset.
+- Score / high score (`gameplay_hud_bind_system`, `game_over_scoreboard_bind_system`).
+- Energy value and LOW cue (`gameplay_hud_bind_system` → energy-bar entity).
+- Current shape and selected shape (per-lane-button colour / glyph override).
+- Selected song and difficulty (`level_select_dynamic_spawn_system` for the per-card entities; static frame from spawner).
+- Game-over reason (`game_over_scoreboard_bind_system`).
+- Song-complete timing/stat table (per-system bind).
+- Settings toggle labels and audio offset (per-system bind).
 
-The screen controller reads existing game state/resolvers and passes current values into generated layout calls or uses generated slots to draw dynamic controls. This preserves dynamic behavior without copying layout data into ECS.
+The bind system reads game state/resolvers and writes the current values into the spawner-emitted entity's atomic components (`UiLabel.text`, per-button colour override, etc.). This preserves dynamic behavior without copying layout data into hand-written caches.
 
-If rguilayout's generated API cannot directly accept a dynamic string for a control, prefer one of these approaches:
+If a control needs a dynamic value that the codegen-emitted spawner does not already attach a `UiLabel` (or equivalent component) to, the resolution is one of:
 
-1. Author the control as a named empty/placeholder slot in `.rgl`, expose it in generated output, and draw the dynamic raygui/custom control from the screen controller using that generated slot.
-2. Adjust the `.rgl`/export pattern so the generated file exposes a generated hook/state struct for dynamic labels.
+1. Author the control as a named slot in `.rgl` so codegen emits the matching `UiLabelTag` / `UiButtonTag` entity with the right per-screen tag.
+2. Add the appropriate atomic component to the spawner output via a codegen template change.
 
-Do not solve this by creating project-owned layout constants or ECS layout mirrors.
+Do not solve this by creating hand-written widget entities outside the spawner contract.
 
 ## Input and event flow
 
-raygui controls perform immediate-mode hit testing. The screen controller converts successful clicks/activations into the same semantic events the game already understands.
+`ui_update_system` performs per-frame hit testing against `UiButtonTag` entities (using their `UiPosition` / `UiBounds`). On a hit, it reads the entity's `OnPress` and invokes the bound action function. Each action function maps to the same semantic event the rest of the game already understands.
 
 Examples:
 
-- Title start -> existing confirm/start event path.
-- Pause resume/menu -> existing pause/menu actions.
-- Level select difficulty/start -> existing level-selection state/actions.
-- HUD pause -> existing pause action.
-- Shape button click/touch -> existing player shape-change path.
+- Title start → existing confirm/start event path.
+- Pause resume / menu → existing pause / menu actions.
+- Level select difficulty / start → existing level-selection state / actions.
+- HUD pause → request `NextPhasePausedTag` (consumed by `game_phase_transition`).
+- Shape button click / touch → existing player shape-change path (`ShapePress*Event`).
 
-For migrated raygui controls, do not spawn parallel ECS hit-test entities. Screen controllers emit semantic UI/gameplay actions directly as they take ownership of those controls.
+Hit-test entities are exactly the same `UiButtonTag` / `LaneButtonTag` entities the renderer draws — there is no parallel hit-target geometry. Action functions emit semantic UI/gameplay actions directly.
 
 ## Build integration
 
-Generated headers are wired into the build as part of `shapeshifter_lib`:
+The UI pipeline is wired into `shapeshifter_lib` as follows:
 
-- `tools/rguilayout/` is the vendored authoring/tooling location and is not built or run by CMake/CI.
+- `tools/rguilayout/` is the vendored authoring/tooling location. `tools/rguilayout/codegen.py` is invoked at CMake configure time to regenerate `app/ui/generated/<screen>_screen.cpp` + `screen_spawners.h` from `content/ui/screens/*.rgl`. The authoring GUI is not run in CI.
 - `.rgl` layout sources live in `content/ui/screens/` unless a future global/root layout source is justified.
-- Generated `.h` exports live under `app/ui/generated/` and are picked up via `target_include_directories(... app/ui)`; consumers `#include "../generated/<screen>_layout.h"`.
-- Screen controller `.cpp` files under `app/ui/screen_controllers/` are globbed into `shapeshifter_lib` (`UI_SCREEN_CONTROLLER_SOURCES`) and consume the generated headers.
-- One screen controller TU owns `RAYGUI_IMPLEMENTATION` and is excluded from unity batching to keep the raygui implementation isolated; today this is `app/ui/screen_controllers/title_screen_controller.cpp`.
+- Codegen output `.cpp` files under `app/ui/generated/` are added to `shapeshifter_lib` via the `RGUILAYOUT_GENERATED_SOURCES` list in `CMakeLists.txt`.
+- `app/ui/raygui_impl.cpp` is the single-TU owner of `RAYGUI_IMPLEMENTATION`. The macro is set via `COMPILE_DEFINITIONS RAYGUI_IMPLEMENTATION` on that source file, and the file is excluded from unity batching (`SKIP_UNITY_BUILD_INCLUSION TRUE`) so the raygui implementation stays isolated.
+- All other UI consumer TUs (`ui_render_system.cpp`, `ui_update_system.cpp`, `screen_lifecycle_system.cpp`, the per-screen bind systems) live in `app/systems/` and pull in raygui headers normally without defining the implementation macro.
 
-The native build (`shapeshifter`, `shapeshifter_tests`) and WASM build compile the generated headers transitively through the screen controllers and stay warning-clean under `-Wall -Wextra -Werror`.
+The native build (`shapeshifter`, `shapeshifter_tests`) and WASM build compile the spawner sources and raygui implementation together and stay warning-clean under `-Wall -Wextra -Werror`.
 
 ## CI and cache
 
-- CI does not run the rguilayout authoring application.
-- Native CI and WASM CI compile screen controllers (and therefore the generated headers they include) as part of `shapeshifter_lib`.
-- CMake cache keys cover the screen controller globs and the generated headers via the standard `CONFIGURE_DEPENDS` glob; no extra cache key changes are required when a new generated header is added alongside a new controller.
+- CI does not run the rguilayout authoring application; it consumes the committed codegen output. The codegen Python script runs at CMake configure time to keep generated sources in sync with `.rgl` edits.
+- Native CI and WASM CI compile all UI consumer systems and codegen output as part of `shapeshifter_lib`.
+- CMake cache keys cover the codegen-output globs via `CONFIGURE_DEPENDS`; adding a new `.rgl` requires a new spawner forward declaration in `screen_spawners.h` (emitted automatically by codegen) and a new row in `screen_lifecycle_system.cpp`'s lifecycle table.
 - No WASM preload changes are needed unless a later design introduces external UI assets. This spec does not require an external `.rgs` style file.
 
 ## Migration phases
@@ -229,26 +240,26 @@ The native build (`shapeshifter`, `shapeshifter_tests`) and WASM build compile t
 1. Use the vendored rguilayout application under `tools/rguilayout/`.
 2. Store screen `.rgl` files as `content/ui/screens/<screen>.rgl`, replacing the matching `content/ui/screens/<screen>.json` layout source as each screen migrates.
 3. Keep `content/ui/routes.json` until routing is moved to code or another non-layout source.
-4. Export generated headers to `app/ui/generated/<screen>_layout.h`.
-5. Wire generated headers and screen controllers into `shapeshifter_lib`.
+4. Codegen emits `app/ui/generated/<screen>_screen.cpp` + entries in `screen_spawners.h`.
+5. Wire codegen output into `shapeshifter_lib`.
 
 ### Phase 2: First screen authoring proof — done
 
-1. Authored and exported the Title screen: `content/ui/screens/title.rgl` + `app/ui/generated/title_layout.h`.
-2. Tap/Enter start behavior and web exit-button gating are preserved by `app/ui/screen_controllers/title_screen_controller.cpp`.
-3. Generated header and controller compile into `shapeshifter_lib`.
+1. Authored Title: `content/ui/screens/title.rgl` → `app/ui/generated/title_screen.cpp`.
+2. Tap/Enter start behavior and web exit-button gating are preserved by the codegen-emitted `OnPress` payloads + per-action handlers in `ui_update_system.cpp`.
+3. Generated source compiles into `shapeshifter_lib` and renders via `ui_render_system`.
 
 ### Phase 3: Build integration — done
 
-raygui/generated-code build support, screen controller compilation, native CI coverage, and WASM CI coverage are in place. `RAYGUI_IMPLEMENTATION` ownership lives on `title_screen_controller.cpp` and that TU is excluded from unity batching.
+raygui codegen build support, spawner compilation, native CI coverage, and WASM CI coverage are in place. `RAYGUI_IMPLEMENTATION` ownership lives on `app/ui/raygui_impl.cpp` and that TU is excluded from unity batching.
 
 ### Phase 4: Menus and overlays — done
 
-Tutorial, Paused, Game Over, Song Complete, Level Select, and Settings each have a generated header under `app/ui/generated/` and a matching screen controller. Their JSON/layout-cache/widget-entity dependencies have been removed.
+Tutorial, Paused, Game Over, Song Complete, Level Select, and Settings each have a codegen-emitted spawner under `app/ui/generated/` and a matching row in `screen_lifecycle_system.cpp`. Their JSON / layout-cache / hand-written widget-entity dependencies have been removed.
 
 ### Phase 5: Gameplay HUD — done
 
-HUD placement is driven by `app/ui/generated/gameplay_hud_layout.h` and `app/ui/screen_controllers/gameplay_hud_screen_controller.cpp`. Shape buttons and the energy bar are implemented as raygui-style custom immediate-mode controls. Stale approach-ring layout data was not migrated; the active proximity-ring timing cue is preserved.
+HUD placement is driven by `app/ui/generated/gameplay_screen.cpp` (entity spawner). Shape buttons (`LaneButtonTag`) and the energy bar (`EnergyBarTag`) are implemented as raygui-style custom immediate-mode draw functions selected by per-kind tag inside `ui_render_system`. Stale approach-ring layout data was not migrated; the active proximity-ring timing cue is preserved via per-`LaneButtonTag` `ApproachRing` components written by `approach_ring_envelope_system`.
 
 ### Phase 6: Delete old UI layout path — done (with one exception)
 
@@ -257,7 +268,7 @@ HUD placement is driven by `app/ui/generated/gameplay_hud_layout.h` and `app/ui/
 3. `ui_layout_cache.h` and all ctx layout cache writes/reads are gone.
 4. `ui_button_spawner.h` is gone; migrated screens do not depend on widget entities/hitboxes.
 5. `UIElementTag` / `UIText` / `UIButton` / `UIShape` components are gone.
-6. Legacy hit-test helpers are gone; migrated controls rely on raygui/controller callbacks and semantic events rather than UI hitbox entities.
+6. Legacy hit-test helpers are gone; migrated controls rely on `ui_update_system` hit-testing `UiButtonTag` entities and dispatching their `OnPress` action functions, which emit the same semantic events the rest of the game already consumes.
 
 ## Validation
 
@@ -265,15 +276,15 @@ HUD placement is driven by `app/ui/generated/gameplay_hud_layout.h` and `app/ui/
 - Native unity build still catches ODR hazards in hand-written code; the `RAYGUI_IMPLEMENTATION` TU is excluded from unity batching.
 - WASM build remains warning-free and does not unity-merge raygui implementation or generated C.
 - No runtime path opens `content/ui/screens/*.json` (those files are gone).
-- No project-owned `HudLayout`, `LevelSelectLayout`, or `OverlayLayout` cache struct exists; the only matches under `app/` are the generated `*LayoutState` structs that are allowed to live inside `app/ui/generated/`.
-- No stale JSON `approach_ring` data is referenced by UI code; active proximity-ring rendering is owned by the gameplay HUD screen controller.
+- No project-owned `HudLayout`, `LevelSelectLayout`, or `OverlayLayout` cache struct exists; layout geometry lives only inside the per-screen spawner `.cpp` files under `app/ui/generated/` as literal constants emitted from each `.rgl` source.
+- No stale JSON `approach_ring` data is referenced by UI code; active proximity-ring rendering is driven by per-`LaneButtonTag` `ApproachRing` components written by `approach_ring_envelope_system` and consumed by `ui_render_system`.
 - Screen behavior parity is verified for title, level select, pause/resume, game over, song complete, settings, and gameplay HUD controls.
 
 ## Open issues / risks
 
 1. Excalidraw is unavailable in this session. If a visual source exists, export or restore it before final visual polish.
 2. Dynamic text/control slots may require a consistent rguilayout naming convention so generated headers expose stable symbols.
-3. Settings is present in `routes.json` only via `GamePhase::Settings` / route support; verify route/state coverage as routes evolve.
+3. Settings is present in `routes.json` only via the `GamePhaseSettingsTag` / route support; verify route/state coverage as routes evolve.
 
 ## Contributing agent inputs
 

--- a/design-docs/rguilayout-portable-c-integration.md
+++ b/design-docs/rguilayout-portable-c-integration.md
@@ -1,238 +1,180 @@
-# rGuiLayout Portable C Integration Spec
+# rguilayout Portable C Integration Spec
 
 ## Status
 
-Active — governs the integration boundary between rguilayout-generated code and game screen controllers.
+Active — governs the integration boundary between rguilayout-authored `.rgl` layout sources, the project's codegen script, and the entity-driven UI runtime in `app/systems/`.
 
 ## Overview
 
-rGuiLayout is a visual editor that generates **portable C/header files** containing UI layout data and immediate-mode draw/input-dispatch code. This spec defines how the game integrates those generated files into the screen rendering pipeline.
+rguilayout is a visual editor that produces `.rgl` project files describing UI controls (rectangles, labels, buttons, dummy frames) with anchors and styles. **This project does not consume `rguilayout`'s native code-export path.** Instead, `tools/rguilayout/codegen.py` parses the committed `.rgl` files directly and emits per-screen entity-spawner C++ sources under `app/ui/generated/`. Each control row in the `.rgl` becomes one ECS entity carrying atomic components plus per-screen and per-kind existential tags. The runtime UI is then a uniform pass over those entities — there is no screen-by-screen render dispatch.
 
-**Key principle:** The generated `.h` file is the source of truth for UI layout and control placement. Game code consumes this portable C API; it does not copy rectangles, rebuild layout caches, or mirror widget state into ECS.
+**Key principle:** The `.rgl` file is the source of truth for UI layout. Codegen output is regenerated deterministically at CMake configure time; hand-written code never creates UI entities outside the spawner contract.
 
-## Goal: Portable Generated C as Integration Boundary
+## Goal: Codegen-Emitted Entity Spawners as the Integration Boundary
 
-The rguilayout export—a portable, pre-compiled `.h` file with no external dependencies except `raylib.h`—becomes the contract between:
+The codegen output — per-screen `spawn_<screen>_screen(reg)` / `despawn_<screen>_screen(reg)` functions emitted to `app/ui/generated/<screen>_screen.cpp` — is the single contract between:
 
-- **Upstream (tool):** rGuiLayout authoring and code generation.
-- **Downstream (game):** Screen controller integration and game state binding.
+- **Upstream (authoring + codegen):** rguilayout `.rgl` files in `content/ui/screens/` and `tools/rguilayout/codegen.py`.
+- **Downstream (runtime):** `app/systems/screen_lifecycle_system.cpp` (calls the spawners on phase tag changes) and `app/systems/ui_render_system.cpp` / `app/systems/ui_update_system.cpp` (consume the resulting entities).
 
+```text
+[rguilayout authoring app]
+         |
+         | author in GUI, save .rgl
+         v
+[content/ui/screens/*.rgl] (editable source — committed)
+         |
+         | tools/rguilayout/codegen.py runs at CMake configure time
+         v
+[app/ui/generated/<screen>_screen.cpp + screen_spawners.h] (committed codegen output)
+         |
+         | linked into shapeshifter_lib
+         v
+[app/systems/screen_lifecycle_system.cpp] (calls spawn_<screen>_screen on
+                                           matching GamePhase*Tag activation)
+         |
+         | UI entities emplaced into the registry
+         v
+[UiLabelTag / UiButtonTag / UiDummyRecTag / LaneButtonTag / EnergyBarTag
+ entities, each carrying UiPosition / UiBounds (+ UiLabel / OnPress / kind
+ overrides) plus a per-screen tag]
+         |
+         | per-frame
+         v
+[app/systems/ui_render_system.cpp]  single pass over UI entities
+[app/systems/ui_update_system.cpp]  hit-test UiButtonTag → invoke OnPress action
 ```
-[rguilayout v4.0 tool]
-         |
-         | author in GUI, export
-         v
-[content/ui/screens/*.rgl] (editable source)
-         |
-         | generate portable C/header
-         v
-[app/ui/generated/*_layout.h] (portable, no dependencies)
-         |
-         | included by screen controller
-         v
-[app/ui/screen_controllers/*_screen_controller.cpp] (game-specific glue)
-         |
-         | calls into render system
-         v
-[app/systems/ui_render_system.cpp]
-```
 
-**Contract:** The generated header is **final**. It is not hand-edited, not post-processed, and not compiled separately. It is included directly by the screen controller and calls raygui primitives during the game's render frame.
+**Contract:** The spawner sources are **final** codegen output. They are not hand-edited, not post-processed, and are regenerated whenever the matching `.rgl` changes. CMake's `add_custom_command(OUTPUT …)` for codegen declares a `DEPENDS` set covering every `.rgl` and the script itself, so a `cmake --build` is sufficient to keep them in sync.
 
 ## Source-of-Truth Flow
 
-### 1. Author in rGuiLayout (Offline)
+### 1. Author in rguilayout (Offline)
 
-- Open `tools/rguilayout/rguilayout.app/` (vendored standalone tool).
-- Load or create `content/ui/screens/<screen>.rgl` layout file.
+- Open the vendored authoring app under `tools/rguilayout/rguilayout.app/` (or any installed `rguilayout` build).
+- Load or create `content/ui/screens/<screen>.rgl`.
 - Arrange raygui controls, anchors, and geometry.
-- Export via CLI or GUI: `rguilayout --input <screen>.rgl --output app/ui/generated/<screen>_layout.h --template embeddable_layout.h`.
-- If extracting from default standalone output is needed, write scratch output under `build/rguilayout-scratch/` only; do not commit it.
+- Save the `.rgl` and commit it to the repo.
+- **Do not use rguilayout's built-in `--template` / code-export feature.** Codegen handles the C++ emission. The native rguilayout exporter is bypassed entirely (see "Why not rguilayout's native code export?" below).
 
-### 2. Generated Portable Header
+### 2. Codegen-Emitted Entity Spawner
 
-The export produces `app/ui/generated/<screen>_layout.h`:
+`tools/rguilayout/codegen.py` parses each `.rgl` and writes `app/ui/generated/<screen>_screen.cpp`:
 
-- **Header-only** or header + minimal inline functions (no `.c` compilation unit required).
-- **No external dependencies** except `raylib.h` (and implicitly raygui, which is a raylib header).
-- **No `main()` or event loop** — it's a library, not a standalone executable.
-- **No `#define RAYGUI_IMPLEMENTATION`** — the caller is responsible for that (see § RAYGUI_IMPLEMENTATION ownership).
-- **Exposes public API:**
-  - Layout constants (width, height, viewport bounds).
-  - State struct (anchors, button-press flags, derived widget state).
-  - `Init()` function: returns initial state.
-  - `Render(state*)` function: draws controls and updates input flags every frame.
-  - Optional: named accessor functions for dynamic content (e.g., `SetScoreText(state*, const char*)`) if the template supports it.
+- One self-contained C++ source per screen. No `.h` per screen — the entire surface is the two function declarations in `screen_spawners.h`.
+- Includes only `components/actions.h`, `components/ui.h`, `tags/tags.h`, and `<entt/entt.hpp>` (and `<string>` where labels are present).
+- `spawn_<screen>_screen(reg)` emplaces one entity per control row, attaching:
+  - The per-screen tag (e.g. `TitleScreenTag`, `PausedScreenTag`) — the membership marker used by despawn.
+  - A per-kind tag (`UiLabelTag` for text, `UiButtonTag` for clickable buttons, `UiDummyRecTag` for non-interactive frames; gameplay-specific kinds such as `LaneButtonTag` / `EnergyBarTag` for HUD).
+  - Atomic `UiPosition`, `UiBounds`, and (for labels and dynamic-text slots) `UiLabel`.
+  - For buttons, `OnPress { action_fn }` where `action_fn` is one of the small set of `void (entt::registry&, entt::entity)` handlers defined in `ui_update_system.cpp` or peer systems. The mapping `.rgl` button name → action function is enforced by the `ActionId` enum (`app/components/actions.h`); codegen verifies every button name appears in the enum and exits non-zero if not.
+- `despawn_<screen>_screen(reg)` issues a single `reg.view<<ScreenTag>>()` walk and destroys every matched entity. Membership in the per-screen tag is the entire signal — there is no manual entity list.
 
-### 3. Screen Controller Integration
+Output is deterministic. Running codegen on identical inputs produces byte-identical output. CMake re-runs codegen only when an input changes (`.rgl`, the codegen script, or `actions.h`).
 
-A thin C++ screen controller includes the generated header and calls it:
+### 3. Runtime Consumers
+
+The codegen output is consumed by three systems:
+
+- `app/systems/screen_lifecycle_system.cpp` — owns a table mapping each `GamePhase*Tag` to its `(spawn, despawn)` pair (plus existence probes for the matching screen tag). Once per frame, the system walks the table and converges the entity set to match the active phase tag. The table is the only place that names individual screens; there is no `switch (phase)` anywhere in the UI pipeline.
+- `app/systems/ui_render_system.cpp` — single render pass over `UiLabelTag` / `UiButtonTag` / `UiDummyRecTag` and the gameplay-HUD-specific kind tags. Each entity is drawn using its atomic `UiPosition` / `UiBounds` plus the per-kind draw callback selected by tag.
+- `app/systems/ui_update_system.cpp` — touch / mouse hit testing against `UiButtonTag` (and `LaneButtonTag` for shape buttons). On a hit, the entity's `OnPress.action` is invoked and emits the semantic event the rest of the game consumes (e.g. `ShapePressCircleEvent`, `MenuConfirmEvent`, request `NextPhasePausedTag`).
+
+Per-screen bind systems (`gameplay_hud_bind_system`, `game_over_scoreboard_bind_system`, etc.) read game state and **mutate** atomic component data on spawner-emitted entities — e.g. write the current score string into a label's `UiLabel.text`, or set a per-button colour override. Bind systems never create or destroy UI entities.
+
+### 4. RAYGUI_IMPLEMENTATION Ownership
+
+raygui is a header-only single-file library that compiles its implementation only when `#define RAYGUI_IMPLEMENTATION` is set in exactly one translation unit. That TU is `app/ui/raygui_impl.cpp`. CMake attaches the macro via `COMPILE_DEFINITIONS RAYGUI_IMPLEMENTATION` on that source and excludes it from unity batching:
+
+```cmake
+set_source_files_properties(
+    app/ui/raygui_impl.cpp
+    PROPERTIES
+        COMPILE_DEFINITIONS RAYGUI_IMPLEMENTATION
+        SKIP_UNITY_BUILD_INCLUSION TRUE
+)
+```
+
+Every other UI consumer TU (`ui_render_system.cpp`, `ui_update_system.cpp`, `screen_lifecycle_system.cpp`, each codegen-emitted spawner, and each bind system) pulls in raygui headers normally without defining the implementation macro.
+
+## Why Not rguilayout's Native Code Export?
+
+rguilayout's built-in `--template` flag generates standalone C/C++ wrappers (one `LayoutState` struct + `Init` / `Render` functions per screen) intended for short-lived prototypes. Adopting that output would re-introduce a screen-by-screen render dispatch (`switch (phase)` calling `RenderTitle` / `RenderPause` / …), which conflicts with Fabian existential processing (Principle 1 in `.squad/decisions.md`). The project's codegen path produces flat ECS entity emplacements instead, which the registry's view queries dispatch on without any central switch.
+
+Concrete reasons the project owns the codegen rather than relying on rguilayout's exporter:
+
+- **Existential dispatch:** Per-kind tags (`UiLabelTag` / `UiButtonTag` / …) replace the per-screen function-pointer table the native exporter would generate.
+- **Action enum integrity:** Codegen cross-checks every button name in every `.rgl` against `ActionId` in `app/components/actions.h`. A button whose name is not in the enum aborts the build with a clear diagnostic; this is impossible to enforce from the native exporter side.
+- **Single-pass rendering:** All UI entities go through one render pass. The native exporter would produce per-screen rendering code that must coexist with the gameplay-HUD custom controls (energy bar, shape buttons), creating two parallel rendering paths.
+- **Deterministic, reviewable output:** The committed codegen output is plain C++ that a reviewer can diff. The native exporter's template substitution is harder to audit and depends on rguilayout's release cadence.
+- **Zero runtime dependency on rguilayout:** Nothing in the runtime imports a rguilayout header. The authoring app stays a developer-only tool; CI never installs or runs it.
+
+## API Shape: Per-Screen Spawner Pair
+
+Every codegen-emitted source follows the same shape:
 
 ```cpp
-// app/ui/screen_controllers/title_screen_controller.cpp
-#include "components/game_state.h"
-#include "systems/input.h"
-#include "screen_controllers/screen_controller_base.h"
-#include <raygui.h>
-#include "ui/generated/title_layout.h"
+// app/ui/generated/<screen>_screen.cpp  (auto-generated; do not edit)
+#include "components/actions.h"
+#include "components/ui.h"
+#include "tags/tags.h"
+#include <entt/entt.hpp>
 
-namespace {
-    using TitleController = RGuiScreenController<TitleLayoutState,
-                                                  &TitleLayout_Init,
-                                                  &TitleLayout_Render>;
-    TitleController title_controller;
-} // anonymous namespace
-
-void init_title_screen_ui() {
-    title_controller.init();
+void spawn_<screen>_screen(entt::registry& reg) {
+    {
+        auto e = reg.create();
+        reg.emplace<<ScreenTag>>(e);
+        reg.emplace<UiLabelTag>(e);                    // (or UiButtonTag / UiDummyRecTag)
+        reg.emplace<UiPosition>(e, x, y);
+        reg.emplace<UiBounds>(e, w, h);
+        reg.emplace<UiLabel>(e, "Static text");        // dynamic text uses an empty UiLabel
+                                                       // mutated by a bind system
+        // For buttons:
+        // reg.emplace<OnPress>(e, &action_fn);
+    }
+    // … one block per control row in the .rgl …
 }
 
-void render_title_screen_ui(entt::registry& reg) {
-    title_controller.render();
-
-#ifndef PLATFORM_WEB
-    if (title_controller.state().ExitButtonPressed) {
-        reg.ctx().get<InputState>().quit_requested = true;
-    }
-#endif
-
-    if (title_controller.state().SettingsButtonPressed) {
-        auto& gs = reg.ctx().get<GameState>();
-        gs.transition_pending = true;
-        gs.next_phase = GamePhase::Settings;
-    }
+void despawn_<screen>_screen(entt::registry& reg) {
+    auto view = reg.view<<ScreenTag>>();
+    reg.destroy(view.begin(), view.end());
 }
 ```
 
-**Key rules for screen controllers:**
-- ✅ Include generated header and call public API.
-- ✅ Read game state and pass it into generated calls (e.g., dynamic text, current selection).
-- ✅ Translate button-press flags into game commands.
-- ✅ Apply platform-specific guards (web/desktop, accessibility).
-- ❌ Do NOT copy layout rectangles, anchor positions, or control state into ECS or `reg.ctx()`.
-- ❌ Do NOT rebuild layout structs or caches.
-- ❌ Do NOT spawn UI widget entities or hitbox entities.
+Forward declarations for every pair live in `app/ui/generated/screen_spawners.h`, which is the single header `screen_lifecycle_system.cpp` includes.
 
-### 4. Render System Call
-
-The UI render system dispatches to the appropriate screen controller:
-
-```cpp
-// app/systems/ui_render_system.cpp
-void ui_render_system(entt::registry& reg) {
-    GamePhase phase = reg.ctx().get<GamePhase>();
-    switch (phase) {
-        case GamePhase::Title:
-            render_title_screen_ui(reg);
-            break;
-        case GamePhase::Tutorial:
-            render_tutorial_screen_ui(reg);
-            break;
-        // ...
-    }
-}
-```
-
-## Why Not Compile Generated C Directly?
-
-rGuiLayout exports `.c` and `.h` files, and the generated `.c` includes `#define RAYGUI_IMPLEMENTATION` by default. This is fine for **standalone tools** but problematic in a game:
-
-- **Ownership conflict:** The game's main loop owns the window, render target, and raygui state initialization. A generated file defining `RAYGUI_IMPLEMENTATION` would conflict with the game's own raygui setup.
-- **Multiple definition risk:** If multiple generated files each define `RAYGUI_IMPLEMENTATION`, the linker fails (ODR violation).
-- **Simplicity:** For a game with 8 screens, it's simpler to **not compile generated C files directly**. Instead, generate header-only or minimal-inline libraries that the game calls from its own render loop.
-
-**Solution:** Use the **embeddable template** (`tools/rguilayout/templates/embeddable_layout.h`) when exporting, which omits the `main()`, event loop, and `RAYGUI_IMPLEMENTATION` guard. The game defines `RAYGUI_IMPLEMENTATION` once via CMake source-level compile definitions on a single controller translation unit.
-
-## Why "Portable Generated C" Instead of "Screen Controllers"?
-
-**Terminology hierarchy:**
-
-- **Portable generated C** is the **contract** — the primary integration boundary. It is produced by rGuiLayout, is portable across projects, and is owned upstream.
-- **Screen controllers** are **implementation** — game-specific glue code that consumes the generated contract and integrates it into the game's render pipeline.
-
-**Why this distinction matters:**
-
-1. **Upstream ownership:** rGuiLayout (the tool) produces the generated `.h` contract. The game adopts it, not the reverse.
-2. **No hand-editing generated files:** Developers must regenerate from `.rgl` after layout changes; they never hand-edit the generated `.h`.
-3. **Portable by design:** The generated file is a **portable library**; it does not know about ECS, game state, or screen controllers. The screen controller provides that knowledge.
-4. **Reusability:** A generated layout could theoretically be used by a different game or tool; screen controllers are always game-specific.
-5. **Clarity for future developers:** "Portable C" signals "do not hand-edit, regenerate from source"; "screen controller" signals "game-specific integration point."
-
-## API Shape: Init / State / Render
-
-Generated layouts follow a consistent immediate-mode API:
-
-```cpp
-// Compile-time constants
-#define SCREEN_NAME_LAYOUT_WIDTH  720
-#define SCREEN_NAME_LAYOUT_HEIGHT 1280
-
-// State struct: holds anchors, button-press flags, derived data
-typedef struct {
-    Vector2 Anchor01;
-    bool StartButtonPressed;
-    bool SettingsButtonPressed;
-} ScreenNameLayoutState;
-
-// Initialization: returns zeroed state struct
-static inline ScreenNameLayoutState ScreenNameLayout_Init(void);
-
-// Render: draws controls, updates input flags
-// Called once per frame from within a BeginDrawing/EndDrawing block
-static inline void ScreenNameLayout_Render(ScreenNameLayoutState* state);
-
-// Optional: dynamic text/value setters (depends on template)
-static inline void ScreenNameLayout_SetScore(ScreenNameLayoutState* state, const char* score_text);
-```
-
-**No update/cleanup functions** unless the template introduces custom resources (e.g., `LoadTexture()`). The portable C design assumes:
-- Initialization is lightweight and done once at app startup or screen entry.
-- Render is called every frame and recomputes layout state from current input.
-- Cleanup is not required (no persistent resources in the layout).
+**No `LayoutState` struct, no `Init` / `Render` functions, no `GuiLayout_*` symbols** — the project does not consume rguilayout's native template output, so those names do not appear anywhere in `app/`.
 
 ## Event-Consumer Design: UI Effects Outside Layout
 
-Dynamic visual effects (screen shake, flashes, color tints) are **UI state**, not layout geometry. The screen controller or a dedicated UI effect system manages them:
+Dynamic visual effects (screen shake, flashes, colour tints) are **render-time state**, not layout geometry. They live in dedicated bind systems and per-entity override components, applied around the standard render pass:
 
 ```cpp
-// UI effects system (separate from layout)
-struct UIEffectState {
-    float flash_alpha;        // from BeatFlashEvent
-    float shake_offset_x;     // from ShakeEvent
-    bool danger_tint;         // from EnergyLowEvent
+// Approach-ring proximity feedback: per-LaneButtonTag entity component
+struct ApproachRing {
+    float ratio;          // 0..1 — written each frame by approach_ring_envelope_system
+    Color color;          // tier colour (perfect / great / ok / miss)
+    bool  active;
 };
 
-// During render:
-void render_title_screen_ui(entt::registry& reg) {
-    UIEffectState effects = compute_effects(reg);
-    
-    // Apply effects before/after layout render
-    if (effects.flash_alpha > 0) {
-        DrawRectangle(0, 0, GetScreenWidth(), GetScreenHeight(),
-                      Color { 255, 255, 255, (unsigned char)(effects.flash_alpha * 255) });
-    }
-    
-    // Render layout at normal position
-    TitleLayout_Render(&title_state);
-    
-    if (effects.shake_offset_x != 0) {
-        // Optional: re-render with offset, or draw overlay
-    }
-}
+// Per-frame in ui_render_system:
+// for each LaneButtonTag entity, draw the button using its UiPosition/UiBounds,
+// then if ApproachRing.active, draw the shrinking ring overlay.
 ```
 
-The layout itself is **static**; effects are **applied around it** during the render frame. This keeps the generated portable C focused and avoids coupling layout geometry to game effects.
+Layout geometry is **static** between `.rgl` edits; effects are **applied around the render pass** by mutating atomic components or drawing overlays. This keeps codegen output focused and avoids coupling layout data to game effects.
 
 ## File Layout and Naming
 
-```
+```text
 tools/rguilayout/
-  rguilayout.app/             # Vendored rGuiLayout v4.0 GUI tool
-  templates/
-    embeddable_layout.h       # Custom code generation template
+  rguilayout.app/             # Vendored rguilayout authoring GUI (developer-only).
+  codegen.py                  # .rgl → entity-spawner C++ emitter.
+  INTEGRATION.md              # Tool-side integration notes.
+  USAGE.md                    # Authoring workflow.
 
 content/ui/screens/
-  title.rgl                   # Editable layout source (rGuiLayout project file)
+  title.rgl                   # Editable layout source (rguilayout project file).
   tutorial.rgl
   level_select.rgl
   gameplay.rgl
@@ -242,99 +184,84 @@ content/ui/screens/
   settings.rgl
 
 app/ui/
+  raygui_impl.cpp             # Single RAYGUI_IMPLEMENTATION TU; excluded from unity.
+  tutorial_dodge_hint.h       # Hand-written tutorial helper.
   generated/
-    title_layout.h            # Portable generated layout API (include only, no compile)
-    tutorial_layout.h
-    level_select_screen_layout.h
-    gameplay_hud_layout.h
-    paused_layout.h
-    game_over_layout.h
-    song_complete_layout.h
-    settings_layout.h
-  screen_controllers/
-    title_screen_controller.cpp/.h      # Screen controller: bridges generated layout to game systems
-    tutorial_screen_controller.cpp/.h
-    level_select_screen_controller.cpp/.h
-    gameplay_hud_screen_controller.cpp/.h
-    paused_screen_controller.cpp/.h
-    game_over_screen_controller.cpp/.h
-    song_complete_screen_controller.cpp/.h
-    settings_screen_controller.cpp/.h
-  
+    title_screen.cpp          # Codegen output: spawn_/despawn_ pair.
+    tutorial_screen.cpp
+    level_select_screen.cpp
+    gameplay_screen.cpp
+    paused_screen.cpp
+    game_over_screen.cpp
+    song_complete_screen.cpp
+    settings_screen.cpp
+    screen_spawners.h         # Forward declarations for every pair.
 ```
 
 **Naming conventions:**
-- Generated files: `<screen>_layout.h` (singular "layout"), lowercase with underscores.
-- Screen controllers: `<screen>_screen_controller.cpp/.h`, matching the logical name.
-- rGuiLayout projects: `<screen>.rgl`, matching controller name.
 
-**Current pattern:** All screens use `app/ui/screen_controllers/` naming. This is the implemented, active architecture.
+- `.rgl` files: `<screen>.rgl`, lowercase with underscores.
+- Codegen output: `app/ui/generated/<screen>_screen.cpp` and `<screen>_screen.cpp` exposes `spawn_<screen>_screen` / `despawn_<screen>_screen`.
+- Per-screen tags: `<Screen>ScreenTag` in `app/tags/tags.h` (CamelCase derived from the file name).
 
-## RAYGUI_IMPLEMENTATION Ownership
-
-raygui is a **header-only single-file library** that compiles its implementation only if `#define RAYGUI_IMPLEMENTATION` is set in exactly one translation unit.
-
-**Rule:** The game defines `RAYGUI_IMPLEMENTATION` once on one source file via CMake (currently `app/ui/screen_controllers/title_screen_controller.cpp`), and excludes that source from unity batching:
-
-```cmake
-set_source_files_properties(
-    app/ui/screen_controllers/title_screen_controller.cpp
-    PROPERTIES
-        COMPILE_DEFINITIONS RAYGUI_IMPLEMENTATION
-        SKIP_UNITY_BUILD_INCLUSION TRUE
-)
-```
-
-**Why this matters:**
-- **ODR safety:** Only one translation unit defines the raygui implementation; multiple `.cpp` files can safely `#include "raygui.h"`.
-- **Consistent global state:** raygui maintains internal state (e.g., GuiSetStyle state, focus tracking). Having one source of truth ensures consistency.
-- **Build isolation:** Generated layouts do not define `RAYGUI_IMPLEMENTATION` (enforced by the embeddable template). Screen controllers include both and remain warning-free.
+**Current pattern:** Every migrated screen is one `.rgl` + one codegen-emitted `.cpp` + one row in the `screen_lifecycle_system.cpp` lifecycle table + one entry in `app/tags/tags.h`. Adding a new screen requires touching exactly those four sites; no boilerplate render-dispatch code is needed.
 
 ## Strict Non-Goals
 
-These are explicitly out of scope for the portable C integration:
+These are explicitly out of scope for the codegen integration:
 
-1. **ECS widget mirrors:** Do NOT create `UIWidgetTag` entities, `UIRectangle` components, or `UIButtonState` in the registry to mirror generated layout data.
-2. **Copying layout data:** Do NOT read generated constants (anchor positions, button rectangles) and store them in `reg.ctx()` layout caches or hand-written structs.
-3. **Hand-editing generated files:** Generated `.h` files are final. If layout changes, regenerate from `.rgl`; never manually edit the export.
-4. **Compiling generated `.c` files:** Do not add a CMake target to compile generated `.c` files as separate translation units. Use header-only generated code.
-5. **Standalone execution:** Generated exports are libraries, not standalone tools. The embeddable template removes `main()` and the event loop.
-6. **No committed standalone scratch files:** Any temporary standalone exports must live in `build/rguilayout-scratch/` (or equivalent ignored build scratch path) and must not be committed.
+1. **Hand-written widget mirrors:** Do NOT create `UIWidgetTag` / `UIRectangle` / `UIButtonState` entities to mirror codegen output. The codegen output IS the entity set.
+2. **Layout-data copying:** Do NOT read codegen-emitted rectangles and store them in `reg.ctx()` layout caches or hand-written structs. If a system needs a rectangle, query the spawner-emitted entity directly.
+3. **Hand-editing codegen output:** `app/ui/generated/*_screen.cpp` and `screen_spawners.h` are final. Any layout change is made in the `.rgl` and codegen is regenerated.
+4. **Adopting rguilayout's native exporter:** Do not add a CMake target for the native `--template` flag. The project's codegen path is the only emitter.
+5. **Per-screen render dispatch:** Do not add `switch (phase)` / per-screen `render_*` functions in `ui_render_system.cpp`. The renderer queries by per-kind tag, not by screen.
+6. **No committed standalone scratch files:** Any temporary standalone rguilayout exports must live in `build/rguilayout-scratch/` (or an ignored scratch path) and must not be committed.
 
-## Migration History: Adapter Naming → Screen Controllers (Completed)
+## Migration History: Native Exporter → Codegen + Entity Spawners
 
-The codebase previously used an `app/ui/adapters/` folder with `<screen>_adapter.cpp/.h` naming. This migration to `app/ui/screen_controllers/` is **complete**. All eight screens have been implemented as screen controllers. There is no `app/ui/adapters/` folder; `app/ui/screen_controllers/` is the only and current pattern.
+This integration replaced two earlier UI shapes in sequence:
+
+1. **Adapter-pattern files** (`app/ui/adapters/<screen>_adapter.cpp`) — removed before any official release of this layer.
+2. **Per-screen render-callback files** (one C++ TU per screen, deleted in #1308 once #1287 entity-driven UI shipped end-to-end). Staging shape used while the rguilayout-native-exporter approach was prototyped. Today there is no per-screen render-callback layer.
+
+The current pattern (codegen + entity spawner + uniform render pass) is the only shape under `app/ui/`.
 
 ### Incorrect Pattern (Avoid)
 
-If you encounter code that rebuilds layout state or copies generated rectangles, this is incorrect and must be fixed:
+If you encounter code that rebuilds layout state or copies codegen-emitted rectangles into hand-written structs, this is incorrect and must be fixed:
 
 ```cpp
-// ❌ WRONG: Copying layout rectangles into a cache
+// ❌ WRONG: Copying spawner-emitted rectangles into a cache
 TitleLayout cached_layout = rebuild_layout_from_constants(reg);
 
 // ❌ WRONG: Storing layout in ECS context
-reg.ctx<TitleLayoutCache>() = cached_layout;
+reg.ctx().emplace<TitleLayoutCache>(cached_layout);
 ```
 
 ### Correct Pattern
 
-Use the `RGuiScreenController` template from `screen_controller_base.h` and mutate game state directly via `reg.ctx()`:
+Bind systems mutate atomic components on the spawner-emitted entities:
 
 ```cpp
-// ✅ CORRECT: Use RGuiScreenController template
-using TitleController = RGuiScreenController<TitleLayoutState,
-                                              &TitleLayout_Init,
-                                              &TitleLayout_Render>;
-TitleController title_controller;
-title_controller.init();
+// ✅ CORRECT: gameplay_hud_bind_system writes the current score into the
+// score-label entity's UiLabel.text every frame. Binding is by position
+// match (the codegen bakes the .rgl slot's exact x/y into the spawner, so
+// the bind system finds its target by querying labels at that position
+// inside the gameplay screen view).
+void gameplay_hud_bind_system(entt::registry& reg) {
+    const auto& score = reg.ctx().get<ScoreState>();
+    for (auto [e, label, pos] :
+            reg.view<UiLabel, UiPosition, GameplayHudTag>().each()) {
+        if (pos.x == kScoreSlotX && pos.y == kScoreSlotY) {
+            ui_label_set(label, format_score(score.value));
+        }
+    }
+}
 
-// ✅ CORRECT: Call render, then dispatch via ECS context mutation
-title_controller.render();
-if (title_controller.state().SettingsButtonPressed) {
-    auto& gs = reg.ctx().get<GameState>();
-    gs.transition_pending = true;
-    gs.next_phase = GamePhase::Settings;
+// ✅ CORRECT: An OnPress action emits the semantic event and (optionally)
+// requests a phase transition via the same tag mechanism used elsewhere.
+void pause_button_action(entt::registry& reg, entt::entity /*entity*/) {
+    request_phase_transition<NextPhasePausedTag>(reg);
 }
 ```
 
@@ -342,68 +269,67 @@ if (title_controller.state().SettingsButtonPressed) {
 
 ### CMake Integration
 
-The build system integrates rGuiLayout as follows:
+The build wires the pipeline as follows:
 
 ```cmake
-# 1. Ensure raygui is available (vendored or vcpkg)
-target_include_directories(shapeshifter PRIVATE ${RAYGUI_INCLUDE_DIR})
+# 1. Discover .rgl sources.
+file(GLOB RGL_SOURCES CONFIGURE_DEPENDS content/ui/screens/*.rgl)
 
-# 2. Add generated layout headers (header-only, automatically included via screen controllers)
-# No explicit CMake target needed for .h files.
-
-# 3. Add screen controller sources to the build
-target_sources(shapeshifter PRIVATE
-    app/ui/screen_controllers/title_screen_controller.cpp
-    app/ui/screen_controllers/tutorial_screen_controller.cpp
-    # ... add others as they land
+# 2. Codegen: .rgl → app/ui/generated/<screen>_screen.cpp + screen_spawners.h.
+add_custom_command(
+    OUTPUT  ${RGUILAYOUT_GENERATED_SOURCES}
+    COMMAND python3 ${CMAKE_SOURCE_DIR}/tools/rguilayout/codegen.py
+            --output-dir   ${CMAKE_SOURCE_DIR}/app/ui/generated
+            --actions-header ${CMAKE_SOURCE_DIR}/app/components/actions.h
+            ${RGL_SOURCES}
+    DEPENDS ${RGL_SOURCES} ${CMAKE_SOURCE_DIR}/tools/rguilayout/codegen.py
 )
 
-# 4. Define raygui implementation on exactly one source and keep it out of unity
+# 3. raygui implementation owner — single TU, excluded from unity.
 set_source_files_properties(
-    app/ui/screen_controllers/title_screen_controller.cpp
+    app/ui/raygui_impl.cpp
     PROPERTIES
         COMPILE_DEFINITIONS RAYGUI_IMPLEMENTATION
         SKIP_UNITY_BUILD_INCLUSION TRUE
+)
+
+# 4. Link codegen output + raygui impl into shapeshifter_lib.
+add_library(shapeshifter_lib STATIC
+    ${SYSTEM_SOURCES} ${UTIL_SOURCES} ${UI_SOURCES} ${ENTITY_SOURCES}
+    ${RGUILAYOUT_GENERATED_SOURCES}
 )
 ```
 
 ### Compiler Warnings
 
-- Generated headers and raygui implementation must compile **zero warnings** with `-Wall -Wextra -Werror` (Clang on Linux/macOS/Windows, Emscripten).
-- Screen controllers must also be warning-clean.
-- If a generated header produces warnings, regenerate from `.rgl` or adjust the template.
+- Codegen output and raygui implementation must compile **zero warnings** with `-Wall -Wextra -Werror` (Clang on Linux/macOS/Windows, Emscripten).
+- If a generated source produces warnings, fix the codegen template — never hand-edit the output.
 
 ### Testing
 
-- **Unit tests** for screen controllers: verify that button-press flags trigger correct game events.
-- **Integration tests** for screen controllers: verify that game state is correctly bound to layout state and displayed.
-- **Visual regression tests** (future): compare rendered layouts against baseline screenshots.
-- **Keyboard/touch tests** for input handling via raygui immediate-mode API.
+- **Unit tests** for `ui_update_system` action handlers: each `OnPress`-bound function is exercised directly by emplacing the matching `OnPress` and entity, then asserting the semantic event / phase transition fires.
+- **Lifecycle tests** for `screen_lifecycle_system`: assert that toggling `GamePhase*Tag` ctx mirrors causes the corresponding `<Screen>ScreenTag` entity view to populate / clear.
+- **Codegen verification** in `tools/test_rguilayout_codegen.py`: parses sample `.rgl` files and asserts the output matches a golden tree, plus rejects `.rgl` files whose button names are not in `ActionId`.
 
 ## Validation Checklist
 
-Traceability for these unchecked checklist items is maintained in
-`docs/acceptance-traceability.md`.
-
 - [ ] All screen `.rgl` files are authored and committed in `content/ui/screens/`.
-- [ ] All generated `<screen>_layout.h` files are committed in `app/ui/generated/`.
-- [ ] No generated files are hand-edited; any layout change regenerates from `.rgl`.
-- [ ] All screen controllers include the corresponding generated header and call `Init()` / `Render()`.
-- [ ] No screen controller copies layout rectangles, rebuilds layout caches, or spawns UI widget entities.
-- [ ] CMakeLists.txt defines `RAYGUI_IMPLEMENTATION` on exactly one source and excludes it from unity.
-- [ ] CMakeLists.txt includes raygui and screen controller sources.
-- [ ] All screens render without visual glitches or layout data corruption.
-- [ ] Button presses dispatch correct game commands; no duplicate events.
+- [ ] All `<screen>_screen.cpp` files are committed in `app/ui/generated/` and were produced by running codegen on the corresponding `.rgl`.
+- [ ] No codegen output is hand-edited; any layout change regenerates via `cmake --build`.
+- [ ] Every button name in every `.rgl` appears in `app/components/actions.h`'s `ActionId` enum.
+- [ ] `screen_lifecycle_system.cpp`'s lifecycle table has one row per migrated screen.
+- [ ] `CMakeLists.txt` defines `RAYGUI_IMPLEMENTATION` on exactly one source (`app/ui/raygui_impl.cpp`) and excludes it from unity.
+- [ ] No system under `app/` creates UI entities outside the codegen-emitted spawners.
 - [ ] Build is warning-free (native and WASM).
-- [x] Legacy `app/ui/adapters/` folder has been migrated to `app/ui/screen_controllers/` (migration complete; all 8 screens implemented as screen controllers).
+- [x] Legacy adapter / per-screen-render-callback folders have been deleted (#1308); the entity-driven UI is the only shape.
 
 ## Open Decisions
 
-1. **Template completeness:** Does rguilayout's `embeddable_layout.h` template require manual post-processing, or does it auto-generate fully? If manual, document the process and consider a helper script.
-2. **Dynamic content:** For screens with per-frame text updates (score, selected song), does the generated header expose setter functions, or do screen controllers directly modify state fields?
-3. **Platform guards:** Should screen controllers apply web/desktop visibility rules inline, or should the generated layout respect platform flags?
-4. **Preloading:** For the gameplay HUD, should layout state be pre-allocated and reused across game phases, or recreated per-phase?
+1. **`tutorial_dodge_hint.h`:** This hand-written helper currently lives under `app/ui/`. Its final disposition is being tracked separately — folded into the tutorial spawner or moved to `app/util/` depending on whether it's reusable.
+2. **Dynamic-content slots:** For per-frame text updates (score, selected song), bind systems mutate `UiLabel.text` on spawner-emitted entities. The convention works; whether to extend it to per-frame `UiBounds` mutation (animations) is open.
+3. **Platform guards:** Currently a single shared spawner emits every entity; platform-only entities (e.g. web-only exit button) are gated by visibility-bind systems that toggle render or hit-test inclusion based on the platform. Confirming this scales to more platform splits is a future task.
+4. **Preloading:** Spawner sources are header-light and parse-light; spawn cost is negligible compared to the rest of the per-phase setup. Pre-allocation has not been needed.
 
 ## Summary
 
-**Portable generated C is the primary integration contract.** rGuiLayout produces self-contained, reusable header files that the game consumes via thin screen-controller code. Screen controllers translate raygui input into game commands and bind dynamic game state to layout text/values, but do not build or cache layout state. This separation keeps generated code portable, screen controller code minimal and focused, and game code independent of UI layout details.
+**Codegen-emitted entity spawners are the primary integration contract.** rguilayout produces editable `.rgl` files; `tools/rguilayout/codegen.py` parses them and emits per-screen spawner functions that emplace UI entities into the registry. `screen_lifecycle_system` swaps entity sets when the active `GamePhase*Tag` mirror changes, and `ui_render_system` / `ui_update_system` walk the entities once per frame. No per-screen render-dispatch code, no `LayoutState` structs, no hand-written widget mirrors. The codegen output is the single source of UI entity creation under `app/`.

--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -526,7 +526,9 @@ constexpr float BUTTON_W        = 140.0f;   // used for spacing calculation
 constexpr float BUTTON_H        = 100.0f;   // unused by circular rendering
 constexpr float BUTTON_SPACING  = 60.0f;
 
-// Derived in gameplay_hud_screen_controller
+// Derived in approach_ring_envelope_system (app/systems/approach_ring_envelope_system.cpp)
+// using gameplay_hud_ring_cue() from app/util/gameplay_hud_ring.{h,cpp}.
+// Written to each LaneButtonTag entity's ApproachRing component per frame.
 float btn_radius = BUTTON_W / 2.8f;         // ≈ 50px
 float btn_cx = btn_area_x
     + i * (BUTTON_W + BUTTON_SPACING)


### PR DESCRIPTION
Closes #1318.

Follow-up to #1312/#1315 — that PR only scrubbed `architecture.md` and `game-flow.md`. This PR finishes the sweep across the remaining design-docs that still described the deleted `app/ui/screen_controllers/` folder (deleted by #1308) as the current, as-built architecture.

## Why this matters

The README pins `design-docs/` as the source of truth for new contributors ("check here before implementing any feature"). Until this PR landed, the docs would have told a new contributor to:
- Add a `<screen>_screen_controller.cpp` under `app/ui/screen_controllers/` (the folder doesn't exist).
- Export raygui ImGui-style `Render…UI()` callbacks from there (the actual entry points are codegen-emitted `spawn_<screen>_screen` / `despawn_<screen>_screen` in `app/ui/generated/`).
- Excludes `title_screen_controller.cpp` from unity builds (the actual `RAYGUI_IMPLEMENTATION` owner is `app/ui/raygui_impl.cpp`).

## Acceptance criteria

- [x] `grep -rn 'screen_controller' design-docs/` returns zero hits.
- [x] No source under `app/` modified — docs-only change.
- [x] Build green with zero warnings (`-Wall -Wextra -Werror`).
- [x] `./build/shapeshifter_tests` → `All tests passed (3140 assertions in 934 test cases)`.

## File-by-file

### `design-docs/raygui-rguilayout-ui-spec.md` (major rewrite)

Replaced screen-controller architecture description with the **entity-spawner architecture**:
- Status / preamble: codegen output under `app/ui/generated/<screen>_screen.cpp`, dispatch via `app/systems/screen_lifecycle_system.{h,cpp}`, single-pass render in `app/systems/ui_render_system.cpp`, button-action dispatch in `app/systems/ui_update_system.cpp`.
- Goals (1, 4) and Non-goals: re-pointed at the entity-spawner contract and `GamePhase*Tag` lifecycle.
- Core decision section: per-screen commit-set is now `.rgl` + codegen `<screen>_screen.cpp` spawner.
- Runtime architecture diagram: redrawn end-to-end (codegen → spawner → screen_lifecycle_system → entities → ui_render_system / ui_update_system).
- Screen migration scope table: each row now points at its codegen spawner + bind system (`gameplay_hud_bind_system`, `game_over_scoreboard_bind_system`) and dynamic-spawn helpers (`level_select_dynamic_spawn_system`).
- HUD treatment: `LaneButtonTag` / `EnergyBarTag` / `UiDummyRecTag` entities. Proximity rings are per-`LaneButtonTag` `ApproachRing` components written by `approach_ring_envelope_system` using `gameplay_hud_ring_cue()` from `app/util/gameplay_hud_ring.{h,cpp}`.
- "Producer / consumer boundary" section (replaces "Screen controller boundary"): three-layer Producer / Coordinator / Renderer description.
- Build integration / CI: single `RAYGUI_IMPLEMENTATION` owner is `app/ui/raygui_impl.cpp` (not `title_screen_controller.cpp`); codegen runs via `add_custom_command` (CONFIGURE_DEPENDS on `*.rgl`).
- Phases 1–6: refactored to describe spawner authoring, codegen wiring, `raygui_impl.cpp` ownership, per-screen migration, HUD custom-control draws, JSON-path deletion.
- Validation: stale `LayoutState` reference → literal-constants-in-spawner shape; `GamePhase::Settings` → `GamePhaseSettingsTag`.

### `design-docs/rguilayout-portable-c-integration.md` (full rewrite)

Was: described the rguilayout native code-export flow (`--template embeddable_layout.h` → Init/Render functions → screen controllers).

Now: describes the project's actual codegen path:
- `tools/rguilayout/codegen.py` parses `.rgl` directly and emits per-screen entity-spawner `.cpp` files under `app/ui/generated/`.
- Each control row → one ECS entity with atomic components + per-screen + per-kind tags.
- `screen_lifecycle_system`'s lifecycle table maps `GamePhase*Tag` to its `(spawn, despawn)` pair; no central switch.
- `ui_render_system` queries by per-kind tag for a single render pass; `ui_update_system` hit-tests `UiButtonTag` entities and invokes `OnPress` actions.
- `app/ui/raygui_impl.cpp` owns `RAYGUI_IMPLEMENTATION`; excluded from unity batching via `SKIP_UNITY_BUILD_INCLUSION`.
- New "Why not rguilayout's native code export?" section explaining the decision (existential dispatch, action enum integrity, single-pass rendering, deterministic reviewable output, zero runtime dep on rguilayout).
- New "API Shape: Per-Screen Spawner Pair" section with the actual spawner shape.
- Strict non-goals, migration history (adapter → screen-render-callback → entity spawner).
- CMake guidance rewritten to match as-built pipeline.
- Validation checklist now keys on codegen output + action enum cross-check + raygui_impl.cpp owner.

### `design-docs/feature-specs.md:208` (one-line fix)

`ui_update_system` comment now points at codegen-emitted `app/ui/generated/<screen>_screen.cpp` spawner contract (not the deleted screen-controller layer).

### `design-docs/rhythm-spec.md:529` (one-line fix)

HUD ring derivation comment now points at `app/systems/approach_ring_envelope_system.cpp` + `gameplay_hud_ring_cue()` in `app/util/gameplay_hud_ring.{h,cpp}` (not the deleted `gameplay_hud_screen_controller`).

## References

- Closes #1318
- #1287 / #1193 — entity-driven `ui_render_system` consuming `UiLabelTag` / `UiButtonTag` entities
- #1308 — Delete `app/ui/screen_controllers/` (post-#1287 cleanup)
- #1312 / #1315 — first scrub of design-docs after #1308 (`architecture.md` + `game-flow.md`)
- `.squad/decisions.md` § "DoD source-text grounding (Fabian)" Principles 0–4
