### PR TITLE
docs: scrub deleted RequiredShape / BlockedLanes / RequiredLane wrappers (#1349)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,12 @@ shape_window_system -> miss_detection_system -> scoring_system
   the player entity: `ShapeWindowMorphInTag` → `ShapeWindowActiveTag` →
   `ShapeWindowMorphOutTag` → absence of all three (Idle). Transitions are
   component-table operations, not enum compares.
-- **Collision resolution** uses EnTT structural views grouped by obstacle components
-  (`BlockedLanes`, `RequiredShape`, `RequiredLane`), not a switch on obstacle kind
+- **Collision resolution** uses EnTT structural views grouped by per-archetype
+  tags on the obstacle entity (`ShapeGateTag` / `SplitPathTag` /
+  `OnsetMarkerTag`) plus per-shape tags (`RequiredShapeCircleTag` / …`SquareTag` /
+  …`TriangleTag` / …`HexagonTag`) and a raw `int8_t` lane index, not a switch on
+  obstacle kind. The legacy `BlockedLanes`, `RequiredShape`, `RequiredLane`
+  wrapper structs were eradicated per issues #1198 / #1202 / #1204.
 - **Section labels** guide beatmap structure and intensity; obstacle patterns are authored per section
 
 ### Project Layout

--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -176,7 +176,9 @@ constexpr int32_t CHAIN_MULT_BONUS_STEPS_CAP = 20; // caps at 2.0x from chain 21
   │  WorldPosition     8B ← world position (single Vector2)     │
   │  MotionVelocity     8B ← dx, dy                             │
   │  ObstacleTag        0B ← marker                             │
-  │  RequiredShape      4B ← shape + lane                       │
+  │  ShapeGate / SplitPath / OnsetMarkerTag  0B ← archetype     │
+  │  RequiredShape*Tag  0B ← one of 4 per-shape tags            │
+  │  int8_t lane        1B ← raw lane index (issue #1198)       │
   │  BeatInfo          12B ← beat_index, arrival_time, spawn    │
   │  TimingGrade        5B ← scoring (existential)              │
   │  ScoredTag          0B ← scored marker (prevents re-fire)   │
@@ -187,15 +189,17 @@ constexpr int32_t CHAIN_MULT_BONUS_STEPS_CAP = 20; // caps at 2.0x from chain 21
 
 ```cpp
 struct BeatEntry {
-    int          beat_index   = 0;           // beat index (not seconds)
-    Shape        shape        = Shape::Circle;
-    int8_t       lane         = 1;
-    uint8_t      blocked_mask = 0;
-    float        time_sec     = 0.0f;        // optional authored timestamp
-    bool         has_time_sec = false;       // true → time_sec wins over beat_index
-    // Archetype kind is a per-archetype tag (ShapeGateTag / SplitPathTag /
-    // OnsetMarkerTag from app/tags/tags.h) on the spawned obstacle entity;
-    // BeatEntry no longer carries a runtime kind discriminator (issue #1202/#1204).
+    int    beat_index   = 0;           // beat index (not seconds)
+    int8_t lane         = 1;
+    float  time_sec     = 0.0f;        // optional authored timestamp
+    bool   has_time_sec = false;       // true → time_sec wins over beat_index
+    // Archetype kind is identified by *which per-kind vector in BeatMap*
+    // the row lives in (shape_gate_* / split_path_* / onset_marker_beats).
+    // Required shape (for shape_gate / split_path) is identified by
+    // *which per-shape sub-vector* the row lives in. The former
+    // `Shape shape` and `uint8_t blocked_mask` fields were eradicated
+    // per issues #1198 / #1202 / #1204 — the columns collapsed into
+    // table membership.
 };
 
 struct BeatMap {
@@ -208,7 +212,17 @@ struct BeatMap {
     float                    duration   = 180.0f;
     std::string              difficulty;
     std::vector<float>       beat_times;     // optional analysed onset table
-    std::vector<BeatEntry>   beats;
+
+    // Seven per-(kind, shape) vectors replace the former single `beats`
+    // vector — see `app/components/beat_map.h`. Hexagon is not a valid
+    // required shape, so no `*_hexagon_beats` vector exists.
+    std::vector<BeatEntry>   shape_gate_circle_beats;
+    std::vector<BeatEntry>   shape_gate_square_beats;
+    std::vector<BeatEntry>   shape_gate_triangle_beats;
+    std::vector<BeatEntry>   split_path_circle_beats;
+    std::vector<BeatEntry>   split_path_square_beats;
+    std::vector<BeatEntry>   split_path_triangle_beats;
+    std::vector<BeatEntry>   onset_marker_beats;
 };
 ```
 

--- a/design-docs/tester-personas-tech-spec.md
+++ b/design-docs/tester-personas-tech-spec.md
@@ -44,9 +44,11 @@
   │ Position             │  8B  │ ~10 max    │ HOT: every frame ×3sys │
   │ Velocity             │  8B  │ ~10 max    │ HOT: scroll_system     │
   │ Obstacle             │  4B  │ ~10 max    │ WARM: collision, decide│
-  │ RequiredShape        │  1B  │ ~6 max     │ WARM: collision, decide│
-  │ BlockedLanes         │  1B  │ ~3 max     │ WARM: collision, decide│
-  │ RequiredLane         │  1B  │ ~2 max     │ WARM: collision, decide│
+  │ ShapeGate/SplitPath/ │  0B  │ ~10 max    │ WARM: archetype select │
+  │   OnsetMarkerTag     │      │            │   (one per obstacle)   │
+  │ RequiredShape*Tag    │  0B  │ ~6 max     │ WARM: collision, decide│
+  │   (per-shape tag)    │      │            │                        │
+  │ int8_t lane          │  1B  │ ~6 max     │ WARM: collision, decide│
   │ BeatInfo             │ 12B  │ ~10 max    │ COLD: beat scheduling  │
   ├──────────────────────┼──────┼────────────┼────────────────────────┤
   │ TestPlayerState      │~2.6KB│ 1 singleton│ COLD: once per frame   │
@@ -62,13 +64,14 @@
 ## Data Flow (Transforms)
 
 ```
-  ┌──────────────┐     ┌──────────────┐     ┌────────────────┐
-  │ Position     │     │ Obstacle     │     │ BeatInfo       │
-  │ (per obs)    │     │ RequiredShape│     │ arrival_time   │
-  │              │     │ BlockedLanes │     │                │
-  └──────┬───────┘     │ RequiredLane │     └───────┬────────┘
-         │             │ Obstacle.kind│             │
-         │             └──────┬───────┘             │
+  ┌──────────────┐     ┌──────────────────┐     ┌────────────────┐
+  │ Position     │     │ Obstacle         │     │ BeatInfo       │
+  │ (per obs)    │     │ RequiredShape*Tag│     │ arrival_time   │
+  │              │     │ ShapeGate /      │     │                │
+  └──────┬───────┘     │   SplitPath /    │     └───────┬────────┘
+         │             │   OnsetMarkerTag │             │
+         │             │ int8_t lane      │             │
+         │             └──────┬───────────┘             │
          ▼                    ▼                     ▼
   ┌──────────────────────────────────────────────────────────┐
   │              test_player_system                          │
@@ -359,16 +362,17 @@ a no-op.
 
   ┌─────────────────────────────────────────────────────────────────┐
   │                                                                 │
-  │  Has RequiredShape?                                             │
-  │    YES → target_shape = required.shape                          │
+  │  has_required_shape_tag(reg, e)?  (any RequiredShape*Tag)       │
+  │    YES → target_shape = current_required_shape(reg, e)          │
+  │           (helper in app/util/shape_tag.h)                      │
   │                                                                 │
-  │  Has BlockedLanes?                                              │
-  │    YES → is current lane blocked?                               │
-  │      YES → target_lane = nearest unblocked lane                 │
-  │      NO  → target_lane stays -1 (no change)                     │
+  │  view<ShapeGateTag>().contains(e)?                              │
+  │    YES → target_lane = reg.get<int8_t>(e)  (positional lane;    │
+  │           player must align here to pass)                       │
   │                                                                 │
-  │  Has RequiredLane?                                               │
-  │    YES → target_lane = required.lane                             │
+  │  view<SplitPathTag>().contains(e)?                              │
+  │    YES → target_lane = reg.get<int8_t>(e)  (required dodge      │
+  │           lane the player must be in)                           │
   │                                                                 │
   └─────────────────────────────────────────────────────────────────┘
 ```
@@ -479,7 +483,8 @@ a no-op.
   void on_obstacle_spawn(entt::registry& reg, entt::entity entity) {
       auto* log = reg.ctx().find<SessionLog>();
       if (!log || !log->file) return;
-      // read Obstacle, BeatInfo, RequiredShape from entity
+      // read Obstacle, BeatInfo, RequiredShape*Tag (via
+      // current_required_shape) and the raw int8_t lane from entity
       // write [GAME] OBSTACLE_SPAWN line
   }
 ```


### PR DESCRIPTION
Closes #1349.

Three design docs still narrated the obstacle data layout in terms of the wrapper structs `RequiredShape { Shape shape; }`, `BlockedLanes { uint8_t mask; }`, and `RequiredLane { int8_t lane; }` — all of which were eradicated in PRs #1240 / #1271 / #1275 per issues #1198 / #1202 / #1204. The current entity-data is:

- `RequiredShape*Tag` — four per-shape zero-column tags in `app/tags/tags.h`.
- Blocked-lane mask → raw `uint8_t` component on the obstacle entity (PR #1240).
- `ShapeGateLane` / `RequiredLane` → raw `int8_t` lane component (PR #1275).

## Changes

### README.md (L167–172)
"Collision resolution" prose now names per-archetype tags (`ShapeGateTag` / `SplitPathTag` / `OnsetMarkerTag`), per-shape tags, and the raw `int8_t` lane index. Adds an explicit past-tense note that the legacy wrappers were eradicated so the deletion is grepable from `README.md`.

### design-docs/tester-personas-tech-spec.md
- **Data-layout table (L41–58):** stale `RequiredShape | 1B`, `BlockedLanes | 1B`, `RequiredLane | 1B` rows replaced with current entity-data (archetype tag 0B, RequiredShape\*Tag 0B, raw `int8_t` lane 1B).
- **Data Flow diagram (L66–79):** obstacle box now lists current components (`RequiredShape*Tag`, `ShapeGateTag` / `SplitPathTag` / `OnsetMarkerTag`, raw `int8_t` lane).
- **Action-determination decision tree (L360–378):** predicates rewritten to call the actual helper API — `has_required_shape_tag(reg, e)`, `view<ShapeGateTag>().contains(e)`, `view<SplitPathTag>().contains(e)`.
- **Code-excerpt comment (L482–483):** `// read Obstacle, BeatInfo, RequiredShape from entity` updated to reference `current_required_shape` and the raw `int8_t` lane.

### design-docs/rhythm-spec.md
- **PER-ENTITY COMPONENTS table (L171–186):** the `RequiredShape 4B ← shape + lane` row was replaced with three rows that match the current archetype (archetype tag 0B, `RequiredShape*Tag` 0B, raw `int8_t` lane 1B).
- **`BeatEntry` / `BeatMap` C++ snippet (L188–226):** tightly coupled to the same eradication wave. Removed stale `Shape shape` and `uint8_t blocked_mask` fields from `BeatEntry`. Replaced the single `std::vector<BeatEntry> beats` with the seven per-(kind, shape) vectors that actually live in `app/components/beat_map.h`.

## Verification

```
$ grep -rn 'BlockedLanes\|RequiredLane\|\bRequiredShape\b' \
    design-docs/ README.md --include='*.md' \
  | grep -v 'RequiredShape\*Tag' \
  | grep -vE 'was unwrapped|was eradicated|was collapsed|were unwrapped|were eradicated|legacy'
(no output)
```

All remaining hits are explicit past-tense / historical context.

Build is green on `main` (969/969 tests pass at baseline); this is a docs-only change.

Follow-up to #1344 / #1345 / #1318 / #1332 (recent docs-drift sweeps).
