### PR TITLE
#1382 architecture.md: sync Scoring constants snippet with app/constants.h

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -83,9 +83,8 @@ namespace constants {
 
     // ── Scoring ───────────────────────────────────────
     constexpr int   PTS_SHAPE_GATE    = 200;
-    constexpr int   PTS_LANE_BLOCK    = 100;
-    constexpr int   PTS_COMBO_GATE    = 200;
     constexpr int   PTS_SPLIT_PATH    = 300;
+    constexpr int   PTS_PER_SECOND    = 10;
     constexpr float CHAIN_MULT_STEP    = 0.05f;
     constexpr int32_t CHAIN_MULT_BONUS_STEPS_CAP = 20; // caps at 2.0x
 


### PR DESCRIPTION
Fixes #1382.

## What

`design-docs/architecture.md` lines 85-88 advertised stale scoring constants `PTS_LANE_BLOCK` and `PTS_COMBO_GATE` that no longer exist in `app/constants.h`. Updated the snippet to match the real source of truth in `app/constants.h:42-46`:

```cpp
constexpr int   PTS_SHAPE_GATE    = 200;
constexpr int   PTS_SPLIT_PATH    = 300;
constexpr int   PTS_PER_SECOND    = 10;
constexpr float CHAIN_MULT_STEP    = 0.05f;
constexpr int32_t CHAIN_MULT_BONUS_STEPS_CAP = 20;
```

Same class of drift as the README cleanup in #1378.

## Verification

- `grep -nE 'PTS_LANE_BLOCK|PTS_COMBO_GATE' design-docs/architecture.md` → no matches.
- `grep -nE 'PTS_SHAPE_GATE|PTS_SPLIT_PATH|PTS_PER_SECOND' design-docs/architecture.md` matches real `app/constants.h` entries.
- Docs-only change — no build/test impact.
