### PR TITLE
#1442 drop stale legacy `*_screen_controller` / `draw_game_over_scoreboard` / `render_gameplay_hud_screen_ui` comment refs in 5 app/ files

### DIFF
--- a/app/systems/game_over_scoreboard_bind_system.cpp
+++ b/app/systems/game_over_scoreboard_bind_system.cpp
@@ -70,15 +70,13 @@ void bind_reason_impl(const GameOverBindContext& ctx, bool for_new_best_row,
     ui_label_set(label, "ENERGY DEPLETED");
 }
 
-// Reason slot at y=685 — shown only when NOT new-best (legacy
-// `reason_y = 685.0f` branch in `draw_game_over_scoreboard`).
+// Reason slot at y=685 — shown only when NOT new-best.
 void bind_reason(const GameOverBindContext& ctx, UiLabel& label) {
     bind_reason_impl(ctx, /*for_new_best_row=*/false, label);
 }
 
-// Reason slot at y=742 — shown only when new-best (legacy
-// `reason_y = 742.0f` branch in `draw_game_over_scoreboard`; the reason
-// moves down to clear room for "NEW BEST!" + "PREV N").
+// Reason slot at y=742 — shown only when new-best (the reason moves down
+// to clear room for "NEW BEST!" + "PREV N").
 void bind_reason_new_best(const GameOverBindContext& ctx, UiLabel& label) {
     bind_reason_impl(ctx, /*for_new_best_row=*/true, label);
 }

--- a/app/systems/gameplay_hud_bind_system.cpp
+++ b/app/systems/gameplay_hud_bind_system.cpp
@@ -19,9 +19,8 @@ constexpr float kHighScoreSlotX =  60.0f, kHighScoreSlotY = 50.0f;
 constexpr float kChainSlotX     =  80.0f, kChainSlotY     = 80.0f;
 constexpr float kEnergyLabelX   =  10.0f, kEnergyLabelY   = 745.0f;
 
-// Font sizes mirror the legacy `render_gameplay_hud_screen_ui` text
-// renders (the values pre-migration were `GuiSetStyle(DEFAULT, TEXT_SIZE, …)`
-// switches with these literals).
+// Font sizes match the pre-#1308 `GuiSetStyle(DEFAULT, TEXT_SIZE, …)`
+// values for visual parity.
 constexpr int kScoreFontSize        = 28;
 constexpr int kHighScoreFontSize    = 18;
 constexpr int kChainFontSizeRegular = 18;

--- a/app/systems/ui_update_system.cpp
+++ b/app/systems/ui_update_system.cpp
@@ -340,8 +340,7 @@ void ui_update_system(entt::registry& reg) {
     // Debounce: ignore button presses inside the active phase's input-delay
     // window so a click that opened the phase does not also dismiss it,
     // and so end-screen prompts honour their longer settling time before
-    // accepting input (matches legacy controller behaviour, e.g.
-    // `paused_screen_controller.cpp` and `song_complete_screen_controller.cpp`).
+    // accepting input.
     const auto& gs = reg.ctx().get<GameState>();
     if (gs.phase_timer <= effective_debounce(reg)) return;
 

--- a/app/util/gameplay_hud_ring.h
+++ b/app/util/gameplay_hud_ring.h
@@ -7,8 +7,7 @@
 #include "../constants.h"
 #include "rhythm_math.h"
 
-// Gameplay HUD approach-ring math (issue #1297, extracted from the legacy
-// `gameplay_hud_screen_controller` during the entity-driven UI migration).
+// Gameplay HUD approach-ring math (issue #1297).
 //
 // All helpers below are pure transforms — no registry, no global state —
 // so the envelope system, the renderer, and the unit tests share the same

--- a/app/util/shape_draw_2d.h
+++ b/app/util/shape_draw_2d.h
@@ -7,9 +7,8 @@
 
 #include <raylib.h>
 
-// Per-shape flat 2D draw table (issue #1202/#1204 mechanic; relocated out of
-// `gameplay_hud_screen_controller.cpp` for shared use by `ui_render_system`
-// per the Title-screen migration in #1294).
+// Per-shape flat 2D draw table (issue #1202/#1204 mechanic). Shared by
+// `ui_render_system` per the Title-screen migration in #1294.
 //
 // Each former `switch (shape)` case is its own row in a function-pointer
 // column indexed by `shape_index(shape)`. The dispatcher reads the column


### PR DESCRIPTION
Closes #1442.

Mirrors the #1425 cleanup. After #1308 deleted `app/ui/screen_controllers/*`, five comment blocks in `app/` still cited the deleted symbols as live references. This PR drops the deleted-symbol breadcrumbs and keeps every surviving rationale.

### Sites (comment-only)

| file | before | after |
|---|---|---|
| `app/util/shape_draw_2d.h:10-12` | "relocated out of `gameplay_hud_screen_controller.cpp` for shared use by `ui_render_system` per the Title-screen migration in #1294" | "Shared by `ui_render_system` per the Title-screen migration in #1294" |
| `app/util/gameplay_hud_ring.h:10-11` | "(issue #1297, extracted from the legacy `gameplay_hud_screen_controller` during the entity-driven UI migration)" | "(issue #1297)" |
| `app/systems/gameplay_hud_bind_system.cpp:22-24` | "Font sizes mirror the legacy `render_gameplay_hud_screen_ui` text renders…" | "Font sizes match the pre-#1308 `GuiSetStyle(DEFAULT, TEXT_SIZE, …)` values for visual parity." |
| `app/systems/game_over_scoreboard_bind_system.cpp:73-74, 79-80` | two refs to non-existent `draw_game_over_scoreboard` | y=685 / y=742 explanation without deleted-function name |
| `app/systems/ui_update_system.cpp:343-344` | "matches legacy controller behaviour, e.g. `paused_screen_controller.cpp` and `song_complete_screen_controller.cpp`" | "so end-screen prompts honour their longer settling time before accepting input" |

### Verification

`grep -rE 'gameplay_hud_screen_controller|render_gameplay_hud_screen_ui|draw_game_over_scoreboard|paused_screen_controller\.cpp|song_complete_screen_controller\.cpp' app/` → zero hits after the change.

### Out of scope (intentionally kept)

- `app/systems/generated/screen_spawners.h:18-19` — names the deleted folder to describe what the generated spawners replace; same shape as the cleaned `ui_render_system.cpp:655-659` block #1425 left in place.
- `tests/test_input_pipeline_behavior.cpp:41-43` — comment names the deleted symbols to motivate a local replacement test fixture; the context is substantive.

### Build / test

Comments-only. Build warning-free (`-Wall -Wextra -Werror`); `shapeshifter_tests` reports `All tests passed (3370 assertions in 963 test cases)`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>