### PR TITLE
#1407 docs/testflight-accessibility-baseline.md § 5: refresh stale Settings UI + persistence paths

### DIFF
--- a/docs/testflight-accessibility-baseline.md
+++ b/docs/testflight-accessibility-baseline.md
@@ -79,10 +79,13 @@
 - Existing settings fields already support baseline toggles:
   - `SettingsState::haptics_enabled`
   - `SettingsState::reduce_motion`
-- Settings UI path:
-  - `app/ui/screen_controllers/settings_screen_controller.cpp`
-- Persisted settings path:
-  - `app/util/settings_persistence.cpp`
+- Settings UI path (entity-driven UI per #1295 / #1317):
+  - `app/systems/settings_screen_bind_system.{h,cpp}`
+  - Codegen-spawned screen entities under `app/systems/generated/`
+- Persisted settings path (split per #1196):
+  - `app/components/settings.h` — `SettingsPersistence`, `SettingsDirtyTag`
+  - `app/systems/settings_system.{h,cpp}` — `settings::mark_dirty_and_save`, `load_settings`
+  - `app/systems/persistence_policy_system.{h,cpp}` — drains the dirty tag
 
 These hooks are the minimum integration points for engineering to satisfy
 A11Y-06, A11Y-08, and A11Y-09.


### PR DESCRIPTION
Closes #1407.

`app/ui/screen_controllers/settings_screen_controller.cpp` was deleted when Settings migrated to entity-driven UI (#1295) and the last `app/ui/` user moved out (#1317). `app/util/settings_persistence.cpp` was deleted when SettingsPersistence split across `components/settings.h` (data), `systems/settings_system.{h,cpp}` (API), and `systems/persistence_policy_system.{h,cpp}` (dirty-tag drain) per #1196.

Refresh § 5 "Implementation Notes" to point at the paths that currently exist on `main` so A11Y-06 / A11Y-08 / A11Y-09 implementers find the right hooks.

## Verification

```sh
$ ls app/systems/settings_screen_bind_system.{h,cpp} app/systems/generated/settings_screen.cpp app/systems/persistence_policy_system.{h,cpp} app/systems/settings_system.{h,cpp} app/components/settings.h
# all present
$ ls app/ui/ app/util/settings_persistence.cpp 2>/dev/null
# both: No such file or directory
```

Doc-only change; no build/test impact.