### PR TITLE
#1482 game_state_end_screen_system.cpp: fold 3 `apply_end_choice_*` siblings onto one template (mirrors #1453 / #1452)

### DIFF
--- a/app/systems/game_state_end_screen_system.cpp
+++ b/app/systems/game_state_end_screen_system.cpp
@@ -32,34 +32,19 @@ void erase_end_choice_tags(entt::registry& reg) {
 // elapses — matching the pre-migration semantics. The handlers are mutually
 // exclusive in practice because input routing only ever emplaces one tag per
 // press; erase_end_choice_tags on consumption keeps that invariant explicit.
-void apply_end_choice_restart(entt::registry& reg) {
-    if (!reg.ctx().find<EndChoiceRestart>()) return;
+template <typename ChoiceTag, typename NextPhaseTag>
+void apply_end_choice(entt::registry& reg) {
+    if (!reg.ctx().find<ChoiceTag>()) return;
     auto& gs = reg.ctx().get<GameState>();
     if (!end_screen_input_ready(reg, gs)) return;
-    request_phase_transition<NextPhasePlayingTag>(reg);
-    erase_end_choice_tags(reg);
-}
-
-void apply_end_choice_level_select(entt::registry& reg) {
-    if (!reg.ctx().find<EndChoiceLevelSelect>()) return;
-    auto& gs = reg.ctx().get<GameState>();
-    if (!end_screen_input_ready(reg, gs)) return;
-    request_phase_transition<NextPhaseLevelSelectTag>(reg);
-    erase_end_choice_tags(reg);
-}
-
-void apply_end_choice_main_menu(entt::registry& reg) {
-    if (!reg.ctx().find<EndChoiceMainMenu>()) return;
-    auto& gs = reg.ctx().get<GameState>();
-    if (!end_screen_input_ready(reg, gs)) return;
-    request_phase_transition<NextPhaseTitleTag>(reg);
+    request_phase_transition<NextPhaseTag>(reg);
     erase_end_choice_tags(reg);
 }
 
 }  // namespace
 
 void game_state_end_screen_system(entt::registry& reg, [[maybe_unused]] float dt) {
-    apply_end_choice_restart(reg);
-    apply_end_choice_level_select(reg);
-    apply_end_choice_main_menu(reg);
+    apply_end_choice<EndChoiceRestart,     NextPhasePlayingTag>(reg);
+    apply_end_choice<EndChoiceLevelSelect, NextPhaseLevelSelectTag>(reg);
+    apply_end_choice<EndChoiceMainMenu,    NextPhaseTitleTag>(reg);
 }


### PR DESCRIPTION
Closes #1482.

## What

Folds three sibling `apply_end_choice_*` helpers in `app/systems/game_state_end_screen_system.cpp` onto one anonymous-namespace template `apply_end_choice<ChoiceTag, NextPhaseTag>(reg)`. The three bodies were textually identical 6-line blocks differing only by the tag types.

## Why

Mirrors the recent Fabian-existential-processing fold pattern (#1453 `spawn_*_obstacle` → template, #1452 `game_camera`/`ui_camera` accessors → template, #1456 `*_sink` → template). Removes 22 lines, adds 7 (net -15 LOC).

## Diff Size

```
app/systems/game_state_end_screen_system.cpp | 29 +++++++----------------------
 1 file changed, 7 insertions(+), 22 deletions(-)
```

## Verification

- `cmake --build build` clean with `-Wall -Wextra -Werror`
- `./build/shapeshifter_tests` green: **3370 assertions in 963 test cases**
- `python3 tools/check_enum_allowlist.py`: **8 enums, all allowlisted**
- `game_state_end_screen_system` signature and the once-per-frame call from `game_state_system.cpp:210` are unchanged.
- No `if`/`switch` branches added — cyclomatic complexity trends down, not up.

