### PR TITLE
#1480 runtime_system_scratch.cpp: inline single-call `gameplay_capacity` helper

### DIFF
--- a/app/systems/runtime_system_scratch.cpp
+++ b/app/systems/runtime_system_scratch.cpp
@@ -15,10 +15,6 @@ namespace {
 
 constexpr std::size_t kMinimumGameplayScratchCapacity = 8;
 
-std::size_t gameplay_capacity(std::size_t beat_capacity) {
-    return std::max(kMinimumGameplayScratchCapacity, beat_capacity);
-}
-
 }  // namespace
 
 void runtime_system_scratch_init(entt::registry& reg) {
@@ -35,7 +31,7 @@ void runtime_system_scratch_init(entt::registry& reg) {
 }
 
 void runtime_system_scratch_reserve(entt::registry& reg, std::size_t beat_capacity) {
-    const std::size_t capacity = gameplay_capacity(beat_capacity);
+    const std::size_t capacity = std::max(kMinimumGameplayScratchCapacity, beat_capacity);
     auto& scoring = reg.ctx().get<ScoringSystemScratch>();
     scoring.miss_buf.reserve(capacity);
     scoring.hit_buf.reserve(capacity);


### PR DESCRIPTION
Closes #1480.

## What

Drops the 1-line anonymous-namespace helper `gameplay_capacity(beat_capacity)` in `app/systems/runtime_system_scratch.cpp` (called from exactly one site at `runtime_system_scratch_reserve`). The `std::max` expression is inlined at the call site.

## Why

Mirrors the recent #1478 / #1476 / #1472 / #1473 / #1469 / #1467 / #1463 single-call helper inline pattern — removes a trivial indirection while keeping the named `capacity` local and the `kMinimumGameplayScratchCapacity` constant intact.

## Diff Size

```
 app/systems/runtime_system_scratch.cpp | 6 +-----
 1 file changed, 1 insertion(+), 5 deletions(-)
```

## Verification

- `cmake --build build` clean with `-Wall -Wextra -Werror`
- `./build/shapeshifter_tests` green: **3370 assertions in 963 test cases**
- `<algorithm>` / `<cstddef>` includes left in place (still needed for `std::max` / `std::size_t`).
- `runtime_system_scratch_reserve` returns the same `capacity` for any `beat_capacity`.