### PR TITLE
#1393 feature-specs.md SPEC 3: drop fake COMBO_GATE_BASE_PTS row, rename surviving rows to match app/constants.h

### DIFF
--- a/design-docs/feature-specs.md
+++ b/design-docs/feature-specs.md
@@ -608,9 +608,8 @@ void obstacle_despawn_system(entt::registry& reg, float dt);
   │  BEAT_PERIOD                 │ 60 / BPM  │ per song            │
   │  SCROLL_SPEED                │ derived   │ BPM + lead-time     │
   │  AUDIO_OFFSET_MS            │ settings  │ calibration         │
-  │  SHAPE_GATE_BASE_PTS        │ 200       │ scoring base        │
-  │  COMBO_GATE_BASE_PTS        │ 200       │ supported kind      │
-  │  SPLIT_PATH_BASE_PTS        │ 300       │ supported kind      │
+  │  PTS_SHAPE_GATE             │ 200       │ scoring base        │
+  │  PTS_SPLIT_PATH             │ 300       │ scoring base        │
   └───────────────────────────────────────────────────────────────┘
 ```
 


### PR DESCRIPTION
Fixes #1393.

## What
Cleans up the SPEC 3 "Balancing Parameters" table in `design-docs/feature-specs.md`:

- Removes the fake `COMBO_GATE_BASE_PTS` row (combo gate is not a shipped archetype).
- Renames the two surviving scoring-base rows to match the actual constants in `app/constants.h`:
  - `SHAPE_GATE_BASE_PTS` → `PTS_SHAPE_GATE`
  - `SPLIT_PATH_BASE_PTS` → `PTS_SPLIT_PATH`
- Updates the surviving Split Path row's NOTES column to "scoring base" to match its sibling now that "supported kind" no longer distinguishes it from a removed row.

## Why
This is the SPEC 3 residual from the same drift-purge cycle as:
- #1386 / #1389 — game.md (Lane Block / Combo Gate)
- #1387 / #1390 — feature-specs.md SPEC 1
- #1388 / #1391 — isometric-perspective.md

Ground truth (`app/constants.h` lines 41–46):
```cpp
constexpr int PTS_SHAPE_GATE = 200;
constexpr int PTS_SPLIT_PATH = 300;
```

A grep for `COMBO_GATE_BASE_PTS|SHAPE_GATE_BASE_PTS|SPLIT_PATH_BASE_PTS|PTS_COMBO_GATE` across `app/` returns zero hits — the only place these names existed was the doc table.

## Verification
- [x] `grep -nE 'COMBO_GATE_BASE_PTS|SHAPE_GATE_BASE_PTS|SPLIT_PATH_BASE_PTS' design-docs/feature-specs.md` → 0 hits.
- [x] `grep -nE 'PTS_SHAPE_GATE|PTS_SPLIT_PATH' design-docs/feature-specs.md` → the two surviving rows.
- [x] Docs-only change; no build/test impact.
