### PR TITLE
#1323 haptics: replace generator_for_style switch with positional std::array slot

### DIFF
--- a/app/systems/haptics_ios_bridge_ios.mm
+++ b/app/systems/haptics_ios_bridge_ios.mm
@@ -7,10 +7,17 @@
 #include <new>
 
 namespace platform::ios {
+
+// UIKit's `UIImpactFeedbackStyle` declares Light/Medium/Heavy as the contiguous
+// integral values 0/1/2 — the only styles we ever pass through this bridge
+// (see `kIOSPatternByEvent` below). Future vendor extensions (Soft/Rigid on
+// iOS 13+) fall outside this range and collapse to the Light slot via
+// `generator_slot_for_style`. Keep this constant in sync with the slot count
+// referenced in #1323 if a new style is ever added to the pattern table.
+constexpr std::size_t kHapticsGeneratorSlotCount = 3;
+
 struct HapticsIOSState {
-    UIImpactFeedbackGenerator* light = nil;
-    UIImpactFeedbackGenerator* medium = nil;
-    UIImpactFeedbackGenerator* heavy = nil;
+    std::array<UIImpactFeedbackGenerator*, kHapticsGeneratorSlotCount> generators{};
 };
 
 namespace {
@@ -44,28 +51,23 @@ IOSPattern ios_pattern_for_event(HapticEvent event) {
     return kIOSPatternByEvent[idx];
 }
 
+// Fabian Principle 1 / issue #1323: positional slot lookup replaces a
+// label→pointer `switch` over `UIImpactFeedbackStyle`. UIKit guarantees
+// `Light=0/Medium=1/Heavy=2` (the only styles we pass); any out-of-range
+// vendor extension (`Soft`/`Rigid`, iOS 13+) collapses to the Light slot.
+std::size_t generator_slot_for_style(UIImpactFeedbackStyle style) noexcept {
+    const auto idx = static_cast<std::size_t>(style);
+    return idx < kHapticsGeneratorSlotCount ? idx : 0;
+}
+
 UIImpactFeedbackGenerator* generator_for_style(HapticsIOSState& state,
                                                 UIImpactFeedbackStyle style) {
-    UIImpactFeedbackGenerator** slot = nullptr;
-    switch (style) {
-        case UIImpactFeedbackStyleLight:
-            slot = &state.light;
-            break;
-        case UIImpactFeedbackStyleMedium:
-            slot = &state.medium;
-            break;
-        case UIImpactFeedbackStyleHeavy:
-            slot = &state.heavy;
-            break;
-        default:
-            slot = &state.light;
-            break;
+    UIImpactFeedbackGenerator*& slot =
+        state.generators[generator_slot_for_style(style)];
+    if (slot == nil) {
+        slot = [[UIImpactFeedbackGenerator alloc] initWithStyle:style];
     }
-
-    if (*slot == nil) {
-        *slot = [[UIImpactFeedbackGenerator alloc] initWithStyle:style];
-    }
-    return *slot;
+    return slot;
 }
 
 void destroy_generator(UIImpactFeedbackGenerator*& generator) {
@@ -119,9 +121,9 @@ void haptics_ios_trigger(HapticsIOSState& state, HapticEvent event) noexcept {
 
 void haptics_ios_reset(HapticsIOSState& state) noexcept {
     @autoreleasepool {
-        destroy_generator(state.light);
-        destroy_generator(state.medium);
-        destroy_generator(state.heavy);
+        for (auto& generator : state.generators) {
+            destroy_generator(generator);
+        }
     }
 }
 


### PR DESCRIPTION
Closes #1323.

## Summary

`generator_for_style` in `app/systems/haptics_ios_bridge_ios.mm` still had the only remaining label→pointer `switch` over a discriminator in `app/`. UIKit guarantees `UIImpactFeedbackStyle` Light/Medium/Heavy occupy the contiguous integral values 0/1/2 — the only styles we ever pass through this bridge (see `kIOSPatternByEvent`). Replacing the three named pointer fields with `std::array<UIImpactFeedbackGenerator*, 3>` and selecting the slot via a bounds-checked cast eliminates the switch and matches the constexpr-table approach #1316/#1320 used for `ios_pattern_for_event` in the same TU.

## What changed

`app/systems/haptics_ios_bridge_ios.mm`:

- `HapticsIOSState`: three named pointers (`light`/`medium`/`heavy`) → `std::array<UIImpactFeedbackGenerator*, kHapticsGeneratorSlotCount> generators{}` (`kHapticsGeneratorSlotCount = 3`).
- New TU-local helper `generator_slot_for_style(UIImpactFeedbackStyle) → std::size_t` that does a bounds-checked cast (out-of-range vendor extensions like Soft/Rigid on iOS 13+ collapse to the Light slot).
- `generator_for_style` now resolves its slot positionally — no `switch`, no `if`-cascade on the style label.
- `haptics_ios_reset` walks the array via range-`for` instead of three named calls.

No public-API change (`haptics_ios_bridge.h` only forward-declares `HapticsIOSState`).

## Acceptance criteria

- [x] No `switch` statements remain in `app/systems/haptics_ios_bridge_ios.mm` — verified by `grep -rn "\\bswitch\\s*(" app/` (only documentation-comment hits in unrelated files remain).
- [x] `HapticsIOSState` stores its generator pointers in a positional container (array indexed by slot).
- [x] iOS build (CI's `iOS ObjC++ compile gate`) + iOS-stub native build remain warning-free under `-Wall -Wextra -Werror`.
- [x] No regression in the haptics test suite (`tests/test_haptic_system.cpp` + `tests/test_haptics_backend.cpp`).
- [x] `grep -rn "\\bswitch\\s*(" app/` returns zero hits in actual code (only comments).

## Local verification (macOS)

- `cmake --build build --config Release` → all targets built, zero warnings, includes the stub-TU path that the native binary actually links.
- `cmake -B build-ios-bridge -DSHAPESHIFTER_IOS_BRIDGE_COMPILE_CHECK=ON -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphonesimulator -DCMAKE_OSX_ARCHITECTURES=arm64` then `cmake --build build-ios-bridge --target shapeshifter_ios_bridge_compile_check_target` → builds cleanly under `-Wall -Wextra -Werror` (mirrors `ci-macos.yml`'s `ios-bridge-compile-gate` job).
- `./build/shapeshifter_tests` → **934 test cases, 3140 assertions, all passing.** Haptics-tagged subset (`[haptic]`): 14 cases, 20 assertions, all passing.
- `python3 tools/check_enum_allowlist.py` → `ok: 8 enum(s) in app/, all allowlisted` (no new enums introduced).

## References

- `.squad/decisions.md` § "DoD source-text grounding (Fabian)" Principle 1 (Existential Processing)
- #1316 / #1320 — sibling migration of `ios_pattern_for_event` in the same TU
- #1204 — cyclomatic-ratchet mechanism (this PR drops the `app/` switch count by 1)