### PR TITLE
#1478 energy_bar_system.cpp: inline 3 single-call anon-ns helpers (energy_bar_bounce / energy_critical_pulse / flash_overlay_strength)

### DIFF
--- a/app/systems/energy_bar_system.cpp
+++ b/app/systems/energy_bar_system.cpp
@@ -9,28 +9,6 @@
 #include <cmath>
 #include <raymath.h>
 
-namespace {
-
-float energy_bar_bounce(float song_time, float beat_period, bool reduce_motion) {
-    if (reduce_motion) return 0.0f;
-    if (beat_period <= 0.0f) return 0.0f;
-    float phase = std::fmod(song_time, beat_period) / beat_period;
-    if (phase < 0.0f) phase = 0.0f;
-    float bounce = 1.0f - phase;
-    return bounce * bounce * bounce;
-}
-
-float energy_critical_pulse(float pulse_time, bool reduce_motion) {
-    if (reduce_motion) return 0.5f;
-    return 0.5f + 0.5f * std::sin(pulse_time * 10.0f);
-}
-
-float flash_overlay_strength(float flash_ratio, bool reduce_motion) {
-    return reduce_motion ? 0.0f : flash_ratio;
-}
-
-} // namespace
-
 void energy_bar_system(entt::registry& reg, [[maybe_unused]] float dt) {
     if (!reg.ctx().contains<GamePhasePlayingTag>()) return;
 
@@ -43,15 +21,18 @@ void energy_bar_system(entt::registry& reg, [[maybe_unused]] float dt) {
     const bool song_playing = song && song->playing;
 
     float bounce = 0.0f;
-    if (song_playing) {
-        bounce = energy_bar_bounce(song->song_time, song->beat_period, reduce_motion);
+    if (song_playing && !reduce_motion && song->beat_period > 0.0f) {
+        float phase = std::fmod(song->song_time, song->beat_period) / song->beat_period;
+        if (phase < 0.0f) phase = 0.0f;
+        const float inv = 1.0f - phase;
+        bounce = inv * inv * inv;
     }
 
     float flash_ratio = 0.0f;
     if (energy->flash_timer > 0.0f && constants::ENERGY_FLASH_DURATION > 0.0f) {
         flash_ratio = Clamp(energy->flash_timer / constants::ENERGY_FLASH_DURATION, 0.0f, 1.0f);
     }
-    const float flash_overlay = flash_overlay_strength(flash_ratio, reduce_motion);
+    const float flash_overlay = reduce_motion ? 0.0f : flash_ratio;
 
     const float fill = Clamp(energy->display, 0.0f, 1.0f);
     float critical_ratio = 0.0f;
@@ -61,7 +42,9 @@ void energy_bar_system(entt::registry& reg, [[maybe_unused]] float dt) {
     }
 
     const float pulse_time = song_playing ? song->song_time : 0.0f;
-    const float critical_pulse = energy_critical_pulse(pulse_time, reduce_motion);
+    const float critical_pulse = reduce_motion
+        ? 0.5f
+        : 0.5f + 0.5f * std::sin(pulse_time * 10.0f);
     const float critical_intensity = critical_ratio * (0.35f + 0.65f * critical_pulse);
 
     auto view = reg.view<EnergyBarTag, EnergyBarLayout, EnergyBarVisual>();


### PR DESCRIPTION
Mirrors #1463 / #1467 / #1469 / #1472 / #1473 / #1476: collapses anon-namespace helpers with exactly one call site in the same TU, body ≤ 7 lines.

### Changes

- `energy_bar_bounce` — guards collapse into the surrounding `if (song_playing)` predicate: `if (song_playing && !reduce_motion && song->beat_period > 0.0f)`. Body inlined as `(1.0f - phase)^3`.
- `energy_critical_pulse` — inlined as a ternary at the call site: `reduce_motion ? 0.5f : 0.5f + 0.5f * sin(pulse_time * 10.0f)`.
- `flash_overlay_strength` — trivial ternary `reduce_motion ? 0.0f : flash_ratio` inlined at the single call site.

The whole anon namespace is removed; net **−15 LOC** (1 file changed, 9 insertions, 26 deletions).

### Verification

- Behaviour byte-identical: same `reduce_motion` short-circuits, same math, same `Clamp` / `std::min` / `std::sin` arguments.
- `cmake --build build` → zero warnings, all targets built.
- `./build/shapeshifter_tests` → **All tests passed (3370 assertions in 963 test cases)** — same as `main` baseline.

### Closes

Closes #1478
