### PR TITLE
#1338 util: add slash-safe join_app_dir helper (drop 4 unsafe GetApplicationDirectory concats)

### DIFF
--- a/app/entities/beat_map.cpp
+++ b/app/entities/beat_map.cpp
@@ -1,4 +1,5 @@
 #include "beat_map.h"
+#include "../util/app_dir_path.h"
 #include "../util/rhythm_math.h"
 #include "../util/shape_lane_mapping.h"
 #include <nlohmann/json.hpp>
@@ -14,19 +15,6 @@
 using json = nlohmann::json;
 namespace {
 constexpr const char* kValidationConstantsPath = "content/constants.json";
-
-std::string constants_path_for_app_dir(const std::string& app_dir) {
-    if (app_dir.empty()) {
-        return kValidationConstantsPath;
-    }
-    const char last = app_dir.back();
-    if (last == '/' || last == '\\') {
-        return app_dir + kValidationConstantsPath;
-    }
-    return app_dir + "/" + kValidationConstantsPath;
-}
-
-
 
 std::string type_error_message(const char* field, const char* expected, const json& value) {
     return std::string("'") + field + "' must be " + expected + " (got " + value.type_name() + ")";
@@ -241,8 +229,9 @@ static bool try_load_constants_from(const std::string& path, ValidationConstants
 
 ValidationConstants load_validation_constants(const std::string& app_dir) {
     ValidationConstants vc;
-    const std::string exe_relative_path =
-        constants_path_for_app_dir(app_dir.empty() ? std::string(GetApplicationDirectory()) : app_dir);
+    const std::string exe_relative_path = util::join_app_dir(
+        app_dir.empty() ? std::string_view(GetApplicationDirectory()) : std::string_view(app_dir),
+        kValidationConstantsPath);
     if (try_load_constants_from(exe_relative_path, vc)) {
         return vc;
     }

--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -2,6 +2,7 @@
 #include "version.h"
 #include "constants.h"
 #include "systems/input.h"
+#include "util/app_dir_path.h"
 #include "components/game_state.h"
 #include "components/scoring.h"
 #include "components/audio.h"
@@ -87,8 +88,8 @@ bool load_text_fonts(TextContext& ctx, const char* font_path) {
 }
 
 bool load_default_text_fonts(TextContext& ctx) {
-    std::string exe_font = std::string(GetApplicationDirectory())
-                         + "content/fonts/LiberationMono-Regular.ttf";
+    std::string exe_font = util::join_app_dir(
+        GetApplicationDirectory(), "content/fonts/LiberationMono-Regular.ttf");
     const char* font_paths[] = {
         exe_font.c_str(),
         "content/fonts/LiberationMono-Regular.ttf",

--- a/app/systems/play_session.cpp
+++ b/app/systems/play_session.cpp
@@ -13,6 +13,7 @@
 #include "high_score_system.h"
 #include "../entities/settings.h"
 #include "../util/rhythm_math.h"
+#include "../util/app_dir_path.h"
 #include "../entities/camera_entity.h"
 #include "../entities/energy_bar_entity.h"
 #include "../entities/player_entity.h"
@@ -146,7 +147,7 @@ void setup_play_session(entt::registry& reg) {
 
     std::vector<BeatMapError> load_errors;
     std::vector<BeatMapError> reported_load_errors;
-    std::string exe_path = std::string(GetApplicationDirectory()) + beatmap_path;
+    std::string exe_path = util::join_app_dir(GetApplicationDirectory(), beatmap_path);
     const char* paths[] = { exe_path.c_str(), beatmap_path };
 
     bool loaded = false;
@@ -231,7 +232,7 @@ void setup_play_session(entt::registry& reg) {
         music->release();
     }
     if (music && !beatmap.song_path.empty()) {
-        std::string exe_audio = std::string(GetApplicationDirectory()) + beatmap.song_path;
+        std::string exe_audio = util::join_app_dir(GetApplicationDirectory(), beatmap.song_path);
         const char* audio_paths[] = { exe_audio.c_str(), beatmap.song_path.c_str() };
         for (const char* path : audio_paths) {
             Music stream = LoadMusicStream(path);

--- a/app/systems/test_player_session.cpp
+++ b/app/systems/test_player_session.cpp
@@ -1,5 +1,6 @@
 #include "test_player_session.h"
 #include "../components/game_state.h"
+#include "../util/app_dir_path.h"
 #include "../util/level_content_config.h"
 #include "../components/obstacle.h"
 #include "../components/scoring.h"
@@ -10,6 +11,7 @@
 #include <cstdio>
 #include <cstring>
 #include <cstdint>
+#include <string>
 
 namespace {
 struct TestPlayerSessionSignals {
@@ -65,22 +67,23 @@ void test_player_init(entt::registry& reg, SkillConfig skill,
     const double runtime_seconds = GetTime();
     const auto runtime_millis = static_cast<unsigned long long>(runtime_seconds * 1000.0);
     const uint32_t sequence = ++session_state->log_sequence;
-    char log_filename[256];
-    std::snprintf(log_filename, sizeof(log_filename),
-        "%ssession_%s_%s_%s_rt%010llu_n%04u.log",
-        GetApplicationDirectory(),
+    char log_basename[256];
+    std::snprintf(log_basename, sizeof(log_basename),
+        "session_%s_%s_%s_rt%010llu_n%04u.log",
         skill.name,
         level_key,
         difficulty_key,
         runtime_millis, sequence);
-    session_log_open(slog, log_filename);
+    const std::string log_filename =
+        util::join_app_dir(GetApplicationDirectory(), log_basename);
+    session_log_open(slog, log_filename.c_str());
     if (slog.file) {
         std::fprintf(slog.file, "skill=%s level=%s difficulty=%s seed=%u\n\n",
                      skill.name, level_key,
                      difficulty_key, seed);
         std::fflush(slog.file);
     }
-    TraceLog(LOG_INFO, "SESSION LOG: %s", log_filename);
+    TraceLog(LOG_INFO, "SESSION LOG: %s", log_filename.c_str());
 
     auto* signals = reg.ctx().find<TestPlayerSessionSignals>();
     if (!signals) {

--- a/app/util/app_dir_path.h
+++ b/app/util/app_dir_path.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace util {
+
+// Slash-safe join of raylib's GetApplicationDirectory() (or any prefix) and a
+// relative path. Returns app_dir + (sep if missing) + rel.
+//
+// raylib's GetApplicationDirectory() *typically* returns a trailing separator
+// on macOS/Linux/Windows, but the contract is not guaranteed across every
+// platform shim (notably some emscripten/sandboxed bundle configurations).
+// Concatenating without normalizing the separator can yield a broken path like
+// "/path/to/appcontent/fonts/..." which silently falls back to the CWD path.
+// Routing through this helper makes that bug class unreachable. See issue
+// #1338 for the catalog of formerly-unsafe call sites.
+//
+// Special cases:
+//   - empty app_dir: returns std::string(rel) — caller's relative path wins.
+//   - empty rel: returns std::string(app_dir) — no spurious separator appended.
+inline std::string join_app_dir(std::string_view app_dir, std::string_view rel) {
+    if (app_dir.empty()) return std::string(rel);
+    if (rel.empty()) return std::string(app_dir);
+    const char last = app_dir.back();
+    const bool has_sep = (last == '/' || last == '\\');
+    std::string out;
+    out.reserve(app_dir.size() + (has_sep ? 0u : 1u) + rel.size());
+    out.append(app_dir);
+    if (!has_sep) out.push_back('/');
+    out.append(rel);
+    return out;
+}
+
+} // namespace util

--- a/tests/test_app_dir_path.cpp
+++ b/tests/test_app_dir_path.cpp
@@ -1,0 +1,32 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "util/app_dir_path.h"
+
+// Issue #1338: raylib's GetApplicationDirectory() *typically* returns a
+// trailing separator on macOS/Linux/Windows, but the contract is not
+// guaranteed across every platform shim. util::join_app_dir is the
+// slash-safe replacement for `std::string(app_dir) + rel`.
+
+TEST_CASE("join_app_dir: empty app_dir returns rel verbatim", "[util][app_dir_path][issue1338]") {
+    CHECK(util::join_app_dir("", "content/fonts/x.ttf") == "content/fonts/x.ttf");
+    CHECK(util::join_app_dir("", "") == "");
+}
+
+TEST_CASE("join_app_dir: empty rel returns app_dir verbatim (no spurious sep)", "[util][app_dir_path][issue1338]") {
+    CHECK(util::join_app_dir("/path/to/app/", "") == "/path/to/app/");
+    CHECK(util::join_app_dir("/path/to/app", "") == "/path/to/app");
+}
+
+TEST_CASE("join_app_dir: app_dir already ending in '/' is not double-slashed", "[util][app_dir_path][issue1338]") {
+    CHECK(util::join_app_dir("/path/to/app/", "content/x.ttf") == "/path/to/app/content/x.ttf");
+}
+
+TEST_CASE("join_app_dir: app_dir ending in '\\\\' (Windows) is not double-slashed", "[util][app_dir_path][issue1338]") {
+    CHECK(util::join_app_dir("C:\\path\\to\\app\\", "content/x.ttf") == "C:\\path\\to\\app\\content/x.ttf");
+}
+
+TEST_CASE("join_app_dir: app_dir missing separator gets '/' inserted", "[util][app_dir_path][issue1338]") {
+    // This is the buggy raylib edge case the helper exists to neutralize:
+    // raw concat would yield "/path/to/appcontent/x.ttf" (broken).
+    CHECK(util::join_app_dir("/path/to/app", "content/x.ttf") == "/path/to/app/content/x.ttf");
+}


### PR DESCRIPTION
Closes #1338.

## Summary
Promote the formerly-private `constants_path_for_app_dir` helper in `app/entities/beat_map.cpp` into a shared `util::join_app_dir` in `app/util/app_dir_path.h`, and route all four unsafe `GetApplicationDirectory()`-concat call sites through it.

## Why
raylib's `GetApplicationDirectory()` *typically* returns a trailing separator on macOS/Linux/Windows, but the contract is not guaranteed across every platform shim (notably some emscripten/sandboxed bundle configurations). Raw `std::string(GetApplicationDirectory()) + "content/..."` would yield broken `"/path/to/appcontent/..."` paths under that edge case, then silently fall back to the CWD path — the second fallback masked the bug.

## Call sites swapped
| File | Old shape | New |
| --- | --- | --- |
| `app/game_loop.cpp:90` | `std::string(GetApplicationDirectory()) + "content/fonts/..."` | `util::join_app_dir(GetApplicationDirectory(), "content/fonts/...")` |
| `app/systems/play_session.cpp:149` | `std::string(GetApplicationDirectory()) + beatmap_path` | `util::join_app_dir(GetApplicationDirectory(), beatmap_path)` |
| `app/systems/play_session.cpp:234` | `std::string(GetApplicationDirectory()) + beatmap.song_path` | `util::join_app_dir(GetApplicationDirectory(), beatmap.song_path)` |
| `app/systems/test_player_session.cpp:71` | `snprintf(buf, "%ssession_%s_..."` with `GetApplicationDirectory()` as first `%s` (same bug class via printf) | `snprintf` builds the basename only; `util::join_app_dir(GetApplicationDirectory(), basename)` prefixes the app dir |
| `app/entities/beat_map.cpp:18-27` | private `constants_path_for_app_dir` helper | deleted; calls `util::join_app_dir(app_dir, kValidationConstantsPath)` |

## Acceptance criteria
- [x] One slash-safe `join_app_dir` helper in `app/util/`.
- [x] All `GetApplicationDirectory() + "content/..."` sites replaced.
- [x] `beat_map.cpp` private `constants_path_for_app_dir` deleted.
- [x] Unit tests covering: empty app_dir, app_dir with `/`, with `\\`, without separator (also empty rel for symmetry).
- [x] Build + all tests pass with zero warnings.

## Verification
```
$ grep -rn 'GetApplicationDirectory())\s*+\|constants_path_for_app_dir' app/
(no matches)

$ ./build/shapeshifter_tests "[issue1338]"
All tests passed (7 assertions in 5 test cases)

$ ./build/shapeshifter_tests "~[bench]" -r compact | tail -1
All tests passed (3345 assertions in 956 test cases)
```

## Scope
File-local helper + 4 call-site swaps + new test file. No public-API or behavior change in the success path. ~50 LOC net.
