### PR TITLE
#1399 docs: drop `glm` from migration-doc dependency claims

### DIFF
--- a/docs/ongoing_migration.md
+++ b/docs/ongoing_migration.md
@@ -4,7 +4,7 @@ This file is the authoritative index for migration-related documentation.
 
 ## Current architecture direction
 
-1. Runtime/platform calls use direct **raylib / raygui** and **glm**.
+1. Runtime/platform calls use direct **raylib / raygui**.
 2. ECS components and gameplay systems remain plain data + free functions.
 3. No compatibility wrapper layer should be introduced.
 

--- a/docs/raylib-migration.md
+++ b/docs/raylib-migration.md
@@ -4,7 +4,7 @@ This document is retained only as historical context.
 
 ## Current architecture direction (authoritative)
 
-- Use direct **raylib / raygui** and **glm** APIs at runtime boundaries.
+- Use direct **raylib / raygui** APIs at runtime boundaries.
 - Keep ECS data backend-neutral: components stay plain data with no rendering/audio backend handles.
 - Do **not** introduce wrapper abstraction layers (`Renderer`, `AudioEngine`, `InputHandler`, `core_types`, `runtime_compat`, etc.).
 

--- a/docs/sokol-migration.md
+++ b/docs/sokol-migration.md
@@ -1,12 +1,12 @@
 # Historical Note: abandoned SDL2 to Sokol migration plan
 
 This document is retained only as historical context. It is not an active
-implementation plan. The current runtime direction is direct **raylib / raygui**
-and **glm**, with no wrapper abstraction layer; see `docs/ongoing_migration.md`
+implementation plan. The current runtime direction is direct **raylib / raygui**,
+with no wrapper abstraction layer; see `docs/ongoing_migration.md`
 for the authoritative migration-document status.
 
 > **Historical only.** This plan is not active. The shipped runtime currently
-> uses direct raylib/raygui APIs with glm, and `docs/ongoing_migration.md`
+> uses direct raylib/raygui APIs, and `docs/ongoing_migration.md`
 > records the authoritative dependency-boundary status. Do not use this file as
 > implementation guidance unless a new issue explicitly reactivates Sokol work.
 


### PR DESCRIPTION
Closes #1399.

Trims the stale `and **glm**` / `with glm` clauses from `docs/ongoing_migration.md`, `docs/raylib-migration.md`, and `docs/sokol-migration.md`. `glm` was removed from `vcpkg.json` and the README Dependencies table per #1343 / #1346, so the surviving migration docs were the last live source of the false claim that the runtime depends on glm.

## Verification

```
$ grep -in glm docs/ongoing_migration.md docs/raylib-migration.md docs/sokol-migration.md
(no matches)

$ grep -rn 'glm::\|#include.*glm\|<glm/' . --include='*.cpp' --include='*.h' --include='*.cmake' --include='CMakeLists.txt' | grep -v 'build/\|build-test\|build-web\|node_modules\|vcpkg_installed\|.git/'
./tests/test_component_raylib_boundaries.cpp:41:    CHECK(transform.find("glm::") == std::string::npos);
./tests/test_component_raylib_boundaries.cpp:42:    CHECK(rendering.find("glm::") == std::string::npos);
./tests/test_component_raylib_boundaries.cpp:43:    CHECK(render_mesh.find("glm::") == std::string::npos);
```

The only surviving `glm` references in the tree are negative asserts in `test_component_raylib_boundaries.cpp` that confirm components do **not** depend on glm.

Docs-only change. Same pattern as #1343 / #1346 / #1349.