### PR TITLE
#1460 drop stale `app/components/music.h` / `app/ui/screen_controllers/*` historical-attribution comment refs in 2 files (mirrors #1442 / #1447)

### DIFF
--- a/app/systems/audio_resources.h
+++ b/app/systems/audio_resources.h
@@ -6,10 +6,10 @@
 // state for the active song. Lives in registry context (not on an entity)
 // and is read/written 1–2× per frame by song_playback_system only.
 //
-// Relocated out of `app/components/music.h` (issue #1351) because this is a
-// ctx-singleton RAII wrapper, not entity-owned plain data — `app/components/`
-// stays reserved for atomic, queryable entity-owned tables per
-// .squad/decisions.md §"app/components parallel audit verdict (consolidated)".
+// Lives beside its owning system (not under `app/components/`) because this
+// is a ctx-singleton RAII wrapper, not entity-owned plain data —
+// `app/components/` stays reserved for atomic, queryable entity-owned tables
+// per .squad/decisions.md §"app/components parallel audit verdict (consolidated)".
 
 inline bool music_stream_is_playable(const Music& music) {
     return IsMusicValid(music) && music.stream.buffer != nullptr;

--- a/tests/test_phase_transition_canonical.cpp
+++ b/tests/test_phase_transition_canonical.cpp
@@ -260,9 +260,8 @@ TEST_CASE("phase_transition: enforcement catches non-UI/non-input direct callers
 
 TEST_CASE("phase_transition: entity-driven UI dispatch guards entry input",
           "[phase_transition][ui]") {
-    // Legacy `app/ui/screen_controllers/*` controllers (deleted in #1308)
-    // gated their button reads on `gs.phase_timer > constants::UI_ENTRY_DEBOUNCE`.
-    // The same guard now lives in `ui_update_system.cpp`'s
+    // The entry-input debounce guard (`gs.phase_timer >
+    // constants::UI_ENTRY_DEBOUNCE`) lives in `ui_update_system.cpp`'s
     // `effective_debounce` table, with end-screen overrides for Game Over
     // and Song Complete.
     const fs::path root = find_repo_root();


### PR DESCRIPTION
Closes #1460.

Two leading-prefix breadcrumb comments still cited files that don't exist on
`main`. Comment-only — same shape as #1442 / #1446 / #1447 / #1457.

### Changes

1. **`app/systems/audio_resources.h:9-12`** — "Relocated out of
   `app/components/music.h` (issue #1351) because" is misattributed history
   (per #1412, `app/components/music.h` never existed on `main`). Reworded
   to "Lives beside its owning system (not under `app/components/`) because"
   so the surviving rationale reads cleanly without claiming a relocation
   that never happened.

2. **`tests/test_phase_transition_canonical.cpp:263-267`** — "Legacy
   `app/ui/screen_controllers/*` controllers (deleted in #1308) gated their
   button reads on `gs.phase_timer > constants::UI_ENTRY_DEBOUNCE`. The
   same guard now lives in…" — same shape as the 2 test-file refs that
   #1447 dropped. Substantive test contract (the guard lives in
   `ui_update_system.cpp`'s `effective_debounce` table, with end-screen
   overrides for Game Over and Song Complete) preserved; only the
   legacy-controller breadcrumb removed.

### Verification

```sh
$ grep -rn "app/components/music\.h" app/ tests/
# 0 hits

$ grep -rn "Legacy \`app/ui/screen_controllers" app/ tests/
# 0 hits
```

- `cmake --build build` — zero warnings.
- `./build/shapeshifter_tests` — **All tests passed (3370 assertions in 963 test cases)**.
