### PR TITLE
#1316 haptics: replace ios_pattern_for_event switch with constexpr table

### DIFF
--- a/app/systems/haptics_ios_bridge_ios.mm
+++ b/app/systems/haptics_ios_bridge_ios.mm
@@ -2,6 +2,8 @@
 
 #import <UIKit/UIKit.h>
 
+#include <array>
+#include <cstddef>
 #include <new>
 
 namespace platform::ios {
@@ -18,21 +20,28 @@ struct IOSPattern {
     int pulse_count = 1;
 };
 
+// Fabian Principle 1 / issue #1316: enum-as-lookup-key into a static table,
+// mirroring `pattern_for_event` in `haptics_backend.cpp:47-72` (issue #1288).
+// Row order must match the `HapticEvent` declaration in
+// `app/systems/haptics.h`; the `static_assert` pins the table size to the
+// trailing enumerator (`UIButtonTap`).
 IOSPattern ios_pattern_for_event(HapticEvent event) {
-    switch (event) {
-        case HapticEvent::LaneSwitch:
-        case HapticEvent::UIButtonTap:
-        case HapticEvent::ShapeShift:
-        case HapticEvent::JumpLand:
-        case HapticEvent::RetryTap:
-            return {UIImpactFeedbackStyleLight, 1};
-        case HapticEvent::NewHighScore:
-            return {UIImpactFeedbackStyleMedium, 1};
-        case HapticEvent::DeathCrash:
-            return {UIImpactFeedbackStyleHeavy, 2};
-        default:
-            return {UIImpactFeedbackStyleLight, 1};
-    }
+    constexpr std::array<IOSPattern, 7> kIOSPatternByEvent{{
+        /* ShapeShift   */ IOSPattern{UIImpactFeedbackStyleLight,  1},
+        /* LaneSwitch   */ IOSPattern{UIImpactFeedbackStyleLight,  1},
+        /* JumpLand     */ IOSPattern{UIImpactFeedbackStyleLight,  1},
+        /* DeathCrash   */ IOSPattern{UIImpactFeedbackStyleHeavy,  2},
+        /* NewHighScore */ IOSPattern{UIImpactFeedbackStyleMedium, 1},
+        /* RetryTap     */ IOSPattern{UIImpactFeedbackStyleLight,  1},
+        /* UIButtonTap  */ IOSPattern{UIImpactFeedbackStyleLight,  1},
+    }};
+    static_assert(kIOSPatternByEvent.size() ==
+                  static_cast<std::size_t>(HapticEvent::UIButtonTap) + 1,
+                  "kIOSPatternByEvent must cover every HapticEvent enumerator");
+
+    const auto idx = static_cast<std::size_t>(event);
+    if (idx >= kIOSPatternByEvent.size()) return IOSPattern{UIImpactFeedbackStyleLight, 1};
+    return kIOSPatternByEvent[idx];
 }
 
 UIImpactFeedbackGenerator* generator_for_style(HapticsIOSState& state,


### PR DESCRIPTION
Closes #1316. Refs #1288 (canonical migration template), #1307, #1311.

## What

`ios_pattern_for_event(HapticEvent)` in `app/systems/haptics_ios_bridge_ios.mm` was the **last surviving** `HapticEvent` label→value `switch` in `app/`. It is now a `constexpr std::array<IOSPattern, 7>` indexed by the enum ordinal, mirroring `pattern_for_event` in `app/systems/haptics_backend.cpp:47-72` (issue #1288) one-for-one.

```cpp
constexpr std::array<IOSPattern, 7> kIOSPatternByEvent{{
    /* ShapeShift   */ IOSPattern{UIImpactFeedbackStyleLight,  1},
    /* LaneSwitch   */ IOSPattern{UIImpactFeedbackStyleLight,  1},
    /* JumpLand     */ IOSPattern{UIImpactFeedbackStyleLight,  1},
    /* DeathCrash   */ IOSPattern{UIImpactFeedbackStyleHeavy,  2},
    /* NewHighScore */ IOSPattern{UIImpactFeedbackStyleMedium, 1},
    /* RetryTap     */ IOSPattern{UIImpactFeedbackStyleLight,  1},
    /* UIButtonTap  */ IOSPattern{UIImpactFeedbackStyleLight,  1},
}};
static_assert(kIOSPatternByEvent.size() ==
              static_cast<std::size_t>(HapticEvent::UIButtonTap) + 1,
              "kIOSPatternByEvent must cover every HapticEvent enumerator");
```

## Acceptance — from the issue

- [x] `switch` replaced with `constexpr std::array<IOSPattern, N>` indexed by `static_cast<std::size_t>(event)`, where `N == static_cast<std::size_t>(HapticEvent::UIButtonTap) + 1` (pinned by `static_assert`, identical pattern to `haptics_backend.cpp` / `to_string(HapticEvent)`).
- [x] `default:` arm dropped — `static_assert` + ordinal bounds-check is the safety net.
- [x] Row order matches the `HapticEvent` declaration in `app/systems/haptics.h` (single source of truth).
- [x] iOS path stays warning-free under `-Wall -Wextra -Werror` — verified locally via the same CI gate (`SHAPESHIFTER_IOS_BRIDGE_COMPILE_CHECK=ON` + `CMAKE_SYSTEM_NAME=iOS` + `CMAKE_OSX_SYSROOT=iphonesimulator`).
- [x] No behavioural change — every event maps to the same `(style, pulse_count)` it did before. Table values vs. prior switch:
  - `ShapeShift / LaneSwitch / JumpLand / RetryTap / UIButtonTap` → `(Light, 1)`
  - `DeathCrash` → `(Heavy, 2)`
  - `NewHighScore` → `(Medium, 1)`

## Explicitly out of scope (per issue)

`switch (style)` on `UIImpactFeedbackStyle` at lines 50–63 stays. That discriminator is an Apple SDK enum bound to instance-variable slot picking (one of three `UIImpactFeedbackGenerator*` slots on `HapticsIOSState`), not a Fabian table-driven lookup of project data.

## Verification

- ✅ `cmake --build build` (native macOS) — green, zero warnings.
- ✅ `./build/shapeshifter_tests` — `All tests passed (3140 assertions in 934 test cases)`.
- ✅ iOS bridge compile-check (mirrors `ios-bridge-compile-gate` CI job in `.github/workflows/ci-macos.yml`):

  ```
  cmake -B build-ios-bridge -S . -Wno-dev \
    -DSHAPESHIFTER_IOS_BRIDGE_COMPILE_CHECK=ON \
    -DCMAKE_SYSTEM_NAME=iOS \
    -DCMAKE_OSX_SYSROOT=iphonesimulator \
    -DCMAKE_OSX_ARCHITECTURES=arm64
  cmake --build build-ios-bridge --config Release --target shapeshifter_ios_bridge_compile_check_target
  ```

  Builds cleanly with `-Wall -Wextra -Werror`.
