### PR TITLE
#1422 level_select_dynamic_spawn_system.h: drop refs to deleted level_select_screen_controller.cpp

### DIFF
--- a/app/systems/level_select_dynamic_spawn_system.h
+++ b/app/systems/level_select_dynamic_spawn_system.h
@@ -5,8 +5,7 @@
 // Level-select dynamic spawner (issue #1296).
 //
 // Emits the per-level card entities and per-card difficulty button
-// entities that the legacy `level_select_screen_controller.cpp` painted
-// imperatively. Run alongside the codegen-emitted
+// entities. Runs alongside the codegen-emitted
 // `spawn_level_select_screen` (which only emits HeaderText + StartButton)
 // by `screen_lifecycle_system` when the LevelSelect phase is entered.
 //
@@ -14,11 +13,9 @@
 // `despawn_level_select_screen(reg)` destroys them on phase exit — no
 // separate despawn function needed.
 //
-// Card geometry mirrors the legacy controller constants (CARD_X=110,
-// CARD_W=500, CARD_H=200, CARD_GAP=40, CARD_START_Y=200) and the
-// difficulty-row constants (DIFF_BTN_W=120, DIFF_BTN_H=50, DIFF_GAP=30,
-// DIFF_START_X=160, DIFF_Y_OFFSET=120). See `app/systems/ui_render_system.cpp`
-// for the matching render constants.
+// Card + difficulty-button geometry constants (`kCard*` / `kDiff*`) live in
+// `level_select_dynamic_spawn_system.cpp` as the single source of truth;
+// see `app/systems/ui_render_system.cpp` for the matching render block.
 void level_select_dynamic_spawn(entt::registry& reg);
 
 // Combined spawn entry-point used by `screen_lifecycle_system` — calls


### PR DESCRIPTION
The .h header comment still cited the `level_select_screen_controller.cpp`
file deleted in #1296 / #1308 and framed the card/difficulty geometry as
"mirroring" that legacy controller's constants. On `main` the constants
themselves are the source of truth, defined as `kCard*` / `kDiff*` in
the matching `.cpp`, and the .cpp's own preamble already documents that.

Rewrite the header preamble to:
- Drop the deleted-file callout, keeping the `#1296` issue breadcrumb.
- Replace the inline constant list (`CARD_X=110` etc.) with a pointer at
  the `kCard*` / `kDiff*` constants in `level_select_dynamic_spawn_system.cpp`
  (single source of truth) and the matching render block in
  `app/systems/ui_render_system.cpp`.

Verification:

```sh
$ grep -rn level_select_screen_controller app/ tests/ docs/ design-docs/
$                                                 # zero hits
$ cmake --build build && ./build/shapeshifter_tests
All tests passed (3370 assertions in 963 test cases)
```

Comment-only change. No behaviour delta.

Closes #1422.