### PR TITLE
#1406 design-docs/beatmap-integration.md § 4.4: refresh stale music + play-session paths

### DIFF
--- a/design-docs/beatmap-integration.md
+++ b/design-docs/beatmap-integration.md
@@ -438,9 +438,9 @@ endif()
   ✅ app/systems/shape_window_system.cpp  — timing window morphing
   ✅ app/systems/energy_system.cpp        — miss tracking and terminal failure
   ✅ app/systems/audio_system.cpp         — dispatcher-driven SFX playback
-  ✅ app/components/music.h               — raylib Music handle + state flags
+  ✅ app/systems/audio_resources.h        — MusicContext (raylib Music handle + state flags)
   ✅ app/game_loop.cpp                    — InitAudioDevice + audio lifecycle
-  ✅ app/session/play_session.cpp         — LoadMusicStream per play session
+  ✅ app/systems/play_session.cpp         — LoadMusicStream per play session
 ```
 
 `audio_system.cpp` is already in `app/systems/` so it's auto-included in


### PR DESCRIPTION
Closes #1406.

`app/components/music.h` never existed under that name on current `main` — the raylib Music handle + state flags live in `app/systems/audio_resources.h` as `MusicContext`, moved beside its owning system per the GPU/audio ctx-resource relocation (#1351). `app/session/play_session.cpp` was relocated to `app/systems/play_session.cpp` when the `app/session/` systems-in-costume folder was deleted (#1200).

Refresh § 4.4 "Source Files Status" so the file paths point to the TUs that actually exist on `main`.

## Verification

```sh
$ ls app/systems/audio_resources.h app/systems/play_session.cpp
app/systems/audio_resources.h
app/systems/play_session.cpp
$ ls app/components/music.h app/session/ 2>/dev/null
# both: No such file or directory
```

Doc-only change; no build/test impact.