### PR TITLE
#1392 game_state_system.cpp: drop "combo obstacles" wording from drain-order comment

### DIFF
--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -81,8 +81,8 @@ void game_state_system(entt::registry& reg, float dt) {
     //
     // Events are enqueued earlier in the same frame by input_system and the
     // gameplay HUD input collector before the fixed-step loop. Shape presses
-    // drain before movement so same-frame mobile tap+swipe combo obstacles
-    // resolve deterministically.
+    // drain before movement so a same-frame mobile tap + swipe both resolve
+    // deterministically.
     //
     // ⚠ Do NOT call disp.clear<>() on any of these queues before this point
     //   within a frame.  Pre-tick systems enqueue same-frame events that


### PR DESCRIPTION
Fixes #1392.

## What
Rewords the drain-order comment in `app/systems/game_state_system.cpp` (lines 82–85) so it no longer references the dropped `combo obstacles` archetype. The drain order itself (shape presses before `Go*Event` movement) is correct and unchanged — only the rationale wording.

## Why
Sister PRs in this cycle purged "Combo Gate" / "combo obstacles" from current-design docs:
- #1386 / #1389 — game.md
- #1387 / #1390 — feature-specs.md SPEC 1
- #1388 / #1391 — isometric-perspective.md

This comment was the last in-tree current-code reference to the dropped archetype. The drain-order constraint is still real (a same-frame mobile tap + swipe must both reach their listeners deterministically) so the wording is reworded to describe that case directly, without naming an obstacle archetype.

## Verification
- [x] `grep -niE 'combo obstacle|combo_gate|lane_block|lane block' app/systems/game_state_system.cpp` → 0 hits.
- [x] `cmake --build build` succeeds with zero warnings (`-Wall -Wextra -Werror`).
- [x] `./build/shapeshifter_tests` passes (3370 assertions in 963 test cases).
- [x] No code/behaviour change; comment only.