### PR TITLE
#1424 beatmap-integration.md §§ 2.2/3.4: drop stale `spawn_rhythm_obstacle()` ref

### DIFF
--- a/design-docs/beatmap-integration.md
+++ b/design-docs/beatmap-integration.md
@@ -211,7 +211,10 @@ The current obstacle components already match the beatmap schema:
 ```
 
 **No new per-entity components required for shape_gate.** The beat scheduler
-creates the standard runtime obstacle archetypes via `spawn_rhythm_obstacle()`.
+creates the standard runtime obstacle archetypes via the kind-specific
+`spawn_<kind>_rhythm()` helpers in `app/entities/obstacle_entity.h`
+(`spawn_shape_gate_rhythm`, `spawn_split_path_rhythm`,
+`spawn_onset_marker_rhythm`).
 
 ---
 ---
@@ -321,8 +324,11 @@ void song_playback_system(entt::registry& reg, float dt) {
 
 ```
   Spawns obstacle entities from BeatMap.beats[] when song_time
-  crosses spawn_time thresholds. It uses spawn_rhythm_obstacle(), so
-  collision, scoring, render, and despawn all work unchanged.
+  crosses spawn_time thresholds. It calls the kind-specific
+  spawn_<kind>_rhythm() helpers (spawn_shape_gate_rhythm,
+  spawn_split_path_rhythm, spawn_onset_marker_rhythm) in
+  app/entities/obstacle_entity.h, so collision, scoring, render,
+  and despawn all work unchanged.
 ```
 
 ## 3.5 Runtime obstacle source — ✅ BEAT-SCHEDULED


### PR DESCRIPTION
Closes #1424.

## Summary

`design-docs/beatmap-integration.md` is labeled "✅ ALREADY IMPLEMENTED" (a current-state spec, not a proposal). Two call-out sites named `spawn_rhythm_obstacle()` — a helper that does not exist on `main`:

```
$ grep -rn 'spawn_rhythm_obstacle\b' app/
(no matches)
```

The actual runtime API in `app/entities/obstacle_entity.h` is kind-specific:

| Helper | Line |
|---|---|
| `spawn_shape_gate_rhythm`   | obstacle_entity.h:47 |
| `spawn_split_path_rhythm`   | obstacle_entity.h:49 |
| `spawn_onset_marker_rhythm` | obstacle_entity.h:51 |

Updated both sites so a reader following the doc to find the spawn site lands on real code:

- § 2.2 (line 214) — "creates the standard runtime obstacle archetypes via the kind-specific `spawn_<kind>_rhythm()` helpers in `app/entities/obstacle_entity.h` (`spawn_shape_gate_rhythm`, `spawn_split_path_rhythm`, `spawn_onset_marker_rhythm`)."
- § 3.4 (line 324) — same redirect inside the ASCII block.

No code changes; docs-only.

## Acceptance criteria

- [x] § 2.2 line 214 updated to name the kind-specific helpers.
- [x] § 3.4 line 324 updated similarly.
- [x] No other functional rewording.
- [x] No code changes.

## Verification

```
$ grep -n 'spawn_rhythm_obstacle' design-docs/beatmap-integration.md
(no matches)

$ grep -n 'spawn_shape_gate_rhythm\|spawn_split_path_rhythm\|spawn_onset_marker_rhythm' design-docs/beatmap-integration.md
216:(`spawn_shape_gate_rhythm`, `spawn_split_path_rhythm`,
217:`spawn_onset_marker_rhythm`).
328:  spawn_<kind>_rhythm() helpers (spawn_shape_gate_rhythm,
329:  spawn_split_path_rhythm, spawn_onset_marker_rhythm) in
```
