### PR TITLE
#1420 beat_map.cpp: collapse identical *_hexagon_sink to one null_shape_sink

### DIFF
--- a/app/entities/beat_map.cpp
+++ b/app/entities/beat_map.cpp
@@ -258,24 +258,24 @@ static std::optional<Shape> parse_shape(const std::string& s) {
 // The former `BeatEntry::shape` discriminator is encoded by which per-shape
 // vector receives the entry. The sink table is indexed by `shape_index()`;
 // Shape::Hexagon is not a valid required shape for shape_gate / split_path,
-// so its slot returns nullptr — the loader treats nullptr as a parse error
-// and emits a "Shape 'hexagon' is not a valid required shape" message.
+// so its slot points at `null_shape_sink` (shared between both tables) —
+// the loader treats nullptr as a parse error and emits a "Shape 'hexagon'
+// is not a valid required shape" message.
 using ShapeBinAccessor = std::vector<BeatEntry>* (*)(BeatMap&);
 
 std::vector<BeatEntry>* sg_circle_sink  (BeatMap& m) { return &m.shape_gate_circle_beats; }
 std::vector<BeatEntry>* sg_square_sink  (BeatMap& m) { return &m.shape_gate_square_beats; }
 std::vector<BeatEntry>* sg_triangle_sink(BeatMap& m) { return &m.shape_gate_triangle_beats; }
-std::vector<BeatEntry>* sg_hexagon_sink (BeatMap& m) { (void)m; return nullptr; }
 std::vector<BeatEntry>* sp_circle_sink  (BeatMap& m) { return &m.split_path_circle_beats; }
 std::vector<BeatEntry>* sp_square_sink  (BeatMap& m) { return &m.split_path_square_beats; }
 std::vector<BeatEntry>* sp_triangle_sink(BeatMap& m) { return &m.split_path_triangle_beats; }
-std::vector<BeatEntry>* sp_hexagon_sink (BeatMap& m) { (void)m; return nullptr; }
+std::vector<BeatEntry>* null_shape_sink (BeatMap& m) { (void)m; return nullptr; }
 
 inline constexpr std::array<ShapeBinAccessor, kShapeCount> kShapeGateSinks{
-    &sg_circle_sink, &sg_square_sink, &sg_triangle_sink, &sg_hexagon_sink
+    &sg_circle_sink, &sg_square_sink, &sg_triangle_sink, &null_shape_sink
 };
 inline constexpr std::array<ShapeBinAccessor, kShapeCount> kSplitPathSinks{
-    &sp_circle_sink, &sp_square_sink, &sp_triangle_sink, &sp_hexagon_sink
+    &sp_circle_sink, &sp_square_sink, &sp_triangle_sink, &null_shape_sink
 };
 
 // ── Per-kind beat-entry sinks (issue #1202/#1204) ───────────


### PR DESCRIPTION
Closes #1420.

`sg_hexagon_sink` and `sp_hexagon_sink` had byte-identical bodies (`(void)m; return nullptr;`) because `Shape::Hexagon` is not a valid required shape for either `shape_gate` or `split_path` obstacles — both table slots are intentional null sentinels meaning "no bin for this shape". Two symbols for the same null sentinel just spread the maintenance surface.

## Changes

- `app/entities/beat_map.cpp:265-279` — replace both `*_hexagon_sink` functions with one shared `null_shape_sink`. Both `kShapeGateSinks[3]` and `kSplitPathSinks[3]` now point at it.
- Comment block at lines 257-263 updated to mention `null_shape_sink` by name.

## Why this is behavior-preserving

- The function-pointer-table return contract is unchanged: `kShapeGateSinks[3]` and `kSplitPathSinks[3]` still return `nullptr` for `Shape::Hexagon`.
- `parse_beat_map` still treats `nullptr` as a parse error and emits the `"Shape 'hexagon' is not a valid required shape for obstacle kind '<kind>'"` message (see `app/entities/beat_map.cpp:586`).
- Covered by `tests/test_beat_map_parser_unknown_fields.cpp:67-78` — the hexagon-required `shape_gate` test still passes.

## Verification

```sh
$ cmake --build build       # zero warnings, all targets built
$ ./build/shapeshifter_tests
All tests passed (3370 assertions in 963 test cases)
```

```sh
$ git grep -n "hexagon_sink" app/
# (no matches)
$ git grep -n "null_shape_sink" app/
app/entities/beat_map.cpp:261:// so its slot points at `null_shape_sink` (shared between both tables) —
app/entities/beat_map.cpp:272:std::vector<BeatEntry>* null_shape_sink (BeatMap& m) { (void)m; return nullptr; }
app/entities/beat_map.cpp:275:    &sg_circle_sink, &sg_square_sink, &sg_triangle_sink, &null_shape_sink
app/entities/beat_map.cpp:278:    &sp_circle_sink, &sp_square_sink, &sp_triangle_sink, &null_shape_sink
```

## Impact

Internal cleanup. No public API, no runtime behavior change, no test changes.
