### PR TITLE
#1367 systems/session_logger_system.cpp: drop unused <cmath> include

### DIFF
--- a/app/systems/session_logger_system.cpp
+++ b/app/systems/session_logger_system.cpp
@@ -6,7 +6,6 @@
 #include "../util/shape_tag.h"
 
 #include <cstdarg>
-#include <cmath>
 #include <string_view>
 #include <utility>
 


### PR DESCRIPTION
Closes #1367.

The file does not use any `<cmath>` symbol (no sin/cos/sqrt/fabs/pow/log/exp/floor/ceil/round/trunc, neither C nor `std::` variants). Dead include.

stdio symbols (`std::fopen`, `std::fprintf`, `std::fwrite`, `std::fflush`) arrive transitively via `session_logger_system.h` which already does `#include <cstdio>`.

Build + tests green locally (963 test cases, 3370 assertions). Mirrors the #1363/#1364 pattern.