### PR TITLE
#1414 beat_map.cpp: fold duplicate kind_string_requires_lane into kind_string_requires_payload

### DIFF
--- a/app/entities/beat_map.cpp
+++ b/app/entities/beat_map.cpp
@@ -282,11 +282,12 @@ inline constexpr std::array<ShapeBinAccessor, kShapeCount> kSplitPathSinks{
 // Parsing dispatches into per-kind vectors directly by the JSON `kind`
 // string. No discriminator enum is reintroduced — see `parse_beat_map`
 // below where each known kind string has its own dispatch branch.
-bool kind_string_requires_shape(std::string_view kind_str) {
-    return kind_str == "shape_gate" || kind_str == "split_path";
-}
-
-bool kind_string_requires_lane(std::string_view kind_str) {
+//
+// `shape_gate` and `split_path` rows both require a shape + lane payload;
+// `onset_marker` rows require neither. The two payload fields are validated
+// independently in `parse_beat_map`, so this single predicate covers both
+// "missing shape" and "missing lane" checks (issue #1414).
+bool kind_string_requires_payload(std::string_view kind_str) {
     return kind_str == "shape_gate" || kind_str == "split_path";
 }
 
@@ -494,7 +495,7 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
             }
             parsed_shape = *shape_opt;
             has_parsed_shape = true;
-        } else if (kind_string_requires_shape(kind_str)) {
+        } else if (kind_string_requires_payload(kind_str)) {
             errors.push_back({entry.beat_index,
                 "Missing required shape for obstacle kind '" + kind_str + "' at beat "
                     + std::to_string(entry.beat_index)});
@@ -507,7 +508,7 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
             parse_ok = false;
             continue;
         }
-        if (!b.contains("lane") && kind_string_requires_lane(kind_str)) {
+        if (!b.contains("lane") && kind_string_requires_payload(kind_str)) {
             errors.push_back({entry.beat_index,
                 "Missing required lane for obstacle kind '" + kind_str + "' at beat "
                     + std::to_string(entry.beat_index)});


### PR DESCRIPTION
## Summary

Closes #1414.

`app/entities/beat_map.cpp` had two byte-identical predicates:

```cpp
bool kind_string_requires_shape(std::string_view kind_str) {
    return kind_str == "shape_gate" || kind_str == "split_path";
}

bool kind_string_requires_lane(std::string_view kind_str) {
    return kind_str == "shape_gate" || kind_str == "split_path";
}
```

Collapse them into one `kind_string_requires_payload()` — the actual joint precondition the JSON loader checks for both the `shape` and `lane` fields. The two `parse_beat_map` call sites that distinguish *which* field is missing keep their distinct error messages ("Missing required shape" vs "Missing required lane"); only the predicate is unified.

## Verification

- `cmake --build build` — clean, zero warnings.
- `./build/shapeshifter_tests` — `All tests passed (3370 assertions in 963 test cases)`.
- `grep -rn 'kind_string_requires_' app/ tests/ tools/` confirms only the survivor remains.
