### PR TITLE
#1436 terminal scoreboard binders: fold byte-identical `bind_score` / `bind_high_score` bodies

### DIFF
--- a/app/components/ui.h
+++ b/app/components/ui.h
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdio>
 
 // Atomic UI components produced by the rguilayout codegen pipeline (#1193).
 // Each control row in a `.rgl` layout file becomes one ECS entity carrying:
@@ -62,6 +63,18 @@ inline void ui_label_set(UiLabel& label, const char* src) noexcept {
         label.text[i] = src[i];
     }
     label.text[i] = '\0';
+}
+
+// One-source helper for the common "format a plain int into the slot's
+// `UiLabel`" pattern used by terminal scoreboard binders (#1436 family —
+// game_over / song_complete `bind_score` / `bind_high_score`). Lives in
+// the components header so per-`*BindContext` binders can share one
+// implementation without reintroducing an anonymous-namespace symbol
+// name reuse across CMake Unity chunks (#1329).
+inline void ui_label_set_int(UiLabel& label, int value) noexcept {
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "%d", value);
+    ui_label_set(label, buf);
 }
 
 struct OnPress {

--- a/app/systems/game_over_scoreboard_bind_system.cpp
+++ b/app/systems/game_over_scoreboard_bind_system.cpp
@@ -35,15 +35,11 @@ bool is_new_best(const GameOverBindContext& ctx) {
 }
 
 void bind_score(const GameOverBindContext& ctx, UiLabel& label) {
-    char buf[32];
-    std::snprintf(buf, sizeof(buf), "%d", ctx.score.score);
-    ui_label_set(label, buf);
+    ui_label_set_int(label, ctx.score.score);
 }
 
 void bind_high_score(const GameOverBindContext& ctx, UiLabel& label) {
-    char buf[32];
-    std::snprintf(buf, sizeof(buf), "%d", ctx.current.value);
-    ui_label_set(label, buf);
+    ui_label_set_int(label, ctx.current.value);
 }
 
 void bind_new_best(const GameOverBindContext& ctx, UiLabel& label) {

--- a/app/systems/song_complete_scoreboard_bind_system.cpp
+++ b/app/systems/song_complete_scoreboard_bind_system.cpp
@@ -33,15 +33,11 @@ struct SongCompleteBindContext {
 using SongCompleteSlotBindFn = void (*)(const SongCompleteBindContext&, UiLabel&);
 
 void bind_score(const SongCompleteBindContext& ctx, UiLabel& label) {
-    char buf[32];
-    std::snprintf(buf, sizeof(buf), "%d", ctx.score.score);
-    ui_label_set(label, buf);
+    ui_label_set_int(label, ctx.score.score);
 }
 
 void bind_high_score(const SongCompleteBindContext& ctx, UiLabel& label) {
-    char buf[32];
-    std::snprintf(buf, sizeof(buf), "%d", ctx.current.value);
-    ui_label_set(label, buf);
+    ui_label_set_int(label, ctx.current.value);
 }
 
 void bind_new_best(const SongCompleteBindContext& ctx, UiLabel& label) {


### PR DESCRIPTION
Closes #1436.

## What

Add a shared `ui_label_set_int(UiLabel&, int)` helper next to
`ui_label_set` in `app/components/ui.h`, and collapse the four
byte-identical 4-line bodies in the terminal scoreboard binders into
one-line calls:

| binder TU | functions |
|---|---|
| `app/systems/game_over_scoreboard_bind_system.cpp` | `bind_score`, `bind_high_score` |
| `app/systems/song_complete_scoreboard_bind_system.cpp` | `bind_score`, `bind_high_score` |

All four had the same body modulo the per-binder `*BindContext` parameter type and the int field they read.

## Why

Pattern matches the recently merged folds (#1417, #1419, #1421, #1430): each removed a `snprintf("%d", …)` / sink-style duplicate while preserving the function-pointer dispatch the caller table needs. This is the same fold for the terminal scoreboard binders.

## Why the helper lives in `app/components/ui.h` (not in a `.cpp` anon namespace)

Per the issue's call-out of #1329: the per-binder `*BindContext` prefix exists specifically because CMake Unity chunking can put two binders in the same jumbo TU. A shared helper inside an anonymous namespace would reintroduce a colliding symbol name across chunks. Putting `ui_label_set_int` next to `ui_label_set` in the components header keeps the binders honest and inherits the existing include surface.

## Diff shape

```
app/components/ui.h                                  | +13
app/systems/game_over_scoreboard_bind_system.cpp     |  +2 -6
app/systems/song_complete_scoreboard_bind_system.cpp |  +2 -6
```

Position-keyed dispatch tables, `*BindContext` types, and per-binder ODR convention are all unchanged.

## Non-goals (preserved from the issue)

- Did **not** fold `gameplay_hud_bind_system.cpp::bind_score` / `bind_high_score` — those take `entt::registry&` + `entt::entity`, read `ScoreDisplay::displayed` (not `ScoreState::score`), and write a different label string (`"BEST: %d"`). Different shape, different signature, intentionally left alone.

## Verification

- [x] Single source of `std::snprintf(buf, sizeof(buf), "%d", n)` + `ui_label_set(label, buf)` exists (one helper, not four copies).
- [x] `bind_score` and `bind_high_score` in both terminal scoreboard binders call the shared helper.
- [x] Per-binder `*BindContext` ODR convention from #1329 preserved (helper lives in `ui.h`, not an anonymous namespace).
- [x] Scoreboard bind tests pass: `[game_over_scoreboard_bind_system]` + `[song_complete_scoreboard_bind_system]` — 8 cases, 29 assertions.
- [x] Full test suite passes: 3370 assertions in 963 test cases.
- [x] Build remains warning-free under `-Wall -Wextra -Werror`.
