### PR TITLE
#1327 settings_screen_bind_system: replace else-if ladder with constexpr SlotRow table

### DIFF
--- a/app/systems/settings_screen_bind_system.cpp
+++ b/app/systems/settings_screen_bind_system.cpp
@@ -22,6 +22,22 @@ constexpr float kHapticsToggleY      = 720.0f;
 constexpr float kReduceMotionToggleX = 152.0f;
 constexpr float kReduceMotionToggleY = 880.0f;
 
+// Bind context — owns the per-frame singleton reads so the per-slot
+// `bind_*` functions are pure transforms over their slot's `UiLabel` +
+// `UiToggleState`. Mirrors the `BindContext` shape used by the sibling
+// `game_over_scoreboard_bind_system` / `song_complete_scoreboard_bind_system` /
+// `gameplay_hud_bind_system` binders. Named `SettingsBindContext` (not the
+// bare `BindContext` used by the siblings) so that the Unity-build chunk
+// that currently merges this TU with `song_complete_scoreboard_bind_system`
+// does not hit an anonymous-namespace ODR collision.
+struct SettingsBindContext {
+    int16_t audio_offset_ms;
+    bool    haptics_on;
+    // Display-side inversion: the visible toggle reads "MOTION: ON" when
+    // motion is NOT reduced. Matches the legacy controller (#1295 spec).
+    bool    motion_on;
+};
+
 void format_offset(int16_t offset_ms, UiLabel& label) {
     char buf[16];
     std::snprintf(buf, sizeof(buf), "%+d ms", static_cast<int>(offset_ms));
@@ -38,6 +54,38 @@ void format_toggle(UiLabel& label, const char* name, bool on) {
     ui_label_set(label, buf);
 }
 
+void bind_audio_offset(const SettingsBindContext& ctx, entt::registry& /*reg*/,
+                       entt::entity /*e*/, UiLabel& label) {
+    format_offset(ctx.audio_offset_ms, label);
+}
+
+void bind_haptics_toggle(const SettingsBindContext& ctx, entt::registry& reg,
+                         entt::entity e, UiLabel& label) {
+    format_toggle(label, "HAPTICS", ctx.haptics_on);
+    reg.emplace_or_replace<UiToggleState>(e, UiToggleState{ctx.haptics_on});
+}
+
+void bind_motion_toggle(const SettingsBindContext& ctx, entt::registry& reg,
+                        entt::entity e, UiLabel& label) {
+    format_toggle(label, "MOTION", ctx.motion_on);
+    reg.emplace_or_replace<UiToggleState>(e, UiToggleState{ctx.motion_on});
+}
+
+using SettingsSlotBindFn = void (*)(const SettingsBindContext&, entt::registry&,
+                                    entt::entity, UiLabel&);
+
+struct SettingsSlotRow {
+    float x;
+    float y;
+    SettingsSlotBindFn fn;
+};
+
+constexpr std::array<SettingsSlotRow, 3> kSettingsScreenSlots = {{
+    {kAudioOffsetDisplayX, kAudioOffsetDisplayY, &bind_audio_offset},
+    {kHapticsToggleX,      kHapticsToggleY,      &bind_haptics_toggle},
+    {kReduceMotionToggleX, kReduceMotionToggleY, &bind_motion_toggle},
+}};
+
 }  // namespace
 
 void settings_screen_bind_system(entt::registry& reg) {
@@ -47,23 +95,20 @@ void settings_screen_bind_system(entt::registry& reg) {
     const auto* state = find_settings_state(reg);
     if (state == nullptr) return;
 
-    const bool haptics_on = state->haptics_enabled;
-    // Display-side inversion: the visible toggle reads "MOTION: ON" when
-    // motion is NOT reduced. Matches the legacy controller (#1295 spec).
-    const bool motion_on  = !state->reduce_motion;
+    const SettingsBindContext ctx{
+        state->audio_offset_ms,
+        state->haptics_enabled,
+        !state->reduce_motion,
+    };
 
     for (auto entity : view) {
         const auto& pos = view.get<UiPosition>(entity);
         auto& label = view.get<UiLabel>(entity);
-
-        if (pos.x == kAudioOffsetDisplayX && pos.y == kAudioOffsetDisplayY) {
-            format_offset(state->audio_offset_ms, label);
-        } else if (pos.x == kHapticsToggleX && pos.y == kHapticsToggleY) {
-            format_toggle(label, "HAPTICS", haptics_on);
-            reg.emplace_or_replace<UiToggleState>(entity, UiToggleState{haptics_on});
-        } else if (pos.x == kReduceMotionToggleX && pos.y == kReduceMotionToggleY) {
-            format_toggle(label, "MOTION", motion_on);
-            reg.emplace_or_replace<UiToggleState>(entity, UiToggleState{motion_on});
+        for (const auto& row : kSettingsScreenSlots) {
+            if (pos.x == row.x && pos.y == row.y) {
+                row.fn(ctx, reg, entity, label);
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #1327.

## Summary

Aligns `settings_screen_bind_system.cpp` with the canonical `constexpr std::array<SlotRow, N>` function-pointer dispatch pattern already used by its three sibling binders. Per `.squad/decisions.md` § "DoD source-text grounding (Fabian)" Principle 1, control-flow ladders dispatching on a discriminator (here: the `(pos.x, pos.y)` slot key) become table lookups.

## Before / After

| binder | pattern |
|---|---|
| `gameplay_hud_bind_system.cpp` | `std::array<SlotRow, 4>` + fn-ptrs ✓ |
| `song_complete_scoreboard_bind_system.cpp` | `std::array<SlotRow, 7>` + fn-ptrs ✓ |
| `game_over_scoreboard_bind_system.cpp` | `std::array<SlotRow, 6>` + fn-ptrs ✓ |
| **`settings_screen_bind_system.cpp` (before)** | **else-if ladder (3 branches)** ✗ |
| **`settings_screen_bind_system.cpp` (after)** | **`std::array<SettingsSlotRow, 3>` + fn-ptrs** ✓ |

The three slot behaviours (audio offset, haptics toggle, motion toggle) are extracted as `bind_audio_offset` / `bind_haptics_toggle` / `bind_motion_toggle` free functions and driven through `constexpr std::array<SettingsSlotRow, 3> kSettingsScreenSlots` indexed by the canonical `(x, y)` literals already baked into `spawn_settings_screen` by the rguilayout codegen.

## Cyclomatic ratchet

3 `if`/`else if` branches in the dispatch → 1 position-match inside a fixed-size loop. Moves the cyclomatic count *down*, per the operational corollary in `.squad/decisions.md` § "DoD source-text grounding (Fabian)".

## Naming note

The structs are `SettingsBindContext` / `SettingsSlotBindFn` / `SettingsSlotRow` rather than the bare `BindContext` / `SlotBindFn` / `SlotRow` used by the three sibling binders. Reason: Unity-build chunk `unity_5_cxx.cxx` currently merges this TU with `song_complete_scoreboard_bind_system.cpp`, and reusing the bare names would hit an anonymous-namespace ODR collision in that chunk. A separate follow-up issue tracks unifying the binder-symbol naming once the latent collision pattern (the three other binders only avoid colliding via lucky Unity chunk placement) is resolved at the build-system layer.

## Validation

- Build (`cmake --build build`): zero warnings, clean link.
- Tests: `./build/shapeshifter_tests [settings_screen_bind_system]` — 14 assertions in 3 cases pass; full suite — 3140 assertions in 934 cases pass.
- No behaviour change. The existing three `[settings_screen_bind_system]` cases in `tests/test_ui_update_system.cpp` exercise all three slots (audio-offset formatting incl. positive/negative sign, both toggle on/off rendering with `UiToggleState` writes, no-op when SettingsScreen entities absent) and pass unmodified.