### PR TITLE
game_loop: clamp raw_dt at source to bound hitch fast-forward (#1352)

### DIFF
--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -44,8 +44,7 @@
 #include <string>
 #include <utility>
 
-static constexpr float FIXED_DT  = 1.0f / 60.0f;
-static constexpr float MAX_ACCUM = 0.1f;
+static constexpr float FIXED_DT = 1.0f / 60.0f;
 
 namespace {
 
@@ -280,9 +279,9 @@ void game_loop_frame(entt::registry& reg, float& accumulator) {
     auto* session_log = reg.ctx().find<SessionLog>();
     if (session_log) session_log_begin_frame(*session_log);
 
-    float raw_dt = GetFrameTime();
+    float raw_dt = clamp_frame_dt(GetFrameTime());
     accumulator += raw_dt;
-    if (accumulator > MAX_ACCUM) accumulator = MAX_ACCUM;
+    if (accumulator > kMaxFrameDt) accumulator = kMaxFrameDt;
 
     compute_screen_transform(reg);
     input_system(reg, raw_dt);

--- a/app/game_loop.h
+++ b/app/game_loop.h
@@ -4,6 +4,21 @@
 #include "util/level_content_config.h"
 #include "systems/test_player.h"
 
+// Per-frame "we will not advance more than this" budget (seconds). The
+// fixed-timestep accumulator and the variable-rate systems' raw_dt share
+// this single canonical hitch cap so a window drag, debugger break,
+// tab-inactive interval, or other main-thread hitch can never fast-forward
+// touch-slot durations, AI action timers, or other dt-driven state
+// (issue #1352).
+inline constexpr float kMaxFrameDt = 0.1f;
+
+// Clamp a raylib GetFrameTime() reading so a single hitch advances dt-driven
+// state by at most kMaxFrameDt in one frame. Called once per frame from
+// game_loop_frame; exported so tests can pin the contract without raylib init.
+inline constexpr float clamp_frame_dt(float raw_dt) noexcept {
+    return raw_dt < kMaxFrameDt ? raw_dt : kMaxFrameDt;
+}
+
 // Initialize platform (window, audio), all game singletons, cameras, meshes, UI.
 // Returns false when platform initialization fails and the run loop must not start.
 bool game_loop_init(entt::registry& reg,

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -1058,7 +1058,7 @@ int main(int argc, char* argv[]) {
 
     // ── TIMING ────────────────────────────────────────────────
     constexpr float FIXED_DT     = 1.0f / 60.0f;   // 16.67ms
-    constexpr float MAX_ACCUM    = 0.1f;            // cap = 6 frames
+    constexpr float kMaxFrameDt  = 0.1f;            // cap = 6 frames (single canonical hitch cap, #1352)
     float           accumulator  = 0.0f;
     double          prev_time    = GetTime();
 
@@ -1067,11 +1067,11 @@ int main(int argc, char* argv[]) {
 
         // ── DELTA TIME ────────────────────────────────────────
         double now = GetTime();
-        float raw_dt = static_cast<float>(now - prev_time);
+        float raw_dt = clamp_frame_dt(static_cast<float>(now - prev_time));
         prev_time = now;
         accumulator += raw_dt;
-        if (accumulator > MAX_ACCUM) {
-            accumulator = MAX_ACCUM;   // prevent spiral of death
+        if (accumulator > kMaxFrameDt) {
+            accumulator = kMaxFrameDt;   // prevent spiral of death
         }
 
         compute_screen_transform(reg);

--- a/tests/test_game_loop_raw_dt_hitch_clamp.cpp
+++ b/tests/test_game_loop_raw_dt_hitch_clamp.cpp
@@ -1,0 +1,84 @@
+// tests/test_game_loop_raw_dt_hitch_clamp.cpp
+//
+// Issue #1352 regression: game_loop_frame used to read raw_dt = GetFrameTime()
+// and pass the unclamped value to two variable-rate systems before the
+// fixed-timestep accumulator clamp kicked in. After a window drag, pause,
+// debugger break, or web tab-inactive interval, GetFrameTime() reports the
+// full hitch duration (seconds), which:
+//
+//   • input_system: accumulated touch_slots[i].duration += raw_dt, spuriously
+//     crossing long-press / gesture-duration thresholds.
+//   • test_player_system: ticked every queued action timer by the full hitch,
+//     fast-forwarding the entire AI plan in a single frame (relevant to the
+//     WASM smoke flake history — see #1341).
+//
+// The fix exposes `kMaxFrameDt` + `clamp_frame_dt(raw_dt)` from game_loop.h
+// and clamps once at the source in game_loop_frame. These tests pin the
+// math of the helper and the bounded-advance contract that downstream
+// systems rely on.
+#include <catch2/catch_test_macros.hpp>
+
+#include "test_helpers.h"
+#include "game_loop.h"
+#include "systems/test_player.h"
+
+TEST_CASE("clamp_frame_dt: caps any hitch reading at kMaxFrameDt", "[game_loop][issue-1352]") {
+    CHECK(kMaxFrameDt == 0.1f);
+
+    // Sub-cap inputs pass through unchanged.
+    CHECK(clamp_frame_dt(0.0f) == 0.0f);
+    CHECK(clamp_frame_dt(1.0f / 60.0f) == 1.0f / 60.0f);
+    CHECK(clamp_frame_dt(1.0f / 30.0f) == 1.0f / 30.0f);
+
+    // At and above the cap, the result is exactly kMaxFrameDt.
+    CHECK(clamp_frame_dt(kMaxFrameDt) == kMaxFrameDt);
+    CHECK(clamp_frame_dt(0.5f) == kMaxFrameDt);
+    CHECK(clamp_frame_dt(3.0f) == kMaxFrameDt);
+    CHECK(clamp_frame_dt(5.0f) == kMaxFrameDt);
+}
+
+TEST_CASE("test_player_system: action timers advance by at most kMaxFrameDt under a hitch",
+          "[test_player][game_loop][issue-1352]") {
+    auto reg = make_rhythm_registry();
+    auto& tp = reg.ctx().emplace<TestPlayerState>();
+    tp.skill  = SKILL_PRO;
+    tp.active = true;
+    tp.rng.seed(42);
+
+    tp.action_count = 1;
+    tp.actions[0].timer        = 1.0f;
+    tp.actions[0].arrival_time = 10.0f;
+    tp.swipe_cooldown_timer    = 1.0f;
+
+    constexpr float k5sHitch = 5.0f;
+    const float clamped = clamp_frame_dt(k5sHitch);
+    REQUIRE(clamped == kMaxFrameDt);
+
+    test_player_system(reg, clamped);
+
+    // Without the upstream clamp, both timers would have dropped by ~5s in
+    // one frame (fast-forwarding the entire AI plan). With the clamp,
+    // they drop by at most kMaxFrameDt.
+    CHECK(tp.actions[0].timer        >= 1.0f - kMaxFrameDt - 1e-6f);
+    CHECK(tp.swipe_cooldown_timer    >= 1.0f - kMaxFrameDt - 1e-6f);
+}
+
+TEST_CASE("InputState: touch-slot duration advances by at most kMaxFrameDt under a hitch",
+          "[input][game_loop][issue-1352]") {
+    auto reg = make_rhythm_registry();
+    auto& input = reg.ctx().get<InputState>();
+
+    // Simulate an active touch carried over a hitch frame.
+    input.touch_slots[0].active   = true;
+    input.touch_slots[0].duration = 0.0f;
+
+    // game_loop_frame clamps GetFrameTime() through clamp_frame_dt before
+    // calling input_system. Reproduce the same accumulation expression
+    // input_system uses (app/systems/input_system.cpp:357) to assert the
+    // bounded-advance contract.
+    constexpr float k5sHitch = 5.0f;
+    const float raw_dt = clamp_frame_dt(k5sHitch);
+    input.touch_slots[0].duration += raw_dt;
+
+    CHECK(input.touch_slots[0].duration <= kMaxFrameDt);
+}


### PR DESCRIPTION
Closes #1352.

`game_loop_frame` used to read `raw_dt = GetFrameTime()` and pass the unclamped value to two variable-rate systems before the fixed-timestep accumulator's `MAX_ACCUM` clamp kicked in. After a window drag, pause, debugger break, or web tab-inactive interval, `GetFrameTime()` reports the full hitch duration (seconds), which:

- `input_system` (`app/systems/input_system.cpp:357`) accumulates `touch_slots[i].duration += raw_dt`, spuriously crossing long-press / gesture-duration thresholds on resume.
- `test_player_system` (`app/systems/test_player_system.cpp:374,377`) ticks every queued AI action timer and the swipe cooldown by the full hitch, fast-forwarding the entire plan in a single frame — relevant to the WASM smoke flake history (#1341).

## Fix

Promote the per-frame cap to a public `kMaxFrameDt` constant + `clamp_frame_dt(raw_dt)` helper in `app/game_loop.h`, clamp once at the source in `game_loop_frame`, and reuse the same constant for the accumulator clamp so there's one canonical hitch cap. Camera systems already mark their `dt` as `[[maybe_unused]]`, so this only affects the input + test-player paths.

```cpp
// before
float raw_dt = GetFrameTime();
accumulator += raw_dt;
if (accumulator > MAX_ACCUM) accumulator = MAX_ACCUM;

// after
float raw_dt = clamp_frame_dt(GetFrameTime());
accumulator += raw_dt;
if (accumulator > kMaxFrameDt) accumulator = kMaxFrameDt;
```

## Tests

New `tests/test_game_loop_raw_dt_hitch_clamp.cpp`:

- `clamp_frame_dt` math: identity below cap, equals `kMaxFrameDt` at and above.
- `test_player_system`: action timer + swipe cooldown advance by `<= kMaxFrameDt` when game_loop_frame would have fed a 5s hitch.
- `InputState` touch-slot duration accumulator: same bound.

```
$ ./build/shapeshifter_tests "[issue-1352]"
All tests passed (12 assertions in 3 test cases)

$ ./build/shapeshifter_tests
All tests passed (3357 assertions in 959 test cases)
```

Zero warnings.

## Docs

`design-docs/architecture.md`: main-loop pseudo-code updated to call `clamp_frame_dt` and use `kMaxFrameDt` (was the stale `MAX_ACCUM`).

## Acceptance criteria (from issue)

- [x] A single hitch (simulated 5s `raw_dt`) causes at most one `kMaxFrameDt`-bounded step in both `input_system`-style touch-slot duration accumulation and `test_player_system` action timers.
- [x] New unit test in `tests/` feeds a 5s `dt` through the clamp and asserts both advances are `<= kMaxFrameDt` in one frame.
- [x] Existing test suite passes; zero warnings.
