### PR TITLE
#1344 feature-specs.md: drop ShapeID / SwipeDirection from Spec 3 dependencies bullet

### DIFF
--- a/design-docs/feature-specs.md
+++ b/design-docs/feature-specs.md
@@ -591,7 +591,7 @@ void obstacle_despawn_system(entt::registry& reg, float dt);
 
 ### Dependencies
 
-- **Input System (Spec 1)** — `ShapeID` and `SwipeDirection` enums are defined there; re-used here.
+- **Input System (Spec 1)** — Spec 1 owns the dispatcher events that drive the player (per-shape `ShapePress*Event`, per-direction `Go*Event`). Spec 3 does not consume those events directly; it only re-uses the `Shape` enum (label / lookup key in `app/components/player.h`) as the shared vocabulary between Spec 1's player-shape mutations and the obstacle factories' `RequiredShape*Tag` emplacement here.
 - **Rhythm Scoring (Spec 2)** — spawned obstacles provide `BeatInfo`, `Obstacle`, and required-action components to collision/scoring.
 - **Settings** — audio calibration shifts beat arrival and spawn timing.
 


### PR DESCRIPTION
Fixes #1344.

## Summary

`design-docs/feature-specs.md` § Spec 3 "Dependencies" (line 594) still claimed:

> **Input System (Spec 1)** — `ShapeID` and `SwipeDirection` enums are defined there; re-used here.

Neither identifier exists anywhere under `app/`:

- `grep -rn 'ShapeID\|SwipeDirection' app/ tests/` → 0 hits.
- `ShapeID` was collapsed into per-shape tags / events in #1202/#1204 (`ShapePressCircleEvent` / `ShapePressSquareEvent` / `ShapePressTriangleEvent` and `RequiredShape*Tag` / `TargetShape*Tag`).
- `SwipeDirection` was eradicated in #1279 (`Eradicate Direction enum + GoEvent if-ladder dispatch`); per-direction `Go*Event` types now carry the swipe outcome directly.

Spec 3's `beat_scheduler_system` spawns obstacle entities — it doesn't actually consume Spec 1's input events at all. The only shared vocabulary is the `Shape` label/lookup key (in `app/components/player.h`).

## Changes

- Rewrote the Spec 1 dependency bullet (line 594) to describe the actual dependency: Spec 3 only re-uses the `Shape` enum label, not any input-side dispatching type.
- Other bullets (Rhythm Scoring, Settings) unchanged.

## Verification

- `grep -n 'ShapeID\|SwipeDirection' design-docs/feature-specs.md` → 0 matches.
- Docs-only PR.

## Acceptance criteria (from #1344)

- [x] `grep -n 'ShapeID\|SwipeDirection' design-docs/feature-specs.md` returns 0 matches.
- [x] Replacement bullet correctly names the dispatcher-driven event types and tags that the rhythm/obstacle pipeline actually consumes (clarified that Spec 3 doesn't consume them at all).
- [x] Other bullets in § "Dependencies" (Rhythm Scoring, Settings) untouched.
- [x] Docs-only PR.

## Related

#1279 (Direction enum eradication), #1202 / #1204 (Shape per-tag table mechanic), #1312 / #1318 / #1332 (prior design-docs deleted-enum sweeps).