### PR TITLE
#1379 game_loop.cpp: drop unused <algorithm> include

### DIFF
--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -39,7 +39,6 @@
 #include "systems/ui_update_system.h"
 
 #include <raylib.h>
-#include <algorithm>
 #include <cstdlib>
 #include <string>
 #include <utility>


### PR DESCRIPTION
Fixes #1379.

## What

Removes line 42 `#include <algorithm>` from `app/game_loop.cpp`. The TU
does not use any `<algorithm>` symbol.

## Verification

Grep covering the full `<algorithm>` symbol surface — sort
(`sort`/`stable_sort`/`nth_element`), search (`find`/`find_if`/`*_of`,
`search`/`search_n`/`*_end`/`*_first_of`, `binary_search`,
`lower_bound`/`upper_bound`/`equal_range`), heap (`push_heap`/`pop_heap`/
`make_heap`/`sort_heap`/`is_heap`/`is_heap_until`), min/max
(`min`/`max`/`clamp`/`minmax`/`min_element`/`max_element`/`minmax_element`),
permutation (`next_permutation`/`prev_permutation`/`is_permutation`),
copy/move/swap (`copy`/`copy_n`/`copy_if`/`copy_backward`/`move_backward`/
`fill`/`fill_n`/`generate`/`generate_n`/`swap_ranges`/`iter_swap`),
partition (`partition`/`stable_partition`/`partition_point`/
`is_partitioned`), merge (`merge`/`inplace_merge`), set
(`includes`/`set_union`/`set_intersection`/`set_difference`/
`set_symmetric_difference`), and others (`reverse`/`reverse_copy`/
`rotate`/`rotate_copy`/`shuffle`/`sample`/`for_each`/`for_each_n`/
`transform`/`count`/`count_if`/`unique`/`unique_copy`/`equal`/`mismatch`/
`adjacent_find`/`lexicographical_compare`/`is_sorted`/`is_sorted_until`)
returns zero true hits.

The only `find` matches are `reg.ctx().find<T>()` — EnTT's registry
context lookup, not `std::find`.

The other three system headers in the same block remain required and
are NOT touched by this PR:
- `<cstdlib>` → `std::getenv` (line 171)
- `<string>` → `std::string` (lines 90, 164)
- `<utility>` → `std::forward` (line 54)

## Build / tests

- `cmake --build build` clean with `-Wall -Wextra -Werror`
- `./build/shapeshifter_tests` → All 3370 assertions in 963 test cases pass

Mirrors #1364 / #1368 / #1369 / #1370 / #1372 / #1376. Same methodology
as #1377 (full symbol-surface grep) to avoid the #1371/#1373/#1374
false-positive pattern.
