### PR TITLE
#1469 camera_system.cpp: drop 3 single-call matrix helpers (slab_matrix / shape_matrix / prism_matrix)

### DIFF
--- a/app/systems/camera_system.cpp
+++ b/app/systems/camera_system.cpp
@@ -201,34 +201,16 @@ RenderTargets& RenderTargets::operator=(RenderTargets&& o) noexcept {
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-// GenMeshCube is centered at origin. Translate to position the slab's
-// bottom-left corner at (x, 0) and center depth on z so z is the beat/timing plane.
-static Matrix slab_matrix(float x, float z, float w, float h, float d) {
-    return MatrixMultiply(MatrixScale(w, h, d),
-                          MatrixTranslate(x + w / 2, h / 2, z));
-}
-
-static Matrix shape_matrix(float cx, float y_3d, float cz, float sz, float radius_scale) {
-    float s = sz * radius_scale;
-    return MatrixMultiply(MatrixScale(s, s, s),
-                          MatrixTranslate(cx, y_3d, cz));
-}
-
-// Triangular prism rotated so one vertex of the cross-section points up (△)
-static Matrix prism_matrix(float cx, float y_3d, float cz, float sz, float radius_scale) {
-    float s = sz * radius_scale;
-    Matrix scale = MatrixScale(s, s, s);
-    Matrix rot = MatrixRotateY(90.0f * DEG2RAD);
-    Matrix translate = MatrixTranslate(cx, y_3d, cz);
-    return MatrixMultiply(MatrixMultiply(scale, rot), translate);
-}
-
-// Pick the correct matrix for a shape mesh (triangle prism needs rotation)
+// Pick the correct matrix for a shape mesh. Triangle prism is rotated 90°
+// around Y so one vertex of the cross-section points up (△); other shapes
+// are uniform-scaled and translated to (cx, y_3d, cz).
 static Matrix make_shape_matrix(uint8_t mesh_index, float cx, float y_3d, float cz,
                                 float sz, float radius_scale) {
+    const float s = sz * radius_scale;
+    Matrix m = MatrixScale(s, s, s);
     if (mesh_index == static_cast<uint8_t>(Shape::Triangle))
-        return prism_matrix(cx, y_3d, cz, sz, radius_scale);
-    return shape_matrix(cx, y_3d, cz, sz, radius_scale);
+        m = MatrixMultiply(m, MatrixRotateY(90.0f * DEG2RAD));
+    return MatrixMultiply(m, MatrixTranslate(cx, y_3d, cz));
 }
 
 // ── game_camera_system: model-to-world transforms for all 3D renderables ────
@@ -262,11 +244,16 @@ void game_camera_system(entt::registry& reg, [[maybe_unused]] float dt) {
         };
 
         // Slab children: no per-kind columns.
+        // GenMeshCube is centered at origin; translate so the slab's bottom-left
+        // corner sits at (mc.x, 0) and the depth dimension is centred on z (the
+        // beat/timing plane).
         for (auto [entity, mc] : reg.view<MeshChild, MeshKindSlab>().each()) {
             float z = 0.0f;
             if (!record_stale_or_compute_z(entity, mc, z)) continue;
             reg.get_or_emplace<ModelTransform>(entity) =
-                ModelTransform{slab_matrix(mc.x, z, mc.width, mc.height, mc.depth),
+                ModelTransform{MatrixMultiply(MatrixScale(mc.width, mc.height, mc.depth),
+                                              MatrixTranslate(mc.x + mc.width / 2,
+                                                              mc.height / 2, z)),
                                 mc.tint};
         }
 


### PR DESCRIPTION
Closes #1469. Applies **Option A** (full inline) from the issue.

### Summary

Three anon-namespace `static Matrix` helpers in `app/systems/camera_system.cpp` each had **exactly one** in-TU call site:

| Helper          | Sole call site                                    | Body                                            |
|-----------------|---------------------------------------------------|-------------------------------------------------|
| `slab_matrix`   | `MeshKindSlab` loop body                          | `MatrixMultiply(MatrixScale, MatrixTranslate)`  |
| `shape_matrix`  | non-Triangle branch of `make_shape_matrix`        | `MatrixMultiply(MatrixScale, MatrixTranslate)`  |
| `prism_matrix`  | Triangle branch of `make_shape_matrix`            | `MatrixMultiply(MatrixMultiply(scale, rot), translate)` |

Per the precedent in #1463 / #1467, the single-call wrappers are deleted and their math is inlined at the point of use:

- `slab_matrix` → inlined directly into the `ModelTransform{...}` ctor in the `MeshKindSlab` loop. The "GenMeshCube centered at origin" comment moved to the loop body so the geometric contract is documented at the point of use.
- `shape_matrix` + `prism_matrix` → folded into `make_shape_matrix`, which now reads top to bottom as: uniform scale → conditional 90° Y-rotation (for `Shape::Triangle`) → translate.

`make_shape_matrix` (2 call sites — `MeshKindShape` loop + player shape transform) is preserved with the same signature and semantics.

### Diff

```
app/systems/camera_system.cpp | 39 +++++++++--------------------------
1 file changed, 13 insertions(+), 26 deletions(-)
```

Net **−13 LOC**. Pure mechanical refactor; identical byte-for-byte matrix output for all three call sites (`MatrixMultiply` is left-associative so the prism rotation order `MatrixMultiply(MatrixMultiply(scale, rot), translate)` is equivalent to `MatrixMultiply(MatrixMultiply(scale, rot), translate)` written sequentially via the local `m` variable).

### Verification

```sh
grep -rn 'slab_matrix\|shape_matrix\|prism_matrix' app/   # 0 hits
grep -rn 'slab_matrix\|shape_matrix\|prism_matrix' tests/ # 4 hits — historical comments in test_pr43_regression.cpp only
```

- Build: zero warnings on native clang (`-Wall -Wextra -Werror`).
- Tests: `3370 assertions in 963 test cases` — all green.

### Out of scope

The four `tests/test_pr43_regression.cpp` comment references to `slab_matrix` describe the historical PR-43 regression scenario being guarded (MeshChild `depth` / `height` field contract). The tests themselves exercise the `DrawSize.h` / `OBSTACLE_3D_HEIGHT` contract, not the matrix-helper function, so they remain valid regression tests. Touching their comments is the historical-attribution-sweep concern tracked by #1442 / #1457 / #1460 / #1464 / #1468, not this PR.

### Sibling PRs

- #1463 — `scoring_system.cpp` (3 `reg.ctx().get<T>()` wrappers)
- #1467 — `obstacle_despawn` / `particle` / `popup_display` (`*_scratch_for` wrappers)
- #1469 — this PR
