### PR TITLE
Refactor ApproachRing.visible bool into ApproachRingVisibleTag (#1331)

### DIFF
--- a/app/components/ui.h
+++ b/app/components/ui.h
@@ -119,7 +119,12 @@ struct UiLabelAlpha {
 // (which knows the beat scheduler and obstacle distances) and the lane
 // button render pass (which knows the button geometry).
 //
-// `visible == false` means no ring draws this frame. Otherwise:
+// `ApproachRing` is the per-button envelope written by
+// `approach_ring_envelope_system`; presence + the
+// `ApproachRingVisibleTag` companion (in `app/tags/tags.h`) together
+// drive the render pass. When the envelope is inactive the system
+// removes the tag (and clears the row); the renderer joins on the tag
+// so the per-frame check is a view filter, not a `try_get` + bool branch.
 //   - `radius` is the ring radius around the button center.
 //   - `alpha_scale` is the global multiplier on the ring color alpha.
 //   - `color_*` are the precomputed tier color (Far / Near / Perfect —
@@ -127,7 +132,6 @@ struct UiLabelAlpha {
 //     into the data the renderer needs, matching Fabian's principle that
 //     the consumer should not branch on labels).
 struct ApproachRing {
-    bool          visible     = false;
     float         radius      = 0.0f;
     float         alpha_scale = 0.0f;
     unsigned char color_r     = 0;

--- a/app/systems/approach_ring_envelope_system.cpp
+++ b/app/systems/approach_ring_envelope_system.cpp
@@ -38,14 +38,19 @@ void write_envelope_for(entt::registry& reg,
         const auto cue = gameplay_hud_ring_cue(nearest_dist, perfect_dist,
                                                 good_dist, ok_dist);
         if (!cue.visible) {
-            reg.emplace_or_replace<ApproachRing>(entity, ApproachRing{});
+            reg.remove<ApproachRing>(entity);
+            reg.remove<ApproachRingVisibleTag>(entity);
             continue;
         }
         const float ratio = gameplay_hud_ring_ratio(nearest_dist, perfect_dist, ok_dist);
         const auto env = approach_ring_envelope(ratio, btn_radius,
                                                 max_ring_radius, reduce_motion);
+        if (env.alpha_scale <= 0.0f) {
+            reg.remove<ApproachRing>(entity);
+            reg.remove<ApproachRingVisibleTag>(entity);
+            continue;
+        }
         ApproachRing ring{};
-        ring.visible     = env.alpha_scale > 0.0f;
         ring.radius      = env.radius;
         ring.alpha_scale = env.alpha_scale;
         ring.color_r     = cue.color.r;
@@ -53,6 +58,7 @@ void write_envelope_for(entt::registry& reg,
         ring.color_b     = cue.color.b;
         ring.color_a     = cue.color.a;
         reg.emplace_or_replace<ApproachRing>(entity, ring);
+        reg.emplace_or_replace<ApproachRingVisibleTag>(entity);
     }
 }
 
@@ -63,9 +69,11 @@ void approach_ring_envelope_system(entt::registry& reg) {
     if (lane_view.begin() == lane_view.end()) return;
     if (!reg.ctx().contains<GamePhasePlayingTag>()) {
         // Clear envelope so the renderer doesn't draw a stale ring after
-        // pause/resume cycles. Empty `ApproachRing` is the "no ring" state.
+        // pause/resume cycles. Absence of `ApproachRingVisibleTag` (and
+        // the optional `ApproachRing` row) is the "no ring" state.
         for (auto entity : lane_view) {
-            reg.emplace_or_replace<ApproachRing>(entity, ApproachRing{});
+            reg.remove<ApproachRing>(entity);
+            reg.remove<ApproachRingVisibleTag>(entity);
         }
         return;
     }

--- a/app/systems/ui_render_system.cpp
+++ b/app/systems/ui_render_system.cpp
@@ -407,7 +407,7 @@ void render_ui_entities(entt::registry& reg) {
                                          icon);
 
                 const auto* ring = r.template try_get<ApproachRing>(entity);
-                if (ring == nullptr || !ring->visible) continue;
+                if (ring == nullptr || !r.template all_of<ApproachRingVisibleTag>(entity)) continue;
                 const Color base_color{ring->color_r, ring->color_g,
                                        ring->color_b, ring->color_a};
                 const Color ring_color = Fade(base_color,

--- a/app/tags/tags.h
+++ b/app/tags/tags.h
@@ -335,3 +335,11 @@ struct LaneButtonTag {};
 // Presence on a UI entity IS the "draw pulse this frame" signal —
 // Fabian existential processing.
 struct ChainBgPulseTag {};
+
+// ApproachRing visibility marker (issue #1331). Emplaced by
+// `approach_ring_envelope_system` alongside `ApproachRing` when the
+// envelope is active for that frame; removed when not. The renderer's
+// lane-button pass joins on `<ApproachRing, ApproachRingVisibleTag>` so
+// the per-frame check is a view filter, not a `try_get` + bool branch —
+// the per-frame existence is the visibility data (Principle 4).
+struct ApproachRingVisibleTag {};

--- a/tests/test_approach_ring_envelope_system.cpp
+++ b/tests/test_approach_ring_envelope_system.cpp
@@ -1,0 +1,124 @@
+// Tests for `approach_ring_envelope_system` per issue #1331. The legacy
+// `ApproachRing::visible` bool was replaced with an `ApproachRingVisibleTag`
+// (Fabian Principle 4 — per-frame existence as the visibility data). These
+// tests verify both halves of the contract:
+//   - When the nearest obstacle is inside the appear window the system
+//     emplaces `ApproachRing` + `ApproachRingVisibleTag` on the matching
+//     lane button.
+//   - When it isn't (no obstacle, wrong shape, paused, etc.) the system
+//     removes both — the renderer's `view<ApproachRing,
+//     ApproachRingVisibleTag>` join keeps the lane dark.
+
+#include "test_helpers.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "components/obstacle.h"
+#include "components/song_state.h"
+#include "components/ui.h"
+#include "constants.h"
+#include "systems/approach_ring_envelope_system.h"
+#include "tags/tags.h"
+#include "util/gameplay_hud_ring.h"
+
+namespace {
+
+entt::entity make_lane_button_circle(entt::registry& reg) {
+    const auto e = reg.create();
+    reg.emplace<LaneButtonTag>(e);
+    reg.emplace<UiBounds>(e, UiBounds{140.0f, 100.0f});
+    reg.emplace<UiShapeIconCircleTag>(e);
+    return e;
+}
+
+entt::entity make_lane_button_square(entt::registry& reg) {
+    const auto e = reg.create();
+    reg.emplace<LaneButtonTag>(e);
+    reg.emplace<UiBounds>(e, UiBounds{140.0f, 100.0f});
+    reg.emplace<UiShapeIconSquareTag>(e);
+    return e;
+}
+
+entt::entity spawn_obstacle_at_y_required_circle(entt::registry& reg, float y) {
+    const auto e = reg.create();
+    reg.emplace<ObstacleTag>(e);
+    reg.emplace<Obstacle>(e);
+    reg.emplace<RequiredShapeCircleTag>(e);
+    reg.emplace<WorldPosition>(e, WorldPosition{{0.0f, y}});
+    return e;
+}
+
+}  // namespace
+
+TEST_CASE("approach_ring_envelope_system emplaces tag when obstacle is inside appear window") {
+    auto reg = make_registry();
+    auto circle_btn = make_lane_button_circle(reg);
+
+    // SongState defaults give a positive ok_distance, so an obstacle parked
+    // a small distance above the player line should be inside the appear
+    // window.
+    spawn_obstacle_at_y_required_circle(reg, constants::PLAYER_Y - 40.0f);
+
+    approach_ring_envelope_system(reg);
+
+    REQUIRE(reg.all_of<ApproachRingVisibleTag>(circle_btn));
+    REQUIRE(reg.all_of<ApproachRing>(circle_btn));
+}
+
+TEST_CASE("approach_ring_envelope_system removes tag when no obstacle is present") {
+    auto reg = make_registry();
+    auto circle_btn = make_lane_button_circle(reg);
+    // Pre-emplace stale visibility to prove the system clears it.
+    reg.emplace<ApproachRing>(circle_btn, ApproachRing{});
+    reg.emplace<ApproachRingVisibleTag>(circle_btn);
+
+    approach_ring_envelope_system(reg);
+
+    REQUIRE_FALSE(reg.all_of<ApproachRingVisibleTag>(circle_btn));
+    REQUIRE_FALSE(reg.all_of<ApproachRing>(circle_btn));
+}
+
+TEST_CASE("approach_ring_envelope_system removes tag when obstacle is outside appear window") {
+    auto reg = make_registry();
+    auto circle_btn = make_lane_button_circle(reg);
+    reg.emplace<ApproachRing>(circle_btn, ApproachRing{});
+    reg.emplace<ApproachRingVisibleTag>(circle_btn);
+
+    // Obstacle far above the player (greater than ok_distance) — outside
+    // the appear window so `gameplay_hud_ring_cue` returns !visible.
+    spawn_obstacle_at_y_required_circle(reg, constants::PLAYER_Y - 10000.0f);
+
+    approach_ring_envelope_system(reg);
+
+    REQUIRE_FALSE(reg.all_of<ApproachRingVisibleTag>(circle_btn));
+    REQUIRE_FALSE(reg.all_of<ApproachRing>(circle_btn));
+}
+
+TEST_CASE("approach_ring_envelope_system isolates lanes by required shape tag") {
+    auto reg = make_registry();
+    auto circle_btn = make_lane_button_circle(reg);
+    auto square_btn = make_lane_button_square(reg);
+
+    // Only the circle lane has an obstacle.
+    spawn_obstacle_at_y_required_circle(reg, constants::PLAYER_Y - 40.0f);
+
+    approach_ring_envelope_system(reg);
+
+    REQUIRE(reg.all_of<ApproachRingVisibleTag>(circle_btn));
+    REQUIRE_FALSE(reg.all_of<ApproachRingVisibleTag>(square_btn));
+}
+
+TEST_CASE("approach_ring_envelope_system clears tag when not in playing phase") {
+    auto reg = make_registry();
+    auto circle_btn = make_lane_button_circle(reg);
+    reg.emplace<ApproachRing>(circle_btn, ApproachRing{});
+    reg.emplace<ApproachRingVisibleTag>(circle_btn);
+    spawn_obstacle_at_y_required_circle(reg, constants::PLAYER_Y - 40.0f);
+
+    set_test_phase<GamePhaseTitleTag>(reg);
+
+    approach_ring_envelope_system(reg);
+
+    REQUIRE_FALSE(reg.all_of<ApproachRingVisibleTag>(circle_btn));
+    REQUIRE_FALSE(reg.all_of<ApproachRing>(circle_btn));
+}


### PR DESCRIPTION
Closes #1331.

## Refactor

Per Fabian Principle 4 (existential processing — per-frame existence IS the data, not a stored discriminator), the lane button approach ring's per-frame visibility is now the presence of a tag, not a `bool` field on the row.

### Files

- **`app/components/ui.h`** — delete `bool visible` from `ApproachRing`.
- **`app/tags/tags.h`** — add `struct ApproachRingVisibleTag {}` next to the other lane-button tags.
- **`app/systems/approach_ring_envelope_system.cpp`** — emplace `ApproachRing` + `ApproachRingVisibleTag` together when the cue is visible and the envelope alpha is positive; remove both when not visible, when envelope alpha is zero, and when the playing-phase ctx-tag is absent (pause/resume).
- **`app/systems/ui_render_system.cpp`** — lane-button render pass now checks `all_of<ApproachRingVisibleTag>` instead of dereferencing `ring->visible`. Per-frame branch is a view filter, not a stored bool.

### Out of scope

`GameplayHudRingCue` (`app/util/gameplay_hud_ring.h`) keeps its `bool visible` field — it's a pure-function return value the envelope system reads, not a registry row, so the bool IS the cue's identity ("the answer to: is there a cue to apply this frame?") rather than per-frame storage.

### Tests

New `tests/test_approach_ring_envelope_system.cpp` covers all five branches:

1. Inside appear window → tag emplaced.
2. No obstacle → tag removed (and stale ApproachRing cleared).
3. Outside appear window → tag removed.
4. Multi-lane: circle obstacle does not light up the square lane.
5. Non-playing phase clears the tag even with an in-window obstacle.

### Verification

- 939 cases / 3150 assertions pass (+5 cases / +10 asserts over baseline).
- Build clean under `-Wall -Wextra -Werror`.
- Zero existing tests had to change — `GameplayHudRingCue{true, …}` storage comparisons in `test_input_pipeline_behavior.cpp` are unaffected (cue type unchanged).