### PR TITLE
rhythm-spec.md: Phase 6 results screen is shipped; only S/A/B/C/D/F grade remains planned (#1356)

### DIFF
--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -784,9 +784,24 @@ if (!song) return;  // no rhythm context — skip
     each frame (FLOOR_PULSE_DECAY = 0.15s).
 ```
 
-## Phase 6 — Results screen (PLANNED)
+## Phase 6 — Results screen (DONE; letter-grade PLANNED)
 ```
-  • SongResults: perfect_count/good_count/ok_count/bad_count/miss_count/max_chain/total_notes
-  • Grade calculation: S/A/B/C/D/F from accuracy %
-  • Results screen: shown on song completion or MISS game-over
+  • SongResults singleton: perfect_count / good_count / ok_count /
+    bad_count / miss_count / max_chain / total_notes defined in
+    components/song_state.h; scoring_system.cpp increments the
+    appropriate counter on every graded ShapeGate resolution.
+  • Phase tags: GamePhaseSongCompleteTag / GamePhaseGameOverTag in
+    tags/tags.h; game_state_terminal_phase_system.cpp enters the
+    SongComplete phase on song completion and the GameOver phase on
+    a MISS game-over.
+  • Song-complete screen: song_complete_scoreboard_bind_system.cpp
+    binds score / high score / new-best / perfect+good /
+    ok+bad+miss / max-chain / energy slots from ScoreState +
+    SongResults + CurrentSongHighScore.
+  • Game-over screen: game_over_scoreboard_bind_system.cpp binds
+    score / high score / new-best from ScoreState +
+    CurrentSongHighScore (no per-tier breakdown on the MISS path).
+  • S/A/B/C/D/F letter grade from accuracy %: PLANNED (no
+    grade-calculation system shipped yet; SongResults carries the
+    raw counts a future letter-grade system would need).
 ```


### PR DESCRIPTION
Closes #1356.

`design-docs/rhythm-spec.md` Phase 6 was marked PLANNED but the runtime had shipped almost all of it — same drift Phase 5 had next door (fixed in #1350 / #1355).

## Was

```
## Phase 6 — Results screen (PLANNED)
  • SongResults: perfect_count/good_count/ok_count/bad_count/miss_count/max_chain/total_notes
  • Grade calculation: S/A/B/C/D/F from accuracy %
  • Results screen: shown on song completion or MISS game-over
```

## Now

Flipped to DONE and rewritten in the same concrete file/function/component style as Phase 5, with one explicit PLANNED bullet for the genuinely-unshipped subset:

- `SongResults` counts live in `app/components/song_state.h:60` and are populated by `app/systems/scoring_system.cpp` on every graded ShapeGate resolution.
- `GamePhaseSongCompleteTag` / `GamePhaseGameOverTag` (`app/tags/tags.h`) drive the two terminal screens; `app/systems/game_state_terminal_phase_system.cpp` enters each phase.
- `song_complete_scoreboard_bind_system.cpp` binds score / high score / new-best / perfect+good / ok+bad+miss / max-chain / energy from `ScoreState` + `SongResults` + `CurrentSongHighScore`.
- `game_over_scoreboard_bind_system.cpp` binds score / high score / new-best on the MISS path (no per-tier breakdown there — called out in the doc).
- S/A/B/C/D/F letter grade from accuracy %: **PLANNED** (no grade-calculation system shipped yet; the doc keeps a PLANNED bullet so the marker still matches reality).

## Acceptance criteria (from #1356)

- [x] L782–787 flipped to DONE and rewritten as an implementation summary naming the actual system / phase-tag / component symbols, mirroring Phase 5 after #1350.
- [x] PLANNED marker kept only for the S/A/B/C/D/F letter grade that is genuinely not shipped.
- [x] A `grep` confirms the file no longer claims a clearly-shipped feature is PLANNED.

Docs-only change; no source or test edits.
