### PR TITLE
#1365 systems/level_select_dynamic_spawn_system.cpp: drop unused <cstdio> include

### DIFF
--- a/app/systems/level_select_dynamic_spawn_system.cpp
+++ b/app/systems/level_select_dynamic_spawn_system.cpp
@@ -6,8 +6,6 @@
 #include "generated/screen_spawners.h"
 #include "../util/level_content_config.h"
 
-#include <cstdio>
-
 // Geometry constants — single source of truth, mirrored by the matching
 // renderer block in `ui_render_system.cpp`. Edits here must keep the
 // renderer constants in sync (kept as separate constexpr there to avoid


### PR DESCRIPTION
Closes #1365.

The file does not use any `<cstdio>` symbol (no printf/fprintf/scanf/FILE/fopen/fclose/etc.). Dead include.

```
rg -nE '\b(printf|fprintf|sprintf|snprintf|scanf|sscanf|fopen|fclose|fread|fwrite|fseek|ftell|fflush|fgets|fputs|fgetc|fputc|getchar|putchar|FILE|stdin|stdout|stderr|EOF|SEEK_SET|SEEK_CUR|SEEK_END)\b' app/systems/level_select_dynamic_spawn_system.cpp
# 0 hits
```

Build + tests green locally (963 test cases, 3370 assertions). Mirrors the #1363/#1364 pattern.