### PR TITLE
#1361 util::join_app_dir: pass through absolute rel paths

### DIFF
--- a/app/util/app_dir_path.h
+++ b/app/util/app_dir_path.h
@@ -5,6 +5,20 @@
 
 namespace util {
 
+// True if `p` is an absolute path. Recognizes:
+//   - POSIX-rooted: leading '/'
+//   - Windows UNC / drive-rooted: leading '\'
+//   - Windows drive-letter: ASCII letter followed by ':' (e.g. "C:\foo", "C:/foo")
+inline bool is_absolute_path(std::string_view p) noexcept {
+    if (p.empty()) return false;
+    if (p.front() == '/' || p.front() == '\\') return true;
+    if (p.size() >= 2 && p[1] == ':') {
+        const char c = p.front();
+        return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+    }
+    return false;
+}
+
 // Slash-safe join of raylib's GetApplicationDirectory() (or any prefix) and a
 // relative path. Returns app_dir + (sep if missing) + rel.
 //
@@ -19,9 +33,16 @@ namespace util {
 // Special cases:
 //   - empty app_dir: returns std::string(rel) — caller's relative path wins.
 //   - empty rel: returns std::string(app_dir) — no spurious separator appended.
+//   - `rel` already absolute: returns std::string(rel) — never prepend app_dir
+//     onto an absolute path (issue #1361). Without this guard, callers that
+//     pass through user-supplied absolute paths (e.g. PlaySessionContentOverride
+//     beatmap_path in tests) produce broken concatenations like
+//     "<app_dir>//var/folders/..." that succeed only via fallback retry and
+//     emit a spurious WARNING: FILEIO line on every load.
 inline std::string join_app_dir(std::string_view app_dir, std::string_view rel) {
     if (app_dir.empty()) return std::string(rel);
     if (rel.empty()) return std::string(app_dir);
+    if (is_absolute_path(rel)) return std::string(rel);
     const char last = app_dir.back();
     const bool has_sep = (last == '/' || last == '\\');
     std::string out;

--- a/tests/test_app_dir_path.cpp
+++ b/tests/test_app_dir_path.cpp
@@ -30,3 +30,34 @@ TEST_CASE("join_app_dir: app_dir missing separator gets '/' inserted", "[util][a
     // raw concat would yield "/path/to/appcontent/x.ttf" (broken).
     CHECK(util::join_app_dir("/path/to/app", "content/x.ttf") == "/path/to/app/content/x.ttf");
 }
+
+// Issue #1361: when the caller passes an already-absolute path as `rel`
+// (e.g. PlaySessionContentOverride beatmap_path pointing at /var/folders/...
+// in tests), the old helper would produce "<app_dir>//var/folders/..." and
+// open() would silently fail before the caller's fallback retry succeeded —
+// leaving a spurious WARNING: FILEIO line in every run.
+
+TEST_CASE("join_app_dir: absolute POSIX rel passes through unchanged", "[util][app_dir_path][issue1361]") {
+    CHECK(util::join_app_dir("/path/to/app/", "/var/folders/06/tmp.json") == "/var/folders/06/tmp.json");
+    CHECK(util::join_app_dir("/path/to/app", "/var/folders/06/tmp.json") == "/var/folders/06/tmp.json");
+}
+
+TEST_CASE("join_app_dir: absolute Windows drive-letter rel passes through unchanged", "[util][app_dir_path][issue1361]") {
+    CHECK(util::join_app_dir("C:\\path\\to\\app\\", "D:\\temp\\beatmap.json") == "D:\\temp\\beatmap.json");
+    CHECK(util::join_app_dir("C:\\path\\to\\app\\", "c:/temp/beatmap.json") == "c:/temp/beatmap.json");
+}
+
+TEST_CASE("join_app_dir: absolute Windows UNC rel passes through unchanged", "[util][app_dir_path][issue1361]") {
+    CHECK(util::join_app_dir("C:\\path\\to\\app\\", "\\\\server\\share\\file.json") == "\\\\server\\share\\file.json");
+}
+
+TEST_CASE("is_absolute_path: recognizes POSIX, Windows UNC, and drive-letter paths", "[util][app_dir_path][issue1361]") {
+    CHECK(util::is_absolute_path("/var/folders/x.json"));
+    CHECK(util::is_absolute_path("\\\\server\\share"));
+    CHECK(util::is_absolute_path("C:\\foo"));
+    CHECK(util::is_absolute_path("c:/foo"));
+    CHECK_FALSE(util::is_absolute_path(""));
+    CHECK_FALSE(util::is_absolute_path("content/x.ttf"));
+    CHECK_FALSE(util::is_absolute_path("9:not-a-drive"));
+    CHECK_FALSE(util::is_absolute_path("AB:not-a-drive")); // two letters then colon is not a drive
+}


### PR DESCRIPTION
Closes #1361.

## Root cause

`util::join_app_dir(app_dir, rel)` blindly prepended `app_dir` to `rel` even when `rel` was already absolute. The test suite's `PlaySessionContentOverride.beatmap_path = beatmap.path.string()` (an absolute `/var/folders/...` temp path) produced `<app_dir>//var/folders/...` — silently failing the first `load_runtime_beat_map` attempt and succeeding only via the caller's fallback retry, while emitting a visible `WARNING: FILEIO` line on every load.

## Fix

`app/util/app_dir_path.h`:
- New `util::is_absolute_path(std::string_view)` recognizing POSIX-rooted, Windows UNC, and Windows drive-letter forms.
- `util::join_app_dir` now short-circuits and returns `rel` verbatim when `is_absolute_path(rel)` is true. Empty/trailing-separator behavior is unchanged.

`tests/test_app_dir_path.cpp`: 4 new test cases covering absolute POSIX, Windows drive-letter (with both `/` and `\\` separators inside), Windows UNC, and the `is_absolute_path` helper directly (positive + negative cases including non-letter drive prefix and the `AB:` two-letter false positive guard).

## Verification

- `./build/shapeshifter_tests [util][app_dir_path]` → 20 assertions in 9 test cases pass (4 new + 5 existing).
- `./build/shapeshifter_tests [issue847]` → 4 assertions pass; the spurious `WARNING: FILEIO ... <app_dir>//var/folders/...` line is gone; absolute temp path opens on first attempt.
- Full `./build/shapeshifter_tests` → 3370 assertions in 963 cases pass.
- Full `ctest` → 976/976 pass, 0 fail (1 skipped: `startup_shutdown_smoke`, normal in headless).
- Zero new warnings on `-Wall -Wextra -Werror`.

## Out of scope

Caller-side fallback array shape (`paths[] = { exe_path.c_str(), beatmap_path }`) — once `join_app_dir` short-circuits absolute paths, the two array entries become identical for absolute inputs (cheap, harmless second attempt). No caller change needed.
