### PR TITLE
#1398 systems/ui_render_system.cpp: drop unused <string> include

### DIFF
--- a/app/systems/ui_render_system.cpp
+++ b/app/systems/ui_render_system.cpp
@@ -24,7 +24,6 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdio>
-#include <string>
 
 // ═════════════════════════════════════════════════════════════════════════════
 // UI render system — 2D overlay pass


### PR DESCRIPTION
Closes #1398.

Removes the single unused `#include <string>` line from `app/systems/ui_render_system.cpp`. The file references no `<string>` symbols (`std::string`, `std::to_string`, `std::wstring`, `std::char_traits`, etc.), so the include is dead weight.

## Verification

```
$ grep -c 'std::string\|std::to_string\|std::stoi\|std::stof\|std::getline\|std::basic_string\|std::wstring\|std::char_traits' app/systems/ui_render_system.cpp
0
$ cmake --build build  # zero warnings
$ ./build/shapeshifter_tests  # All tests passed (3370 assertions in 963 test cases)
```

Same pattern as #1363 / #1366 / #1376 / #1379.