### PR TITLE
#1431 test_tutorial_dodge_hint.cpp: drop ref to deleted tutorial_layout.h

### DIFF
--- a/tests/test_tutorial_dodge_hint.cpp
+++ b/tests/test_tutorial_dodge_hint.cpp
@@ -1,8 +1,9 @@
 // Regression test for #513: the Tutorial "DODGE LANES" hint must vary with
 // the runtime input-capability flag, not the compile-time PLATFORM_HAS_KEYBOARD
-// macro. The previous compile-time #ifdef in app/systems/generated/tutorial_layout.h
-// shipped keyboard-only copy to touch-only Web browsers because the
-// Web build defines PLATFORM_HAS_KEYBOARD (CMakeLists.txt:198).
+// macro. The previous compile-time #ifdef (since replaced by the runtime
+// switch in app/util/tutorial_dodge_hint.h) shipped keyboard-only copy to
+// touch-only Web browsers because the Web build defines PLATFORM_HAS_KEYBOARD
+// (CMakeLists.txt:198).
 
 #include <catch2/catch_test_macros.hpp>
 #include <cstring>


### PR DESCRIPTION
Closes #1431.

`tests/test_tutorial_dodge_hint.cpp` header comment described the
original #513 regression in terms of the now-deleted
`app/systems/generated/tutorial_layout.h` compile-time `#ifdef`. The
runtime switch has lived in `app/util/tutorial_dodge_hint.h` for
several cycles (the path the test already `#include`s), and #1418
already scrubbed the matching ref from production code comments.

Keep the #513 rationale (compile-time → runtime capability flag) but
point at the current location instead of a path that no longer exists.

## Acceptance criteria
- [x] Regression rationale preserved; ref updated to `app/util/tutorial_dodge_hint.h`.
- [x] `grep -n tutorial_layout.h tests/` returns no matches.
- [x] Test still builds and passes (10 assertions / 1 test case).