### PR TITLE
#1438 gameplay_hud_bind_system.cpp::bind_score: collapse `snprintf("%d", n)` + `ui_label_set` onto `ui_label_set_int` (#1437 follow-up)

### DIFF
--- a/app/systems/gameplay_hud_bind_system.cpp
+++ b/app/systems/gameplay_hud_bind_system.cpp
@@ -58,9 +58,7 @@ void bind_score(const GameplayHudBindContext& ctx, entt::registry& reg, entt::en
     if (ctx.display == nullptr) {
         ui_label_set(label, "");
     } else {
-        char buf[32];
-        std::snprintf(buf, sizeof(buf), "%d", ctx.display->displayed);
-        ui_label_set(label, buf);
+        ui_label_set_int(label, ctx.display->displayed);
     }
     reg.emplace_or_replace<UiLabelFontSize>(e, UiLabelFontSize{kScoreFontSize});
     reg.emplace_or_replace<UiLabelAlpha>(e, UiLabelAlpha{1.0f});


### PR DESCRIPTION
Closes #1438.

## What

#1437 added `ui_label_set_int(UiLabel&, int)` to `app/components/ui.h` and folded the four `snprintf("%d", n)` + `ui_label_set(label, buf)` bodies in the two terminal scoreboard binders. The PR description explicitly carved out `gameplay_hud_bind_system.cpp::bind_score` from the fold:

> Did **not** fold `gameplay_hud_bind_system.cpp::bind_score` / `bind_high_score` — those take `entt::registry&` + `entt::entity`, read `ScoreDisplay::displayed` (not `ScoreState::score`), and write a different label string (`"BEST: %d"`). Different shape, different signature, intentionally left alone.

That carve-out applies to the **outer function shape**. But the inner snippet on lines 61–63 is exactly what `ui_label_set_int` exists to express:

```cpp
} else {
    char buf[32];
    std::snprintf(buf, sizeof(buf), "%d", ctx.display->displayed);
    ui_label_set(label, buf);
}
```

This PR collapses just those three lines onto `ui_label_set_int(label, ctx.display->displayed)`. The outer `if (ctx.display == nullptr)` guard, the `entt::registry& reg, entt::entity e` parameters, and the post-write `emplace_or_replace<UiLabelFontSize/Alpha>` calls stay untouched.

After this fold, `app/systems/` contains **zero remaining `snprintf("%d", n)` + `ui_label_set` pairs**. The other snprintf+ui_label_set sites all carry extra literal text (`"BEST: %d"`, `"PERFECT %d  GOOD %d"`, `"OK %d  BAD %d  MISS %d"`, `"MAX CHAIN %d"`, `"NEW BEST! PREV %d"`, `"PREV %d"`, `"CHAIN %d"` / `"CHAIN %d!"`, `"%+d ms"`, `"ENERGY %.0f%%"`) and stay as multi-arg `snprintf` calls. The two non-`ui_label_set` snprintf sites (`ui_render_system.cpp:188` writes to a `GuiLabel` char buffer; `popup_entity.cpp:41` writes to `PopupDisplay::text`) write to non-`UiLabel` targets and stay as-is.

## Why the helper still applies despite different signature

The carve-out in #1437 was about the **whole-function fold** (replace the 4-line body with a 1-line call into a shared `bind_int_label(&Context::field)` table entry). That mechanic doesn't survive the gameplay HUD's extra `reg.emplace_or_replace<…>(e, …)` postscript. But `ui_label_set_int` is a single-statement helper at the **expression** level, not the function level — it composes fine inside the existing `if/else` block without touching the outer function signature.

## Diff shape

```
app/systems/gameplay_hud_bind_system.cpp | 4 +---
1 file changed, 1 insertion(+), 3 deletions(-)
```

`<cstdio>` is still needed for `bind_high_score` (`"BEST: %d"`) and `bind_chain` (`"CHAIN %d"` / `"CHAIN %d!"`), so the include stays.

## Verification

```
$ cmake --build build
... zero warnings ...
[100%] Built target shapeshifter_tests

$ ./build/shapeshifter_tests "[gameplay_hud]"
All tests passed (45 assertions in 8 test cases)

$ ctest --test-dir build
100% tests passed, 0 tests failed out of 976
```

The existing `[gameplay_hud][bind][issue1297][issue1333]` test
"`ScoreSlot formats ScoreDisplay::displayed as plain integer`" asserts
`label_text == "1234"` on `ScoreDisplay::displayed = 1234`, confirming the
helper produces byte-identical output.

## Acceptance criteria

- [x] `bind_score` in `gameplay_hud_bind_system.cpp` calls `ui_label_set_int(label, ctx.display->displayed)` for the non-null branch.
- [x] `bind_high_score` / `bind_chain` stay as-is (multi-arg format strings).
- [x] `<cstdio>` include preserved (still used by sibling binders).
- [x] `[gameplay_hud][bind]` tests pass — 45 assertions in 8 cases.
- [x] Full suite passes — 976/976.
- [x] Build remains warning-free under `-Wall -Wextra -Werror`.
