### PR TITLE
#1430 game_over_scoreboard_bind_system.cpp: fold duplicate `bind_reason` + `bind_reason_new_best`

### DIFF
--- a/app/systems/game_over_scoreboard_bind_system.cpp
+++ b/app/systems/game_over_scoreboard_bind_system.cpp
@@ -60,25 +60,31 @@ void bind_prev_best(const GameOverBindContext& ctx, UiLabel& label) {
     ui_label_set(label, buf);
 }
 
-// Reason slot at y=685 — shown only when NOT new-best (legacy
-// `reason_y = 685.0f` branch in `draw_game_over_scoreboard`).
-void bind_reason(const GameOverBindContext& ctx, UiLabel& label) {
-    if (!ctx.energy_depleted || is_new_best(ctx)) {
+// Reason text is the same string ("ENERGY DEPLETED") regardless of which
+// row gets to render it; only the row's `for_new_best_row` flag picks
+// which (x=110) row is active for the current `is_new_best(ctx)` state.
+// One source of the literal, two trampolines for the position-keyed
+// dispatch table below.
+void bind_reason_impl(const GameOverBindContext& ctx, bool for_new_best_row,
+                      UiLabel& label) {
+    if (!ctx.energy_depleted || is_new_best(ctx) != for_new_best_row) {
         ui_label_set(label, "");
         return;
     }
     ui_label_set(label, "ENERGY DEPLETED");
 }
 
+// Reason slot at y=685 — shown only when NOT new-best (legacy
+// `reason_y = 685.0f` branch in `draw_game_over_scoreboard`).
+void bind_reason(const GameOverBindContext& ctx, UiLabel& label) {
+    bind_reason_impl(ctx, /*for_new_best_row=*/false, label);
+}
+
 // Reason slot at y=742 — shown only when new-best (legacy
 // `reason_y = 742.0f` branch in `draw_game_over_scoreboard`; the reason
 // moves down to clear room for "NEW BEST!" + "PREV N").
 void bind_reason_new_best(const GameOverBindContext& ctx, UiLabel& label) {
-    if (!ctx.energy_depleted || !is_new_best(ctx)) {
-        ui_label_set(label, "");
-        return;
-    }
-    ui_label_set(label, "ENERGY DEPLETED");
+    bind_reason_impl(ctx, /*for_new_best_row=*/true, label);
 }
 
 // Per-slot bind table. Position-keyed identification matches the


### PR DESCRIPTION
Closes #1430.

`bind_reason` (y=685, "not new_best" branch) and `bind_reason_new_best`
(y=742, "new_best" branch) differed only in the polarity of one
`is_new_best(ctx)` test; both wrote the same `"ENERGY DEPLETED"`
literal and both gated on `ctx.energy_depleted`.

Fold by introducing `bind_reason_impl(ctx, for_new_best_row, label)` —
one source for the visibility predicate and one source for the literal.
The two binders survive as one-line trampolines so the position-keyed
slot table (`kGameOverSlots`, matching the (x, y) rows codegen'd from
`content/ui/screens/game_over.rgl`) keeps its existing function-pointer
dispatch. The per-trampoline comment that documents *when* each row
fires (legacy `reason_y` branch) is preserved.

## Acceptance criteria
- [x] Only one source of the `"ENERGY DEPLETED"` literal in this TU
  (line 74; line 63 mentions it in a comment for context).
- [x] Both reason slots (y=685, y=742) still render under their
  respective visibility rules.
- [x] Existing Game Over scoreboard tests pass — `[game_over_scoreboard_bind_system]`
  tag green (19/19 assertions across 5 cases).
- [x] Full suite green: 3370/3370 assertions across 963 cases.
- [x] Build remains warning-free under `-Wall -Wextra -Werror`.
- [x] Per-row comments still document new-best vs not-new-best
  visibility.
