### PR TITLE
#1466 drop 3 single-call `*_scratch_for(reg)` anon-ns wrappers (mirrors #1462 / #1463)

### DIFF
--- a/app/systems/obstacle_despawn_system.cpp
+++ b/app/systems/obstacle_despawn_system.cpp
@@ -5,25 +5,17 @@
 #include "../constants.h"
 #include "../entities/obstacle_render_entity.h"
 
-namespace {
-
-ObstacleDespawnScratch& despawn_scratch_for(entt::registry& reg) {
-    return reg.ctx().get<ObstacleDespawnScratch>();
-}
-
-}  // namespace
-
 // Destroys obstacle entities that have scrolled past the despawn boundary.
 void obstacle_despawn_system(entt::registry& reg, [[maybe_unused]] float dt) {
     // Per-registry scratch retains capacity across frames without sharing mutable
     // state between registries.
-    auto& to_destroy = despawn_scratch_for(reg).to_destroy;
+    auto& scratch = reg.ctx().get<ObstacleDespawnScratch>();
+    auto& to_destroy = scratch.to_destroy;
     to_destroy.clear();
 
     auto view = reg.view<ObstacleTag, WorldPosition>();
     for (auto [entity, wt] : view.each()) {
         if (wt.position.y > constants::DESTROY_Y) {
-            auto& scratch = despawn_scratch_for(reg);
             if (to_destroy.size() >= to_destroy.capacity()) {
                 ++scratch.capacity_exceeded_count;
             }

--- a/app/systems/particle_system.cpp
+++ b/app/systems/particle_system.cpp
@@ -6,23 +6,15 @@
 #include "../constants.h"
 #include "../entities/settings.h"
 
-namespace {
-
-ParticleSystemScratch& particle_scratch_for(entt::registry& reg) {
-    return reg.ctx().get<ParticleSystemScratch>();
-}
-
-}  // namespace
-
 void particle_system(entt::registry& reg, float dt) {
-    auto& expired = particle_scratch_for(reg).expired;
+    auto& scratch = reg.ctx().get<ParticleSystemScratch>();
+    auto& expired = scratch.expired;
     expired.clear();
 
     auto view = reg.view<ParticleTag, ParticleData>();
     for (auto [entity, pdata] : view.each()) {
         pdata.remaining -= dt;
         if (pdata.remaining <= 0.0f) {
-            auto& scratch = particle_scratch_for(reg);
             if (expired.size() >= expired.capacity()) {
                 ++scratch.capacity_exceeded_count;
             }

--- a/app/systems/popup_display_system.cpp
+++ b/app/systems/popup_display_system.cpp
@@ -5,20 +5,13 @@
 #include "../components/transform.h"
 #include "../entities/settings.h"
 
-namespace {
-
-PopupDisplayScratch& popup_scratch_for(entt::registry& reg) {
-    return reg.ctx().get<PopupDisplayScratch>();
-}
-
-}  // namespace
-
 // Per-frame: only fade the alpha channel. Text, font size, and base RGB are
 // set once at spawn via init_popup_display() (#251). The system used to
 // re-snprintf and emplace_or_replace<PopupDisplay> every tick; that re-did
 // static work on every frame for every popup and forced storage churn.
 void popup_display_system(entt::registry& reg, float dt) {
-    auto& expired = popup_scratch_for(reg).expired;
+    auto& scratch = reg.ctx().get<PopupDisplayScratch>();
+    auto& expired = scratch.expired;
     expired.clear();
 
     // Reduce-motion (#534): zero the kinetic envelope of decorative
@@ -46,7 +39,6 @@ void popup_display_system(entt::registry& reg, float dt) {
         if (alpha_ratio > 1.0f) alpha_ratio = 1.0f;
         pd.a = static_cast<uint8_t>(static_cast<float>(col.a) * alpha_ratio);
         if (popup.remaining <= 0.0f) {
-            auto& scratch = popup_scratch_for(reg);
             if (expired.size() >= expired.capacity()) {
                 ++scratch.capacity_exceeded_count;
             }


### PR DESCRIPTION
Closes #1466.

Mirrors #1462 / #1463. Three anonymous-namespace 1-line wrappers around `reg.ctx().get<T>()` survived in fixed-tick systems:

| File | Wrapper | Body | In-TU call sites |
|---|---|---|---|
| `app/systems/obstacle_despawn_system.cpp` | `despawn_scratch_for(reg)` | `return reg.ctx().get<ObstacleDespawnScratch>();` | 2 |
| `app/systems/particle_system.cpp` | `particle_scratch_for(reg)` | `return reg.ctx().get<ParticleSystemScratch>();` | 2 |
| `app/systems/popup_display_system.cpp` | `popup_scratch_for(reg)` | `return reg.ctx().get<PopupDisplayScratch>();` | 2 |

Each wrapper had one call site at function entry (capturing the scratch sub-field) and one inside a per-iteration loop body (incrementing `capacity_exceeded_count`). Slightly stronger than #1463 because the second call site is in a loop body: hoisting `auto& scratch = reg.ctx().get<...>();` once at function entry removes both the wrapper *and* the redundant per-iteration ctx hash lookup.

### Diff shape

```
app/systems/obstacle_despawn_system.cpp |  +2 -10
app/systems/particle_system.cpp         |  +2 -10
app/systems/popup_display_system.cpp    |  +2 -10
3 files changed, 6 insertions(+), 30 deletions(-)
```

Each anonymous namespace becomes empty after the drop and is removed too.

### Why deletion rather than a template helper

Per #1463: each wrapper is in an anonymous namespace with **no cross-TU callers** (verified by `grep -rn '<name>' app/ tests/`), so they have no symbol-stability contract to preserve. Inlining is strictly less code than introducing a `template<typename T> T& ctx_get_for(reg)` helper would be. The camera-singleton fold (#1452) earned its template because of multi-TU callers; these three don't.

### Verification

```sh
$ grep -rn 'despawn_scratch_for\|particle_scratch_for\|popup_scratch_for' app/ tests/
# (0 hits)

$ cmake --build build
# zero warnings (-Wall -Wextra -Werror)

$ ./build/shapeshifter_tests
# All tests passed (3370 assertions in 963 test cases)
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>