### PR TITLE
#1468 drop stale `deleted in #1308` / legacy gameplay_hud_screen_controller historical-attribution refs in 4 files (mirrors #1442 / #1447 / #1457 / #1460 / #1464)

### DIFF
--- a/design-docs/feature-specs.md
+++ b/design-docs/feature-specs.md
@@ -200,8 +200,7 @@ void wire_input_dispatcher(entt::registry& reg);
 // `ui_update_system` to hit-test `UiPosition`/`UiBounds`/`OnPress`
 // entities and dispatch the matching action. The screen-spawner
 // functions in `app/systems/generated/<screen>_screen.cpp` (codegen output)
-// emplace those entities at phase entry; the prior per-screen raygui
-// producer layer was deleted in #1308. Gameplay HUD lane buttons
+// emplace those entities at phase entry. Gameplay HUD lane buttons
 // (Circle / Square / Triangle) emit `ShapePress*Event`s through this
 // same system; the Pause button enqueues a `NextPhasePausedTag` phase
 // transition.

--- a/design-docs/raygui-rguilayout-ui-spec.md
+++ b/design-docs/raygui-rguilayout-ui-spec.md
@@ -4,7 +4,7 @@
 
 Implemented. All migration phases described below have shipped; this spec now documents the as-built rguilayout / raygui entity-spawner UI architecture.
 
-This spec replaced the legacy JSON-driven UI layout path with raygui controls and rguilayout-authored/generated layout files. The current implementation lives under `app/systems/generated/<screen>_screen.cpp` (per-screen spawner functions emitted by `tools/rguilayout/` codegen), `app/systems/screen_lifecycle_system.{h,cpp}` (per-tag spawn/despawn dispatch), `app/systems/ui_render_system.cpp` (single render pass over `UiLabelTag` / `UiButtonTag` / `UiDummyRecTag` entities), and `app/systems/ui_update_system.cpp` (button-action dispatch). An intermediate per-screen render-callback folder used during migration was deleted in #1308 once #1287 (entity-driven UI) completed.
+This spec replaced the legacy JSON-driven UI layout path with raygui controls and rguilayout-authored/generated layout files. The current implementation lives under `app/systems/generated/<screen>_screen.cpp` (per-screen spawner functions emitted by `tools/rguilayout/` codegen), `app/systems/screen_lifecycle_system.{h,cpp}` (per-tag spawn/despawn dispatch), `app/systems/ui_render_system.cpp` (single render pass over `UiLabelTag` / `UiButtonTag` / `UiDummyRecTag` entities), and `app/systems/ui_update_system.cpp` (button-action dispatch).
 
 Current runtime note: proximity rings are active HUD timing feedback driven by `app/systems/approach_ring_envelope_system.cpp` (which writes per-button `ApproachRing` components consumed by `app/systems/ui_render_system.cpp`) and are specified by
 `design-docs/rhythm-spec.md`. The migration preserved this behavior; the
@@ -158,7 +158,7 @@ app/systems/ui_update_system.cpp                           (Input dispatch)
    - reads OnPress and invokes the bound action function
 ```
 
-The single producer is the codegen output under `app/systems/generated/`. Hand-written code never creates UI entities outside this contract; bind systems (`gameplay_hud_bind_system`, `game_over_scoreboard_bind_system`, etc.) only **mutate** atomic component data on spawner-emitted entities. An intermediate per-screen render-callback folder was the staging shape during migration and was deleted in #1308 once #1287 (entity-driven UI) shipped.
+The single producer is the codegen output under `app/systems/generated/`. Hand-written code never creates UI entities outside this contract; bind systems (`gameplay_hud_bind_system`, `game_over_scoreboard_bind_system`, etc.) only **mutate** atomic component data on spawner-emitted entities.
 
 Spawner sources may contain:
 

--- a/tests/test_input_pipeline_behavior.cpp
+++ b/tests/test_input_pipeline_behavior.cpp
@@ -36,17 +36,13 @@ static void run_pipeline(entt::registry& reg, float dt = 0.016f) {
 
 namespace {
 
-// ── Gameplay HUD test fixtures (issue #1297 migration) ──────────────
+// ── Gameplay HUD test fixtures (issue #1297) ────────────────────────
 //
-// The legacy `gameplay_hud_screen_controller.*` exposed direct helpers
-// (`gameplay_hud_apply_button_presses`, `gameplay_hud_*_input_bounds`)
-// for tests; after the entity-driven migration those symbols are gone.
-// These small local fixtures replace them: the bounds match the
-// `.rgl`-baked positions (validated by a dedicated geometry test
-// below), and `apply_button_presses_for_test` reproduces the legacy
-// enqueue / phase-transition behaviour without going through the
-// hit-test pipeline. Tests that exercise the hit-test pipeline
-// explicitly call `spawn_gameplay_screen` + `ui_update_system`.
+// The bounds match the `.rgl`-baked positions (validated by a dedicated
+// geometry test below), and `apply_button_presses_for_test` reproduces
+// the per-tick enqueue / phase-transition behaviour without going
+// through the hit-test pipeline. Tests that exercise the hit-test
+// pipeline explicitly call `spawn_gameplay_screen` + `ui_update_system`.
 constexpr Rectangle kHudCircleBoundsForTest   {130.0f, 1140.0f, 140.0f, 100.0f};
 constexpr Rectangle kHudSquareBoundsForTest   {290.0f, 1140.0f, 140.0f, 100.0f};
 constexpr Rectangle kHudTriangleBoundsForTest {450.0f, 1140.0f, 140.0f, 100.0f};
@@ -65,10 +61,9 @@ void apply_button_presses_for_test(entt::registry& reg,
 }
 
 // Runs the entity-driven hit-test dispatch (`ui_update_system`) against
-// a freshly spawned gameplay HUD entity set. Tests that previously
-// called `gameplay_hud_process_button_input(reg)` now route through
-// this helper so they cover the new code path including the lane
-// button hit-test geometry and the Pause action handler.
+// a freshly spawned gameplay HUD entity set. Tests covering the lane
+// button hit-test geometry and the Pause action handler route through
+// this helper so they exercise the live code path.
 void run_gameplay_hud_input_dispatch(entt::registry& reg) {
     spawn_gameplay_screen(reg);
     auto& gs = reg.ctx().get<GameState>();

--- a/tools/rguilayout/INTEGRATION.md
+++ b/tools/rguilayout/INTEGRATION.md
@@ -89,13 +89,11 @@ end-to-end by ECS:
   against the pointer-release event and dispatches `OnPress::action` through
   the per-`ActionId` function-pointer table (`kActionHandlers`).
 
-The legacy `app/ui/screen_controllers/*` OOP bridge and the matching
-`app/ui/generated/*_layout.h` god-struct headers were deleted in #1308 (refs
-#1287 OoS-B / #1193). The single `RAYGUI_IMPLEMENTATION` translation unit
-now lives at `app/util/raygui_impl.cpp` (moved from `app/ui/` in #1317
-sub-PR 1). Issue #1325 sub-PR 3 then relocated the codegen output from
-`app/ui/generated/` to `app/systems/generated/`, completing the Section-7
-folder-allowlist sweep (`app/ui/` no longer exists).
+The single `RAYGUI_IMPLEMENTATION` translation unit lives at
+`app/util/raygui_impl.cpp`; the codegen output lives under
+`app/systems/generated/`. There is no `app/ui/` folder, no per-screen
+OOP controller bridge, and no `*_layout.h` god-struct header — every
+control is one entity carrying atomic components.
 
 ## Doctrine
 


### PR DESCRIPTION
Comment-/prose-only cleanup that drops stale `deleted in #1308` and
legacy `gameplay_hud_screen_controller` historical-attribution
breadcrumbs surfaced by the squad's parallel-pass scan. Mirrors the
precedent set by #1442 / #1447 / #1457 / #1460 / #1464 / #1465.

## Hits

- **`tests/test_input_pipeline_behavior.cpp`** — drop the legacy
  `gameplay_hud_screen_controller` / `gameplay_hud_apply_button_presses`
  / `gameplay_hud_*_input_bounds` symbol-name attributions plus the
  `gameplay_hud_process_button_input(reg)` follow-up ref in the same
  fixture block; the remaining prose still describes what the local
  fixtures do.
- **`design-docs/raygui-rguilayout-ui-spec.md`** — drop the two
  trailing "per-screen render-callback folder … was deleted in #1308"
  sentences from the spec status paragraph and the spawner-sources
  paragraph (current-architecture prose, not history sections).
- **`design-docs/feature-specs.md`** — drop "the prior per-screen
  raygui producer layer was deleted in #1308." from the
  `ui_update_system` declaration comment.
- **`tools/rguilayout/INTEGRATION.md`** — rewrite the doctrine
  paragraph to state the live shape (`RAYGUI_IMPLEMENTATION` at
  `app/util/raygui_impl.cpp`, codegen output at
  `app/systems/generated/`, no `app/ui/` folder, no `*_layout.h`
  god-struct) without the `deleted in #1308 / #1317 / #1325` chain.

## Out of scope (intentional history sections — untouched)

- `design-docs/rguilayout-portable-c-integration.md:227` under
  `## Migration History: Native Exporter → Codegen + Entity Spawners`
- `design-docs/rguilayout-portable-c-integration.md:326` — completed
  checklist item documenting that the migration shipped

## Verification

```
$ rg -n "deleted in #1308" tests/ design-docs/raygui-rguilayout-ui-spec.md design-docs/feature-specs.md tools/rguilayout/INTEGRATION.md
(no matches)

$ rg -n "gameplay_hud_screen_controller|gameplay_hud_apply_button_presses|gameplay_hud_.*_input_bounds|gameplay_hud_process_button_input" tests/
(no matches)

$ cmake --build build
[100%] Built target shapeshifter_tests
(zero warnings under Clang -Wall -Wextra -Werror)

$ ./build/shapeshifter_tests --reporter compact
All tests passed (3370 assertions in 963 test cases)

$ python3 tools/check_enum_allowlist.py
ok: 8 enum(s) in app/, all allowlisted
```

Net delta: **-8 LOC across 4 files**.

Closes #1468.
