### PR TITLE
#1386 design-docs/game.md: drop Lane Block / Combo Gate from Obstacle Types

### DIFF
--- a/design-docs/game.md
+++ b/design-docs/game.md
@@ -104,21 +104,16 @@ See `rhythm-design.md` for the full timing-window grading table and `rhythm-spec
 
 | Obstacle        | Status          | Player Action Required    | Timed? | Base Points |
 |-----------------|-----------------|---------------------------|--------|-------------|
-| Shape Gate      | Shipped         | Tap correct shape button  | YES    | 200         |
-| Lane Block      | Legacy/back-compat | Avoid blocked lane     | NO     | 100 (unused legacy) |
-| Combo Gate      | Future design   | Shape + swipe (2 actions) | YES    | TBD         |
-| Split Path      | Future design   | Shape + correct lane      | YES    | TBD         |
+| Shape Gate      | Shipped         | Tap correct shape button  | YES    | `PTS_SHAPE_GATE = 200` |
+| Split Path      | Future design   | Shape + correct lane      | YES    | `PTS_SPLIT_PATH = 300` |
 
 Shipped beatmaps currently use required `shape_gate` obstacles only. They may also include non-blocking `onset_marker` rows for authored onset metadata; runtime skips those rows and they do not score, block, or count as required obstacles.
 
-Lane Block remains a legacy runtime enum/constant for backward compatibility
-(`PTS_LANE_BLOCK = 100`) but is not parsed from active beatmaps and is not
-current shipped content. Vertical bars, Combo Gates, and Split Paths are
-archived/future-only design space and have no live shipped content.
+`PTS_SPLIT_PATH` exists in `app/constants.h` so that future split-path content can ship without re-tuning, but no split-path archetype is currently parsed from beatmaps. Earlier archetypes from pre-shipped design drafts are not present in code or content, and their associated scoring constants have been removed.
 
-### Future Combo / Split-Path Obstacles
+### Future Split-Path Obstacles
 
-If combo or split-path obstacles return, their timing and scoring rules need a new committed design pass before content ships. Older drafts treated combo obstacles as two timed actions (for example, switch to ● and swipe left) with independent timing grades, but that is not current shipped behavior.
+If split-path obstacles return, their timing and scoring rules need a new committed design pass before content ships. Earlier drafts also explored combo obstacles (two timed actions, e.g. switch to ● and swipe left, with independent timing grades) but that archetype is not on the current roadmap.
 
 ---
 


### PR DESCRIPTION
Closes #1386.

## Summary

`design-docs/game.md`'s "Obstacle Types" table still listed **Lane Block** and **Combo Gate** as if they were live obstacle archetypes, and a footnote claimed `PTS_LANE_BLOCK = 100` survived in code. Both claims contradict `app/constants.h`, which has only `PTS_SHAPE_GATE`, `PTS_SPLIT_PATH`, and `PTS_PER_SECOND` in the Scoring section. `grep -rn 'PTS_LANE_BLOCK\|PTS_COMBO_GATE' app/` returns zero hits.

Sister PRs #1381 (README), #1382 (architecture.md), and #1385 (feature-specs.md SPEC 1) already purged the same stale concepts elsewhere. This is the remaining instance.

## Changes (`design-docs/game.md` only)

- Remove the **Lane Block** and **Combo Gate** rows from the Obstacle Types table.
- Annotate surviving rows with their real constant names (`PTS_SHAPE_GATE = 200`, `PTS_SPLIT_PATH = 300`) so the table cannot silently drift away from `app/constants.h` again.
- Rewrite the post-table paragraph to stop naming dropped archetypes; explain that `PTS_SPLIT_PATH` is held for future content.
- Rename `### Future Combo / Split-Path Obstacles` → `### Future Split-Path Obstacles` and reframe the combo-obstacles sentence as historical-exploration context rather than current/future intent.

## Acceptance criteria (from #1386)

- [x] Obstacle Types table lists only obstacle archetypes that ship in current beatmaps, plus existing `onset_marker` note immediately below.
- [x] `Lane Block` and `Combo Gate` table rows removed; `Split Path` retained but clearly labelled future design with its real constant.
- [x] The "Lane Block remains a legacy runtime enum/constant... `PTS_LANE_BLOCK = 100`" paragraph is gone.
- [x] `grep -niE 'PTS_LANE_BLOCK|PTS_COMBO_GATE|Lane Block|Combo Gate|combo gate|lane block' design-docs/game.md` returns zero hits.

## Verification

```
$ grep -niE 'PTS_LANE_BLOCK|PTS_COMBO_GATE|Lane Block|Combo Gate|combo gate|lane block' design-docs/game.md
$ echo $?
1
```

Docs-only change; no code or build impact.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>