### PR TITLE
#1457 drop stale `title_screen_controller` / `game_over_screen_controller` / `gameplay_hud_apply_button_presses` comment refs in 4 files (mirrors #1442)

### DIFF
--- a/app/systems/title_start_tap_system.h
+++ b/app/systems/title_start_tap_system.h
@@ -4,10 +4,8 @@
 
 // Title-screen "tap anywhere to start" gesture (issue #1294 migration).
 //
-// Replaces the legacy `title_screen_controller`'s
-// `read_title_pointer_release` + `title_tap_in_dead_zone` helpers — which
-// were derived from raygui layout-state accessors — with an entity-driven
-// hit-test. The rule preserved across the migration:
+// Replaces a raygui-layout-state-derived pointer-release helper with an
+// entity-driven hit-test. The rule preserved across the migration:
 //
 //   * If the active phase is GamePhaseTitleTag,
 //   * AND `InputState::click || InputState::touch_up` fires this frame,

--- a/app/systems/ui_update_system.cpp
+++ b/app/systems/ui_update_system.cpp
@@ -212,11 +212,10 @@ void apply_difficulty_action(entt::registry& reg, entt::entity entity) {
     lss.selected_difficulty = diff_idx->value;
 }
 
-// Gameplay HUD pause action (issue #1297). Replaces the legacy
-// `gameplay_hud_apply_button_presses` Pause branch, which called
-// `request_phase_transition<NextPhasePausedTag>` directly. Per
-// `gameplay_hud_apply_button_presses`, the legacy controller silently
-// skipped Pause outside `GamePhasePlayingTag`; the same guard lives here.
+// Gameplay HUD pause action (issue #1297). The pre-migration Pause path
+// called `request_phase_transition<NextPhasePausedTag>` directly and
+// silently skipped Pause outside `GamePhasePlayingTag`; the same guard
+// lives here.
 void pause_button_action(entt::registry& reg, entt::entity /*entity*/) {
     if (!reg.ctx().contains<GamePhasePlayingTag>()) return;
     request_phase_transition<NextPhasePausedTag>(reg);

--- a/app/util/raygui_impl.cpp
+++ b/app/util/raygui_impl.cpp
@@ -5,12 +5,8 @@
 // in `CMakeLists.txt` defines the macro for this source and excludes it
 // from unity builds so the single-definition rule holds.
 //
-// Replaces the same role previously held by
-// `app/ui/screen_controllers/title_screen_controller.cpp` before that
-// folder was deleted (issue #1308 / refs #1287 OoS-B / #1193).
-//
-// Moved from `app/ui/raygui_impl.cpp` to `app/util/` per issue #1317
-// sub-PR 1 (closes `app/ui/` per .squad/decisions.md § 7 folder allowlist):
-// this file is build-glue util, not a UI screen.
+// Lives in `app/util/` per issue #1317 sub-PR 1 (closes `app/ui/` per
+// .squad/decisions.md § 7 folder allowlist): this file is build-glue
+// util, not a UI screen.
 
 #include <raygui.h>

--- a/tests/test_game_over_screen.cpp
+++ b/tests/test_game_over_screen.cpp
@@ -1,8 +1,6 @@
 // Game Over screen entity-driven UI tests (issue #1293, refs #1287, #1193 OoS-A).
 //
-// The legacy `app/ui/screen_controllers/game_over_screen_controller.cpp`
-// render path was removed from `app/systems/ui_render_system.cpp` this
-// cycle. The hook-based scoreboard tests that mocked the layout-render +
+// The hook-based scoreboard tests that mocked the layout-render +
 // value-draw hooks have been replaced with bind-system + lifecycle
 // assertions that operate on the entity-driven UI (`UiLabelTag` entities
 // spawned by `spawn_game_over_screen()`).


### PR DESCRIPTION
Four comment blocks still cited screen-controller files / symbols deleted
in #1308. Same pattern as #1425 / #1442 / #1444 / #1446 / #1449:
the load-bearing rationale stays; the deleted-symbol names go.

Surgical edits:

* `app/util/raygui_impl.cpp:8-14` — drop the "Replaces the same role
  previously held by `title_screen_controller.cpp`" paragraph. The
  `RAYGUI_IMPLEMENTATION`-in-one-TU rationale (lines 1-6) and the
  `app/util/` folder-allowlist provenance (now lines 8-10) survive.

* `tests/test_game_over_screen.cpp:3-5` — drop the
  "`game_over_screen_controller.cpp` render path was removed from
  `ui_render_system.cpp` this cycle" sentence; keep the
  hook-based-tests-replaced-with-bind-system-and-lifecycle-assertions
  rationale and the where-the-button-tests-live-now paragraph.

* `app/systems/ui_update_system.cpp:215-218` — drop the two
  `gameplay_hud_apply_button_presses` mentions; keep the load-bearing
  "silently skipped Pause outside `GamePhasePlayingTag`; the same guard
  lives here" rationale that justifies the
  `if (!reg.ctx().contains<GamePhasePlayingTag>()) return;` guard in
  the function body.

* `app/systems/title_start_tap_system.h:7-9` — discovered during
  verification grep. Drop the `title_screen_controller`'s
  `read_title_pointer_release` / `title_tap_in_dead_zone` helper names
  (also deleted in #1308); keep the rule-preserved-across-the-migration
  block and the Fabian Principle 1 dead-zone rationale.

Out of scope (kept intentionally per #1442's OoS classification):
`tests/test_input_pipeline_behavior.cpp:41-43` names the deleted
`gameplay_hud_*_input_bounds` + `gameplay_hud_apply_button_presses`
symbols to motivate why the local test fixtures exist. Context useful;
don't touch.

Validated:
- `cmake --build build` — zero warnings.
- `./build/shapeshifter_tests` — all 3370 assertions in 963 cases pass.
- The five ghost-symbol grep returns only the OoS
  `tests/test_input_pipeline_behavior.cpp:42` hit after the fix.

Closes #1457.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
