### PR TITLE
#1448 settings_screen_bind_system.cpp: fold byte-identical `bind_haptics_toggle` / `bind_motion_toggle` onto one helper

### DIFF
--- a/app/systems/settings_screen_bind_system.cpp
+++ b/app/systems/settings_screen_bind_system.cpp
@@ -60,16 +60,25 @@ void bind_audio_offset(const SettingsBindContext& ctx, entt::registry& /*reg*/,
     format_offset(ctx.audio_offset_ms, label);
 }
 
+// Shared body for the two toggle binders below. Differs across the two
+// callers only in the `name` literal + the `on` bool source on `ctx`;
+// folded so the per-tier symbols stay distinct (the position-keyed
+// `kSettingsScreenSlots` table references them as function pointers)
+// without two byte-identical bodies.
+void bind_toggle_impl(entt::registry& reg, entt::entity e, UiLabel& label,
+                      const char* name, bool on) {
+    format_toggle(label, name, on);
+    reg.emplace_or_replace<UiToggleState>(e, UiToggleState{on});
+}
+
 void bind_haptics_toggle(const SettingsBindContext& ctx, entt::registry& reg,
                          entt::entity e, UiLabel& label) {
-    format_toggle(label, "HAPTICS", ctx.haptics_on);
-    reg.emplace_or_replace<UiToggleState>(e, UiToggleState{ctx.haptics_on});
+    bind_toggle_impl(reg, e, label, "HAPTICS", ctx.haptics_on);
 }
 
 void bind_motion_toggle(const SettingsBindContext& ctx, entt::registry& reg,
                         entt::entity e, UiLabel& label) {
-    format_toggle(label, "MOTION", ctx.motion_on);
-    reg.emplace_or_replace<UiToggleState>(e, UiToggleState{ctx.motion_on});
+    bind_toggle_impl(reg, e, label, "MOTION", ctx.motion_on);
 }
 
 using SettingsSlotBindFn = void (*)(const SettingsBindContext&, entt::registry&,


### PR DESCRIPTION
Closes #1448.

`bind_haptics_toggle` and `bind_motion_toggle` had byte-identical two-line bodies modulo a `const char*` label literal and a bool source on `SettingsBindContext`. Folded onto a private `bind_toggle_impl(reg, e, label, name, on)` helper inside the same anonymous namespace; each public per-tier symbol shrinks to a single one-line thin call.

### Diff (anonymous namespace, settings_screen_bind_system.cpp)

```diff
+// Shared body for the two toggle binders below. Differs across the two
+// callers only in the `name` literal + the `on` bool source on `ctx`;
+// folded so the per-tier symbols stay distinct (the position-keyed
+// `kSettingsScreenSlots` table references them as function pointers)
+// without two byte-identical bodies.
+void bind_toggle_impl(entt::registry& reg, entt::entity e, UiLabel& label,
+                      const char* name, bool on) {
+    format_toggle(label, name, on);
+    reg.emplace_or_replace<UiToggleState>(e, UiToggleState{on});
+}
+
 void bind_haptics_toggle(const SettingsBindContext& ctx, entt::registry& reg,
                          entt::entity e, UiLabel& label) {
-    format_toggle(label, "HAPTICS", ctx.haptics_on);
-    reg.emplace_or_replace<UiToggleState>(e, UiToggleState{ctx.haptics_on});
+    bind_toggle_impl(reg, e, label, "HAPTICS", ctx.haptics_on);
 }

 void bind_motion_toggle(const SettingsBindContext& ctx, entt::registry& reg,
                         entt::entity e, UiLabel& label) {
-    format_toggle(label, "MOTION", ctx.motion_on);
-    reg.emplace_or_replace<UiToggleState>(e, UiToggleState{ctx.motion_on});
+    bind_toggle_impl(reg, e, label, "MOTION", ctx.motion_on);
 }
```

### Family

Same shape as the recently merged folds:

- #1432 (`bind_reason` / `bind_reason_new_best` → `bind_reason_impl`)
- #1437 (`bind_score` / `bind_high_score` → `ui_label_set_int`)
- #1441 (`init_popup_display_{perfect,good,ok,bad}` → one helper)
- #1445 (`spawn_score_popup_{perfect,good,ok,bad}` → one template)

### Constraints respected

- The helper lives in the existing anonymous namespace so the per-binder `Settings*` ODR convention from #1329 (CMake Unity chunking can co-locate two `*_bind_system.cpp` files in the same jumbo TU) is preserved — no symbol name leaks across binders.
- `kSettingsScreenSlots` keeps its function-pointer rows pointing at `&bind_haptics_toggle` / `&bind_motion_toggle`; only the bodies collapsed.
- `bind_audio_offset` is structurally different (formats an `int16_t` audio-offset via `format_offset`; no toggle) and stays as-is.

### Build / test

Build warning-free under `-Wall -Wextra -Werror`. `shapeshifter_tests` reports `All tests passed (3370 assertions in 963 test cases)`. Focused `[settings]` filter reports `All tests passed (124 assertions in 29 test cases)`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
