### PR TITLE
#1366 systems/ui_render_system.cpp: drop unused <utility> include

### DIFF
--- a/app/systems/ui_render_system.cpp
+++ b/app/systems/ui_render_system.cpp
@@ -25,7 +25,6 @@
 #include <cstddef>
 #include <cstdio>
 #include <string>
-#include <utility>
 
 // ═════════════════════════════════════════════════════════════════════════════
 // UI render system — 2D overlay pass


### PR DESCRIPTION
Closes #1366.

The file does not use `std::move`, `std::forward`, `std::swap`, `std::pair`, `std::exchange`, or any other `<utility>` symbol. Dead include.

```
rg -nE '\bstd::(move|forward|swap|pair|exchange|make_pair|as_const|in_place|piecewise_construct)\b|\bstd::declval\b' app/systems/ui_render_system.cpp
# 0 hits
```

Build + tests green locally (963 test cases, 3370 assertions). Mirrors the #1363/#1364 pattern.