### PR TITLE
#1452 camera_entity.h: fold 4 byte-identical singleton-accessor bodies onto one template helper

### DIFF
--- a/app/entities/camera_entity.h
+++ b/app/entities/camera_entity.h
@@ -16,54 +16,54 @@ void spawn_game_camera(entt::registry& reg);
 void spawn_ui_camera(entt::registry& reg);
 
 // Accessors — safe after spawn_game_camera / spawn_ui_camera are called.
-inline GameCamera& game_camera(entt::registry& reg) {
-    auto view = reg.view<GameCamera>();
+//
+// All four accessor bodies (game/ui × mutable/const) follow the same
+// view-iterate-validate-return contract; the only per-camera differences
+// are the component type and the two error-message string literals naming
+// the component + the spawner. Per the byte-identical fold pattern the
+// squad has already merged in #1430 / #1436 / #1440 / #1443 / #1448 (and
+// #1452 for this header), the public per-camera symbols remain (callers
+// in `camera_system.cpp`, `game_render_system.cpp`, `ui_render_system.cpp`,
+// and `tests/test_camera_entity_contracts.cpp` reference them by name) and
+// thin-call into one detail helper templated on both the component type
+// and the registry type so the same template covers both mutable and
+// const overloads.
+namespace camera_entity_detail {
+template <typename CamComp, typename RegT>
+inline auto& camera_singleton(RegT& reg, const char* missing_msg, const char* multi_msg) {
+    auto view = reg.template view<CamComp>();
     auto it = view.begin();
     if (it == view.end()) {
-        throw std::logic_error("GameCamera entity is missing; call spawn_game_camera() first");
+        throw std::logic_error(missing_msg);
     }
     const auto entity = *it;
     if (++it != view.end()) {
-        throw std::logic_error("multiple GameCamera entities exist");
+        throw std::logic_error(multi_msg);
     }
-    return view.get<GameCamera>(entity);
+    return view.template get<CamComp>(entity);
+}
+}  // namespace camera_entity_detail
+
+inline GameCamera& game_camera(entt::registry& reg) {
+    return camera_entity_detail::camera_singleton<GameCamera>(reg,
+        "GameCamera entity is missing; call spawn_game_camera() first",
+        "multiple GameCamera entities exist");
 }
 
 inline UICamera& ui_camera(entt::registry& reg) {
-    auto view = reg.view<UICamera>();
-    auto it = view.begin();
-    if (it == view.end()) {
-        throw std::logic_error("UICamera entity is missing; call spawn_ui_camera() first");
-    }
-    const auto entity = *it;
-    if (++it != view.end()) {
-        throw std::logic_error("multiple UICamera entities exist");
-    }
-    return view.get<UICamera>(entity);
+    return camera_entity_detail::camera_singleton<UICamera>(reg,
+        "UICamera entity is missing; call spawn_ui_camera() first",
+        "multiple UICamera entities exist");
 }
 
 inline const GameCamera& game_camera(const entt::registry& reg) {
-    auto view = reg.view<const GameCamera>();
-    auto it = view.begin();
-    if (it == view.end()) {
-        throw std::logic_error("GameCamera entity is missing; call spawn_game_camera() first");
-    }
-    const auto entity = *it;
-    if (++it != view.end()) {
-        throw std::logic_error("multiple GameCamera entities exist");
-    }
-    return view.get<const GameCamera>(entity);
+    return camera_entity_detail::camera_singleton<const GameCamera>(reg,
+        "GameCamera entity is missing; call spawn_game_camera() first",
+        "multiple GameCamera entities exist");
 }
 
 inline const UICamera& ui_camera(const entt::registry& reg) {
-    auto view = reg.view<const UICamera>();
-    auto it = view.begin();
-    if (it == view.end()) {
-        throw std::logic_error("UICamera entity is missing; call spawn_ui_camera() first");
-    }
-    const auto entity = *it;
-    if (++it != view.end()) {
-        throw std::logic_error("multiple UICamera entities exist");
-    }
-    return view.get<const UICamera>(entity);
+    return camera_entity_detail::camera_singleton<const UICamera>(reg,
+        "UICamera entity is missing; call spawn_ui_camera() first",
+        "multiple UICamera entities exist");
 }


### PR DESCRIPTION
Closes #1452.

`app/entities/camera_entity.h` carried four `inline` accessors
(`game_camera` / `ui_camera`, each in mutable + const overload) whose
bodies were structurally byte-identical: the same view-iterate-validate-
return contract, differing only in the component type and the two
error-message string literals naming the component + its spawner.

Same byte-identical fold pattern the squad has already merged in
#1430 / #1436 / #1440 / #1443 / #1448 / #1416: keep the public per-
camera symbols (callers in `app/systems/camera_system.cpp`,
`app/systems/game_render_system.cpp`, `app/systems/ui_render_system.cpp`,
and `tests/test_camera_entity_contracts.cpp` reference them by name)
and thin-call into one detail helper templated on both the component
type and the registry type so the same template covers both mutable
and const overloads.

## Diff shape

- New `camera_entity_detail::camera_singleton<CamComp, RegT>(reg, missing_msg, multi_msg)` template — one ~10-line helper that holds the singleton-access contract (view → first-entity-or-throw → no-second-entity-or-throw → `view.get<>`).
- Each of the 4 public accessors becomes a 3-line thin call passing the per-camera error strings verbatim.

## Verification

- `./build.sh` clean with `-Wall -Wextra -Werror`.
- `./build/shapeshifter_tests --reporter compact` → "All tests passed (3370 assertions in 963 test cases)".
- `./build/shapeshifter_startup_shutdown_smoke` exits cleanly.
- `tests/test_camera_entity_contracts.cpp` (which exercises both throw paths and the mutable/const return-reference identities) passes unchanged.

## Why this matters

- 4 × ~12-line bodies → 4 × 3-line bodies + 1 × ~10-line template; the duplicated view/iterate/validate logic now lives in one place.
- Future invariant changes (e.g., switching to a different exception type, adding a "registry context still alive" precondition) edit one site instead of four.
- Zero behaviour change: every error message is preserved verbatim; the public accessor signatures, return references, and overload set stay byte-identical from a caller's perspective.