### PR TITLE
#1402 design-docs/game.md: Obstacle Types — mark Split Path as shipped runtime

### DIFF
--- a/design-docs/game.md
+++ b/design-docs/game.md
@@ -102,18 +102,16 @@ See `rhythm-design.md` for the full timing-window grading table and `rhythm-spec
 
 ## Obstacle Types
 
-| Obstacle        | Status          | Player Action Required    | Timed? | Base Points |
-|-----------------|-----------------|---------------------------|--------|-------------|
-| Shape Gate      | Shipped         | Tap correct shape button  | YES    | `PTS_SHAPE_GATE = 200` |
-| Split Path      | Future design   | Shape + correct lane      | YES    | `PTS_SPLIT_PATH = 300` |
+| Obstacle        | Status                                          | Player Action Required    | Timed? | Base Points |
+|-----------------|-------------------------------------------------|---------------------------|--------|-------------|
+| Shape Gate      | Shipped                                         | Tap correct shape button  | YES    | `PTS_SHAPE_GATE = 200` |
+| Split Path      | Shipped runtime; no shipped beatmap authors yet | Shape + correct lane      | YES    | `PTS_SPLIT_PATH = 300` |
 
-Shipped beatmaps currently use required `shape_gate` obstacles only. They may also include non-blocking `onset_marker` rows for authored onset metadata; runtime skips those rows and they do not score, block, or count as required obstacles.
+Both archetypes are fully wired through the runtime: factories (`spawn_shape_gate_*` / `spawn_split_path_*` in `app/entities/obstacle_entity.{h,cpp}`), per-kind tags (`ShapeGateTag` / `SplitPathTag` in `app/tags/tags.h`), beatmap parsing (`shape_gate` and `split_path` kinds in `app/entities/beat_map.cpp`), the rhythm scheduler (`schedule_split_path_bin` in `app/systems/beat_scheduler_system.cpp`), and scoring constants (`PTS_SHAPE_GATE`, `PTS_SPLIT_PATH` in `app/constants.h`).
 
-`PTS_SPLIT_PATH` exists in `app/constants.h` so that future split-path content can ship without re-tuning, but no split-path archetype is currently parsed from beatmaps. Earlier archetypes from pre-shipped design drafts are not present in code or content, and their associated scoring constants have been removed.
+Shipped beatmap content (`content/beatmaps/*_beatmap.json`) currently uses required `shape_gate` obstacles only. Beatmaps may also include non-blocking `onset_marker` rows for authored onset metadata; runtime skips those rows and they do not score, block, or count as required obstacles. Split-path beats are absent from shipped beatmap files, but the parser and scheduler recognise the `split_path` kind as soon as authoring adds it.
 
-### Future Split-Path Obstacles
-
-If split-path obstacles return, their timing and scoring rules need a new committed design pass before content ships. Earlier drafts also explored combo obstacles (two timed actions, e.g. switch to ● and swipe left, with independent timing grades) but that archetype is not on the current roadmap.
+Earlier archetypes from pre-shipped design drafts (Lane Block, Combo Gate, Lane Push, Low Bar / High Bar) are not present in code or content; see `architecture.md` § 5.3–5.4 for the archived archetype notes. Their associated scoring constants have been removed. Earlier drafts also explored combo obstacles (two timed actions, e.g. switch to ● and swipe left, with independent timing grades); that archetype is not on the current roadmap.
 
 ---
 


### PR DESCRIPTION
Closes #1402.

## Problem

`design-docs/game.md` listed Split Path with `Status: Future design`, claimed "no split-path archetype is currently parsed from beatmaps", and carried a "### Future Split-Path Obstacles" sub-heading that implied the archetype was unbuilt. All three contradict shipped code:

- `app/entities/obstacle_entity.h:23-50` — `SplitPathSpawn` + `spawn_split_path_obstacle()` / `spawn_split_path_rhythm()`.
- `app/entities/obstacle_entity.cpp:36-100` — `create_split_path()` emplaces `SplitPathTag`, required-shape tag, required-lane `int8_t`.
- `app/tags/tags.h:83` — `struct SplitPathTag {};`.
- `app/entities/beat_map.cpp:269-321, 569-629` — parser sinks `split_path_{circle,square,triangle}_beats`; the `valid_kind` allowlist accepts `"split_path"`.
- `app/systems/beat_scheduler_system.cpp:95-167` — `schedule_split_path_bin()` runs every frame against all three per-shape bins.
- `app/constants.h:43` — `constexpr int PTS_SPLIT_PATH = 300;`.
- `app/components/beat_map.h:64-66` — `BeatMap` holds the three `split_path_*_beats` vectors as first-class storage.

What *is* true is that no shipped beatmap file (`content/beatmaps/*_beatmap.json`) authors a split_path row — a content observation, not a runtime status.

## Change

- Update the **Status** cell for Split Path to `Shipped runtime; no shipped beatmap authors yet`.
- Replace the muddled paragraph with two cleaner ones: one citing the shipped runtime wiring, one separating code-shipped from content-authored.
- Drop the misleading `### Future Split-Path Obstacles` sub-heading. The combo-obstacle parenthetical (also a draft that did not ship) folds into the same paragraph that mentions the archived Lane Block / Combo Gate / Lane Push / Low Bar / High Bar archetypes (cross-ref to `architecture.md` § 5.3-5.4 where the archived archetype notes already live).

No dangling internal anchor links — `grep -rn "Future Split-Path"` is empty across the repo.

## Validation

- `cmake --build build -- -j 8` → zero warnings.
- `./build/shapeshifter_tests` → all 3370 assertions in 963 test cases pass.
- `grep -n "Future design\|Future Split-Path\|no split-path archetype is currently parsed" design-docs/game.md` → empty.

Docs-only; no compiled code affected.