### PR TITLE
#1443 popup_entity.cpp: fold 4 byte-identical `spawn_score_popup_{perfect,good,ok,bad}` bodies onto one helper (follow-up to #1440)

### DIFF
--- a/app/entities/popup_entity.cpp
+++ b/app/entities/popup_entity.cpp
@@ -41,6 +41,22 @@ void init_popup_display_label(PopupDisplay& pd, const Color& base, const char* t
     std::snprintf(pd.text, sizeof(pd.text), "%s", text);
 }
 
+// Shared body for the four per-timing-tier spawners (#1443). All four
+// previously had byte-identical bodies that differed only by the tag type,
+// the color literal, and the label argument forwarded to
+// `init_popup_display_label`. The public per-tier symbols remain (tests and
+// call sites use them directly) and now thin-call into this impl.
+template <typename TimingTag>
+entt::entity spawn_score_popup_timed(entt::registry& reg, float x, float y, int points,
+                                     Color color, const char* label) {
+    auto popup = create_popup_archetype(reg, x, y, points, color);
+    reg.emplace<TimingTag>(popup);
+    PopupDisplay pd{};
+    init_popup_display_label(pd, color, label);
+    reg.emplace<PopupDisplay>(popup, pd);
+    return popup;
+}
+
 }  // namespace
 
 void init_popup_display_untimed(PopupDisplay& pd,
@@ -68,43 +84,23 @@ void init_popup_display_bad(PopupDisplay& pd, const Color& base) {
 }
 
 entt::entity spawn_score_popup_perfect(entt::registry& reg, float x, float y, int points) {
-    const Color color{80, 255, 220, 255};  // bright cyan
-    auto popup = create_popup_archetype(reg, x, y, points, color);
-    reg.emplace<TimingPerfectTag>(popup);
-    PopupDisplay pd{};
-    init_popup_display_perfect(pd, color);
-    reg.emplace<PopupDisplay>(popup, pd);
-    return popup;
+    return spawn_score_popup_timed<TimingPerfectTag>(reg, x, y, points,
+                                                     Color{80, 255, 220, 255}, "PERFECT");
 }
 
 entt::entity spawn_score_popup_good(entt::registry& reg, float x, float y, int points) {
-    const Color color{140, 255, 80, 255};  // lime green
-    auto popup = create_popup_archetype(reg, x, y, points, color);
-    reg.emplace<TimingGoodTag>(popup);
-    PopupDisplay pd{};
-    init_popup_display_good(pd, color);
-    reg.emplace<PopupDisplay>(popup, pd);
-    return popup;
+    return spawn_score_popup_timed<TimingGoodTag>(reg, x, y, points,
+                                                  Color{140, 255, 80, 255}, "GOOD");
 }
 
 entt::entity spawn_score_popup_ok(entt::registry& reg, float x, float y, int points) {
-    const Color color{255, 200, 60, 255};  // amber
-    auto popup = create_popup_archetype(reg, x, y, points, color);
-    reg.emplace<TimingOkTag>(popup);
-    PopupDisplay pd{};
-    init_popup_display_ok(pd, color);
-    reg.emplace<PopupDisplay>(popup, pd);
-    return popup;
+    return spawn_score_popup_timed<TimingOkTag>(reg, x, y, points,
+                                                Color{255, 200, 60, 255}, "OK");
 }
 
 entt::entity spawn_score_popup_bad(entt::registry& reg, float x, float y, int points) {
-    const Color color{255, 90, 70, 255};  // red-orange
-    auto popup = create_popup_archetype(reg, x, y, points, color);
-    reg.emplace<TimingBadTag>(popup);
-    PopupDisplay pd{};
-    init_popup_display_bad(pd, color);
-    reg.emplace<PopupDisplay>(popup, pd);
-    return popup;
+    return spawn_score_popup_timed<TimingBadTag>(reg, x, y, points,
+                                                 Color{255, 90, 70, 255}, "BAD");
 }
 
 entt::entity spawn_score_popup_untimed(entt::registry& reg, float x, float y, int points) {


### PR DESCRIPTION
Closes #1443.

Follow-up to #1440, which folded the matching `init_popup_display_{perfect,good,ok,bad}` bodies one layer down. The four `spawn_score_popup_*` callers in the same TU were themselves byte-identical except for the timing tag, the Color literal, and the label argument.

### Diff shape

| function | tag | Color | label |
|---|---|---|---|
| `spawn_score_popup_perfect` | `TimingPerfectTag` | `{80, 255, 220, 255}` | `"PERFECT"` |
| `spawn_score_popup_good`    | `TimingGoodTag`    | `{140, 255, 80, 255}` | `"GOOD"` |
| `spawn_score_popup_ok`      | `TimingOkTag`      | `{255, 200, 60, 255}` | `"OK"` |
| `spawn_score_popup_bad`     | `TimingBadTag`     | `{255, 90, 70, 255}` | `"BAD"` |

### Implementation

- New private template `spawn_score_popup_timed<TimingTag>(reg, x, y, points, color, label)` in the existing anonymous namespace alongside `init_popup_display_label`.
- The four public per-tier symbols shrink to one-line thin calls.
- `spawn_score_popup_untimed` is structurally different (no Timing tag; pulls `ScorePopup::value` for the label) so it stays as-is.

### Public API preserved

- `app/entities/popup_entity.h` unchanged.
- Call sites in `app/systems/popup_feedback_system.cpp:39-43` and 17 `tests/test_popup_display_system.cpp` test cases continue to bind the per-tier symbols.
- The four `init_popup_display_{tier}` wrappers also stay; tests reach them directly per the #1440 commit comment.

Net: 32-line block replaced by 22 lines (4 × four-line thin calls + 11-line template).

### Build / test

Build warning-free (`-Wall -Wextra -Werror`). `shapeshifter_tests` reports `All tests passed (3370 assertions in 963 test cases)`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>