### PR TITLE
game_render_system.cpp: inline 3 single-call draw_* helpers (#1473)

### DIFF
--- a/app/systems/game_render_system.cpp
+++ b/app/systems/game_render_system.cpp
@@ -10,41 +10,28 @@
 #include <raylib.h>
 #include <rlgl.h>
 
-static void draw_shape(const camera::ShapeMeshes& sm, const ModelTransform& mt,
-                       const MeshKindShape& kind) {
-    if (kind.mesh_index >= kShapeCount) return;
-    Material mat = sm.material;
-    mat.maps[MATERIAL_MAP_DIFFUSE].color = mt.tint;
-    DrawMesh(sm.shapes[kind.mesh_index], mat, mt.mat);
-}
-
-static void draw_slab(const camera::ShapeMeshes& sm, const ModelTransform& mt) {
-    Material mat = sm.material;
-    mat.maps[MATERIAL_MAP_DIFFUSE].color = mt.tint;
-    DrawMesh(sm.slab, mat, mt.mat);
-}
-
-static void draw_quad(const camera::ShapeMeshes& sm, const ModelTransform& mt) {
-    Material mat = sm.material;
-    mat.maps[MATERIAL_MAP_DIFFUSE].color = mt.tint;
-    DrawMesh(sm.quad, mat, mt.mat);
-}
-
 // Per Fabian existential processing (issue #1202/#1204), the former
 // `switch(mesh_type)` is replaced by one transform per mesh-kind tag.
 template <typename PassTag>
 static void draw_pass(const entt::registry& reg, const camera::ShapeMeshes& sm) {
     for (auto [_, mt, kind] :
              reg.view<const ModelTransform, const PassTag, const MeshKindShape>().each()) {
-        draw_shape(sm, mt, kind);
+        if (kind.mesh_index >= kShapeCount) continue;
+        Material mat = sm.material;
+        mat.maps[MATERIAL_MAP_DIFFUSE].color = mt.tint;
+        DrawMesh(sm.shapes[kind.mesh_index], mat, mt.mat);
     }
     for (auto [_, mt] :
              reg.view<const ModelTransform, const PassTag, const MeshKindSlab>().each()) {
-        draw_slab(sm, mt);
+        Material mat = sm.material;
+        mat.maps[MATERIAL_MAP_DIFFUSE].color = mt.tint;
+        DrawMesh(sm.slab, mat, mt.mat);
     }
     for (auto [_, mt] :
              reg.view<const ModelTransform, const PassTag, const MeshKindQuad>().each()) {
-        draw_quad(sm, mt);
+        Material mat = sm.material;
+        mat.maps[MATERIAL_MAP_DIFFUSE].color = mt.tint;
+        DrawMesh(sm.quad, mat, mt.mat);
     }
 }
 


### PR DESCRIPTION
All three file-static helpers (`draw_shape`, `draw_slab`,
`draw_quad`) had exactly one call site inside the same TU
(`draw_pass<PassTag>`). The 3-line "copy material, tint diffuse,
DrawMesh" body is now expressed inline in each per-mesh-kind loop —
no behaviour change. The early-return guard in the shape path
becomes a `continue` since it now lives inside a `for`.

The mesh-kind tag in the view (`MeshKindShape` / `MeshKindSlab` /
`MeshKindQuad`) already names what each loop draws, so the helper
name was documentation duplicating the tag name.

Verified:
- grep confirms no cross-TU / test refs to any helper.
- Native build + 3370-assertion test suite green, zero warnings.

Mirrors the single-call file-static wrapper precedent set by
#1463 / #1467 / #1469.

Closes #1473

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
