### PR TITLE
#1462 scoring_system.cpp: drop 3 single-call `reg.ctx().get<T>()` wrappers

### DIFF
--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -18,24 +18,12 @@
 
 namespace {
 
-ScoringSystemScratch& scoring_scratch_for(entt::registry& reg) {
-    return reg.ctx().get<ScoringSystemScratch>();
-}
-
-PendingEnergyEffects& pending_energy_for(entt::registry& reg) {
-    return reg.ctx().get<PendingEnergyEffects>();
-}
-
 void enqueue_energy_effect(entt::registry& reg, float delta, bool flash = false) {
-    auto& pending = pending_energy_for(reg);
+    auto& pending = reg.ctx().get<PendingEnergyEffects>();
     if (pending.events.size() >= pending.events.capacity()) {
         ++pending.capacity_exceeded_count;
     }
     pending.events.push_back(PendingEnergyEffects::Event{delta, flash});
-}
-
-ScorePopupRequestQueue& popup_queue_for(entt::registry& reg) {
-    return reg.ctx().get<ScorePopupRequestQueue>();
 }
 
 // Per-tier traits — Fabian per-value table: each specialization carries the
@@ -261,8 +249,8 @@ void scoring_system(entt::registry& reg, float dt) {
     auto* results = reg.ctx().find<SongResults>();   // #309: hoisted above loop
 
     // Hoist single scratch lookup — miss_buf and hit_buf share the same struct.
-    auto& scratch     = scoring_scratch_for(reg);
-    auto& popup_queue = popup_queue_for(reg);
+    auto& scratch     = reg.ctx().get<ScoringSystemScratch>();
+    auto& popup_queue = reg.ctx().get<ScorePopupRequestQueue>();
 
     // Miss pass: single owner of ENERGY_DRAIN_MISS and miss_count.
     // Collect first, then remove view components after iteration (#315).


### PR DESCRIPTION
Closes #1462.

Drops three single-call `reg.ctx().get<T>()` wrappers from
`app/systems/scoring_system.cpp`:

- `scoring_scratch_for(reg)` (1 call site at line 264)
- `pending_energy_for(reg)` (1 call site at line 30 inside `enqueue_energy_effect`)
- `popup_queue_for(reg)`     (1 call site at line 265)

Each wrapper was an anonymous-namespace 1-line alias of
`reg.ctx().get<T>()`. The same TU already calls `reg.ctx().get<...>()`
/ `reg.ctx().find<...>()` directly at four other sites
(lines 248, 249, 261, 345 pre-change), so inlining matches the
established idiom and removes the one-call indirection asymmetry.

Net change: **−13 lines**, zero behavioural change (mechanical
replacement).

### Verification

```sh
$ grep -rn "scoring_scratch_for\|pending_energy_for\|popup_queue_for" app/ tests/
# (0 hits)

$ cmake --build build
# zero warnings (-Wall -Wextra -Werror)

$ ./build/shapeshifter_tests
# All tests passed (3370 assertions in 963 test cases)
```

### Why deletion rather than a template helper

#1452 folded four `camera_singleton<...>` wrappers onto one template
helper because the per-camera symbols had **multi-TU callers** in
`camera_system.cpp`, `game_render_system.cpp`, `ui_render_system.cpp`,
and `tests/test_camera_entity_contracts.cpp` — the wrappers earned
their keep as the stable public surface.

The three wrappers here are in an **anonymous namespace** with
**exactly one in-TU call site each**, so they have no symbol-stability
contract to preserve. Deletion is strictly less code than introducing
a `template<typename T> T& ctx_get_for(reg)` helper would be.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
