### PR TITLE
#1387 feature-specs.md SPEC 1: drop TAP_DEBOUNCE_SEC + INPUT_BUFFER_SIZE residuals + combo-obstacles user-story rationale

### DIFF
--- a/design-docs/feature-specs.md
+++ b/design-docs/feature-specs.md
@@ -78,7 +78,7 @@ The Input System translates raw touch / mouse / keyboard events into game action
 - As a player, I want to **swipe up** so that my character can jump when vertical movement is supported.
 - As a player, I want to **swipe down** so that my character can slide when vertical movement is supported.
 - As a player, I want to **tap a shape button** so that my character shifts to that shape instantly.
-- As a player, I want to **swipe AND tap nearly simultaneously** (combo obstacles) and have both actions register.
+- As a player, I want to **swipe AND tap nearly simultaneously** so that quick shape changes during movement both register in the same frame.
 - As a player, I want **accidental micro-touches** (jitter) to be ignored so I don't misfire.
 
 ## Acceptance Criteria
@@ -279,10 +279,8 @@ void game_state_system(entt::registry& reg, float dt);
   │  ZONE_SPLIT_Y           │  0.80      │  fraction of screen │
   │  MIN_SWIPE_DIST_DP      │  50        │  density-indep px   │
   │  MAX_SWIPE_TIME_SEC     │  0.300     │  seconds            │
-  │  TAP_DEBOUNCE_SEC       │  0.100     │  seconds            │
   │  BUTTON_HIT_PADDING_DP  │  12        │  expand hit-rect    │
   │  MAX_SIMULTANEOUS_TOUCH │  2         │  fingers tracked    │
-  │  INPUT_BUFFER_SIZE      │  2         │  1 swipe + 1 tap    │
   └───────────────────────────────────────────────────────────┘
 ```
 


### PR DESCRIPTION
Closes #1387.

## Summary

PR #1385 (closing #1383) removed input-buffer / tap-debounce claims from SPEC 1's **Overview**, **Acceptance Criteria**, and **Edge Cases** but left two residual locations in `design-docs/feature-specs.md` that still describe behavior the Input System does not implement.

Sister PR #1389 is purging the same 'combo obstacle' archetype from `game.md`; this PR finishes the cleanup in `feature-specs.md`.

## Changes (`design-docs/feature-specs.md` only)

- **Balancing Parameters table** (lines 273–287): remove `TAP_DEBOUNCE_SEC` and `INPUT_BUFFER_SIZE` rows. `grep -rn 'TAP_DEBOUNCE\|INPUT_BUFFER\|tap_debounce\|input_buffer' app/` returns zero hits — the Input System emits typed events directly on the EnTT dispatcher with no debounce timer and no buffer struct. Surviving rows (`ZONE_SPLIT_Y`, `MIN_SWIPE_DIST_DP`, `MAX_SWIPE_TIME_SEC`, `BUTTON_HIT_PADDING_DP`, `MAX_SIMULTANEOUS_TOUCH`) all correspond to real input-system tunables.
- **User Stories** (line 81): reword `'(combo obstacles)'` parenthetical to `'so that quick shape changes during movement both register in the same frame'`. The story itself — swipe + tap can both fire in one frame — stays; only the nonexistent-obstacle justification is gone.

## Acceptance criteria (from #1387)

- [x] Balancing Parameters table no longer contains a `TAP_DEBOUNCE_SEC` row.
- [x] Balancing Parameters table no longer contains an `INPUT_BUFFER_SIZE` row.
- [x] Surviving rows correspond to real input-system tunables.
- [x] User story at line 81 drops `(combo obstacles)` and replaces with a current-game justification; the swipe-+-tap behavior stays.
- [x] `grep -nE 'TAP_DEBOUNCE|INPUT_BUFFER|tap[ _]debounce|input[ _]buffer|combo obstacle' design-docs/feature-specs.md` returns zero hits (case-insensitive).

## Verification

```
$ grep -niE 'TAP_DEBOUNCE|INPUT_BUFFER|tap[ _]debounce|input[ _]buffer|combo obstacle' design-docs/feature-specs.md
$ echo $?
1
```

Docs-only change; no code or build impact.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>