### PR TITLE
#1440 popup_entity.cpp: fold 4 byte-identical `init_popup_display_*` bodies onto one helper

### DIFF
--- a/app/entities/popup_entity.cpp
+++ b/app/entities/popup_entity.cpp
@@ -31,6 +31,16 @@ void apply_base_alpha(PopupDisplay& pd, const Color& base) {
     pd.a = base.a;
 }
 
+// Shared body for the four per-timing-tier init helpers (#1440). All four
+// previously had byte-identical bodies that differed only by the label
+// literal; the public per-tier symbols remain (tests and call sites use
+// them directly) and now thin-call into this impl.
+void init_popup_display_label(PopupDisplay& pd, const Color& base, const char* text) {
+    apply_base_alpha(pd, base);
+    pd.font_size = FontSize::Medium;
+    std::snprintf(pd.text, sizeof(pd.text), "%s", text);
+}
+
 }  // namespace
 
 void init_popup_display_untimed(PopupDisplay& pd,
@@ -42,27 +52,19 @@ void init_popup_display_untimed(PopupDisplay& pd,
 }
 
 void init_popup_display_perfect(PopupDisplay& pd, const Color& base) {
-    apply_base_alpha(pd, base);
-    pd.font_size = FontSize::Medium;
-    std::snprintf(pd.text, sizeof(pd.text), "%s", "PERFECT");
+    init_popup_display_label(pd, base, "PERFECT");
 }
 
 void init_popup_display_good(PopupDisplay& pd, const Color& base) {
-    apply_base_alpha(pd, base);
-    pd.font_size = FontSize::Medium;
-    std::snprintf(pd.text, sizeof(pd.text), "%s", "GOOD");
+    init_popup_display_label(pd, base, "GOOD");
 }
 
 void init_popup_display_ok(PopupDisplay& pd, const Color& base) {
-    apply_base_alpha(pd, base);
-    pd.font_size = FontSize::Medium;
-    std::snprintf(pd.text, sizeof(pd.text), "%s", "OK");
+    init_popup_display_label(pd, base, "OK");
 }
 
 void init_popup_display_bad(PopupDisplay& pd, const Color& base) {
-    apply_base_alpha(pd, base);
-    pd.font_size = FontSize::Medium;
-    std::snprintf(pd.text, sizeof(pd.text), "%s", "BAD");
+    init_popup_display_label(pd, base, "BAD");
 }
 
 entt::entity spawn_score_popup_perfect(entt::registry& reg, float x, float y, int points) {


### PR DESCRIPTION
Closes #1440.

## What changed

`app/entities/popup_entity.cpp` lines 44-65 had four per-timing-tier popup initializers (`init_popup_display_perfect` / `_good` / `_ok` / `_bad`) whose bodies were byte-identical except for a single string literal ("PERFECT" / "GOOD" / "OK" / "BAD"):

```cpp
void init_popup_display_perfect(PopupDisplay& pd, const Color& base) {
    apply_base_alpha(pd, base);
    pd.font_size = FontSize::Medium;
    std::snprintf(pd.text, sizeof(pd.text), "%s", "PERFECT");
}
// ... × 4
```

This PR introduces one anonymous-namespace `init_popup_display_label(pd, base, text)` helper and thin-calls into it from each of the four public symbols. The header API (`popup_entity.h`) and per-tier test surface (`tests/test_popup_display_system.cpp` lines 70/80/90/100/284) are untouched.

## Out of scope

`spawn_score_popup_{perfect,good,ok,bad}` (lines 70-108) are **not** folded. `app/systems/popup_feedback_system.cpp:39-42` dispatches per-tier queues through a function-pointer table where each spawner is one row — keeping them as separate symbols IS the dispatch (Fabian Principle 1, `.squad/decisions.md` §9). Issue body explains this explicitly.

## Validation

- `cmake --build build` — zero warnings under `-Wall -Wextra -Werror`.
- `./build/shapeshifter_tests` — **All tests passed (3370 assertions in 963 test cases)**, including the per-tier init tests (`init_popup_display_perfect` formats "PERFECT" + Medium font, etc.) and every `spawn_score_popup_*` test in `tests/test_popup_display_system.cpp`.

## Pattern

Same shape as the active dedup family:
- #1421 (collapse identical `sg/sp_hexagon_sink` → `null_shape_sink`)
- #1430/#1435 (fold `bind_reason` + `bind_reason_new_best`)
- #1437 (fold `bind_score` + `bind_high_score`)
- #1439 (replace `snprintf + ui_label_set` with `ui_label_set_int`)

Net diff: +14 / −12, one file.