### PR TITLE
test_player_system.cpp: inline 10 single-call helpers (#1476)

### DIFF
--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -86,59 +86,8 @@ static bool test_player_vertical_done(const TestPlayerAction& action) {
     return action.vertical_done;
 }
 
-static void test_player_mark_shape_done(TestPlayerAction& action) {
-    action.shape_done = true;
-}
-
-static void test_player_mark_lane_done(TestPlayerAction& action) {
-    action.lane_done = true;
-}
-
-static void test_player_mark_vertical_done(TestPlayerAction& action) {
-    action.vertical_done = true;
-}
-
-static bool test_player_needs_shape(const TestPlayerAction& action) {
-    return action.shape_press != nullptr && !test_player_shape_done(action);
-}
-
 static bool test_player_needs_lane(const TestPlayerAction& action) {
     return lane_utils::is_valid(action.target_lane) && !test_player_lane_done(action);
-}
-
-static bool valid_scroll_speed(float scroll_speed) {
-    return std::isfinite(scroll_speed) && scroll_speed > 0.0f;
-}
-
-static bool test_player_needs_vertical(const TestPlayerAction& action) {
-    return (action.wants_jump || action.wants_slide) && !test_player_vertical_done(action);
-}
-
-static bool test_player_action_done(const TestPlayerAction& action) {
-    const bool shape_done = (action.shape_press == nullptr) ||
-                            test_player_shape_done(action);
-    const bool lane_done = !lane_utils::is_valid(action.target_lane) ||
-                           test_player_lane_done(action);
-    const bool vertical_done = !(action.wants_jump || action.wants_slide) ||
-                               test_player_vertical_done(action);
-    return shape_done && lane_done && vertical_done;
-}
-
-static const SkillConfig& test_player_config(const TestPlayerState& state) {
-    return state.skill;
-}
-
-static void test_player_push_action(TestPlayerState& state, const TestPlayerAction& action) {
-    if (state.action_count < TestPlayerState::MAX_ACTIONS) {
-        state.actions[state.action_count++] = action;
-    }
-}
-
-static void test_player_remove_action(TestPlayerState& state, int idx) {
-    if (idx >= 0 && idx < state.action_count) {
-        state.actions[idx] = state.actions[state.action_count - 1];
-        --state.action_count;
-    }
 }
 
 // Determine the required action for an obstacle.
@@ -273,7 +222,7 @@ void test_player_system(entt::registry& reg, float dt) {
         state->action_count = 0;
     }
 
-    const auto& cfg = test_player_config(*state);
+    const auto& cfg = state->skill;
 
     // ── Find player ──────────────────────────────────────────
     auto player_view = reg.view<PlayerTag, WorldPosition, PlayerShape, ShapeWindow, Lane>();
@@ -337,7 +286,9 @@ void test_player_system(entt::registry& reg, float dt) {
             action.timer = reaction;
         }
 
-        test_player_push_action(*state, action);
+        if (state->action_count < TestPlayerState::MAX_ACTIONS) {
+            state->actions[state->action_count++] = action;
+        }
         reg.get_or_emplace<TestPlayerPlannedTag>(entity);
 
         if (log) {
@@ -434,9 +385,9 @@ void test_player_system(entt::registry& reg, float dt) {
                                     action.shape_not_before_time > 0.0f &&
                                     song->song_time < action.shape_not_before_time);
         bool waiting_on_lane = test_player_needs_lane(action);
-        if (test_player_needs_shape(action) && !waiting_on_lane && !too_early_for_shape) {
+        if (action.shape_press != nullptr && !test_player_shape_done(action) && !waiting_on_lane && !too_early_for_shape) {
             action.shape_press->enqueue(disp);
-            test_player_mark_shape_done(action);
+            action.shape_done = true;
             key_injected = true;
 
             if (log) {
@@ -491,7 +442,7 @@ void test_player_system(entt::registry& reg, float dt) {
                 auto* obeat = reg.try_get<BeatInfo>(oe);
                 if (obeat) {
                     if (obeat->arrival_time >= action.arrival_time) continue; // farther, don't care
-                } else if (valid_scroll_speed(song->scroll_speed)) {
+                } else if (std::isfinite(song->scroll_speed) && song->scroll_speed > 0.0f) {
                     const float o_arrival = song_time + odist / song->scroll_speed;
                     if (o_arrival >= action.arrival_time) continue; // farther, don't care
                 }
@@ -534,7 +485,7 @@ void test_player_system(entt::registry& reg, float dt) {
             state->swipe_cooldown_timer = TestPlayerState::SWIPE_COOLDOWN;
             // Check if we've reached the target
             if (p_lane.current == action.target_lane) {
-                test_player_mark_lane_done(action);
+                action.lane_done = true;
             }
             key_injected = true;
             continue;
@@ -557,7 +508,7 @@ void test_player_system(entt::registry& reg, float dt) {
                 }
             }
         }
-        if (test_player_needs_vertical(action) && !reg.any_of<Jumping, Sliding>(player_entity)
+        if ((action.wants_jump || action.wants_slide) && !test_player_vertical_done(action) && !reg.any_of<Jumping, Sliding>(player_entity)
             && !vert_zone_blocked && !vert_blocked_by_shape) {
             if (action.wants_jump) {
                 disp.enqueue<GoUpEvent>({});
@@ -574,7 +525,7 @@ void test_player_system(entt::registry& reg, float dt) {
                         static_cast<unsigned>(entt::to_integral(action.obstacle)), act_beat);
                 }
             }
-            test_player_mark_vertical_done(action);
+            action.vertical_done = true;
             key_injected = true;
             continue;
         }
@@ -583,13 +534,20 @@ void test_player_system(entt::registry& reg, float dt) {
     // ── CLEANUP completed actions ────────────────────────────
     for (int i = state->action_count - 1; i >= 0; --i) {
         auto& action = state->actions[i];
-        bool done = test_player_action_done(action);
+        const bool shape_done = (action.shape_press == nullptr) ||
+                                test_player_shape_done(action);
+        const bool lane_done = !lane_utils::is_valid(action.target_lane) ||
+                               test_player_lane_done(action);
+        const bool vertical_done = !(action.wants_jump || action.wants_slide) ||
+                                   test_player_vertical_done(action);
+        const bool done = shape_done && lane_done && vertical_done;
         // Entity no longer an active obstacle (scored + processed by scoring_system,
         // or destroyed by obstacle_despawn_system)
         bool expired = !reg.valid(action.obstacle) ||
                        !reg.all_of<Obstacle>(action.obstacle);
         if (done || expired) {
-            test_player_remove_action(*state, i);
+            state->actions[i] = state->actions[state->action_count - 1];
+            --state->action_count;
         }
     }
 }


### PR DESCRIPTION
Sibling of #1463 / #1467 / #1469 / #1472 / #1473 — collapses ten
file-static / namespace-static wrappers in
`app/systems/test_player_system.cpp` that each had exactly one
in-TU call site and zero cross-TU / test references.

### Inlined (10)

| Old helper                          | Inlined to                                                                    | Call site |
|-------------------------------------|-------------------------------------------------------------------------------|-----------|
| `test_player_mark_shape_done`       | `action.shape_done = true;`                                                   | L439      |
| `test_player_mark_lane_done`        | `action.lane_done = true;`                                                    | L537      |
| `test_player_mark_vertical_done`    | `action.vertical_done = true;`                                                | L577      |
| `test_player_needs_shape`           | `action.shape_press != nullptr && !test_player_shape_done(action)`            | L437      |
| `valid_scroll_speed`                | `std::isfinite(s) && s > 0.0f`                                                | L494      |
| `test_player_needs_vertical`        | `(action.wants_jump \|\| action.wants_slide) && !test_player_vertical_done(action)` | L560 |
| `test_player_action_done`           | 6-line three-bool compose (composed from surviving `*_done` predicates)       | L586      |
| `test_player_config`                | `state->skill`                                                                | L276      |
| `test_player_push_action`           | 3-line capacity-guarded push                                                  | L340      |
| `test_player_remove_action`         | 4-line swap-and-pop (bounds guard dropped — the only call site is the         | L592      |
|                                     | reverse-iterating cleanup loop, which guarantees `0 <= i < action_count`)     |           |

### Survivors (out of scope)

Per the issue's explicit "out of scope" list, these still have >1
internal call site and stay:
`test_player_shape_done` / `_lane_done` / `_vertical_done` (read
3, 3, 2 times respectively, including from the new inlined
`action_done` block), `test_player_needs_lane` (3 reads),
`lane_overlap_rect` / `lane_centers_overlap`, `determine_action`,
and the per-shape press dispatch table.

### Verification

- `cmake --build build` — zero warnings (clang `-Wall -Wextra -Werror`).
- `ctest --test-dir build` — 975 passed / 0 failed / 1 skipped (the
  skipped one is the display-bound `startup_shutdown_smoke`,
  unrelated).
- Diff: 1 file changed, **19 insertions(+), 61 deletions(−)** — net
  −42 LOC, matching the issue's `~−50` estimate.
- Each inlined expression is literally what the helper returned /
  wrote — the test-player bot's PERCEIVE / PLAN / EXECUTE decision
  flow and session-log output are unchanged.

Closes #1476.
