### PR TITLE
platform_display.cpp: inline 2 single-call wasm_unset_* helpers (#1472)

### DIFF
--- a/app/platform_display.cpp
+++ b/app/platform_display.cpp
@@ -46,22 +46,16 @@ struct WasmLoopState {
     bool visibilitychange_armed = false;
 };
 
-static void wasm_unset_beforeunload(WasmLoopState& state) {
-    if (!state.beforeunload_armed) return;
-    emscripten_set_beforeunload_callback(nullptr, nullptr);
-    state.beforeunload_armed = false;
-}
-
-static void wasm_unset_visibilitychange(WasmLoopState& state) {
-    if (!state.visibilitychange_armed) return;
-    emscripten_set_visibilitychange_callback(nullptr, false, nullptr);
-    state.visibilitychange_armed = false;
-}
-
 void platform_disarm_wasm_beforeunload(entt::registry& reg) {
     if (auto* state = reg.ctx().find<WasmLoopState>()) {
-        wasm_unset_beforeunload(*state);
-        wasm_unset_visibilitychange(*state);
+        if (state->beforeunload_armed) {
+            emscripten_set_beforeunload_callback(nullptr, nullptr);
+            state->beforeunload_armed = false;
+        }
+        if (state->visibilitychange_armed) {
+            emscripten_set_visibilitychange_callback(nullptr, false, nullptr);
+            state->visibilitychange_armed = false;
+        }
         state->reg = nullptr;
         state->accumulator = 0.0f;
     } else {


### PR DESCRIPTION
Both file-static helpers (`wasm_unset_beforeunload`,
`wasm_unset_visibilitychange`) had exactly one call site inside the
same TU (`platform_disarm_wasm_beforeunload`). The 3-line
armed-then-clear pattern is now expressed inline at the only call
site — no behaviour change.

Verified:
- grep confirms no cross-TU / test refs to either helper.
- Native build + 3370-assertion test suite green, zero warnings.
- Emscripten branch syntax-checks clean (`emcc -fsyntax-only`).

Mirrors the single-call file-static wrapper precedent set by
#1463 / #1467 / #1469.

Closes #1472

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
