### PR TITLE
#1481 audio_dispatcher.cpp: inline single-call `warm_audio_haptic_dispatcher`

### DIFF
--- a/app/systems/audio_dispatcher.cpp
+++ b/app/systems/audio_dispatcher.cpp
@@ -25,14 +25,6 @@ struct AudioHapticDispatcherConnections {
     }
 };
 
-void warm_audio_haptic_dispatcher(entt::dispatcher& disp) {
-    // Move first vector allocation out of the first gameplay audio frame.
-    disp.enqueue<PlaySfxEvent>(PlaySfxEvent{});
-    disp.enqueue<PlayHapticEvent>(PlayHapticEvent{});
-    disp.clear<PlaySfxEvent>();
-    disp.clear<PlayHapticEvent>();
-}
-
 }  // namespace
 
 // audio_system and haptic_system own their post-render event drains.
@@ -58,7 +50,11 @@ void wire_audio_haptic_dispatcher(entt::registry& reg) {
     state->haptic =
         disp->sink<PlayHapticEvent>().connect<&haptic_handle_play>(reg);
 
-    warm_audio_haptic_dispatcher(*disp);
+    // Move first vector allocation out of the first gameplay audio frame.
+    disp->enqueue<PlaySfxEvent>(PlaySfxEvent{});
+    disp->enqueue<PlayHapticEvent>(PlayHapticEvent{});
+    disp->clear<PlaySfxEvent>();
+    disp->clear<PlayHapticEvent>();
 }
 
 void unwire_audio_haptic_dispatcher(entt::registry& reg) {


### PR DESCRIPTION
Closes #1481.

## What

Drops the 4-line anonymous-namespace helper `warm_audio_haptic_dispatcher(disp)` in `app/systems/audio_dispatcher.cpp` (called from exactly one site in `wire_audio_haptic_dispatcher`). The four sequential `enqueue`/`clear` calls are inlined at the original call site, preserving the intent comment.

## Why

Mirrors the recent #1478 / #1476 / #1472 / #1473 / #1469 / #1467 / #1463 single-call helper inline pattern. The helper name documented intent but added a layer of indirection over four trivial dispatcher calls. The inlined version keeps the explanatory `// Move first vector allocation...` comment at the call site.

Because `disp` is an `entt::dispatcher*` at the call site (vs. the helper's reference parameter), the inlined version uses `->` instead of `.`.

## Diff Size

```
 app/systems/audio_dispatcher.cpp | 14 +++++---------
 1 file changed, 5 insertions(+), 9 deletions(-)
```

## Verification

- `cmake --build build` clean with `-Wall -Wextra -Werror`
- `./build/shapeshifter_tests` green: **3370 assertions in 963 test cases**
- `wire_audio_haptic_dispatcher` behavior unchanged; warm-allocation still happens once per (re-)wire.
- `AudioHapticDispatcherConnections` struct, raw-`entt::connection` rationale comment, and `unwire_audio_haptic_dispatcher` are untouched.