### PR TITLE
#1425 ui_render_system.cpp: drop stale "legacy controller path" migration comments

### DIFF
--- a/app/systems/ui_render_system.cpp
+++ b/app/systems/ui_render_system.cpp
@@ -62,10 +62,10 @@ const Font& popup_font_for_size(const TextContext& ctx, FontSize font_size) {
 // screen's entities and trivially partitions by tag.
 //
 // Per-screen visual specifics (font size, alignment, label vs centered
-// label, button colour overrides) currently match the legacy raygui
-// defaults; per-screen visual tweaks migrate row-by-row as their screen
-// migrates off the legacy controller path. See #1287 for the per-screen
-// sub-issue ladder.
+// label, button colour overrides) match the raygui defaults the deleted
+// legacy `app/ui/screen_controllers/*` controllers used, kept for visual
+// parity (#1287 entity-driven render path replaced those controllers in
+// #1308; no per-screen migration remains).
 //
 // Migration boundary: a button press dispatch lives in
 // `app/systems/ui_update_system.cpp` — that system hit-tests against
@@ -642,11 +642,6 @@ void ui_render_system(entt::registry& reg, float /*alpha*/) {
         DrawRectangleRec({0, 0, constants::SCREEN_W_F, constants::SCREEN_H_F},
                          {0, 0, 0, 160});
     }
-
-    // UI rendering is handled by the entity-driven `render_ui_entities`
-    // call below (issue #1287). Screens still on the legacy controller
-    // path render via the per-phase dispatch further down; each will be
-    // migrated off in a follow-up sub-issue.
 
     // Make raygui hit-testing use virtual-space coordinates even when the
     // window is letterboxed/scaled relative to the fixed 720x1280 UI space.


### PR DESCRIPTION
Closes #1425.

## Summary

Two comment blocks in `app/systems/ui_render_system.cpp` described the #1287 entity-driven UI render path as a migration in progress off `app/ui/screen_controllers/*`. #1308 deleted that folder; the migration is complete. Both comments misled readers — one pointed at a "per-phase dispatch further down" that does not exist.

### Site 1 (lines 64–68) — rewritten

Before:
```cpp
// Per-screen visual specifics (font size, alignment, label vs centered
// label, button colour overrides) currently match the legacy raygui
// defaults; per-screen visual tweaks migrate row-by-row as their screen
// migrates off the legacy controller path. See #1287 for the per-screen
// sub-issue ladder.
```

After:
```cpp
// Per-screen visual specifics (font size, alignment, label vs centered
// label, button colour overrides) match the raygui defaults the deleted
// legacy `app/ui/screen_controllers/*` controllers used, kept for visual
// parity (#1287 entity-driven render path replaced those controllers in
// #1308; no per-screen migration remains).
```

### Site 2 (lines 646–649) — deleted

```cpp
// UI rendering is handled by the entity-driven `render_ui_entities`
// call below (issue #1287). Screens still on the legacy controller
// path render via the per-phase dispatch further down; each will be
// migrated off in a follow-up sub-issue.
```

There is no "per-phase dispatch further down" — the next code is `SetMouseOffset` setup followed by `render_ui_entities(reg)`. The lower block (now lines 655–659) already documents the correct state: *"Every screen renders here; the legacy `app/ui/screen_controllers/*` dispatch was deleted in #1308."*

## Acceptance criteria

- [x] Site 1 rewritten as a current-state statement; no forward-looking migration language.
- [x] Site 2 four-line stale block deleted.
- [x] No code changes (comments-only).
- [x] Build warning-free (`-Wall -Wextra -Werror`).
- [x] All tests pass.

## Verification

```
$ cmake --build build
... zero warnings ...
[100%] Built target shapeshifter_tests

$ ./build/shapeshifter_tests
All tests passed (3370 assertions in 963 test cases)
```
