### PR TITLE
#1329 binders: prefix anonymous-namespace types to eliminate Unity ODR landmine

### DIFF
--- a/app/systems/game_over_scoreboard_bind_system.cpp
+++ b/app/systems/game_over_scoreboard_bind_system.cpp
@@ -17,36 +17,40 @@ namespace {
 // debounce window before `game_state_enter_terminal_phase_game_over`
 // populates it. `EnergyDepletedDeath` is a presence-only ctx tag (no
 // payload) so we carry a bool for it.
-struct BindContext {
+//
+// Per-binder prefix (`GameOver*`) avoids an anonymous-namespace ODR
+// collision with the sibling `*_bind_system.cpp` files when CMake Unity
+// chunking happens to place two binders in the same jumbo TU (issue #1329).
+struct GameOverBindContext {
     const ScoreState& score;
     const CurrentSongHighScore& current;
     const TerminalResultState* result;
     bool energy_depleted;
 };
 
-using SlotBindFn = void (*)(const BindContext&, UiLabel&);
+using GameOverSlotBindFn = void (*)(const GameOverBindContext&, UiLabel&);
 
-bool is_new_best(const BindContext& ctx) {
+bool is_new_best(const GameOverBindContext& ctx) {
     return ctx.result != nullptr && ctx.result->new_best;
 }
 
-void bind_score(const BindContext& ctx, UiLabel& label) {
+void bind_score(const GameOverBindContext& ctx, UiLabel& label) {
     char buf[32];
     std::snprintf(buf, sizeof(buf), "%d", ctx.score.score);
     ui_label_set(label, buf);
 }
 
-void bind_high_score(const BindContext& ctx, UiLabel& label) {
+void bind_high_score(const GameOverBindContext& ctx, UiLabel& label) {
     char buf[32];
     std::snprintf(buf, sizeof(buf), "%d", ctx.current.value);
     ui_label_set(label, buf);
 }
 
-void bind_new_best(const BindContext& ctx, UiLabel& label) {
+void bind_new_best(const GameOverBindContext& ctx, UiLabel& label) {
     ui_label_set(label, is_new_best(ctx) ? "NEW BEST!" : "");
 }
 
-void bind_prev_best(const BindContext& ctx, UiLabel& label) {
+void bind_prev_best(const GameOverBindContext& ctx, UiLabel& label) {
     if (!is_new_best(ctx)) {
         ui_label_set(label, "");
         return;
@@ -58,7 +62,7 @@ void bind_prev_best(const BindContext& ctx, UiLabel& label) {
 
 // Reason slot at y=685 — shown only when NOT new-best (legacy
 // `reason_y = 685.0f` branch in `draw_game_over_scoreboard`).
-void bind_reason(const BindContext& ctx, UiLabel& label) {
+void bind_reason(const GameOverBindContext& ctx, UiLabel& label) {
     if (!ctx.energy_depleted || is_new_best(ctx)) {
         ui_label_set(label, "");
         return;
@@ -69,7 +73,7 @@ void bind_reason(const BindContext& ctx, UiLabel& label) {
 // Reason slot at y=742 — shown only when new-best (legacy
 // `reason_y = 742.0f` branch in `draw_game_over_scoreboard`; the reason
 // moves down to clear room for "NEW BEST!" + "PREV N").
-void bind_reason_new_best(const BindContext& ctx, UiLabel& label) {
+void bind_reason_new_best(const GameOverBindContext& ctx, UiLabel& label) {
     if (!ctx.energy_depleted || !is_new_best(ctx)) {
         ui_label_set(label, "");
         return;
@@ -82,13 +86,13 @@ void bind_reason_new_best(const BindContext& ctx, UiLabel& label) {
 // into the spawn block, so a layout edit that moves a slot will silently
 // miss its bind (caught by a visible empty placeholder in playtest before
 // any production build).
-struct SlotRow {
+struct GameOverSlotRow {
     float x;
     float y;
-    SlotBindFn fn;
+    GameOverSlotBindFn fn;
 };
 
-constexpr std::array<SlotRow, 6> kGameOverSlots = {{
+constexpr std::array<GameOverSlotRow, 6> kGameOverSlots = {{
     {210.0f, 540.0f, &bind_score},
     {210.0f, 634.0f, &bind_high_score},
     {110.0f, 665.0f, &bind_new_best},
@@ -103,7 +107,7 @@ void game_over_scoreboard_bind_system(entt::registry& reg) {
     auto view = reg.view<GameOverScreenTag, UiLabelTag, UiPosition, UiLabel>();
     if (view.begin() == view.end()) return;
 
-    const BindContext ctx{
+    const GameOverBindContext ctx{
         reg.ctx().get<ScoreState>(),
         reg.ctx().get<CurrentSongHighScore>(),
         reg.ctx().find<TerminalResultState>(),

--- a/app/systems/gameplay_hud_bind_system.cpp
+++ b/app/systems/gameplay_hud_bind_system.cpp
@@ -41,7 +41,10 @@ constexpr int kChainMeaningfulThreshold = 5;
 // Chain visibility threshold (legacy `score->chain_count >= 2`).
 constexpr int kChainVisibleThreshold = 2;
 
-struct BindContext {
+// Per-binder prefix (`GameplayHud*`) avoids an anonymous-namespace ODR
+// collision with the sibling `*_bind_system.cpp` files when CMake Unity
+// chunking happens to place two binders in the same jumbo TU (issue #1329).
+struct GameplayHudBindContext {
     const ScoreState*           score;
     const ScoreDisplay*         display;
     const CurrentSongHighScore* current;
@@ -51,7 +54,7 @@ bool bind_pos_matches(float x, float y, float ex, float ey) noexcept {
     return ex == x && ey == y;
 }
 
-void bind_score(const BindContext& ctx, entt::registry& reg, entt::entity e, UiLabel& label) {
+void bind_score(const GameplayHudBindContext& ctx, entt::registry& reg, entt::entity e, UiLabel& label) {
     if (ctx.display == nullptr) {
         ui_label_set(label, "");
     } else {
@@ -63,7 +66,7 @@ void bind_score(const BindContext& ctx, entt::registry& reg, entt::entity e, UiL
     reg.emplace_or_replace<UiLabelAlpha>(e, UiLabelAlpha{1.0f});
 }
 
-void bind_high_score(const BindContext& ctx, entt::registry& reg, entt::entity e, UiLabel& label) {
+void bind_high_score(const GameplayHudBindContext& ctx, entt::registry& reg, entt::entity e, UiLabel& label) {
     const int32_t high = ctx.current ? ctx.current->value : 0;
     char buf[32];
     std::snprintf(buf, sizeof(buf), "BEST: %d", high);
@@ -72,7 +75,7 @@ void bind_high_score(const BindContext& ctx, entt::registry& reg, entt::entity e
     reg.emplace_or_replace<UiLabelAlpha>(e, UiLabelAlpha{kHighScoreAlpha});
 }
 
-void bind_chain(const BindContext& ctx, entt::registry& reg, entt::entity e, UiLabel& label) {
+void bind_chain(const GameplayHudBindContext& ctx, entt::registry& reg, entt::entity e, UiLabel& label) {
     const int chain = ctx.score ? ctx.score->chain_count : 0;
     if (chain < kChainVisibleThreshold) {
         ui_label_set(label, "");
@@ -94,22 +97,22 @@ void bind_chain(const BindContext& ctx, entt::registry& reg, entt::entity e, UiL
     }
 }
 
-void bind_energy_label(const BindContext& /*ctx*/, entt::registry& reg, entt::entity e, UiLabel& /*label*/) {
+void bind_energy_label(const GameplayHudBindContext& /*ctx*/, entt::registry& reg, entt::entity e, UiLabel& /*label*/) {
     // Static "ENERGY" text is set at spawn time by the codegen; this bind
     // just keeps the per-slot font size + alpha in sync each frame.
     reg.emplace_or_replace<UiLabelFontSize>(e, UiLabelFontSize{kEnergyLabelFontSize});
     reg.emplace_or_replace<UiLabelAlpha>(e, UiLabelAlpha{kEnergyLabelAlpha});
 }
 
-using SlotBindFn = void (*)(const BindContext&, entt::registry&, entt::entity, UiLabel&);
+using GameplayHudSlotBindFn = void (*)(const GameplayHudBindContext&, entt::registry&, entt::entity, UiLabel&);
 
-struct SlotRow {
+struct GameplayHudSlotRow {
     float x;
     float y;
-    SlotBindFn fn;
+    GameplayHudSlotBindFn fn;
 };
 
-constexpr std::array<SlotRow, 4> kGameplayHudSlots = {{
+constexpr std::array<GameplayHudSlotRow, 4> kGameplayHudSlots = {{
     {kScoreSlotX,     kScoreSlotY,     &bind_score},
     {kHighScoreSlotX, kHighScoreSlotY, &bind_high_score},
     {kChainSlotX,     kChainSlotY,     &bind_chain},
@@ -122,7 +125,7 @@ void gameplay_hud_bind_system(entt::registry& reg) {
     auto view = reg.view<GameplayHudTag, UiLabelTag, UiPosition, UiLabel>();
     if (view.begin() == view.end()) return;
 
-    const BindContext ctx{
+    const GameplayHudBindContext ctx{
         reg.ctx().find<ScoreState>(),
         reg.ctx().find<ScoreDisplay>(),
         reg.ctx().find<CurrentSongHighScore>(),

--- a/app/systems/settings_screen_bind_system.cpp
+++ b/app/systems/settings_screen_bind_system.cpp
@@ -24,12 +24,13 @@ constexpr float kReduceMotionToggleY = 880.0f;
 
 // Bind context — owns the per-frame singleton reads so the per-slot
 // `bind_*` functions are pure transforms over their slot's `UiLabel` +
-// `UiToggleState`. Mirrors the `BindContext` shape used by the sibling
+// `UiToggleState`. Mirrors the `*BindContext` shape used by the sibling
 // `game_over_scoreboard_bind_system` / `song_complete_scoreboard_bind_system` /
-// `gameplay_hud_bind_system` binders. Named `SettingsBindContext` (not the
-// bare `BindContext` used by the siblings) so that the Unity-build chunk
-// that currently merges this TU with `song_complete_scoreboard_bind_system`
-// does not hit an anonymous-namespace ODR collision.
+// `gameplay_hud_bind_system` binders.
+//
+// Per-binder prefix (`Settings*`) avoids an anonymous-namespace ODR
+// collision with the sibling `*_bind_system.cpp` files when CMake Unity
+// chunking happens to place two binders in the same jumbo TU (issue #1329).
 struct SettingsBindContext {
     int16_t audio_offset_ms;
     bool    haptics_on;

--- a/app/systems/song_complete_scoreboard_bind_system.cpp
+++ b/app/systems/song_complete_scoreboard_bind_system.cpp
@@ -18,7 +18,11 @@ namespace {
 // semantics: a SongResults / EnergyState / TerminalResultState may be
 // absent during the Song Complete debounce window before
 // `game_state_enter_terminal_phase_song_complete` populates them.
-struct BindContext {
+//
+// Per-binder prefix (`SongComplete*`) avoids an anonymous-namespace ODR
+// collision with the sibling `*_bind_system.cpp` files when CMake Unity
+// chunking happens to place two binders in the same jumbo TU (issue #1329).
+struct SongCompleteBindContext {
     const ScoreState& score;
     const CurrentSongHighScore& current;
     const TerminalResultState* result;
@@ -26,21 +30,21 @@ struct BindContext {
     const EnergyState* energy;
 };
 
-using SlotBindFn = void (*)(const BindContext&, UiLabel&);
+using SongCompleteSlotBindFn = void (*)(const SongCompleteBindContext&, UiLabel&);
 
-void bind_score(const BindContext& ctx, UiLabel& label) {
+void bind_score(const SongCompleteBindContext& ctx, UiLabel& label) {
     char buf[32];
     std::snprintf(buf, sizeof(buf), "%d", ctx.score.score);
     ui_label_set(label, buf);
 }
 
-void bind_high_score(const BindContext& ctx, UiLabel& label) {
+void bind_high_score(const SongCompleteBindContext& ctx, UiLabel& label) {
     char buf[32];
     std::snprintf(buf, sizeof(buf), "%d", ctx.current.value);
     ui_label_set(label, buf);
 }
 
-void bind_new_best(const BindContext& ctx, UiLabel& label) {
+void bind_new_best(const SongCompleteBindContext& ctx, UiLabel& label) {
     if (ctx.result == nullptr || !ctx.result->new_best) {
         ui_label_set(label, "");
         return;
@@ -50,7 +54,7 @@ void bind_new_best(const BindContext& ctx, UiLabel& label) {
     ui_label_set(label, buf);
 }
 
-void bind_perfect_good(const BindContext& ctx, UiLabel& label) {
+void bind_perfect_good(const SongCompleteBindContext& ctx, UiLabel& label) {
     const int p = ctx.results ? ctx.results->perfect_count : 0;
     const int g = ctx.results ? ctx.results->good_count : 0;
     char buf[48];
@@ -58,7 +62,7 @@ void bind_perfect_good(const BindContext& ctx, UiLabel& label) {
     ui_label_set(label, buf);
 }
 
-void bind_ok_bad_miss(const BindContext& ctx, UiLabel& label) {
+void bind_ok_bad_miss(const SongCompleteBindContext& ctx, UiLabel& label) {
     const int o = ctx.results ? ctx.results->ok_count   : 0;
     const int b = ctx.results ? ctx.results->bad_count  : 0;
     const int m = ctx.results ? ctx.results->miss_count : 0;
@@ -67,14 +71,14 @@ void bind_ok_bad_miss(const BindContext& ctx, UiLabel& label) {
     ui_label_set(label, buf);
 }
 
-void bind_max_chain(const BindContext& ctx, UiLabel& label) {
+void bind_max_chain(const SongCompleteBindContext& ctx, UiLabel& label) {
     const int c = ctx.results ? ctx.results->max_chain : 0;
     char buf[32];
     std::snprintf(buf, sizeof(buf), "MAX CHAIN %d", c);
     ui_label_set(label, buf);
 }
 
-void bind_energy(const BindContext& ctx, UiLabel& label) {
+void bind_energy(const SongCompleteBindContext& ctx, UiLabel& label) {
     if (ctx.energy == nullptr) {
         ui_label_set(label, "");
         return;
@@ -91,13 +95,13 @@ void bind_energy(const BindContext& ctx, UiLabel& label) {
 // (x, y) into the spawn block, so a layout edit that moves a slot will
 // silently miss its bind (caught by a visible "0" / empty placeholder in
 // playtest before any production build).
-struct SlotRow {
+struct SongCompleteSlotRow {
     float x;
     float y;
-    SlotBindFn fn;
+    SongCompleteSlotBindFn fn;
 };
 
-constexpr std::array<SlotRow, 7> kSongCompleteSlots = {{
+constexpr std::array<SongCompleteSlotRow, 7> kSongCompleteSlots = {{
     {160.0f, 463.0f, &bind_score},
     {160.0f, 573.0f, &bind_high_score},
     {120.0f, 620.0f, &bind_new_best},
@@ -113,7 +117,7 @@ void song_complete_scoreboard_bind_system(entt::registry& reg) {
     auto view = reg.view<SongCompleteScreenTag, UiLabelTag, UiPosition, UiLabel>();
     if (view.begin() == view.end()) return;
 
-    const BindContext ctx{
+    const SongCompleteBindContext ctx{
         reg.ctx().get<ScoreState>(),
         reg.ctx().get<CurrentSongHighScore>(),
         reg.ctx().find<TerminalResultState>(),


### PR DESCRIPTION
Fixes #1329.

## What

The three pre-existing scoreboard/HUD binder TUs each defined `BindContext`, `SlotBindFn`, and `SlotRow` inside an anonymous namespace, with different fields/signatures in each file. CMake Unity (jumbo) builds happened to place those TUs in *different* chunks at the time, so the C++ ABI never tripped over the three incompatible definitions in the same TU — until PR #1328 added a fourth binder using the same names in a chunk that collided with `song_complete_scoreboard_bind_system.cpp`. That PR worked around the symptom with a `Settings*` prefix; this PR pulls the same convention back through the pre-existing binders so the underlying fragility is gone.

Approach is **option (A)** from #1329's acceptance criteria (per-binder prefix), which the issue listed as the preferred minimal-risk path.

| binder | renames |
| --- | --- |
| `gameplay_hud_bind_system.cpp` | `BindContext` → `GameplayHudBindContext`, `SlotBindFn` → `GameplayHudSlotBindFn`, `SlotRow` → `GameplayHudSlotRow` |
| `song_complete_scoreboard_bind_system.cpp` | `BindContext` → `SongCompleteBindContext`, `SlotBindFn` → `SongCompleteSlotBindFn`, `SlotRow` → `SongCompleteSlotRow` |
| `game_over_scoreboard_bind_system.cpp` | `BindContext` → `GameOverBindContext`, `SlotBindFn` → `GameOverSlotBindFn`, `SlotRow` → `GameOverSlotRow` |

Also rewords the `settings_screen_bind_system.cpp` comment that previously read "named `SettingsBindContext` … so the Unity-build chunk does not hit an anonymous-namespace ODR collision" — the workaround is now the documented convention, not a one-off dodge.

## Verification

- Default chunked Unity build (`cmake --build build`): green. Full suite passes — `./build/shapeshifter_tests` reports `All tests passed (3140 assertions in 934 test cases)`.
- Repro from the issue: rebuild with `-DCMAKE_UNITY_BUILD_BATCH_SIZE=1000` so all five `*_bind_system.cpp` TUs are concatenated into a single Unity TU. The resulting `unity_0_cxx.cxx` `#include`s all of `game_over_scoreboard_bind_system.cpp`, `gameplay_hud_bind_system.cpp`, `settings_screen_bind_system.cpp`, `song_complete_scoreboard_bind_system.cpp`, and `tutorial_dodge_hint_bind_system.cpp`, and `shapeshifter_lib` builds clean. Before this change, that configuration would have failed with `redefinition of 'BindContext'` (same class of error PR #1328 hit).
- Zero warnings (`-Wall -Wextra -Werror` is unchanged).

## Out of scope

- The `tests/` Unity build still has unrelated `find_repo_root` / `read_file` collisions under `-DCMAKE_UNITY_BUILD_BATCH_SIZE=1000`. Those are inside `tests/*.cpp` and are independent of the production binder ODR landmine #1329 was about. Not touching them here to keep the PR scoped.
