### PR TITLE
#1429 feature-specs.md § SPEC 3: drop stale `spawn_rhythm_obstacle()` ref

### DIFF
--- a/design-docs/feature-specs.md
+++ b/design-docs/feature-specs.md
@@ -453,7 +453,11 @@ from BPM/lead-time math and stays constant within a song.
   spawn_time = calibrated_arrival_time - lead_time
                     │
                     ▼
-  spawn_rhythm_obstacle(... BeatInfo{beat_index, arrival, spawn})
+  spawn_<kind>_rhythm(... BeatInfo{beat_index, arrival, spawn})
+   ├─ spawn_shape_gate_rhythm  (kind = shape_gate)
+   └─ spawn_split_path_rhythm  (kind = split_path)
+  (defined in app/entities/obstacle_entity.h; the scheduler
+   skips spawn for onset_marker per the metadata-only branch above)
 ```
 
 ## User Stories


### PR DESCRIPTION
Closes #1429.

The SPEC 3 (BEATMAP SCHEDULING) diagram still showed `spawn_rhythm_obstacle(... BeatInfo{...})` as the runtime spawn point, but that function no longer exists — `grep -rn 'spawn_rhythm_obstacle' app/` returns no matches.

Replace the dead call with the per-kind helpers the scheduler actually uses (`spawn_shape_gate_rhythm`, `spawn_split_path_rhythm` in `app/entities/obstacle_entity.h`), and reaffirm the existing diagram note that the scheduler skips spawn for `onset_marker` (metadata only).

Sibling of merged #1424 which fixed the same drift in `design-docs/beatmap-integration.md §§ 2.2/3.4`.

## Verification

- `grep -n spawn_rhythm_obstacle design-docs/feature-specs.md` → no matches.
- `grep -rn spawn_rhythm_obstacle design-docs/ docs/` → no matches.
- Names match `app/entities/obstacle_entity.h` per-kind helpers.