### PR TITLE
#1333 Add tests for level_select_dynamic_spawn_system + gameplay_hud_bind_system

### DIFF
--- a/tests/test_gameplay_hud_bind_system.cpp
+++ b/tests/test_gameplay_hud_bind_system.cpp
@@ -1,0 +1,219 @@
+// Tests for gameplay HUD bind system (issues #1297, #1333).
+//
+// `gameplay_hud_bind_system` is a position-keyed bind for the dynamic-text
+// HUD slots (`ScoreSlot`, `HighScoreSlot`, `ChainSlot`, `EnergyLabel`).
+// It runs every gameplay frame; a regression in format strings, font
+// sizing, alpha, or the `ChainBgPulseTag` insert/remove would silently
+// break the in-game readout.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <string>
+
+#include "test_helpers.h"
+#include "components/scoring.h"
+#include "components/ui.h"
+#include "systems/gameplay_hud_bind_system.h"
+#include "systems/generated/screen_spawners.h"
+#include "tags/tags.h"
+
+using Catch::Matchers::WithinAbs;
+
+namespace {
+
+constexpr float kScoreSlotX     =  60.0f, kScoreSlotY     = 20.0f;
+constexpr float kHighScoreSlotX =  60.0f, kHighScoreSlotY = 50.0f;
+constexpr float kChainSlotX     =  80.0f, kChainSlotY     = 80.0f;
+constexpr float kEnergyLabelX   =  10.0f, kEnergyLabelY   = 745.0f;
+
+bool pos_at(const UiPosition& pos, float x, float y) {
+    return pos.x == x && pos.y == y;
+}
+
+entt::entity find_slot(entt::registry& reg, float x, float y) {
+    auto view = reg.view<GameplayHudTag, UiLabelTag, UiPosition>();
+    for (auto entity : view) {
+        const auto& pos = view.get<UiPosition>(entity);
+        if (pos_at(pos, x, y)) return entity;
+    }
+    return entt::null;
+}
+
+std::string label_text(const entt::registry& reg, entt::entity e) {
+    const auto& label = reg.get<UiLabel>(e);
+    return std::string(label.text.data());
+}
+
+}  // namespace
+
+TEST_CASE("gameplay_hud_bind_system: ScoreSlot formats ScoreDisplay::displayed as plain integer",
+          "[gameplay_hud][bind][issue1297][issue1333]") {
+    auto reg = make_registry();
+    spawn_gameplay_screen(reg);
+
+    reg.ctx().get<ScoreDisplay>().displayed = 1234;
+    gameplay_hud_bind_system(reg);
+
+    const auto e = find_slot(reg, kScoreSlotX, kScoreSlotY);
+    REQUIRE(reg.valid(e));
+
+    CHECK(label_text(reg, e) == "1234");
+
+    const auto* font = reg.try_get<UiLabelFontSize>(e);
+    REQUIRE(font != nullptr);
+    CHECK(font->size == 28);
+
+    const auto* alpha = reg.try_get<UiLabelAlpha>(e);
+    REQUIRE(alpha != nullptr);
+    CHECK_THAT(alpha->value, WithinAbs(1.0f, 0.0001f));
+}
+
+TEST_CASE("gameplay_hud_bind_system: HighScoreSlot formats CurrentSongHighScore as 'BEST: %d'",
+          "[gameplay_hud][bind][issue1297][issue1333]") {
+    auto reg = make_registry();
+    spawn_gameplay_screen(reg);
+
+    reg.ctx().get<CurrentSongHighScore>().value = 5678;
+    gameplay_hud_bind_system(reg);
+
+    const auto e = find_slot(reg, kHighScoreSlotX, kHighScoreSlotY);
+    REQUIRE(reg.valid(e));
+
+    CHECK(label_text(reg, e) == "BEST: 5678");
+
+    const auto* font = reg.try_get<UiLabelFontSize>(e);
+    REQUIRE(font != nullptr);
+    CHECK(font->size == 18);
+
+    const auto* alpha = reg.try_get<UiLabelAlpha>(e);
+    REQUIRE(alpha != nullptr);
+    CHECK_THAT(alpha->value, WithinAbs(0.7f, 0.0001f));
+}
+
+TEST_CASE("gameplay_hud_bind_system: ChainSlot is empty and ChainBgPulseTag absent when chain < 2",
+          "[gameplay_hud][bind][issue1297][issue1333]") {
+    auto reg = make_registry();
+    spawn_gameplay_screen(reg);
+
+    reg.ctx().get<ScoreState>().chain_count = 1;
+    gameplay_hud_bind_system(reg);
+
+    const auto e = find_slot(reg, kChainSlotX, kChainSlotY);
+    REQUIRE(reg.valid(e));
+
+    CHECK(label_text(reg, e) == "");
+    CHECK_FALSE(reg.all_of<ChainBgPulseTag>(e));
+
+    // chain_count == 0 path also drops the tag (and label).
+    reg.ctx().get<ScoreState>().chain_count = 0;
+    reg.emplace<ChainBgPulseTag>(e);  // simulate a stale halo from a prior frame
+    gameplay_hud_bind_system(reg);
+    CHECK(label_text(reg, e) == "");
+    CHECK_FALSE(reg.all_of<ChainBgPulseTag>(e));
+}
+
+TEST_CASE("gameplay_hud_bind_system: ChainSlot shows 'CHAIN N' below the meaningful threshold without the halo",
+          "[gameplay_hud][bind][issue1297][issue1333]") {
+    auto reg = make_registry();
+    spawn_gameplay_screen(reg);
+
+    reg.ctx().get<ScoreState>().chain_count = 2;
+    gameplay_hud_bind_system(reg);
+
+    const auto e = find_slot(reg, kChainSlotX, kChainSlotY);
+    REQUIRE(reg.valid(e));
+
+    CHECK(label_text(reg, e) == "CHAIN 2");
+    CHECK_FALSE(reg.all_of<ChainBgPulseTag>(e));
+
+    const auto* font = reg.try_get<UiLabelFontSize>(e);
+    REQUIRE(font != nullptr);
+    CHECK(font->size == 18);
+
+    const auto* alpha = reg.try_get<UiLabelAlpha>(e);
+    REQUIRE(alpha != nullptr);
+    CHECK_THAT(alpha->value, WithinAbs(0.7f, 0.0001f));
+}
+
+TEST_CASE("gameplay_hud_bind_system: ChainSlot adds '!' and ChainBgPulseTag at the meaningful threshold (chain >= 5)",
+          "[gameplay_hud][bind][issue1297][issue1333]") {
+    auto reg = make_registry();
+    spawn_gameplay_screen(reg);
+
+    reg.ctx().get<ScoreState>().chain_count = 5;
+    gameplay_hud_bind_system(reg);
+
+    const auto e = find_slot(reg, kChainSlotX, kChainSlotY);
+    REQUIRE(reg.valid(e));
+
+    CHECK(label_text(reg, e) == "CHAIN 5!");
+    CHECK(reg.all_of<ChainBgPulseTag>(e));
+
+    const auto* font = reg.try_get<UiLabelFontSize>(e);
+    REQUIRE(font != nullptr);
+    CHECK(font->size == 20);
+
+    const auto* alpha = reg.try_get<UiLabelAlpha>(e);
+    REQUIRE(alpha != nullptr);
+    CHECK_THAT(alpha->value, WithinAbs(0.95f, 0.0001f));
+}
+
+TEST_CASE("gameplay_hud_bind_system: ChainBgPulseTag is removed when chain falls back below threshold",
+          "[gameplay_hud][bind][issue1297][issue1333]") {
+    auto reg = make_registry();
+    spawn_gameplay_screen(reg);
+
+    // Streak peaks: emplace the halo.
+    reg.ctx().get<ScoreState>().chain_count = 7;
+    gameplay_hud_bind_system(reg);
+    const auto e = find_slot(reg, kChainSlotX, kChainSlotY);
+    REQUIRE(reg.valid(e));
+    CHECK(reg.all_of<ChainBgPulseTag>(e));
+
+    // Streak drops (still visible, no halo).
+    reg.ctx().get<ScoreState>().chain_count = 3;
+    gameplay_hud_bind_system(reg);
+    CHECK(label_text(reg, e) == "CHAIN 3");
+    CHECK_FALSE(reg.all_of<ChainBgPulseTag>(e));
+
+    // Streak breaks (cleared, no halo).
+    reg.ctx().get<ScoreState>().chain_count = 0;
+    gameplay_hud_bind_system(reg);
+    CHECK(label_text(reg, e) == "");
+    CHECK_FALSE(reg.all_of<ChainBgPulseTag>(e));
+}
+
+TEST_CASE("gameplay_hud_bind_system: EnergyLabel keeps its static text and gets per-slot font/alpha",
+          "[gameplay_hud][bind][issue1297][issue1333]") {
+    auto reg = make_registry();
+    spawn_gameplay_screen(reg);
+
+    gameplay_hud_bind_system(reg);
+
+    const auto e = find_slot(reg, kEnergyLabelX, kEnergyLabelY);
+    REQUIRE(reg.valid(e));
+
+    // Static label is set at spawn by the codegen — bind must NOT clobber it.
+    CHECK(label_text(reg, e) == "ENERGY");
+
+    const auto* font = reg.try_get<UiLabelFontSize>(e);
+    REQUIRE(font != nullptr);
+    CHECK(font->size == 16);
+
+    const auto* alpha = reg.try_get<UiLabelAlpha>(e);
+    REQUIRE(alpha != nullptr);
+    CHECK_THAT(alpha->value, WithinAbs(0.8f, 0.0001f));
+}
+
+TEST_CASE("gameplay_hud_bind_system: no gameplay-HUD entities is a safe no-op",
+          "[gameplay_hud][bind][issue1297][issue1333]") {
+    auto reg = make_registry();
+    // Intentionally don't spawn the gameplay screen.
+    reg.ctx().get<ScoreDisplay>().displayed = 999;
+    reg.ctx().get<ScoreState>().chain_count = 7;
+    reg.ctx().get<CurrentSongHighScore>().value = 42;
+
+    REQUIRE_NOTHROW(gameplay_hud_bind_system(reg));
+    CHECK(reg.view<GameplayHudTag>().size() == 0);
+}

--- a/tests/test_level_select_dynamic_spawn_system.cpp
+++ b/tests/test_level_select_dynamic_spawn_system.cpp
@@ -1,0 +1,188 @@
+// Tests for level-select dynamic spawn system (issues #1296, #1333).
+//
+// `level_select_dynamic_spawn_system` paints the per-level cards and
+// per-(level, difficulty) buttons that the legacy controller drew
+// imperatively. The system runs every time the player enters Level
+// Select; a regression in card/button geometry or `ActionId` assignment
+// would silently break level selection.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+
+#include "test_helpers.h"
+#include "components/actions.h"
+#include "components/ui.h"
+#include "systems/level_select_dynamic_spawn_system.h"
+#include "systems/generated/screen_spawners.h"
+#include "tags/tags.h"
+#include "util/level_content_config.h"
+
+namespace {
+
+constexpr float kCardX        = 110.0f;
+constexpr float kCardW        = 500.0f;
+constexpr float kCardH        = 200.0f;
+constexpr float kCardStartY   = 200.0f;
+constexpr float kCardGap      = 40.0f;
+constexpr float kDiffBtnW     = 120.0f;
+constexpr float kDiffBtnH     = 50.0f;
+constexpr float kDiffBtnGap   = 30.0f;
+constexpr float kDiffStartX   = kCardX + 50.0f;
+constexpr float kDiffYOffset  = 120.0f;
+
+constexpr float kCardYTolerance = 0.01f;
+
+bool near(float a, float b) {
+    const float d = a - b;
+    return d >= -kCardYTolerance && d <= kCardYTolerance;
+}
+
+}  // namespace
+
+TEST_CASE("level_select_dynamic_spawn: spawns one card per level with monotonically increasing Y",
+          "[level_select][ui][issue1296][issue1333]") {
+    auto reg = make_registry();
+    spawn_level_select_screen_full(reg);
+
+    auto card_view = reg.view<LevelCardTag, LevelSelectScreenTag,
+                              LevelIndex, UiPosition, UiBounds>();
+
+    int card_count = 0;
+    bool seen[content_config::LEVEL_COUNT] = {false, false, false};
+    float y_by_index[content_config::LEVEL_COUNT] = {0.0f, 0.0f, 0.0f};
+
+    for (auto entity : card_view) {
+        ++card_count;
+        const auto& idx    = card_view.get<LevelIndex>(entity);
+        const auto& pos    = card_view.get<UiPosition>(entity);
+        const auto& bounds = card_view.get<UiBounds>(entity);
+
+        REQUIRE(idx.value >= 0);
+        REQUIRE(idx.value < content_config::LEVEL_COUNT);
+        CHECK_FALSE(seen[idx.value]);
+        seen[idx.value] = true;
+        y_by_index[idx.value] = pos.y;
+
+        CHECK(near(pos.x, kCardX));
+        const float expected_y = kCardStartY +
+            static_cast<float>(idx.value) * (kCardH + kCardGap);
+        CHECK(near(pos.y, expected_y));
+        CHECK(near(bounds.w, kCardW));
+        CHECK(near(bounds.h, kCardH));
+    }
+
+    CHECK(card_count == content_config::LEVEL_COUNT);
+
+    // Monotonic Y by level_index (independent of EnTT iteration order).
+    for (int i = 1; i < content_config::LEVEL_COUNT; ++i) {
+        CHECK(y_by_index[i] > y_by_index[i - 1]);
+    }
+
+    // Cards are NOT generic UI buttons (issue #1296 — Level Select Pass C
+    // dispatches them via `LevelIndex` reads in `ui_update_system`).
+    int card_ui_button_count = 0;
+    for (auto entity : reg.view<LevelCardTag, UiButtonTag>()) {
+        (void)entity;
+        ++card_ui_button_count;
+    }
+    CHECK(card_ui_button_count == 0);
+}
+
+TEST_CASE("level_select_dynamic_spawn: spawns 3 difficulty buttons per card with matching ActionId",
+          "[level_select][ui][issue1296][issue1333]") {
+    auto reg = make_registry();
+    spawn_level_select_screen_full(reg);
+
+    auto diff_view = reg.view<DifficultyButtonTag, UiButtonTag,
+                              LevelSelectScreenTag, LevelIndex,
+                              DifficultyIndex, UiPosition, UiBounds, OnPress,
+                              UiLabel>();
+
+    constexpr int kExpectedTotal =
+        content_config::LEVEL_COUNT * content_config::DIFFICULTY_COUNT;
+
+    constexpr ActionId kExpectedAction[content_config::DIFFICULTY_COUNT] = {
+        ActionId::DifficultyEasy,
+        ActionId::DifficultyMedium,
+        ActionId::DifficultyHard,
+    };
+
+    int total = 0;
+    bool seen[content_config::LEVEL_COUNT][content_config::DIFFICULTY_COUNT] = {};
+
+    for (auto entity : diff_view) {
+        ++total;
+        const auto& li      = diff_view.get<LevelIndex>(entity);
+        const auto& di      = diff_view.get<DifficultyIndex>(entity);
+        const auto& pos     = diff_view.get<UiPosition>(entity);
+        const auto& bounds  = diff_view.get<UiBounds>(entity);
+        const auto& press   = diff_view.get<OnPress>(entity);
+        const auto& label   = diff_view.get<UiLabel>(entity);
+
+        REQUIRE(li.value >= 0);
+        REQUIRE(li.value < content_config::LEVEL_COUNT);
+        REQUIRE(di.value >= 0);
+        REQUIRE(di.value < content_config::DIFFICULTY_COUNT);
+        CHECK_FALSE(seen[li.value][di.value]);
+        seen[li.value][di.value] = true;
+
+        const float expected_x = kDiffStartX +
+            static_cast<float>(di.value) * (kDiffBtnW + kDiffBtnGap);
+        const float card_y = kCardStartY +
+            static_cast<float>(li.value) * (kCardH + kCardGap);
+        const float expected_y = card_y + kDiffYOffset;
+        CHECK(near(pos.x, expected_x));
+        CHECK(near(pos.y, expected_y));
+        CHECK(near(bounds.w, kDiffBtnW));
+        CHECK(near(bounds.h, kDiffBtnH));
+
+        CHECK(press.action == kExpectedAction[di.value]);
+
+        const std::string expected_label{content_config::DIFFICULTY_NAMES[di.value]};
+        CHECK(std::string(label.text.data()) == expected_label);
+    }
+
+    CHECK(total == kExpectedTotal);
+
+    for (int li = 0; li < content_config::LEVEL_COUNT; ++li) {
+        for (int di = 0; di < content_config::DIFFICULTY_COUNT; ++di) {
+            CHECK(seen[li][di]);
+        }
+    }
+}
+
+TEST_CASE("level_select_dynamic_spawn: despawn_level_select_screen removes every spawned entity",
+          "[level_select][ui][issue1296][issue1333]") {
+    auto reg = make_registry();
+
+    CHECK(reg.view<LevelSelectScreenTag>().size() == 0);
+
+    spawn_level_select_screen_full(reg);
+    const std::size_t spawned = reg.view<LevelSelectScreenTag>().size();
+    CHECK(spawned > 0);
+
+    despawn_level_select_screen(reg);
+
+    CHECK(reg.view<LevelSelectScreenTag>().size() == 0);
+    CHECK(reg.view<LevelCardTag>().size() == 0);
+    CHECK(reg.view<DifficultyButtonTag>().size() == 0);
+}
+
+TEST_CASE("level_select_dynamic_spawn: respawning idempotently rebuilds the full set",
+          "[level_select][ui][issue1296][issue1333]") {
+    auto reg = make_registry();
+    spawn_level_select_screen_full(reg);
+    const auto first_count = reg.view<LevelSelectScreenTag>().size();
+
+    despawn_level_select_screen(reg);
+    CHECK(reg.view<LevelSelectScreenTag>().size() == 0);
+
+    spawn_level_select_screen_full(reg);
+    CHECK(reg.view<LevelSelectScreenTag>().size() == first_count);
+    CHECK(reg.view<LevelCardTag>().size()
+          == static_cast<std::size_t>(content_config::LEVEL_COUNT));
+    CHECK(reg.view<DifficultyButtonTag>().size()
+          == static_cast<std::size_t>(
+              content_config::LEVEL_COUNT * content_config::DIFFICULTY_COUNT));
+}


### PR DESCRIPTION
## Summary

Closes #1333. Both systems landed via #1296 (PR #1304) and #1297 (PR #1305) with zero dedicated test coverage. They run on critical paths (every Level-Select entry and every gameplay frame respectively), so a regression in card geometry, ActionId mapping, score format, font/alpha cues, or the ChainBgPulseTag insert/remove logic would silently break the in-game readout or unselectable songs.

## `tests/test_level_select_dynamic_spawn_system.cpp` (4 cases, 73 asserts)

- **spawns one card per level with monotonically increasing Y**: asserts N=`content_config::LEVEL_COUNT` cards spawn with canonical CARD_X / CARD_W / CARD_H, each `LevelIndex` appears exactly once, and Y(i) > Y(i-1) when sorted by index (independent of EnTT iteration order). Also asserts cards are NOT `UiButtonTag` entities (issue #1296 Pass C handles them via `LevelIndex` reads, not the generic button hit pass).
- **spawns 3 difficulty buttons per card with matching ActionId**: asserts exactly LEVEL_COUNT × DIFFICULTY_COUNT button entities exist; each carries the full per-button component set; positions follow the kDiffStartX / kDiffYOffset / kDiffBtnW / Gap formulas; `OnPress.action` matches the constexpr kRow table (Easy=0, Medium=1, Hard=2); `UiLabel` matches `content_config::DIFFICULTY_NAMES[di]`.
- **despawn_level_select_screen removes every spawned entity**: asserts the codegen despawner cleans up cards + difficulty buttons (every spawned entity carries `LevelSelectScreenTag`).
- **respawning idempotently rebuilds the full set**: asserts a spawn → despawn → spawn cycle leaves the same entity counts.

## `tests/test_gameplay_hud_bind_system.cpp` (8 cases, 115 asserts)

- **ScoreSlot formats ScoreDisplay::displayed as plain integer**: asserts the (60, 20) slot's UiLabel becomes `"1234"` for ScoreDisplay = 1234, `UiLabelFontSize=28`, `UiLabelAlpha=1.0`.
- **HighScoreSlot formats CurrentSongHighScore as 'BEST: %d'**: asserts the (60, 50) slot's UiLabel becomes `"BEST: 5678"`, font 18, alpha 0.7.
- **ChainSlot is empty and ChainBgPulseTag absent when chain < 2**: asserts blank label for chain=1, no `ChainBgPulseTag`, and that a stale `ChainBgPulseTag` from a prior frame is removed when chain drops to 0.
- **ChainBgPulseTag is removed when chain falls back below threshold**: chain=7 → chain=3 → chain=0 transition; halo lifecycle must follow the threshold deterministically.
- **EnergyLabel keeps its static text and gets per-slot font/alpha**: asserts the bind does NOT clobber the codegen-baked `"ENERGY"` text while still writing font 16 / alpha 0.8.
- **no gameplay-HUD entities is a safe no-op**: asserts the system is defensive when the gameplay screen has not been spawned yet (early return when the view is empty).

## Verification

```
$ ./build/shapeshifter_tests
All tests passed (3328 assertions in 946 test cases)
```

- Baseline before this PR: 934 cases / 3140 assertions. Net +12 cases / +188 assertions.
- Build clean (-Wall -Wextra -Werror).
- New tests construct a fresh `entt::registry` per case via `make_registry()`; no shared global state, no random-order flake risk.
