### PR TITLE
#1376 game_loop.h: drop unused <cstdint> include

### DIFF
--- a/app/game_loop.h
+++ b/app/game_loop.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <cstdint>
 #include <entt/entt.hpp>
 #include "util/level_content_config.h"
 #include "systems/test_player.h"


### PR DESCRIPTION
Fixes #1376.

## What

Removes line 2 `#include <cstdint>` from `app/game_loop.h`. The header only
declares free functions taking `bool` / `int` / `float` / `const char*` and
two `inline constexpr float` helpers (`kMaxFrameDt`, `clamp_frame_dt`). No
`<cstdint>` symbol is referenced.

## Verification

Independently re-ran a strict word-boundary grep across the full `<cstdint>`
symbol surface — fixed-width int aliases (`int{8..64}_t`, `uint{8..64}_t`),
pointer/`max` variants (`intptr_t`, `uintptr_t`, `intmax_t`, `uintmax_t`),
fast/least aliases, and the `INT*_MAX/MIN`, `UINT*_MAX`, `SIZE_MAX`,
`PTRDIFF_MAX`, `WCHAR_MAX/MIN`, `WINT_MAX/MIN` macros — and got zero hits
in `app/game_loop.h`.

Audited all five consumers of the header (`app/game_loop.cpp`, `app/main.cpp`,
`app/platform_display.cpp`, `tests/smoke/startup_shutdown_smoke.cpp`,
`tests/test_game_loop_raw_dt_hitch_clamp.cpp`) for the same symbol set: zero
hits, so removing the transitive include cannot break them.

## Build / tests

- `cmake --build build` clean with `-Wall -Wextra -Werror`
- `./build/shapeshifter_tests` → All 3370 assertions in 963 test cases pass

Mirrors #1364 / #1368 / #1369 / #1370 / #1372.