### PR TITLE
components: move SFXBank ctx-resource owner beside sfx_bank_system (#1358)

### DIFF
--- a/app/components/audio.h
+++ b/app/components/audio.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <raylib.h>
 
 // `Count` is a sentinel (always last); `static_cast<int>(SFX::Count)` replaces
 // the former `magic_enum::enum_count<SFX>()` lookup (issue #1204 bonus).
@@ -22,19 +21,7 @@ static_assert(static_cast<int>(SFX::Count) == 6,
 static_assert(static_cast<int>(SFX::ShapeShift) == 0,
               "SFX enum must be zero-based for array indexing");
 
-// Resident sound bank initialised by sfx_bank_init (app/systems/sfx_bank.cpp).
-struct SFXBank {
-    static constexpr int SFX_COUNT = static_cast<int>(SFX::Count);
-    Sound sounds[SFX_COUNT]       = {};
-    bool  sound_loaded[SFX_COUNT] = {};
-    bool  loaded                  = false;
-
-    SFXBank() = default;
-    SFXBank(const SFXBank&) = delete;
-    SFXBank& operator=(const SFXBank&) = delete;
-    SFXBank(SFXBank&& other) noexcept;
-    SFXBank& operator=(SFXBank&& other) noexcept;
-    ~SFXBank();
-
-    void release();
-};
+// The resident sound bank that owns raylib Sound handles for each SFX lives
+// in `app/systems/sfx_bank_resources.h` (issue #1358). `app/components/audio.h`
+// stays plain data — see .squad/decisions.md §"app/components parallel audit
+// verdict (consolidated)".

--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -5,7 +5,6 @@
 #include "util/app_dir_path.h"
 #include "components/game_state.h"
 #include "components/scoring.h"
-#include "components/audio.h"
 #include "systems/sfx_bank.h"
 #include "systems/audio_routing.h"
 #include "entities/settings.h"

--- a/app/systems/audio_system.cpp
+++ b/app/systems/audio_system.cpp
@@ -1,6 +1,7 @@
 #include "all_systems.h"
 #include "audio_routing.h"
 #include "audio_events.h"
+#include "sfx_bank_resources.h"
 
 #include <raylib.h>
 

--- a/app/systems/sfx_bank.cpp
+++ b/app/systems/sfx_bank.cpp
@@ -1,4 +1,5 @@
 #include "sfx_bank.h"
+#include "sfx_bank_resources.h"
 #include "../components/audio.h"
 
 #include <raylib.h>

--- a/app/systems/sfx_bank_resources.h
+++ b/app/systems/sfx_bank_resources.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "../components/audio.h"  // SFX enum (drives SFX_COUNT)
+
+#include <raylib.h>
+
+// Audio runtime resource owner: holds the resident raylib Sound handles for
+// each `SFX`. Lives in registry context (not on an entity), populated by
+// `sfx_bank_init` and torn down by `sfx_bank_unload` / the destructor.
+//
+// Relocated out of `app/components/audio.h` (issue #1358, follow-up to
+// #1351) because this is a ctx-singleton RAII wrapper, not entity-owned
+// plain data — `app/components/` stays reserved for atomic, queryable
+// entity-owned tables per .squad/decisions.md §"app/components parallel
+// audit verdict (consolidated)".
+struct SFXBank {
+    static constexpr int SFX_COUNT = static_cast<int>(SFX::Count);
+    Sound sounds[SFX_COUNT]       = {};
+    bool  sound_loaded[SFX_COUNT] = {};
+    bool  loaded                  = false;
+
+    SFXBank() = default;
+    SFXBank(const SFXBank&) = delete;
+    SFXBank& operator=(const SFXBank&) = delete;
+    SFXBank(SFXBank&& other) noexcept;
+    SFXBank& operator=(SFXBank&& other) noexcept;
+    ~SFXBank();
+
+    void release();
+};

--- a/benchmarks/bench_systems.cpp
+++ b/benchmarks/bench_systems.cpp
@@ -12,7 +12,6 @@
 #include "components/rendering.h"
 #include "components/particle.h"
 #include "components/rhythm.h"
-#include "components/audio.h"
 #include "systems/audio_routing.h"
 #include "constants.h"
 #include "systems/all_systems.h"

--- a/tests/test_audio_system.cpp
+++ b/tests/test_audio_system.cpp
@@ -4,6 +4,7 @@
 
 #include "components/audio.h"
 #include "systems/sfx_bank.h"
+#include "systems/sfx_bank_resources.h"
 #include "test_helpers.h"
 
 TEST_CASE("audio_system: drains queued SFX safely without playable sounds", "[audio]") {

--- a/tests/test_gpu_resource_lifecycle.cpp
+++ b/tests/test_gpu_resource_lifecycle.cpp
@@ -15,6 +15,7 @@
 #include <type_traits>
 
 #include "components/audio.h"
+#include "systems/sfx_bank_resources.h"
 #include "systems/audio_resources.h"
 #include "components/camera_resources.h"
 #include "systems/camera_resources.h"


### PR DESCRIPTION
Closes #1358.

## Why

Follow-up to #1351 / PR #1357. `SFXBank` (in `app/components/audio.h:26–40`) is the same family of ctx-singleton audio resource owner as `MusicContext` / `TextContext` / `RenderTargets` / `camera::ShapeMeshes` were before #1351. It owns raylib `Sound sounds[SFX_COUNT]`, has deleted copy, custom move ctor/assign, a `~SFXBank()` destructor, and a `release()` that calls `UnloadSound` — i.e. RAII, **not** entity-owned plain data.

Per `.squad/decisions.md` §"app/components parallel audit verdict (consolidated)":

> `app/components/` stays reserved for atomic, queryable entity-owned data. Dispatcher payloads, ctx scratch buffers, session state, persistence helpers, and render-config helpers should move beside their owning systems/modules.

`SFXBank` belongs beside `sfx_bank.cpp`.

## Changes

- **New** `app/systems/sfx_bank_resources.h` — declares the `SFXBank` struct (members, deleted copy, move ctor/assign, dtor, `release()`). Includes `components/audio.h` for the `SFX` enum that drives `SFX_COUNT`.
- **`app/components/audio.h`** drops the `SFXBank` struct and the `<raylib.h>` include; keeps only the `SFX` enum + contiguity `static_assert`s. The header is now trivially destructible plain data.
- **`app/systems/sfx_bank.cpp`** — definitions of `SFXBank::release()`, `~SFXBank()`, move ctor/assign stay here; `+#include "sfx_bank_resources.h"`. `components/audio.h` still included for the `SFX` enum.
- **`app/systems/audio_system.cpp`** — `+#include "sfx_bank_resources.h"` (still gets `SFX` + `PlaySfxEvent` via `audio_events.h`).
- **`tests/test_audio_system.cpp`** and **`tests/test_gpu_resource_lifecycle.cpp`** — `+#include "systems/sfx_bank_resources.h"`.
- **`app/game_loop.cpp`** and **`benchmarks/bench_systems.cpp`** — drop now-unused `components/audio.h` includes (both only used `sfx_bank_init` / `wire_audio_haptic_dispatcher`, never `SFX`/`SFXBank`/`PlaySfxEvent` directly).

Untouched: `tests/test_components.cpp` and `tests/test_helpers.h` still pull `SFX` from `components/audio.h` (correct — that's where the enum lives), and `app/systems/audio_events.h` still pulls `SFX` from there for the `PlaySfxEvent` payload.

## Acceptance criteria (from #1358)

- [x] `app/components/audio.h` is a trivially-destructible plain-data header (no deleted copy, no custom move, no `Unload*` chain). The new header has only the `SFX` enum + static_asserts.
- [x] Every `app/components/*.h` is plain data (closes the loop on #1351 acceptance criterion 2 across the whole tree).
- [x] Build green with zero warnings (`-Wall -Wextra -Werror`).
- [x] All tests pass (959 test cases / 3357 assertions).

## Diff stat

```
 app/components/audio.h                | 21 ++++-----------------
 app/game_loop.cpp                     |  1 -
 app/systems/audio_system.cpp          |  1 +
 app/systems/sfx_bank.cpp              |  1 +
 app/systems/sfx_bank_resources.h      | 30 ++++++++++++++++++++++++++++++
 benchmarks/bench_systems.cpp          |  1 -
 tests/test_audio_system.cpp           |  1 +
 tests/test_gpu_resource_lifecycle.cpp |  1 +
 8 files changed, 38 insertions(+), 19 deletions(-)
```

Cross-refs: #1351, PR #1357, `.squad/decisions.md` §"app/components parallel audit verdict (consolidated)".
