### PR TITLE
#1317 ui: move raygui_impl.cpp from app/ui/ to app/util/ (sub-PR 1 of 3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,11 +179,11 @@ set_source_files_properties(${RGUILAYOUT_GENERATED_SOURCES}
 
 # raygui is header-only and requires one implementation owner TU. Keep the
 # `RAYGUI_IMPLEMENTATION` macro rooted in a tiny dedicated source file
-# (`app/ui/raygui_impl.cpp`) so deleting any other screen-related TU never
+# (`app/util/raygui_impl.cpp`) so deleting any other screen-related TU never
 # breaks the build. Skipping unity-build inclusion guarantees the macro is
-# emitted exactly once.
+# emitted exactly once. Picked up by the `app/util/*.cpp` glob above.
 set_source_files_properties(
-    app/ui/raygui_impl.cpp
+    app/util/raygui_impl.cpp
     PROPERTIES
         COMPILE_DEFINITIONS RAYGUI_IMPLEMENTATION
         SKIP_UNITY_BUILD_INCLUSION TRUE

--- a/app/util/raygui_impl.cpp
+++ b/app/util/raygui_impl.cpp
@@ -8,5 +8,9 @@
 // Replaces the same role previously held by
 // `app/ui/screen_controllers/title_screen_controller.cpp` before that
 // folder was deleted (issue #1308 / refs #1287 OoS-B / #1193).
+//
+// Moved from `app/ui/raygui_impl.cpp` to `app/util/` per issue #1317
+// sub-PR 1 (closes `app/ui/` per .squad/decisions.md § 7 folder allowlist):
+// this file is build-glue util, not a UI screen.
 
 #include <raygui.h>

--- a/design-docs/raygui-rguilayout-ui-spec.md
+++ b/design-docs/raygui-rguilayout-ui-spec.md
@@ -221,7 +221,7 @@ The UI pipeline is wired into `shapeshifter_lib` as follows:
 - `tools/rguilayout/` is the vendored authoring/tooling location. `tools/rguilayout/codegen.py` is invoked at CMake configure time to regenerate `app/ui/generated/<screen>_screen.cpp` + `screen_spawners.h` from `content/ui/screens/*.rgl`. The authoring GUI is not run in CI.
 - `.rgl` layout sources live in `content/ui/screens/` unless a future global/root layout source is justified.
 - Codegen output `.cpp` files under `app/ui/generated/` are added to `shapeshifter_lib` via the `RGUILAYOUT_GENERATED_SOURCES` list in `CMakeLists.txt`.
-- `app/ui/raygui_impl.cpp` is the single-TU owner of `RAYGUI_IMPLEMENTATION`. The macro is set via `COMPILE_DEFINITIONS RAYGUI_IMPLEMENTATION` on that source file, and the file is excluded from unity batching (`SKIP_UNITY_BUILD_INCLUSION TRUE`) so the raygui implementation stays isolated.
+- `app/util/raygui_impl.cpp` is the single-TU owner of `RAYGUI_IMPLEMENTATION`. The macro is set via `COMPILE_DEFINITIONS RAYGUI_IMPLEMENTATION` on that source file, and the file is excluded from unity batching (`SKIP_UNITY_BUILD_INCLUSION TRUE`) so the raygui implementation stays isolated.
 - All other UI consumer TUs (`ui_render_system.cpp`, `ui_update_system.cpp`, `screen_lifecycle_system.cpp`, the per-screen bind systems) live in `app/systems/` and pull in raygui headers normally without defining the implementation macro.
 
 The native build (`shapeshifter`, `shapeshifter_tests`) and WASM build compile the spawner sources and raygui implementation together and stay warning-clean under `-Wall -Wextra -Werror`.
@@ -251,7 +251,7 @@ The native build (`shapeshifter`, `shapeshifter_tests`) and WASM build compile t
 
 ### Phase 3: Build integration — done
 
-raygui codegen build support, spawner compilation, native CI coverage, and WASM CI coverage are in place. `RAYGUI_IMPLEMENTATION` ownership lives on `app/ui/raygui_impl.cpp` and that TU is excluded from unity batching.
+raygui codegen build support, spawner compilation, native CI coverage, and WASM CI coverage are in place. `RAYGUI_IMPLEMENTATION` ownership lives on `app/util/raygui_impl.cpp` and that TU is excluded from unity batching.
 
 ### Phase 4: Menus and overlays — done
 

--- a/design-docs/rguilayout-portable-c-integration.md
+++ b/design-docs/rguilayout-portable-c-integration.md
@@ -84,11 +84,11 @@ Per-screen bind systems (`gameplay_hud_bind_system`, `game_over_scoreboard_bind_
 
 ### 4. RAYGUI_IMPLEMENTATION Ownership
 
-raygui is a header-only single-file library that compiles its implementation only when `#define RAYGUI_IMPLEMENTATION` is set in exactly one translation unit. That TU is `app/ui/raygui_impl.cpp`. CMake attaches the macro via `COMPILE_DEFINITIONS RAYGUI_IMPLEMENTATION` on that source and excludes it from unity batching:
+raygui is a header-only single-file library that compiles its implementation only when `#define RAYGUI_IMPLEMENTATION` is set in exactly one translation unit. That TU is `app/util/raygui_impl.cpp`. CMake attaches the macro via `COMPILE_DEFINITIONS RAYGUI_IMPLEMENTATION` on that source and excludes it from unity batching:
 
 ```cmake
 set_source_files_properties(
-    app/ui/raygui_impl.cpp
+    app/util/raygui_impl.cpp
     PROPERTIES
         COMPILE_DEFINITIONS RAYGUI_IMPLEMENTATION
         SKIP_UNITY_BUILD_INCLUSION TRUE
@@ -184,7 +184,6 @@ content/ui/screens/
   settings.rgl
 
 app/ui/
-  raygui_impl.cpp             # Single RAYGUI_IMPLEMENTATION TU; excluded from unity.
   tutorial_dodge_hint.h       # Hand-written tutorial helper.
   generated/
     title_screen.cpp          # Codegen output: spawn_/despawn_ pair.
@@ -196,6 +195,9 @@ app/ui/
     song_complete_screen.cpp
     settings_screen.cpp
     screen_spawners.h         # Forward declarations for every pair.
+
+app/util/
+  raygui_impl.cpp             # Single RAYGUI_IMPLEMENTATION TU; excluded from unity.
 ```
 
 **Naming conventions:**
@@ -287,7 +289,7 @@ add_custom_command(
 
 # 3. raygui implementation owner — single TU, excluded from unity.
 set_source_files_properties(
-    app/ui/raygui_impl.cpp
+    app/util/raygui_impl.cpp
     PROPERTIES
         COMPILE_DEFINITIONS RAYGUI_IMPLEMENTATION
         SKIP_UNITY_BUILD_INCLUSION TRUE
@@ -318,7 +320,7 @@ add_library(shapeshifter_lib STATIC
 - [ ] No codegen output is hand-edited; any layout change regenerates via `cmake --build`.
 - [ ] Every button name in every `.rgl` appears in `app/components/actions.h`'s `ActionId` enum.
 - [ ] `screen_lifecycle_system.cpp`'s lifecycle table has one row per migrated screen.
-- [ ] `CMakeLists.txt` defines `RAYGUI_IMPLEMENTATION` on exactly one source (`app/ui/raygui_impl.cpp`) and excludes it from unity.
+- [ ] `CMakeLists.txt` defines `RAYGUI_IMPLEMENTATION` on exactly one source (`app/util/raygui_impl.cpp`) and excludes it from unity.
 - [ ] No system under `app/` creates UI entities outside the codegen-emitted spawners.
 - [ ] Build is warning-free (native and WASM).
 - [x] Legacy adapter / per-screen-render-callback folders have been deleted (#1308); the entity-driven UI is the only shape.

--- a/tools/rguilayout/INTEGRATION.md
+++ b/tools/rguilayout/INTEGRATION.md
@@ -92,7 +92,8 @@ end-to-end by ECS:
 The legacy `app/ui/screen_controllers/*` OOP bridge and the matching
 `app/ui/generated/*_layout.h` god-struct headers were deleted in #1308 (refs
 #1287 OoS-B / #1193). The single `RAYGUI_IMPLEMENTATION` translation unit
-now lives at `app/ui/raygui_impl.cpp`.
+now lives at `app/util/raygui_impl.cpp` (moved from `app/ui/` in #1317
+sub-PR 1, completing the Section-7 folder-allowlist sweep).
 
 ## Doctrine
 


### PR DESCRIPTION
Refs #1317 (umbrella). First of three sub-PRs to eliminate `app/ui/` and close the Section-7 folder-allowlist gap (`.squad/decisions.md` § 7).

## Scope — sub-PR 1 of 3 (smallest bucket)

Per #1317's suggested split:

| Bucket | Files | Destination | This PR |
|---|---|---|---|
| (1) raygui implementation TU | `raygui_impl.cpp` | `app/util/raygui_impl.cpp` | ✅ this PR |
| (2) Hand-written helpers | `tutorial_dodge_hint.h` | `app/util/` or fold | follow-up |
| (3) rguilayout codegen output | `generated/*.cpp` + `screen_spawners.h` | `app/systems/generated/` + tools/rguilayout codegen output path | follow-up |

`raygui_impl.cpp` is a one-line build-glue TU (`#include <raygui.h>` paired with the CMake-side `COMPILE_DEFINITIONS RAYGUI_IMPLEMENTATION` + `SKIP_UNITY_BUILD_INCLUSION TRUE` properties). It is not a UI screen or controller; it is build glue, which makes `app/util/` the honest fit under the 5-folder allowlist (`components/ entities/ systems/ tags/ util/`).

## Mechanics

- `git mv app/ui/raygui_impl.cpp app/util/raygui_impl.cpp` — file content unchanged apart from a one-paragraph breadcrumb note added to the header comment pointing to this issue.
- `CMakeLists.txt`: updated the path in the existing `set_source_files_properties(... app/util/raygui_impl.cpp ...)` call and refreshed the surrounding comment. The `file(GLOB UTIL_SOURCES CONFIGURE_DEPENDS app/util/*.cpp)` line picks up the new path automatically; the `SKIP_UNITY_BUILD_INCLUSION TRUE` property is preserved so the `RAYGUI_IMPLEMENTATION` macro is still emitted exactly once (verified in the build log — a dedicated `app/util/raygui_impl.cpp.o` object is produced instead of being folded into a unity batch).
- The `file(GLOB UI_SOURCES CONFIGURE_DEPENDS app/ui/*.cpp)` glob now expands to an empty list (`app/ui/` contains only `tutorial_dodge_hint.h` + `generated/` after this move). That is fine — expanding an empty variable in `add_library` is a no-op. The glob will be deleted in sub-PR 3 when the last `app/ui/*` files move out.

## Docs scrub

The old path is referenced in active design docs at three sites; all updated to `app/util/raygui_impl.cpp`:

- `design-docs/raygui-rguilayout-ui-spec.md` (Phase 3 + file-roles)
- `design-docs/rguilayout-portable-c-integration.md` (impl-ownership section, file-layout tree, CMake snippet, validation checklist)
- `tools/rguilayout/INTEGRATION.md` (post-#1308 note)

`.squad/decisions-archive.md` and `.squad/agents/*/history-archive.md` intentionally left alone (historical breadcrumbs).

## Verification

- ✅ `cmake --build build` — green, zero warnings. Build log confirms `app/util/raygui_impl.cpp.o` is compiled as a standalone TU (not folded into a unity batch), preserving the `SKIP_UNITY_BUILD_INCLUSION` invariant.
- ✅ `./build/shapeshifter_tests` — `All tests passed (3140 assertions in 934 test cases)`.
- ✅ iOS bridge compile-check (`SHAPESHIFTER_IOS_BRIDGE_COMPILE_CHECK=ON` + iphonesimulator sysroot) — still green (independent of this move but verified).

## Acceptance (umbrella, partial)

- [x] **Bucket (1)** done: `raygui_impl.cpp` now lives at `app/util/raygui_impl.cpp`.
- [x] No other source under `app/` references the old `ui/raygui_impl.cpp` path.
- [x] `CMakeLists.txt` `SKIP_UNITY_BUILD_INCLUSION` invariant preserved.
- [x] Build + tests + zero-warning standard green on native macOS + iOS bridge compile gate.
- [ ] `app/ui/` directory does not exist — **deferred to sub-PR 3** (last bucket).

Refs #1317 (umbrella), #1308 (predecessor: deleted screen_controllers/), #1193 (`app/ui/` migration umbrella).
