### PR TITLE
#1363 components/ui.h: drop unused <cstring> include

### DIFF
--- a/app/components/ui.h
+++ b/app/components/ui.h
@@ -4,7 +4,6 @@
 
 #include <array>
 #include <cstddef>
-#include <cstring>
 
 // Atomic UI components produced by the rguilayout codegen pipeline (#1193).
 // Each control row in a `.rgl` layout file becomes one ECS entity carrying:


### PR DESCRIPTION
## Summary

Drops the unused `#include <cstring>` from `app/components/ui.h`. The header uses no `<cstring>` symbols — `ui_label_set()` is hand-written as an indexed loop, not `std::memcpy`/`std::strncpy` — and `<array>` + `<cstddef>` cover all remaining standard-library uses.

## Diff

```diff
 #include <array>
 #include <cstddef>
-#include <cstring>
```

`-1 +0` LoC. Closes #1363.

## Verification

- `cmake --build build` → clean, **zero warnings** (`-Wall -Wextra -Werror`).
- `./build/shapeshifter_tests` → **3370 assertions / 963 test cases pass**.
- 23 downstream TUs (`grep #include components/ui.h`) all rebuilt successfully — no silent transitive-include reliance.

## Context

Continues the cadence of one-header unused-include drops: #1093 / #1094 / #1100 / #1119 / #1123 / #1132 / #1133 / #1154 / #1156.

The include was introduced in `828b2af2c` (2026-05-16, part of the entity-driven UI migration #1297) but was never used.
