### PR TITLE
#1464 drop stale `app/ui/screen_controllers/*` historical-attribution comment refs in 3 files

### DIFF
--- a/app/systems/generated/screen_spawners.h
+++ b/app/systems/generated/screen_spawners.h
@@ -15,8 +15,7 @@
 //
 // Wired by `screen_lifecycle_system` (`app/systems/screen_lifecycle_system.h`),
 // which keeps the entity set in sync with the active `GamePhase*Tag` ctx
-// mirror seeded by `enter_phase<...>()`. Replaces the legacy
-// `app/ui/screen_controllers/*` controllers that #1308 deleted.
+// mirror seeded by `enter_phase<...>()`.
 
 void spawn_title_screen(entt::registry& reg);
 void despawn_title_screen(entt::registry& reg);

--- a/app/systems/screen_lifecycle_system.h
+++ b/app/systems/screen_lifecycle_system.h
@@ -3,8 +3,7 @@
 #include <entt/entt.hpp>
 
 // Keeps per-screen UI entity sets in sync with the active `GamePhase*Tag`
-// ctx mirror (issue #1287, refs #1193 OoS-A; legacy controllers deleted
-// in #1308).
+// ctx mirror (issue #1287, refs #1193 OoS-A).
 //
 // Per Fabian's existential processing, the membership "which entities
 // belong to which screen" lives in tag presence — not in an enum field,

--- a/app/systems/ui_render_system.cpp
+++ b/app/systems/ui_render_system.cpp
@@ -62,10 +62,8 @@ const Font& popup_font_for_size(const TextContext& ctx, FontSize font_size) {
 // screen's entities and trivially partitions by tag.
 //
 // Per-screen visual specifics (font size, alignment, label vs centered
-// label, button colour overrides) match the raygui defaults the deleted
-// legacy `app/ui/screen_controllers/*` controllers used, kept for visual
-// parity (#1287 entity-driven render path replaced those controllers in
-// #1308; no per-screen migration remains).
+// label, button colour overrides) are kept inline as the raygui defaults
+// that the per-screen render constants below mirror.
 //
 // Migration boundary: a button press dispatch lives in
 // `app/systems/ui_update_system.cpp` — that system hit-tests against
@@ -655,8 +653,6 @@ void ui_render_system(entt::registry& reg, float /*alpha*/) {
     // Entity-driven render pass — issue #1287. Iterates every spawned UI
     // entity for the active screen (the screen lifecycle system already
     // partitions by `GamePhase*Tag`, so this pass is screen-agnostic).
-    // Every screen renders here; the legacy `app/ui/screen_controllers/*`
-    // dispatch was deleted in #1308.
 
     render_ui_entities(reg);
 


### PR DESCRIPTION
Closes #1464.

Four leading-prefix breadcrumb comments still cited the legacy
`app/ui/screen_controllers/*` controllers as historical context — same
shape as #1442 / #1447 / #1457 / #1460. The controller tree was deleted
by #1308 and the entity-driven render path (#1287) is the only path that
exists on `main`.

### Changes

1. **`app/systems/generated/screen_spawners.h:18-19`** — drop the
   trailing "Replaces the legacy \`app/ui/screen_controllers/*\`
   controllers that #1308 deleted." sentence. The preceding paragraph
   already explains the codegen, per-screen tag, and screen-lifecycle
   wiring.

2. **`app/systems/ui_render_system.cpp:64-68`** — keep the
   "per-screen visual specifics … kept inline as the raygui defaults
   that the per-screen render constants below mirror." rationale
   (load-bearing for the magic numbers that follow); drop the "deleted
   legacy … replaced those controllers in #1308; no per-screen
   migration remains" historical-attribution framing.

3. **`app/systems/ui_render_system.cpp:655-659`** — drop the trailing
   "Every screen renders here; the legacy … dispatch was deleted in
   #1308." sentence. The first three lines already describe the
   current pass.

4. **`app/systems/screen_lifecycle_system.h:5-7`** — keep the
   `#1287` + `#1193 OoS-A` forward refs to the design history that
   explains the current ECS shape; drop the trailing "; legacy
   controllers deleted in #1308" clause.

Comment-only — no behavior change.

### Verification

```sh
$ grep -rn 'app/ui/screen_controllers' app/ tests/
# 0 hits
```

- `cmake --build build` — zero warnings.
- `./build/shapeshifter_tests` — All tests passed (3370 assertions in 963 test cases).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
