### PR TITLE
#1447 drop stale legacy-controller / deleted-layout-header comment refs in 2 test files (mirrors #1431 + #1444)

### DIFF
--- a/tests/test_game_over_screen.cpp
+++ b/tests/test_game_over_screen.cpp
@@ -71,9 +71,7 @@ TEST_CASE("game_over: rgl declares SCORE and HIGH SCORE labels alongside slots (
 }
 
 // Issue #1293 + #533: codegen must materialize the SCORE / HIGH SCORE
-// labels into the generated spawner so the runtime renders them. Replaces
-// the legacy snapshot test against `app/ui/generated/game_over_layout.h`
-// (the legacy header survives until OoS-B but no longer drives runtime).
+// labels into the generated spawner so the runtime renders them.
 TEST_CASE("game_over: generated spawner emits SCORE and HIGH SCORE labels (#533)",
           "[game_over][ui][issue533]") {
     const std::string spawner = read_file("app/systems/generated/game_over_screen.cpp");

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -491,8 +491,9 @@ TEST_CASE("title settings navigation: pending Settings transition reaches Settin
     gs.phase_timer = 2.0f;
     request_phase_transition<NextPhaseSettingsTag>(reg);
 
-    // Proxy for title gear click path: title_screen_controller sets
-    // transition_pending + next_phase=Settings, then fixed-step consumes it.
+    // Proxy for title gear click path: the title-screen Settings tap
+    // request enqueues a `NextPhaseSettingsTag` transition (seeded here
+    // directly), and fixed-step consumes it.
     game_state_system(reg, 0.016f);
     REQUIRE(reg.ctx().contains<GamePhaseSettingsTag>());
     CHECK_FALSE(is_phase_transition_pending(reg));


### PR DESCRIPTION
Closes #1447.

Mirrors #1431 (test-side) and #1444 (app/-side). After #1308 deleted `app/ui/screen_controllers/*` and the `app/ui/generated/*` headers, two test files still cited the deleted artefacts as live references.

### Sites (comment-only)

| file | before | after |
|---|---|---|
| `tests/test_game_over_screen.cpp:73-76` | "Replaces the legacy snapshot test against `app/ui/generated/game_over_layout.h` (the legacy header survives until OoS-B but no longer drives runtime)." | (clause dropped; first sentence describing what the test asserts stays) |
| `tests/test_game_state_extended.cpp:494-495` | "Proxy for title gear click path: `title_screen_controller` sets `transition_pending` + `next_phase=Settings`, then fixed-step consumes it." | "Proxy for title gear click path: the title-screen Settings tap request enqueues a `NextPhaseSettingsTag` transition (seeded here directly), and fixed-step consumes it." |

### Verification

`grep -rn 'app/ui/generated/game_over_layout.h\|title_screen_controller' tests/` → zero hits after the change.

The `app/ui/generated/game_over_layout.h` reference was factually wrong — `ls app/ui/` returns "No such file or directory", so the "survives until OoS-B" claim hadn't been true since #1308 deleted the folder.

### Out of scope (intentionally kept)

- `tests/test_input_pipeline_behavior.cpp:41-43` — block names deleted `gameplay_hud_screen_controller.*` symbols to motivate the local test fixtures that replaced them; #1444 already inspected this and explicitly kept it for being substantive context.

### Build / test

Comments-only. Build warning-free (`-Wall -Wextra -Werror`); `shapeshifter_tests` reports `All tests passed (3370 assertions in 963 test cases)`. The `title settings navigation` test case in `test_game_state_extended.cpp` still passes (only the in-test comment changed).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
