### PR TITLE
rhythm-spec.md: Phase 5 audio is shipped via raylib (not planned SDL_mixer) (#1350)

### DIFF
--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -772,11 +772,16 @@ if (!song) return;  // no rhythm context — skip
   • Removed: HP bar (HP mechanic never shipped)
 ```
 
-## Phase 5 — Audio playback (PLANNED)
+## Phase 5 — Audio playback (DONE)
 ```
-  • song_playback_system: sync song_time to SDL_mixer playback position
-  • audio_system: load + play audio file from BeatMap.song_path
-  • Beat pulse VFX on beat_tick event
+  • song_playback_system: syncs song_time to the raylib music stream via
+    GetMusicTimePlayed(); pumps UpdateMusicStream() every frame; starts /
+    pauses / resumes / stops the stream from per-phase ctx-tags.
+  • play_session.cpp: LoadMusicStream(BeatMap.song_path) per play session;
+    UnloadMusicStream on session end (MusicContext destructor).
+  • Beat pulse VFX: floor_visuals::pulse_for_beat() in
+    components/camera_resources.h decays per-beat against song_time
+    each frame (FLOOR_PULSE_DECAY = 0.15s).
 ```
 
 ## Phase 6 — Results screen (PLANNED)


### PR DESCRIPTION
Closes #1350.

`design-docs/rhythm-spec.md` L761–766 marked audio playback as **Phase 5 — PLANNED** and pointed at `SDL_mixer`. Two drift problems:

1. **Library is wrong.** This project has never depended on SDL_mixer. Audio uses raylib (`LoadMusicStream`, `PlayMusicStream`, `UpdateMusicStream`, `UnloadMusicStream`, `GetMusicTimePlayed`). `grep -rn 'SDL' app/` returns zero hits.
2. **Phase is shipped, not planned.** The runtime already implements all three bullets:
   - `app/components/music.h::MusicContext` holds the live raylib `Music` stream + playback flags (the destructor calls `UnloadMusicStream`).
   - `app/systems/song_playback_system.cpp` pumps `UpdateMusicStream()` every frame and syncs `song_time` via `GetMusicTimePlayed()`.
   - `app/systems/play_session.cpp` owns `LoadMusicStream(song_path)` per play session.
   - Beat pulse VFX is computed per-frame via `floor_visuals::pulse_for_beat()` in `app/components/camera_resources.h` (`FLOOR_PULSE_DECAY = 0.15s`) — no `BeatTickEvent` dispatch needed because it polls `song_time` against the beat times.

## Change

Rewrites the Phase 5 block as the current implementation summary, flipped to DONE, naming the actual raylib symbols + file locations.

## Verification

```
$ grep -rn 'SDL' design-docs/ README.md
(no output)
```

Docs-only change — no build/test impact.

## Acceptance criteria (from issue)

- [x] L761–766 rewritten as the current implementation summary (no `PLANNED` marker, no `SDL_mixer`).
- [x] `grep -rn 'SDL' design-docs/ README.md` returns zero hits.
