### PR TITLE
#1341 wasm smoke: re-baseline difficulty-nav hash + 5s budget to kill flake

### DIFF
--- a/tests/wasm_runtime_smoke.cjs
+++ b/tests/wasm_runtime_smoke.cjs
@@ -409,9 +409,18 @@ async function main() {
 
     // Regression coverage for #934: selecting a difficulty before confirming
     // must not leave the browser build in a frozen/scattered gameplay frame.
+    //
+    // #1341: waitForVisualChange returns the first-detected-different hash,
+    // which can be a transient mid-animation frame from the ArrowDown press.
+    // Re-baseline against a settled screenshot (mirrors line 396 for ArrowDown)
+    // so the next visual diff isn't competing with a still-tweening row cursor.
+    // Use the 5000 ms budget that waitForTitlePhase precedent uses elsewhere
+    // for CI runners under GPU contention.
+    await page.waitForTimeout(250);
+    const beforeDifficultyNavigationHash = sha256(await page.screenshot());
     await page.keyboard.press('ArrowRight');
-    const afterDifficultyNavigationHash = await waitForVisualChange(afterLevelSelectNavigationHash, 2500);
-    if (afterLevelSelectNavigationHash === afterDifficultyNavigationHash) {
+    const afterDifficultyNavigationHash = await waitForVisualChange(beforeDifficultyNavigationHash, 5000);
+    if (beforeDifficultyNavigationHash === afterDifficultyNavigationHash) {
       fatal.push('no-visual-response-after-difficulty-navigation');
     }
     if (!(await waitForTitlePhase('LevelSelect', 1500))) {


### PR DESCRIPTION
Fixes #1341.

## Root cause

`waitForVisualChange` returns the **first** detected different hash. On a CI runner under GPU contention, that hash can be a *mid-animation frame* from the preceding `ArrowDown` press. Using that transient frame as the baseline for the next press (`ArrowRight`) means the subsequent stable frame can coincidentally hash back to the transient value, fatal-flagging a navigation that actually succeeded.

This explains why 3 of the last 4 main pushes flaked on the `no-visual-response-after-difficulty-navigation` assertion despite two of them being Markdown-only — the regression lives in the smoke harness, not in `app/`.

## Fix

Mirror the pattern already used between the title-click and ArrowDown steps (line 396): settle 250 ms, re-screenshot a stable baseline, then press `ArrowRight` and diff against that. Bump the polling budget from 2500 ms to 5000 ms, matching the `waitForTitlePhase` precedent used elsewhere in the same function for the same class of GPU-contention slack.

```diff
+    // #1341: waitForVisualChange returns the first-detected-different hash,
+    // which can be a transient mid-animation frame from the ArrowDown press.
+    // Re-baseline against a settled screenshot (mirrors line 396 for ArrowDown)
+    // so the next visual diff isn't competing with a still-tweening row cursor.
+    // Use the 5000 ms budget that waitForTitlePhase precedent uses elsewhere
+    // for CI runners under GPU contention.
+    await page.waitForTimeout(250);
+    const beforeDifficultyNavigationHash = sha256(await page.screenshot());
     await page.keyboard.press('ArrowRight');
-    const afterDifficultyNavigationHash = await waitForVisualChange(afterLevelSelectNavigationHash, 2500);
-    if (afterLevelSelectNavigationHash === afterDifficultyNavigationHash) {
+    const afterDifficultyNavigationHash = await waitForVisualChange(beforeDifficultyNavigationHash, 5000);
+    if (beforeDifficultyNavigationHash === afterDifficultyNavigationHash) {
       fatal.push('no-visual-response-after-difficulty-navigation');
     }
```

## Why not raise a phase/lane marker for difficulty cursor

That was option 3 in the issue's proposed approaches. It would require an `app/` change to publish difficulty-cursor index into `document.title` (similar to the existing `[Lane:N]` marker for Playing). The screenshot-diff path is the existing convention for screen transitions that don't have a dedicated marker, and the re-baseline pattern is already used one block above — so this PR keeps the fix scoped to the harness and avoids cross-cutting `app/` plumbing that wasn't broken.

## Scope

- Pure JS test-harness change.
- No `app/` or build delta.
- Downstream consumer (`afterDifficultyNavigationHash` used as baseline for the `Enter` step on line 434+) is unaffected — the Title→Tutorial/Playing transition produces a screen-wide visual delta that cannot collide with the transient-frame issue.

## Verification

- Native build: incremental rebuild clean, **zero warnings**.
- Native tests: `./build/shapeshifter_tests` — **all 3345 assertions in 956 test cases pass**.
- JS syntax: `node --check tests/wasm_runtime_smoke.cjs` passes.
- Full validation will happen via CI on this PR (WebAssembly smoke).

## Cross-refs

- #711 (closed 2026-05-11): previous deterministic LevelSelect breakage; distinct cause.
- #934: regression this assertion guards.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>