### PR TITLE
#1453 obstacle_entity.cpp: fold 6 byte-identical spawn_*_obstacle / spawn_*_rhythm bodies onto two template helpers

### DIFF
--- a/app/entities/obstacle_entity.cpp
+++ b/app/entities/obstacle_entity.cpp
@@ -16,6 +16,32 @@ void finish_obstacle(entt::registry& reg, entt::entity e) {
     reg.emplace<ObstacleTag>(e);
 }
 
+// Shared finalizers for the six per-kind `spawn_*` wrappers below
+// (#1453). All six wrappers were byte-identical apart from which private
+// `create_*` builder they invoked: the non-rhythm trio appended a
+// `Vector2{0, params.speed}` velocity, the rhythm trio appended a
+// `BeatInfo`. Per the byte-identical fold pattern the squad has already
+// merged in #1430 / #1436 / #1440 / #1443 / #1448 / #1416, the public
+// per-kind symbols remain (call sites in `app/systems/beat_scheduler_system.cpp`
+// and several `tests/*.cpp` files reference them by name) and thin-call
+// into one of these two finalizers parameterized on the builder.
+template <typename Builder, typename Params>
+entt::entity spawn_with_velocity(entt::registry& reg, Builder build, const Params& params) {
+    auto e = build(reg, params);
+    reg.emplace<Vector2>(e, Vector2{0.0f, params.speed});
+    finish_obstacle(reg, e);
+    return e;
+}
+
+template <typename Builder, typename Params>
+entt::entity spawn_with_beat(entt::registry& reg, Builder build, const Params& params,
+                             const BeatInfo& beat_info) {
+    auto e = build(reg, params);
+    reg.emplace<BeatInfo>(e, beat_info);
+    finish_obstacle(reg, e);
+    return e;
+}
+
 entt::entity create_shape_gate(entt::registry& reg, const ShapeGateSpawn& params) {
     if (!is_valid_shape(params.shape)) {
         throw std::logic_error("Invalid obstacle shape");
@@ -67,46 +93,28 @@ entt::entity create_onset_marker(entt::registry& reg, const OnsetMarkerSpawn& pa
 } // namespace
 
 entt::entity spawn_shape_gate_obstacle(entt::registry& reg, const ShapeGateSpawn& params) {
-    auto e = create_shape_gate(reg, params);
-    reg.emplace<Vector2>(e, Vector2{0.0f, params.speed});
-    finish_obstacle(reg, e);
-    return e;
+    return spawn_with_velocity(reg, create_shape_gate, params);
 }
 
 entt::entity spawn_split_path_obstacle(entt::registry& reg, const SplitPathSpawn& params) {
-    auto e = create_split_path(reg, params);
-    reg.emplace<Vector2>(e, Vector2{0.0f, params.speed});
-    finish_obstacle(reg, e);
-    return e;
+    return spawn_with_velocity(reg, create_split_path, params);
 }
 
 entt::entity spawn_onset_marker_obstacle(entt::registry& reg, const OnsetMarkerSpawn& params) {
-    auto e = create_onset_marker(reg, params);
-    reg.emplace<Vector2>(e, Vector2{0.0f, params.speed});
-    finish_obstacle(reg, e);
-    return e;
+    return spawn_with_velocity(reg, create_onset_marker, params);
 }
 
 entt::entity spawn_shape_gate_rhythm(entt::registry& reg, const ShapeGateSpawn& params,
                                      const BeatInfo& beat_info) {
-    auto e = create_shape_gate(reg, params);
-    reg.emplace<BeatInfo>(e, beat_info);
-    finish_obstacle(reg, e);
-    return e;
+    return spawn_with_beat(reg, create_shape_gate, params, beat_info);
 }
 
 entt::entity spawn_split_path_rhythm(entt::registry& reg, const SplitPathSpawn& params,
                                      const BeatInfo& beat_info) {
-    auto e = create_split_path(reg, params);
-    reg.emplace<BeatInfo>(e, beat_info);
-    finish_obstacle(reg, e);
-    return e;
+    return spawn_with_beat(reg, create_split_path, params, beat_info);
 }
 
 entt::entity spawn_onset_marker_rhythm(entt::registry& reg, const OnsetMarkerSpawn& params,
                                        const BeatInfo& beat_info) {
-    auto e = create_onset_marker(reg, params);
-    reg.emplace<BeatInfo>(e, beat_info);
-    finish_obstacle(reg, e);
-    return e;
+    return spawn_with_beat(reg, create_onset_marker, params, beat_info);
 }


### PR DESCRIPTION
Closes #1453.

`app/entities/obstacle_entity.cpp` carried six public per-kind spawn
wrappers (`spawn_shape_gate_obstacle` / `spawn_split_path_obstacle` /
`spawn_onset_marker_obstacle` and their `_rhythm` counterparts) whose
bodies were byte-identical within each trio. The only thing that
differed across the three siblings in either trio was *which private
`create_*` helper got called* — the velocity vs `BeatInfo` finalize
step itself was the same line three times.

Same byte-identical fold pattern the squad has already merged in
#1430 / #1436 / #1440 / #1443 / #1448 / #1416: keep the public per-
kind symbols (call sites in `app/systems/beat_scheduler_system.cpp`,
`tests/test_obstacle_archetypes.cpp`, `tests/test_components.cpp`,
`tests/test_high_score_integration.cpp`, `tests/test_perspective.cpp`,
`tests/test_pr43_regression.cpp` reference them by name) and thin-call
into two finalizers — `spawn_with_velocity` and `spawn_with_beat` —
parameterized on the builder so the per-kind `create_*` function is
the only thing the call site has to supply.

## Diff shape

- New `spawn_with_velocity<Builder, Params>(reg, build, params)` template — runs `build(reg, params)`, emplaces `Vector2{0, params.speed}`, calls `finish_obstacle`.
- New `spawn_with_beat<Builder, Params>(reg, build, params, beat_info)` template — same shape but emplaces `BeatInfo` instead.
- Each of the 6 public `spawn_*_obstacle` / `spawn_*_rhythm` wrappers becomes a one-line thin call.

## Verification

- `./build.sh` clean with `-Wall -Wextra -Werror`.
- `./build/shapeshifter_tests --reporter compact` → "All tests passed (3370 assertions in 963 test cases)".
- The 6 test files that drive these spawners by name pass unchanged.

## Why this matters

- 6 × 4-line bodies (24 LoC) → 6 × 1-line bodies (~6 LoC) + 2 × ~6-line templates (~12 LoC). Net ~6 LoC saved, plus the "velocity vs BeatInfo" pivot is a single edit instead of three.
- Future additions to every obstacle's finalize step (e.g., a new debug tag) edit one template body rather than six wrapper bodies.
- Zero behaviour change: entity-construction order, the components emplaced, and the call to `finish_obstacle` are preserved verbatim.