### PR TITLE
#1388 isometric-perspective.md: drop "lane blocks" from rectangle-obstacles example

### DIFF
--- a/design-docs/isometric-perspective.md
+++ b/design-docs/isometric-perspective.md
@@ -231,13 +231,14 @@ the correct perspective distortion.
 
 Same as circle but with 6 points.  Each vertex projected independently.
 
-### Rectangle obstacles (full-width bars, lane blocks, gates)
+### Rectangle obstacles (e.g. shape gates)
 
 Already shown in the square example.  Each corner is a vertex with its
 own y, so top edge is narrower than bottom edge.
 
 ```
-  Full-width bar at y=300, h=20:
+  Rectangle at y=300, h=20 (illustrative — same math applies to any
+  axis-aligned rectangle):
 
   Before:                        After:
   ┌──────────────────────┐       ╱──────────────────╲     ← y=300


### PR DESCRIPTION
Closes #1388.

## Summary

The rectangle-obstacles section in `design-docs/isometric-perspective.md` still enumerated obstacle archetypes that are not part of current shipped content:

- Heading at line 234 read `### Rectangle obstacles (full-width bars, lane blocks, gates)`.
- ASCII art beneath it was captioned `Full-width bar at y=300, h=20`.

Lane blocks were removed from current gameplay (README #1381, architecture.md #1382, game.md drift in #1386). Full-width / vertical bars are archived/future-only per game.md. The current shipped rectangle obstacle is the Shape Gate.

The projection math itself is fully agnostic to which rectangle archetype is being projected, so the example stays — only the framing changes.

## Changes (`design-docs/isometric-perspective.md` only)

- Heading: `### Rectangle obstacles (e.g. shape gates)` — picks the one concrete shipped rectangle as the example.
- ASCII art caption: `Rectangle at y=300, h=20 (illustrative — same math applies to any axis-aligned rectangle)` — keeps the pedagogy without naming archived/dropped archetypes.

## Acceptance criteria (from #1388)

- [x] Heading at line 234 no longer enumerates 'lane blocks' as a current obstacle. Now reads `### Rectangle obstacles (e.g. shape gates)`.
- [x] Remaining mention of 'Rectangle' is clearly tagged as illustrative-of-projection (`illustrative — same math applies to any axis-aligned rectangle`), not a claim of shipped content.
- [x] `grep -nE 'lane block' design-docs/isometric-perspective.md` returns zero hits (case-insensitive).

## Verification

```
$ grep -niE 'lane block' design-docs/isometric-perspective.md
$ echo $?
1
```

Docs-only change; no code or build impact.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>