### PR TITLE
#1343 README: drop magic_enum + glm from Dependencies table

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 A rhythm game where obstacles ARE the beats. Match shapes and dodge lane blocks in time with the music — the closer to the beat, the higher your score.
 
 Built with **C++20** and **EnTT** using Data-Oriented Design.
-Current architecture direction is direct **raylib/raygui + glm**
+Current architecture direction is direct **raylib/raygui**
 at runtime boundaries, without wrapper abstraction layers.
 
 **[Play in browser](https://yashasg.github.io/friendly-parakeet/)** (WebAssembly)
@@ -246,10 +246,8 @@ The level designer uses song structure (intro/verse/chorus/bridge) to control de
 | Library | Version | Purpose |
 |---------|---------|---------|
 | raylib / raygui | vcpkg | Runtime input, rendering, text, audio, immediate-mode UI |
-| glm | vcpkg | Math data and transforms |
 | [EnTT](https://github.com/skypjack/entt) | 3.16.0 | Entity Component System |
 | [nlohmann-json](https://github.com/nlohmann/json) | 3.12+ | Beatmap JSON parsing |
-| magic_enum | vcpkg | Compile-time enum introspection and naming |
 | [Catch2](https://github.com/catchorg/Catch2) | 3.13+ | Testing framework |
 
 ## CI/CD


### PR DESCRIPTION
Fixes #1343.

## Summary

`README.md` Dependencies table (and one earlier prose mention) listed two libraries that aren't in this project:

- `magic_enum` — removed in commit e576740a (#1204 bonus cleanup). No `#include` hits anywhere in `app/ tests/ tools/`. Surviving mentions in `app/` are explanatory comments of the form "replaces the former `magic_enum::enum_name(...)` lookup".
- `glm` — not in `vcpkg.json` (deps: entt, raylib, raygui, nlohmann-json, catch2) and not used in code. Game uses raw raylib types.

A new contributor reading the README would expect `glm::vec2` and `magic_enum::enum_name` to be available; both produce a compile error.

## Changes

- Drop the `glm` row from the Dependencies table.
- Drop the `magic_enum` row from the Dependencies table.
- Drop `+ glm` from the architecture-direction one-liner at the top.

## Verification

- `grep -i 'magic_enum\|glm' README.md` → 0 hits.
- No code changes; docs-only PR.
- Build & tests unaffected (not run for docs-only PR per loop.md DoD).

## Acceptance criteria (from #1343)

- [x] Dependencies table lists exactly the libraries in vcpkg.json (raylib/raygui, EnTT, nlohmann-json, Catch2).
- [x] `grep -i 'magic_enum\|glm' README.md` returns 0 matches.
- [x] No code or build-config changes.