### PR TITLE
#1415 tutorial dodge-hint comments: drop refs to deleted tutorial_layout.h

### DIFF
--- a/app/systems/tutorial_dodge_hint_bind_system.h
+++ b/app/systems/tutorial_dodge_hint_bind_system.h
@@ -7,9 +7,10 @@
 //
 // The .rgl emits a single `DodgeHint` label with empty text (a dynamic-text
 // slot). Runtime selects keyboard vs swipe copy per platform via
-// `web_input_touch_capable`; per-platform text was previously hard-coded
-// behind `#ifdef PLATFORM_HAS_KEYBOARD` in `tutorial_layout.h`, which
-// produced incorrect copy on touch-only Web browsers (#513).
+// `web_input_touch_capable`; before #513 the copy was hard-coded behind
+// `#ifdef PLATFORM_HAS_KEYBOARD`, which produced incorrect copy on
+// touch-only Web browsers. The runtime selector now lives in
+// `tutorial_dodge_hint_text()` (`app/util/tutorial_dodge_hint.h`).
 //
 // Runs after `screen_lifecycle_system` (which spawns the entity) and
 // before `ui_render_system` (which reads `UiLabel::text`). No-op when the

--- a/app/util/tutorial_dodge_hint.h
+++ b/app/util/tutorial_dodge_hint.h
@@ -1,12 +1,12 @@
 // Tutorial "DODGE LANES" hint copy — runtime selection.
 //
-// Issue #513: the generated tutorial_layout.h previously selected the hint
-// at compile time via #ifdef PLATFORM_HAS_KEYBOARD. PLATFORM_HAS_KEYBOARD
-// is defined for both Desktop and Web (CMakeLists.txt), so a touch-only
-// mobile browser was being told keyboard-only copy even
-// though the runtime accepts swipes (#499). Selection is now done by the
-// tutorial controller using this pure helper, so the call site is unit
-// testable without an OpenGL context.
+// Issue #513: per-platform copy used to be picked at compile time via
+// `#ifdef PLATFORM_HAS_KEYBOARD`, but PLATFORM_HAS_KEYBOARD is defined for
+// both Desktop and Web (CMakeLists.txt), so a touch-only mobile browser
+// was being told keyboard-only copy even though the runtime accepts swipes
+// (#499). Selection now happens at runtime in
+// `app/systems/tutorial_dodge_hint_bind_system.cpp` via this pure helper,
+// so the call site is unit-testable without an OpenGL context.
 
 #ifndef SHAPESHIFTER_TUTORIAL_DODGE_HINT_H
 #define SHAPESHIFTER_TUTORIAL_DODGE_HINT_H


### PR DESCRIPTION
## Summary

Closes #1415.

Two header comments still pointed at a generated `tutorial_layout.h` that no longer exists in the tree (and at a "tutorial controller" that used to live in the `app/ui/screen_controllers/` folder deleted by #1308):

- `app/util/tutorial_dodge_hint.h:3-9`
- `app/systems/tutorial_dodge_hint_bind_system.h:5-12`

Rewrite both blocks to point a reader at the current runtime path — `tutorial_dodge_hint_bind_system.cpp` calling `tutorial_dodge_hint_text()` in `app/util/tutorial_dodge_hint.h` — while keeping the #499 / #513 issue-history breadcrumb. Comment-only change; behavior unchanged.

## Verification

- `grep -rn 'tutorial_layout\.h' app/` returns nothing.
- `cmake --build build` — clean, zero warnings.
- `./build/shapeshifter_tests` — `All tests passed (3370 assertions in 963 test cases)`.

## Note on the second acceptance bullet in #1415

The issue's second acceptance checkbox ("grep `screen_controllers` returns nothing") was over-aggressive — the remaining mentions in `ui_update_system.cpp`, `ui_render_system.cpp`, `screen_spawners.h`, and `raygui_impl.cpp` are explicit past-tense historical breadcrumbs that each cite #1308. Those are intentional and stay.
