### PR TITLE
#1332 Scrub deleted enums (WindowPhase/ObstacleKind/TimingTier/DeathCause/TestPlayerSkill/VMode) from design-docs

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -178,22 +178,26 @@ struct PlayerShape {
 ///                        resolves (collision_system compares it against
 ///                        BeatInfo.arrival_time).
 ///
-/// `WindowPhase` lives in `components/window_phase.h` so it can be shared by
-/// player.h and rhythm.h without a header cycle.
-enum class WindowPhase : uint8_t {
-    Idle     = 0,   // no active window
-    MorphIn  = 1,   // accepting a press that will become the next shape
-    Active   = 2,   // on-beat scoring window open
-    MorphOut = 3,   // window closing; settling animation
-};
-
+/// The former `WindowPhase` enum (Idle/MorphIn/Active/MorphOut) was
+/// eradicated per issue #1202/#1204 (Fabian existential processing) —
+/// the phase identity now lives as a per-phase tag on the player entity:
+///
+///   `ShapeWindowMorphInTag`   present → window accepting the next press
+///   `ShapeWindowActiveTag`    present → on-beat scoring window open
+///   `ShapeWindowMorphOutTag`  present → window closing / settling animation
+///   none present              → Idle (no active window — no data needed)
+///
+/// The target shape the press is morphing toward is similarly a per-shape
+/// tag (`TargetShapeCircleTag` / `TargetShapeSquareTag` /
+/// `TargetShapeTriangleTag` / `TargetShapeHexagonTag`) on the same entity.
+/// Phase transitions are component-table operations; no enum compare,
+/// no `switch`. See `app/systems/shape_window_system.cpp` for the
+/// canonical transitions.
 struct ShapeWindow {
-    Shape       target_shape;   // shape the player will become at MorphIn end
-    WindowPhase phase;          // current rhythm window phase
-    bool        graded;         // a TimingGrade has already been emitted
-    float       window_timer;   // seconds into the current phase
-    float       window_start;   // song_time when the current window opened
-    float       press_time;     // song_time of the latest valid press (-1 = none)
+    bool  graded       = false;  // a TimingGrade has already been emitted
+    float window_timer = 0.0f;   // seconds into the current phase
+    float window_start = 0.0f;   // song_time when the current window opened
+    float press_time   = -1.0f;  // song_time of the latest valid press (-1 = none)
 };
 
 /// Lane occupancy and transition. 8 bytes.
@@ -244,14 +248,13 @@ struct Sliding {
 /// Empty tag — marks all obstacle entities. 0 bytes.
 struct ObstacleTag {};
 
-/// Authored/spawn-time obstacle kind. Runtime entities do not store this in
-/// Obstacle; systems infer it from presence of obstacle-specific components.
-/// LowBar/HighBar were removed from the runtime obstacle enum and remain archival only.
-enum class ObstacleKind : uint8_t {
-    ShapeGate,   // must match shape
-    SplitPath,   // shape + specific lane
-    OnsetMarker, // visual beat/onset marker; no collision/scoring
-};
+/// Per-archetype zero-column tags in `app/tags/tags.h` (issue #1202/#1204):
+///   ShapeGateTag   — must match shape; lane stored as raw int8_t component.
+///   SplitPathTag   — shape + required dodge lane; raw int8_t component.
+///   OnsetMarkerTag — visual beat/onset marker; no collision/scoring.
+/// The former `enum class ObstacleKind` and any `switch (kind)` dispatch
+/// were eradicated; consumer systems filter by view (`view<ShapeGateTag, …>`
+/// vs `view<SplitPathTag, …>`). LowBar/HighBar archetypes are archival only.
 
 struct Obstacle {
     int16_t      base_points = 200;   // PTS_SHAPE_GATE etc.
@@ -259,15 +262,6 @@ struct Obstacle {
     constexpr Obstacle() = default;
     constexpr explicit Obstacle(int16_t points) : base_points(points) {}
 };
-
-constexpr ObstacleKind obstacle_kind_from_components(bool has_required_shape,
-                                                     bool has_required_lane) {
-    (void)has_required_shape;
-    if (has_required_lane) {
-        return ObstacleKind::SplitPath;
-    }
-    return ObstacleKind::ShapeGate;
-}
 
 // Existential tag: presence means the obstacle has been cleared and awaits scoring.
 struct ScoredTag {};
@@ -356,13 +350,15 @@ struct ScoreState {
     float   passive_score_remainder = 0.0f;  // fractional passive score carried across fixed ticks
 };
 
-/// Score popup entity component. 8 bytes.
+/// Score popup entity component. The tier discriminator that used to live
+/// here was migrated to per-tier tags (TimingPerfectTag / TimingGoodTag /
+/// TimingOkTag / TimingBadTag from `app/tags/tags.h`) emplaced on the
+/// popup entity itself (issue #1202/#1204). Static text + base color are
+/// baked into a sibling `PopupDisplay` row at spawn time.
 struct ScorePopup {
-    int32_t    value           = 0;              // points to display
-    bool       has_timing_tier = false;          // false when no TimingGrade was present
-    TimingTier timing_tier     = TimingTier::Ok; // valid only when has_timing_tier is true
-    float      remaining       = 0.0f;           // seconds left to display
-    float      max_time        = 0.0f;           // initial lifetime for fade/scale
+    int32_t value     = 0;     // points to display
+    float   remaining = 0.0f;  // seconds left to display
+    float   max_time  = 0.0f;  // initial lifetime for fade/scale
 };
 ```
 
@@ -1429,72 +1425,76 @@ void motion_system(entt::registry& reg, float dt) {
 
 ### 8.5 Collision Detection Strategy
 
-With only 5–15 obstacles on screen and 1 player, brute-force is optimal:
+With only 5–15 obstacles on screen and 1 player, brute-force is optimal.
+The system dispatches by **archetype tag** (issue #1202/#1204) — one view
+per archetype, no `switch` on a discriminator:
 
 ```cpp
 void collision_system(entt::registry& reg, float dt) {
     // Get player state (single entity)
-    auto player_view = reg.view<PlayerTag, WorldPosition, PlayerShape, Lane>();
-    // Early-out: exactly one player
-    auto [p_ent, p_pos, p_shape, p_lane] = *player_view.each().begin();
+    auto player_view = reg.view<PlayerTag, WorldPosition, Lane>();
+    auto [p_ent, p_pos, p_lane] = *player_view.each().begin();
+
+    // Current shape lives as a `Shape*Tag` on the player entity, not a
+    // field on PlayerShape (issue #1202/#1204).
+    const Shape p_shape = current_shape_from_tag(reg, p_ent);
 
     // Grounded entities have neither Jumping nor Sliding; only Jumping
     // carries a y_offset (Sliding leaves it at 0). No enum compare.
     const auto* p_jump = reg.try_get<Jumping>(p_ent);
-    float player_x = p_pos.position.x;
     float player_y = p_pos.position.y + (p_jump ? p_jump->y_offset : 0.0f);
 
-    // Linear scan of obstacles — 15 entities max
-    auto obs_view = reg.view<ObstacleTag, WorldPosition, Obstacle>(
+    // ShapeGate pass: filtered by archetype tag, no discriminator.
+    auto gate_view = reg.view<ObstacleTag, WorldPosition, ShapeGateTag>(
         entt::exclude<ScoredTag, ResolvedObstacleTag, NonScorableTag>);
-    for (auto entity : obs_view) {
-        const auto& o_pos = obs_view.get<WorldPosition>(entity);
-
-        // Broad phase: vertical proximity check
+    for (auto entity : gate_view) {
+        const auto& o_pos = gate_view.get<WorldPosition>(entity);
         float dy = o_pos.position.y - player_y;
-        if (dy < -40.0f || dy > 40.0f) continue;  // not overlapping vertically
+        if (dy < -40.0f || dy > 40.0f) continue;  // broad phase
 
-        // Narrow phase: per-obstacle-kind match test
-        bool cleared = check_obstacle_cleared(reg, entity, p_shape, p_lane);
-        if (cleared) {
+        if (check_shape_gate_cleared(reg, entity, p_shape)) {
             reg.emplace<ScoredTag>(entity);
-            // scoring_system will pick this up next
         } else if (dy >= 0.0f) {
-            // Obstacle has reached player and shape doesn't match → CRASH.
-            // Deferred per #482: request the swap; game_state_system
-            // performs it on the next tick.
             request_phase_transition<NextPhaseGameOverTag>(reg);
-            return;  // stop checking — game over
+            return;
+        }
+    }
+
+    // SplitPath pass: same shape, different match (shape + lane). The two
+    // archetype views never share entities — exactly Fabian's existential
+    // processing.
+    auto split_view = reg.view<ObstacleTag, WorldPosition, SplitPathTag>(
+        entt::exclude<ScoredTag, ResolvedObstacleTag, NonScorableTag>);
+    for (auto entity : split_view) {
+        const auto& o_pos = split_view.get<WorldPosition>(entity);
+        float dy = o_pos.position.y - player_y;
+        if (dy < -40.0f || dy > 40.0f) continue;
+
+        if (check_split_path_cleared(reg, entity, p_shape, p_lane)) {
+            reg.emplace<ScoredTag>(entity);
+        } else if (dy >= 0.0f) {
+            request_phase_transition<NextPhaseGameOverTag>(reg);
+            return;
         }
     }
 }
 
-// Per-kind match logic — no virtual dispatch, kind inferred from components
-bool check_obstacle_cleared(entt::registry& reg, entt::entity e,
-                             const PlayerShape& shape,
-                             const Lane& lane) {
-    if (reg.all_of<NonScorableTag>(e)) {
-        return false;
-    }
+// Per-archetype match logic — no virtual dispatch, no `switch` on a
+// discriminator. The archetype IS the obstacle's tag (issue #1202/#1204);
+// `collision_system` already runs one view per archetype tag, so the
+// callee only needs to test the archetype-specific match condition.
+bool check_shape_gate_cleared(entt::registry& reg, entt::entity e,
+                              Shape player_shape) {
+    if (reg.all_of<NonScorableTag>(e)) return false;
+    return player_shape == current_required_shape(reg, e);
+}
 
-    const ObstacleKind kind = obstacle_kind_from_components(
-        reg.all_of<RequiredShape>(e),
-        reg.all_of<RequiredLane>(e));
-
-    switch (kind) {
-        case ObstacleKind::ShapeGate:
-            return shape.current == reg.get<RequiredShape>(e).shape;
-
-        case ObstacleKind::SplitPath: {
-            bool shape_ok = shape.current == reg.get<RequiredShape>(e).shape;
-            bool lane_ok  = lane.current == reg.get<RequiredLane>(e).lane;
-            return shape_ok && lane_ok;
-        }
-
-        case ObstacleKind::OnsetMarker:
-            return false;
-    }
-    return false;
+bool check_split_path_cleared(entt::registry& reg, entt::entity e,
+                              Shape player_shape, const Lane& lane) {
+    if (reg.all_of<NonScorableTag>(e)) return false;
+    const bool shape_ok = player_shape == current_required_shape(reg, e);
+    const bool lane_ok  = lane.current == reg.get<int8_t>(e);
+    return shape_ok && lane_ok;
 }
 ```
 
@@ -1632,14 +1632,17 @@ app/
 │
 ├── components/                  ← all component structs
 │   ├── transform.h              ← WorldPosition, MotionVelocity
-│   ├── window_phase.h           ← WindowPhase (shared by player.h and rhythm.h)
 │   ├── player.h                 ← PlayerTag, PlayerShape, ShapeWindow, Lane,
 │   │                              Jumping, Sliding (per-state vertical motion tables;
-│   │                              absence of both = grounded)
+│   │                              absence of both = grounded). Window phase lives
+│   │                              as `ShapeWindow*Tag` on the player entity (see
+│   │                              `app/tags/tags.h`).
 │   ├── obstacle.h               ← obstacle tags (ScoredTag, MissTag,
 │   │                              ResolvedObstacleTag, NonScorableTag,
-│   │                              OnsetMarkerTag) and requirements
-│   │                              (RequiredShape, RequiredLane, ShapeGateLane)
+│   │                              OnsetMarkerTag) and per-archetype tags
+│   │                              (ShapeGateTag, SplitPathTag in tags.h);
+│   │                              required shape lives as `RequiredShape*Tag`,
+│   │                              lane index as a raw int8_t component.
 │   ├── scoring.h                ← ScoreState, ScorePopup
 │   ├── input_events.h           ← per-shape ShapePress*Event, per-action
 │   │                              Menu*Event, per-direction Go*Event
@@ -1650,7 +1653,8 @@ app/
 │   ├── rendering.h              ← DrawSize, ScreenPosition; back-compat shim
 │   │                              for the camera/mesh splits (issue #1194)
 │   ├── particle.h               ← ParticleData, ParticleTag
-│   ├── rhythm.h                 ← BeatInfo, TimingGrade, TimingTier
+│   ├── rhythm.h                 ← BeatInfo, TimingGrade (precision only;
+│   │                              tier is a `Timing*Tag` from `tags.h`)
 │   └── song_state.h             ← SongState
 │
 ├── systems/                     ← all system free functions

--- a/design-docs/beatmap-integration.md
+++ b/design-docs/beatmap-integration.md
@@ -112,14 +112,19 @@ singletons (`SongState`, `EnergyState`, `SongResults`) live in registry context.
 All are cold data read a few times per frame, not iterated in bulk.
 
 ```cpp
-// Defined in beat_map.h and re-exported by rhythm.h
+// Defined in beat_map.h and re-exported by rhythm.h. The authored kind is
+// carried as a per-archetype tag on the spawned obstacle entity (issue
+// #1202/#1204) — `ShapeGateTag` / `SplitPathTag` / `OnsetMarkerTag` from
+// `app/tags/tags.h`. BeatEntry retains the authored discriminator only as
+// a loader-side spawn hint; runtime systems never re-read it.
 struct BeatEntry {
     int          beat_index   = 0;       //  4B
-    ObstacleKind kind         = ObstacleKind::ShapeGate;  // 1B
-    Shape        shape        = Shape::Circle;            // 1B
+    Shape        shape        = Shape::Circle;  // 1B
     int8_t       lane         = 1;       //  1B
     float        time_sec     = 0.0f;    // optional authored timestamp
     bool         has_time_sec = false;
+    // (authored archetype kind hint is internal to the loader; runtime
+    // entities discover archetype via their tag)
 };
 
 struct BeatMap {
@@ -196,11 +201,11 @@ The current obstacle components already match the beatmap schema:
 > and emitted in shipped beatmaps. LowBar/HighBar were removed from the runtime obstacle enum.
 
 ```
-  ObstacleKind::ShapeGate      → "shape_gate"       ✓  required shipped obstacle
-  ObstacleKind::SplitPath      → "split_path"       ✓  runtime-supported, not generated today
-  ObstacleKind::OnsetMarker    → "onset_marker"     ✓  non-blocking shipped metadata
+  ShapeGateTag    → "shape_gate"       ✓  required shipped obstacle
+  SplitPathTag    → "split_path"       ✓  runtime-supported, not generated today
+  OnsetMarkerTag  → "onset_marker"     ✓  non-blocking shipped metadata
 
-  RequiredShape { shape }      → beatmap "shape" field  ✓
+  `RequiredShape*Tag` (per-shape) → beatmap "shape" field  ✓
 ```
 
 **No new per-entity components required for shape_gate.** The beat scheduler
@@ -238,7 +243,7 @@ creates the standard runtime obstacle archetypes via `spawn_rhythm_obstacle()`.
   │  FIXED TICK (tick_fixed_systems — fixed_tick_runner.cpp):        │
   │  ✅ game_state_system          (phase + semantic input drain)   │
   │  ✅ song_playback_system       (advances SongState.song_time)   │
-  │  ✅ tick_playing_systems       (gated on GamePhase::Playing)    │
+  │  ✅ tick_playing_systems       (gated on GamePhasePlayingTag) │
   │  ✅ obstacle_despawn_system    (destroy off-camera obstacles)   │
   │  ✅ popup_feedback_system      (drain ScorePopupRequestQueue)   │
   │  ✅ popup_display_system       (ScorePopup timer → fade/cull)   │
@@ -280,7 +285,7 @@ creates the standard runtime obstacle archetypes via `spawn_rhythm_obstacle()`.
 
 ```cpp
 void song_playback_system(entt::registry& reg, float dt) {
-    if (reg.ctx().get<GameState>().phase != GamePhase::Playing) return;
+    if (!reg.ctx().contains<GamePhasePlayingTag>()) return;
 
     auto* song  = reg.ctx().find<SongState>();
     auto* music = reg.ctx().find<MusicContext>();
@@ -486,7 +491,7 @@ Music starts or resumes from `song_playback_system` when the active phase is
 `Playing` and `SongState.playing` is true:
 
 ```cpp
-if (music_loaded && gs.phase == GamePhase::Playing && song && song->playing) {
+if (music_loaded && reg.ctx().contains<GamePhasePlayingTag>() && song && song->playing) {
     if (!music->started) {
         PlayMusicStream(music->stream);
         music->started = true;
@@ -534,7 +539,8 @@ Ordered by dependency chain. Steps marked ✅ are already on `main`.
   STEP 2 — Data Components                         ✅ DONE
   ─────────────────────────────
   • BeatMap, BeatEntry, SongState, SongResults, EnergyState in rhythm.h/song_state.h
-  • TimingGrade, WindowPhase, BeatInfo all defined
+  • TimingGrade (precision-only), ShapeWindow*Tag (per-phase tags in
+    `app/tags/tags.h`), BeatInfo all defined
 
   STEP 3 — Beat Map Loader                         ✅ DONE
   ─────────────────────────────
@@ -603,7 +609,7 @@ Ordered by dependency chain. Steps marked ✅ are already on `main`.
   │                                    │  past, then trigger results screen.  │
   ├────────────────────────────────────┼──────────────────────────────────────┤
   │  Game paused                       │  song_playback_system guards on      │
-  │                                    │  GamePhase::Playing. song_time       │
+  │                                    │  GamePhasePlayingTag. song_time      │
   │                                    │  freezes. Music: PauseMusicStream(). │
   │                                    │  Resume: ResumeMusicStream().        │
   ├────────────────────────────────────┼──────────────────────────────────────┤

--- a/design-docs/energy-bar.md
+++ b/design-docs/energy-bar.md
@@ -125,28 +125,36 @@ Current shipped behavior:
 MISS: enqueue_energy_effect(reg, -ENERGY_DRAIN_MISS, true)
 ```
 
-The miss no longer kills the player directly. `energy_system` requests the
-`GamePhase::GameOver` transition in the same fixed tick that drains energy
-to ≤ 0 (provided a `SongState` exists), setting
-`GameOverState::cause = DeathCause::EnergyDepleted`. `game_state_system`
-retains a fallback check that catches pre-existing `energy <= 0` while phase
-is `Playing` (defense-in-depth, not the primary path).
+The miss no longer kills the player directly. `energy_system` emplaces
+`EnergyDepletedDeath` on `reg.ctx()` in the same fixed tick that drains
+energy to ≤ 0 (provided a `SongState` exists); `game_state_system`
+consumes that ctx tag and inserts `GamePhaseGameOverTag` on the next
+tick. The former `GameOverState::cause = DeathCause::EnergyDepleted`
+field was eradicated per issue #1202/#1204 — the cause is the presence
+of the `EnergyDepletedDeath` ctx tag. `game_state_system` retains a
+fallback check that catches pre-existing `energy <= 0` while the
+`GamePhasePlayingTag` is present (defense-in-depth, not the primary path).
 
 Miss still increments `results->miss_count` and still emplaces
 `ScoredTag` (obstacle is consumed, not re-triggered).
 
 ### 2. scoring_system.cpp — on scored obstacle with TimingGrade
 
-After computing points, enqueue an energy delta based on timing tier:
+After computing points, enqueue an energy delta selected by the
+per-tier tag (`TimingPerfectTag` / `TimingGoodTag` / `TimingOkTag` /
+`TimingBadTag` from `app/tags/tags.h`). The former `switch (timing->tier)`
+discriminator was eradicated per issue #1202/#1204; the canonical
+mechanic is a per-tag view (one transform per tier), e.g.:
 
-```
-switch (timing->tier) {
-    case TimingTier::Perfect: enqueue_energy_effect(reg, ENERGY_RECOVER_PERFECT); break;
-    case TimingTier::Good:    enqueue_energy_effect(reg, ENERGY_RECOVER_GOOD);    break;
-    case TimingTier::Ok:      enqueue_energy_effect(reg, ENERGY_RECOVER_OK);      break;
-    case TimingTier::Bad:     enqueue_energy_effect(reg, -ENERGY_DRAIN_BAD, true);
-                              break;
-}
+```cpp
+for (auto e : reg.view<ScoredTag, TimingPerfectTag>())
+    enqueue_energy_effect(reg, ENERGY_RECOVER_PERFECT);
+for (auto e : reg.view<ScoredTag, TimingGoodTag>())
+    enqueue_energy_effect(reg, ENERGY_RECOVER_GOOD);
+for (auto e : reg.view<ScoredTag, TimingOkTag>())
+    enqueue_energy_effect(reg, ENERGY_RECOVER_OK);
+for (auto e : reg.view<ScoredTag, TimingBadTag>())
+    enqueue_energy_effect(reg, -ENERGY_DRAIN_BAD, true);
 ```
 
 

--- a/design-docs/feature-specs.md
+++ b/design-docs/feature-specs.md
@@ -346,32 +346,35 @@ the energy bar; energy reaching zero ends the run.
 ### ECS Components (C++ structs)
 
 ```cpp
-enum class TimingTier : uint8_t {
-    Bad,
-    Ok,
-    Good,
-    Perfect,
-};
+// The former `enum class TimingTier { Bad, Ok, Good, Perfect }` was
+// eradicated per issue #1202/#1204 (Fabian existential processing).
+// The tier discriminator now lives as one of four zero-column tags
+// (TimingPerfectTag / TimingGoodTag / TimingOkTag / TimingBadTag) from
+// `app/tags/tags.h`, emplaced on the obstacle/popup entity by
+// `emplace_timing_tier_tag_for_delta_abs()` in `app/util/rhythm_math.h`.
 
 struct TimingGrade {
-    TimingTier tier      = TimingTier::Bad;
-    float      precision = 0.0f;  // 0.0 = edge, 1.0 = dead center
+    float precision = 0.0f;  // 0.0 = edge, 1.0 = dead center
 };
 
 struct ScoreState {
     int32_t score = 0;
-    int32_t displayed_score = 0;
-    int32_t high_score = 0;
     int32_t chain_count = 0;
     float passive_score_remainder = 0.0f;
 };
 
+// ScoreDisplay holds the HUD's smoothly-animated readout.
+struct ScoreDisplay {
+    int32_t displayed = 0;
+};
+
+// ScorePopup carries only the value + lifetime. The tier discriminator is a
+// per-tier tag (Timing*Tag) on the popup entity itself; static text/color are
+// baked into a sibling `PopupDisplay` row at spawn time.
 struct ScorePopup {
-    int32_t value = 0;
-    bool has_timing_tier = false;
-    TimingTier timing_tier = TimingTier::Ok;
-    float remaining = 0.0f;
-    float max_time = 0.0f;
+    int32_t value     = 0;
+    float   remaining = 0.0f;
+    float   max_time  = 0.0f;
 };
 ```
 
@@ -488,19 +491,23 @@ struct Obstacle {
     int16_t base_points = 200;
 };
 
-enum class ObstacleKind : uint8_t {
-    ShapeGate,
-    SplitPath,
-    OnsetMarker,
-};
+// The former `enum class ObstacleKind { ShapeGate, SplitPath, OnsetMarker }`
+// was eradicated per issue #1202/#1204. Archetype identity now lives as a
+// zero-column tag in `app/tags/tags.h`:
+//   ShapeGateTag   — must match shape; lane stored as raw `int8_t` component.
+//   SplitPathTag   — shape + dodge lane; raw `int8_t` component.
+//   OnsetMarkerTag — visual beat marker; non-blocking, non-scoring.
+// Consumers filter by view (`view<ShapeGateTag, …>` vs `view<SplitPathTag, …>`);
+// no `switch (kind)` dispatch remains in `app/`.
 
-struct RequiredShape {
-    Shape shape = Shape::Circle;
-};
+// `RequiredShape { Shape shape }` was unwrapped to per-shape tags
+// (`RequiredShapeCircleTag` / …`SquareTag` / …`TriangleTag` / …`HexagonTag`)
+// on the obstacle entity. Read via `current_required_shape(reg, e)` from
+// `app/util/shape_tag.h`.
 
-struct RequiredLane {
-    int8_t lane = 0;
-};
+// Lane index is a raw int8_t component on the obstacle entity (issue #1198).
+// Semantics depend on the archetype tag — ShapeGateTag = positional lane,
+// SplitPathTag = required dodge lane.
 
 struct BeatInfo {
     int beat_index = 0;
@@ -642,7 +649,9 @@ obstacle_despawn_system -> popup_feedback_system -> popup_display_system ->
 energy_system -> energy_bar_system -> particle_system
 ```
 
-`tick_playing_systems` is a `GamePhase::Playing`-gated bundle:
+`tick_playing_systems` is gated on the active `GamePhasePlayingTag`
+(emplaced on `reg.ctx()` by `game_state_system`; see
+`app/systems/playing_systems_runner.cpp`):
 
 ```
 beat_log_system -> beat_scheduler_system -> shape_window_activation_system ->
@@ -679,8 +688,8 @@ shape_window_system -> miss_detection_system -> scoring_system
   │  TimingGrade            │ per-ent  │ Spec 2 — Rhythm Scoring │
   │  Obstacle               │ per-ent  │ Spec 3 — Scheduling     │
   │  BeatInfo               │ per-ent  │ Spec 3 — Scheduling     │
-  │  RequiredShape          │ per-ent  │ Spec 3 — Scheduling     │
-  │  RequiredLane           │ per-ent  │ Spec 3 — Scheduling     │
+  │  RequiredShape*Tag      │ tag      │ Spec 3 — Scheduling     │
+  │  int8_t (lane index)    │ per-ent  │ Spec 3 — Scheduling     │
   │  ScoredTag              │ tag      │ Spec 2/3 bridge         │
   │  MissTag                │ tag      │ Spec 2/3 bridge         │
   └─────────────────────────┴──────────┴─────────────────────────┘

--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -128,16 +128,15 @@ constexpr float MIN_MORPH        = 0.060f;
 // morph_duration = max(BASE_MORPH_BEATS * beat_period, MIN_MORPH)
 
 // ── Window scale factors (applied to remaining window on early hit) ──
-// Exposed only via window_scale_for_tier() in app/util/rhythm_math.h —
-// no named constexpr constants exist; callers pass a TimingTier.
-inline float window_scale_for_tier(TimingTier tier) {
-    switch (tier) {
-        case TimingTier::Perfect: return 0.50f;  // halve remaining window
-        case TimingTier::Good:    return 0.75f;  // cut by 25%
-        case TimingTier::Ok:      return 1.00f;  // no change (default)
-        case TimingTier::Bad:     return 1.00f;  // no window-collapse reward
-    }
-    return 1.00f;
+// The former `TimingTier` enum and per-tier `switch` were eradicated per
+// issue #1202/#1204. The canonical mechanic is a single delta-keyed
+// lookup that consults the threshold ladder directly — Perfect/Good/Ok/Bad
+// are zero-column tags emplaced alongside the returned scale. See
+// `app/util/rhythm_math.h::window_scale_from_delta_abs()`:
+inline float window_scale_from_delta_abs(float delta_seconds_abs) {
+    if (delta_seconds_abs <= kTimingPerfectSeconds + kEps) return 0.50f;
+    if (delta_seconds_abs <= kTimingGoodSeconds    + kEps) return 0.75f;
+    return 1.00f;  // Ok and Bad: neutral (no window-collapse reward)
 }
 
 // ── Morph duration (seconds to animate shape change) ────────────────
@@ -189,12 +188,14 @@ constexpr int32_t CHAIN_MULT_BONUS_STEPS_CAP = 20; // caps at 2.0x from chain 21
 ```cpp
 struct BeatEntry {
     int          beat_index   = 0;           // beat index (not seconds)
-    ObstacleKind kind         = ObstacleKind::ShapeGate;
     Shape        shape        = Shape::Circle;
     int8_t       lane         = 1;
     uint8_t      blocked_mask = 0;
     float        time_sec     = 0.0f;        // optional authored timestamp
     bool         has_time_sec = false;       // true → time_sec wins over beat_index
+    // Archetype kind is a per-archetype tag (ShapeGateTag / SplitPathTag /
+    // OnsetMarkerTag from app/tags/tags.h) on the spawned obstacle entity;
+    // BeatEntry no longer carries a runtime kind discriminator (issue #1202/#1204).
 };
 
 struct BeatMap {
@@ -248,20 +249,25 @@ struct SongState {
 ## PlayerShape (per entity)
 
 ```cpp
-enum class WindowPhase { Idle, MorphIn, Active, MorphOut };
+// The former `enum class WindowPhase { Idle, MorphIn, Active, MorphOut }`
+// was eradicated per issue #1202/#1204. The phase identity lives as one of
+// three per-phase tags on the player entity (Idle = absence of all three):
+//   ShapeWindowMorphInTag, ShapeWindowActiveTag, ShapeWindowMorphOutTag
+// Both are declared in `app/tags/tags.h`; transitions are component-table
+// operations (emplace/remove), no enum compare. The target shape the press
+// is morphing toward similarly lives as `TargetShapeCircleTag` / `…SquareTag` /
+// `…TriangleTag` / `…HexagonTag` on the same entity. The current settled
+// shape lives as `ShapeCircleTag` / `…SquareTag` / etc.
 
 struct PlayerShape {
-    Shape current = Shape::Circle;  // player_entity initializes this to Hexagon
     float morph_t = 1.0f;           // [0,1] visual interpolation; 1.0 = settled
 };
 
 struct ShapeWindow {
-    Shape       target_shape = Shape::Circle; // player_entity initializes this to Hexagon
-    WindowPhase phase        = WindowPhase::Idle;
-    bool        graded       = false;         // window already graded this cycle
-    float       window_timer = 0.0f;          // seconds in current phase/window
-    float       window_start = 0.0f;          // absolute song_time of window start
-    float       press_time   = -1.0f;         // absolute song_time of input
+    bool  graded       = false;   // window already graded this cycle
+    float window_timer = 0.0f;    // seconds in current phase/window
+    float window_start = 0.0f;    // absolute song_time of window start
+    float press_time   = -1.0f;   // absolute song_time of input
 };
 ```
 
@@ -355,8 +361,9 @@ struct SongResults {
            ↓
   ┌─ TIMING WINDOW ────────────────────────────────────────────┐
   │ shape_window_system                            ★ NEW       │
-  │   → advances WindowPhase state machine                     │
-  │     Active → MorphOut → Idle (Hexagon)                    │
+  │   → advances per-phase tag state machine                   │
+  │     ShapeWindowActiveTag → ShapeWindowMorphOutTag → Idle   │
+  │     (Idle = no per-phase tag present; Hexagon)             │
   │   → guarded by SongState existing (not song->playing)      │
   │   → MorphIn ticking is owned by                            │
   │     shape_window_activation_system above                   │

--- a/design-docs/tester-personas-tech-spec.md
+++ b/design-docs/tester-personas-tech-spec.md
@@ -151,23 +151,23 @@ while (accumulator >= FIXED_DT) {
 ```cpp
 // app/systems/test_player.h
 
-enum class TestPlayerSkill : uint8_t { Pro = 0, Good = 1, Bad = 2 };
+// The former `enum class TestPlayerSkill { Pro, Good, Bad }` and its
+// 3-row `SKILL_TABLE[]` index lookup were eradicated per issue #1202/#1204
+// (Fabian existential processing). Each former enum value is now a named
+// `SkillConfig` constant; the active skill is the `SkillConfig` value
+// itself on `TestPlayerState::skill` (no discriminator, no index).
 
 struct SkillConfig {
-    float vision_range;     // px from PLAYER_Y upward
-    float reaction_min;     // seconds
-    float reaction_max;     // seconds
-    bool  aim_perfect;      // true = delay to hit Perfect window
+    float       vision_range;   // px from PLAYER_Y upward
+    float       reaction_min;   // seconds
+    float       reaction_max;   // seconds
+    bool        aim_perfect;    // true = delay to hit Perfect window
+    const char* name;           // CLI key + session-log key
 };
 
-static constexpr SkillConfig SKILL_TABLE[] = {
-    // Pro:   fast reflexes, wide vision, aims for Perfect
-    { 800.0f, 0.300f, 0.500f, true  },
-    // Good:  moderate reflexes, medium vision, reacts ASAP
-    { 600.0f, 0.500f, 0.800f, false },
-    // Bad:   slow reflexes, narrow vision, reacts ASAP
-    { 400.0f, 0.800f, 1.200f, false },
-};
+inline constexpr SkillConfig SKILL_PRO  { 800.0f, 0.300f, 0.500f, true,  "pro"  };
+inline constexpr SkillConfig SKILL_GOOD { 600.0f, 0.500f, 0.800f, false, "good" };
+inline constexpr SkillConfig SKILL_BAD  { 400.0f, 0.800f, 1.200f, false, "bad"  };
 ```
 
 **DoD note**: Table lookup, not inheritance. All personas use the same
@@ -183,22 +183,33 @@ struct TestPlayerAction {
     float        arrival_time = 0.0f;      // song_time when obstacle reaches player
 
     // Required actions (determined from obstacle components)
-    Shape  target_shape      = Shape::Hexagon; // Hexagon = no shape change needed
-    int8_t target_lane       = -1;             // -1 = no lane change needed
-    VMode  target_vertical   = VMode::Grounded;// Grounded = no jump/slide needed
+    // The former `Shape target_shape = Shape::Hexagon` sentinel was
+    // replaced by `const ShapePressSpec* shape_press` (issue #1202 PR C3):
+    // nullptr means "no shape change", a non-null pointer carries both
+    // the press-enqueue function and the log labels for that shape.
+    const ShapePressSpec* shape_press = nullptr;
+    int8_t target_lane                = -1;             // -1 = no lane change needed
+    // The former `VMode target_vertical = VMode::Grounded` enum was split
+    // into two independent boolean columns (issue #1202/#1204); both false
+    // means "grounded — no change needed".
+    bool   wants_jump                 = false;
+    bool   wants_slide                = false;
 
-    // Execution state (packed into uint8_t bitmask)
-    //   bit 0: shape_done
-    //   bit 1: lane_done
-    //   bit 2: vertical_done
-    uint8_t done_flags       = 0;
+    // Per-sub-action completion. Three independent boolean columns
+    // (the former `ActionDoneBit` bitmask was eradicated per issue
+    // #1202/#1204 — per Fabian's existential processing, each completion
+    // flag is its own column).
+    bool shape_done    = false;
+    bool lane_done     = false;
+    bool vertical_done = false;
 };
 ```
 
-**DoD note**: Bools replaced with bitmask. `target_shape = Hexagon` means
-"no change needed" — existential encoding via sentinel value instead of a
-separate `need_shape` boolean. Same pattern for `target_lane = -1` and
-`target_vertical = Grounded`.
+**DoD note**: Sentinel-free choice encoding. `shape_press = nullptr` means
+"no shape change needed" (the pointer's value IS the choice — identity-is-the-choice
+mechanic, no enum compare). `target_lane = -1` and `!wants_jump && !wants_slide`
+follow the same per-column-defaults-mean-absence pattern. Per-sub-action
+completion is three independent boolean columns rather than a packed bitmask.
 
 ## TestPlayerState (context singleton)
 
@@ -207,7 +218,9 @@ separate `need_shape` boolean. Same pattern for `target_lane = -1` and
 
 struct TestPlayerState {
     // ── Hot ──────────────────────────────────────────────────
-    TestPlayerSkill skill   = TestPlayerSkill::Pro;
+    // `skill` is a `SkillConfig` row value (one of `SKILL_PRO` / `SKILL_GOOD` /
+    // `SKILL_BAD`), not a discriminator — the row IS the choice.
+    SkillConfig     skill   = SKILL_PRO;
     bool            active  = false;
 
     // Delay between consecutive lane swipes (simulates human re-swipe time)
@@ -318,8 +331,9 @@ a no-op.
 ## Auto-Start (Title / GameOver / SongComplete screens)
 
 ```cpp
-  if (gs.phase == GamePhase::Title || gs.phase == GamePhase::GameOver ||
-      gs.phase == GamePhase::SongComplete) {
+  if (reg.ctx().contains<GamePhaseTitleTag>() ||
+      reg.ctx().contains<GamePhaseGameOverTag>() ||
+      reg.ctx().contains<GamePhaseSongCompleteTag>()) {
       if (gs.phase_timer > constants::TEST_PLAYER_AUTO_START_DELAY) {
           // Restart on end screens, Confirm on Title — same dispatcher path
           // a real menu button press would take.
@@ -610,8 +624,10 @@ inside `tick_playing_systems`.
 ```
   app/
     systems/
-      test_player.h            ← TestPlayerSkill, SkillConfig, TestPlayerAction,
-      │                           TestPlayerState (context singleton)
+      test_player.h            ← SkillConfig + named SKILL_PRO/GOOD/BAD constants,
+      │                           TestPlayerAction (sentinel-free choice encoding),
+      │                           TestPlayerState (context singleton). No
+      │                           `TestPlayerSkill` enum exists in app/ today.
       test_player_system.cpp   ← AI: perceive, decide, wait, execute
       │                           Platform-portable: enqueues events
       │                           directly on the EnTT dispatcher


### PR DESCRIPTION
## Summary

Closes #1332. Follow-up to #1312 (PR #1315) and #1318 (PR #1319). The Fabian eradication wave (#1271/#1277/#1279/#1309/#1316/#1323/#1327/#1330) deleted these enums from `app/`, but six design docs still described them as the current architecture. This PR rewrites the stale prose so every doc cites the canonical tag-based / table-based mechanic — or marks the deprecated form explicitly as 'former' history-section text.

## Per-doc edits

- **architecture.md** — `WindowPhase` enum + `ShapeWindow::phase` field, `ObstacleKind` enum + helper + 3-arm `check_obstacle_cleared` switch (§8 collision pseudocode), `TimingTier` field on ScorePopup example, `window_phase.h` + `TimingTier` entries in file-layout tree. Collision pseudocode now dispatches by archetype tag (one view per ShapeGateTag / SplitPathTag) rather than a single `obs_view` + switch — matches `app/systems/collision_system.cpp`.
- **feature-specs.md** — `enum class TimingTier` definition + `TimingGrade.tier` / `ScorePopup.{has_timing_tier,timing_tier}` example fields; `enum class ObstacleKind` definition; one `GamePhase::Playing` gate phrase; `RequiredShape` / `RequiredLane` entries in the component registry table.
- **energy-bar.md** — `GameOverState::cause = DeathCause::EnergyDepleted` narrative; `switch (timing->tier)` four-arm example replaced with four per-tier views (`view<ScoredTag, TimingPerfectTag>()` etc).
- **beatmap-integration.md** — `ObstacleKind kind` field on BeatEntry; `ObstacleKind::X → 'x'` mapping table; three `GamePhase::Playing` gating references; one `WindowPhase` mention in Step-2 ledger.
- **tester-personas-tech-spec.md** — `enum class TestPlayerSkill` + SKILL_TABLE[] index lookup (replaced with the actual named SKILL_PRO/GOOD/BAD constants from `app/systems/test_player.h:30-32`); TestPlayerAction `Shape target_shape` / `VMode target_vertical` / `done_flags` bitmask (replaced with the actual `shape_press` pointer + `wants_jump` / `wants_slide` bools + three independent done bools); three `GamePhase::X` Auto-Start checks; file-layout tree note.
- **rhythm-spec.md** — `window_scale_for_tier(TimingTier)` switch (replaced with `window_scale_from_delta_abs` matching `app/util/rhythm_math.h:28`); `ObstacleKind kind` on BeatEntry; `enum class WindowPhase` + `ShapeWindow::phase` field; one `WindowPhase state machine` flow-box line.

## Verification

```
$ grep -nE 'WindowPhase|ObstacleKind|TimingTier|DeathCause|TestPlayerSkill|VerticalState|\\bVMode\\b|GamePhase::' design-docs/*.md | grep -v archive | wc -l
12
```

All 12 remaining hits are explicit 'former' / 'old' history-section prose (acceptance criterion #1).

Build clean; 3140 assertions / 934 test cases pass (docs-only change).

## Out of scope

- `design-docs/archive/*` (historical record; untouched per the issue).
- New design content unrelated to the eradication wave.
