### PR TITLE
#1446 ui_update_system.cpp: drop stale `tutorial_screen_controller.cpp` comment refs (mirrors #1444)

### DIFF
--- a/app/systems/ui_update_system.cpp
+++ b/app/systems/ui_update_system.cpp
@@ -18,8 +18,7 @@
 
 #include <raylib.h>  // CheckCollisionPointRec, Rectangle, Vector2
 
-// Tutorial screen continue action (issue #1291; moved out of the deleted
-// `app/ui/screen_controllers/tutorial_screen_controller.cpp` per #1308).
+// Tutorial screen continue action (issue #1291).
 // Marks FTUE complete + persists settings + requests Playing phase.
 // Exposed via `ui_update_system.h` so the FTUE end-to-end test in
 // `tests/test_game_state_extended.cpp` can drive it directly; the
@@ -102,9 +101,7 @@ void level_select_button_action(entt::registry& reg, entt::entity /*entity*/) {
 }
 
 // Tutorial screen action (issue #1291). Dispatches to
-// `tutorial_screen_continue` (defined above; previously lived in
-// `app/ui/screen_controllers/tutorial_screen_controller.cpp` until #1308
-// deleted that folder).
+// `tutorial_screen_continue` (defined above).
 void continue_button_action(entt::registry& reg, entt::entity /*entity*/) {
     tutorial_screen_continue(reg);
 }


### PR DESCRIPTION
Closes #1446.

Mirrors the #1444 cleanup. After #1308 deleted `app/ui/screen_controllers/*`, two comment blocks in `app/systems/ui_update_system.cpp` still cited the deleted `tutorial_screen_controller.cpp` as if it were a live reference. Each block had a useful surviving rationale plus a deleted-file breadcrumb; the breadcrumb is dropped, the rationale stays.

### Sites (comment-only)

| file | before | after |
|---|---|---|
| `app/systems/ui_update_system.cpp:21-22` | `Tutorial screen continue action (issue #1291; moved out of the deleted` `app/ui/screen_controllers/tutorial_screen_controller.cpp` `per #1308).` | `Tutorial screen continue action (issue #1291).` |
| `app/systems/ui_update_system.cpp:104-107` | `Tutorial screen action (issue #1291). Dispatches to` `tutorial_screen_continue` `(defined above; previously lived in` `app/ui/screen_controllers/tutorial_screen_controller.cpp` `until #1308 deleted that folder).` | `Tutorial screen action (issue #1291). Dispatches to` `tutorial_screen_continue` `(defined above).` |

### Verification

`grep -rn tutorial_screen_controller app/` → zero hits after the change.

### Out of scope (intentionally kept, same shape as #1444's keep-set)

- `app/systems/generated/screen_spawners.h:18-19` — names the deleted folder to describe the file's purpose.
- `app/util/raygui_impl.cpp:7-10` — purpose statement explaining why this file owns the `RAYGUI_IMPLEMENTATION` TU role.
- `app/systems/title_start_tap_system.h:5-23` — file's purpose statement plus a contract list that still describes current behaviour.

### Build / test

Comments-only. Build warning-free (`-Wall -Wextra -Werror`); `shapeshifter_tests` reports `All tests passed (3370 assertions in 963 test cases)`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
