### PR TITLE
#1412 docs: redirect stale `app/components/music.h` refs to `app/systems/audio_resources.h`

### DIFF
--- a/design-docs/beatmap-integration.md
+++ b/design-docs/beatmap-integration.md
@@ -190,7 +190,9 @@ struct MusicContext {
 };
 ```
 
-Defined in `app/components/music.h`. It owns the raylib `Music` handle and is
+Defined in `app/systems/audio_resources.h` (relocated from the never-shipped
+`app/components/music.h` per #1351 — it ships beside its owning systems).
+It owns the raylib `Music` handle and is
 emplaced in `reg.ctx()` alongside `SongState`.
 
 ## 2.2 Existing Components — No Changes Needed

--- a/docs/audio-pipeline-spec.md
+++ b/docs/audio-pipeline-spec.md
@@ -4,8 +4,9 @@
 > Historical implementation plan. The current runtime uses `EnergyState`,
 > dispatcher-based `PlaySfxEvent` / `PlayHapticEvent` audio routing, and CMake
 > content copy rules; use `README.md`, `design-docs/beatmap-integration.md`,
-> and the code under `app/components/audio.h`, `app/components/music.h`, and
-> `app/systems/` as the authoritative
+> and the code under `app/components/audio.h`, `app/systems/audio_resources.h`
+> (where `MusicContext` actually lives — relocated from the never-shipped
+> `app/components/music.h` per #1351), and `app/systems/` as the authoritative
 > implementation reference.
 
 ## Data Flow Diagram


### PR DESCRIPTION
Closes #1412.

Two docs cited `app/components/music.h` as the home of `MusicContext`. That file never shipped — `MusicContext` was relocated to `app/systems/audio_resources.h` per #1351, and the header self-documents that history (line 9: "Relocated out of `app/components/music.h` (issue #1351)…").

PR #1410 caught the §4.4 occurrence (line 441) but missed the parallel one in §2.1.1 of the same file plus the matching one in `docs/audio-pipeline-spec.md`'s preamble. This PR fixes both.

## Changes

- `design-docs/beatmap-integration.md:193` — § 2.1.1 "MusicContext (singleton for audio state) — ✅ IMPLEMENTED" now points at `app/systems/audio_resources.h` and historicizes the never-shipped `app/components/music.h` path with a #1351 reference.
- `docs/audio-pipeline-spec.md:7` — preamble authoritative-references list updated the same way.

## Left untouched (intentionally)

- `docs/audio-pipeline-spec.md:346` ("Create `app/components/music.h`")
- `docs/audio-pipeline-spec.md:901` ("**NEW FILE** — `MusicContext` struct")

Both are inside the doc's historical *proposal* body. The doc is marked "Historical implementation plan" — these are correctly archival. Only the preamble (which directs readers to *current* code) was wrong.

## Verification

```sh
$ grep -rn "app/components/music\.h" design-docs/ docs/
design-docs/beatmap-integration.md:194:`app/components/music.h` per #1351 — it ships beside its owning systems).
docs/audio-pipeline-spec.md:9:> `app/components/music.h` per #1351), and `app/systems/` as the authoritative
docs/audio-pipeline-spec.md:346:Create **`app/components/music.h`**:
docs/audio-pipeline-spec.md:901:| 3a | `app/components/music.h` | **NEW FILE** — `MusicContext` struct | — |
```

All four remaining hits are either the new historicized notes (now correctly contextualized with #1351) or the historical-proposal body of the audio-pipeline-spec doc (acceptable per its "Historical implementation plan" header).

## Impact

Doc-only. No source code touched. Build/tests unaffected.

```sh
$ cmake --build build  # zero warnings, all targets built
$ ./build/shapeshifter_tests  # All tests passed (3370 assertions in 963 test cases)
```
