### PR TITLE
#1372 systems/camera_system.cpp: drop unused <cmath> include

### DIFF
--- a/app/systems/camera_system.cpp
+++ b/app/systems/camera_system.cpp
@@ -18,7 +18,6 @@
 #include <raymath.h>
 #include <rlgl.h>
 #include <algorithm>
-#include <cmath>
 #include <stdexcept>
 
 namespace camera {


### PR DESCRIPTION
Closes #1372.

## What

Removes the unused `#include <cmath>` from `app/systems/camera_system.cpp` (line 21). No `<cmath>` symbol is referenced in this TU.

## Why this one is safe (unlike the sibling .h, which I closed)

I audited all four members of the recent `<cmath>` cleanup batch:

| File | `std::isfinite` / `<cmath>` symbol present? | Verdict |
|---|---|---|
| `app/systems/beat_scheduler_system.cpp` (#1374) | YES (line 143) | closed as invalid |
| `app/systems/scroll_system.cpp` (#1371) | YES (line 17) | closed as invalid |
| `app/systems/camera_system.h` (#1373) | YES (line 40, in inline `screen_to_virtual`) | closed as invalid |
| **`app/systems/camera_system.cpp` (#1372)** | **NO** | **this PR** |

The original repro regex on each issue body was incomplete (no `isfinite`/`isnan`/`isinf`); a corrected grep over the trig/exp/log family + classification macros confirms only this .cpp file is clean.

## Verification

- `cmake --build build` → green, zero warnings (`-Wall -Wextra -Werror`)
- `./build/shapeshifter_tests` → all 963 test cases / 3370 assertions pass

Mirrors the pattern in #1364 / #1368 / #1369 / #1370.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>