### PR TITLE
#1428 audio-pipeline-spec.md: add grep-friendly STATUS banner

### DIFF
--- a/docs/audio-pipeline-spec.md
+++ b/docs/audio-pipeline-spec.md
@@ -1,13 +1,17 @@
 
 # SHAPESHIFTER: Audio & Content Data Pipeline — Implementation Specification
 
-> Historical implementation plan. The current runtime uses `EnergyState`,
-> dispatcher-based `PlaySfxEvent` / `PlayHapticEvent` audio routing, and CMake
-> content copy rules; use `README.md`, `design-docs/beatmap-integration.md`,
-> and the code under `app/components/audio.h`, `app/systems/audio_resources.h`
-> (where `MusicContext` actually lives — relocated from the never-shipped
-> `app/components/music.h` per #1351), and `app/systems/` as the authoritative
-> implementation reference.
+> **STATUS:** Historical implementation log. The body below preserves the
+> original plan-of-record (including the never-shipped
+> `app/components/music.h` proposal under § Change 3), but the runtime
+> shipped differently: `MusicContext` lives in
+> `app/systems/audio_resources.h` — not `app/components/music.h`, which
+> was never created (see #1351). The rest of the runtime uses
+> `EnergyState` plus dispatcher-based `PlaySfxEvent` / `PlayHapticEvent`
+> routing and CMake content copy rules. For current truth see
+> `README.md`, `design-docs/beatmap-integration.md`,
+> `app/components/audio.h`, `app/systems/audio_resources.h`, and
+> `app/systems/`.
 
 ## Data Flow Diagram
 


### PR DESCRIPTION
Closes #1428.

`docs/audio-pipeline-spec.md` still plans the never-shipped
`app/components/music.h` (§ Change 3 + migration table at line 901).
The runtime ended up putting `MusicContext` in
`app/systems/audio_resources.h` per #1351 — the existing top-of-file
note already says so, but as a generic blockquote that doesn't grep as
a status marker.

Rewrite that note as `> **STATUS:** Historical implementation log.` so:
- it sorts as a status banner (grep-friendly `STATUS:` token);
- readers are told the body is the original plan (not current truth)
  within the first 15 lines;
- the `app/components/music.h` (never created) → `audio_resources.h`
  relocation and #1351 cross-ref are flagged up-front.

Body unchanged — the 25+ scattered `music.h` refs remain as the
historical plan-of-record (rewrite is explicitly out of scope per the
issue).

## Acceptance criteria
- [x] STATUS / Implementation Note block within the first ~15 lines of
  `docs/audio-pipeline-spec.md` (now line 4).
- [x] Banner is grep-friendly — starts with `> **STATUS:**`.
- [x] Banner states (a) historical implementation log, (b) `MusicContext`
  in `app/systems/audio_resources.h` not `app/components/music.h`,
  (c) cross-ref #1351.
- [x] No other content changes.
