### PR TITLE
#1488 game_state_terminal_phase_system.cpp: inline 3 single-call anon-ns helpers (`persist_dirty_high_scores`, `emit_terminal_feedback_game_over`, `emit_terminal_feedback_song_complete`)

### DIFF
--- a/app/systems/game_state_terminal_phase_system.cpp
+++ b/app/systems/game_state_terminal_phase_system.cpp
@@ -10,22 +10,6 @@
 
 namespace {
 
-void persist_dirty_high_scores(entt::registry& reg,
-                               const HighScoreState& high_scores,
-                               HighScorePersistence& persistence) {
-    if (!reg.ctx().contains<HighScoreDirtyTag>()) return;
-
-    if (persistence.path.empty()) {
-        persistence.last_save = persistence::Result{persistence::Status::PathUnavailable, {}};
-        return;
-    }
-
-    persistence.last_save = high_score::save_high_scores(high_scores, persistence.path);
-    if (persistence.last_save.ok()) {
-        reg.ctx().erase<HighScoreDirtyTag>();
-    }
-}
-
 bool update_and_persist_high_score(entt::registry& reg) {
     auto& score = reg.ctx().get<ScoreState>();
     auto& current = reg.ctx().get<CurrentSongHighScore>();
@@ -46,7 +30,16 @@ bool update_and_persist_high_score(entt::registry& reg) {
             if (score_exceeds_high_score && recorded_new_high_score && has_active_high_score_key) {
                 reg.ctx().emplace<HighScoreDirtyTag>();
             }
-            persist_dirty_high_scores(reg, *hs, *hp);
+            if (reg.ctx().contains<HighScoreDirtyTag>()) {
+                if (hp->path.empty()) {
+                    hp->last_save = persistence::Result{persistence::Status::PathUnavailable, {}};
+                } else {
+                    hp->last_save = high_score::save_high_scores(*hs, hp->path);
+                    if (hp->last_save.ok()) {
+                        reg.ctx().erase<HighScoreDirtyTag>();
+                    }
+                }
+            }
         }
     } else if (score_exceeds_high_score) {
         current.value = score.score;
@@ -61,31 +54,17 @@ bool update_and_persist_high_score(entt::registry& reg) {
     return recorded_new_high_score;
 }
 
-void emit_terminal_feedback_game_over(entt::registry& reg, bool is_new_high_score) {
-    auto* disp = reg.ctx().find<entt::dispatcher>();
-    if (!disp) return;
-
-    disp->enqueue<PlaySfxEvent>({SFX::Crash});
-    disp->enqueue<PlayHapticEvent>({HapticEvent::DeathCrash});
-    if (is_new_high_score) {
-        disp->enqueue<PlayHapticEvent>({HapticEvent::NewHighScore});
-    }
-}
-
-void emit_terminal_feedback_song_complete(entt::registry& reg, bool is_new_high_score) {
-    auto* disp = reg.ctx().find<entt::dispatcher>();
-    if (!disp) return;
-
-    if (is_new_high_score) {
-        disp->enqueue<PlayHapticEvent>({HapticEvent::NewHighScore});
-    }
-}
-
 }  // namespace
 
 void game_state_enter_terminal_phase_game_over(entt::registry& reg) {
     const bool is_new_high_score = update_and_persist_high_score(reg);
-    emit_terminal_feedback_game_over(reg, is_new_high_score);
+    if (auto* disp = reg.ctx().find<entt::dispatcher>()) {
+        disp->enqueue<PlaySfxEvent>({SFX::Crash});
+        disp->enqueue<PlayHapticEvent>({HapticEvent::DeathCrash});
+        if (is_new_high_score) {
+            disp->enqueue<PlayHapticEvent>({HapticEvent::NewHighScore});
+        }
+    }
 
     enter_phase<GamePhaseGameOverTag>(reg);
 
@@ -97,7 +76,11 @@ void game_state_enter_terminal_phase_game_over(entt::registry& reg) {
 
 void game_state_enter_terminal_phase_song_complete(entt::registry& reg) {
     const bool is_new_high_score = update_and_persist_high_score(reg);
-    emit_terminal_feedback_song_complete(reg, is_new_high_score);
+    if (auto* disp = reg.ctx().find<entt::dispatcher>()) {
+        if (is_new_high_score) {
+            disp->enqueue<PlayHapticEvent>({HapticEvent::NewHighScore});
+        }
+    }
 
     enter_phase<GamePhaseSongCompleteTag>(reg);
 }


### PR DESCRIPTION
Closes #1488.

## Change
Drop 3 single-call anon-ns helpers:
- `persist_dirty_high_scores` (15 lines) — inlined into its sole caller `update_and_persist_high_score` as an `if (HighScoreDirtyTag)` cascade.
- `emit_terminal_feedback_game_over` (10 lines) — inlined at the call site in `game_state_enter_terminal_phase_game_over`.
- `emit_terminal_feedback_song_complete` (8 lines) — inlined at the call site in `game_state_enter_terminal_phase_song_complete`.

The two `emit_terminal_feedback_*` siblings differ structurally (game-over emits 3 events, song-complete only 1) so they are not templatable — inline rather than fold onto a single template.

`update_and_persist_high_score` remains in the anon namespace (it has 2 call sites — both terminal-phase entry functions).

## Verification
- `cmake --build build` clean under `-Wall -Wextra -Werror`.
- `./build/shapeshifter_tests`: **All tests passed (3370 assertions in 963 test cases)**.
- Net: +22/-39 lines.

Same single-call anon-ns cleanup theme as #1467 / #1471 / #1473 / #1475 / #1477 / #1479 / #1484 / #1485.