### PR TITLE
#1487 level_select_dynamic_spawn_system.cpp: inline 2 single-call anon-ns helpers (`diff_x_for`, `action_for_difficulty`)

### DIFF
--- a/app/systems/level_select_dynamic_spawn_system.cpp
+++ b/app/systems/level_select_dynamic_spawn_system.cpp
@@ -25,26 +25,15 @@ constexpr float kDiffBtnGap   = 30.0f;
 constexpr float kDiffStartX   = kCardX + 50.0f;
 constexpr float kDiffYOffset  = 120.0f;
 
+// Per Fabian Principle 1: indexed table, no switch on the discriminator.
+constexpr ActionId kDifficultyAction[content_config::DIFFICULTY_COUNT] = {
+    ActionId::DifficultyEasy,
+    ActionId::DifficultyMedium,
+    ActionId::DifficultyHard,
+};
+
 float card_y_for(int level_index) {
     return kCardStartY + static_cast<float>(level_index) * (kCardH + kCardGap);
-}
-
-float diff_x_for(int diff_index) {
-    return kDiffStartX +
-           static_cast<float>(diff_index) * (kDiffBtnW + kDiffBtnGap);
-}
-
-ActionId action_for_difficulty(int diff_index) {
-    // Per Fabian Principle 1: indexed table, no switch on the discriminator.
-    constexpr ActionId kRow[content_config::DIFFICULTY_COUNT] = {
-        ActionId::DifficultyEasy,
-        ActionId::DifficultyMedium,
-        ActionId::DifficultyHard,
-    };
-    if (diff_index < 0 || diff_index >= content_config::DIFFICULTY_COUNT) {
-        return ActionId::None;
-    }
-    return kRow[diff_index];
 }
 
 }  // namespace
@@ -84,11 +73,13 @@ void level_select_dynamic_spawn(entt::registry& reg) {
             reg.emplace<UiButtonTag>(e);
             reg.emplace<LevelIndex>(e, li);
             reg.emplace<DifficultyIndex>(e, di);
-            reg.emplace<UiPosition>(e, diff_x_for(di), diff_y);
+            reg.emplace<UiPosition>(e,
+                kDiffStartX + static_cast<float>(di) * (kDiffBtnW + kDiffBtnGap),
+                diff_y);
             reg.emplace<UiBounds>(e, kDiffBtnW, kDiffBtnH);
             auto& label = reg.emplace<UiLabel>(e);
             ui_label_set(label, content_config::DIFFICULTY_NAMES[di]);
-            reg.emplace<OnPress>(e, action_for_difficulty(di));
+            reg.emplace<OnPress>(e, kDifficultyAction[di]);
         }
     }
 }


### PR DESCRIPTION
Closes #1487.

## Change
Drop 2 single-call anon-ns helpers:
- `diff_x_for(int)` (4 lines) — inlined as a 2-line `kDiffStartX + di * (kDiffBtnW + kDiffBtnGap)` expression at the sole call site.
- `action_for_difficulty(int)` (12 lines) — the `kRow` constexpr lookup table is hoisted to anon-namespace scope as `kDifficultyAction`, preserving the Fabian Principle 1 comment. The function's bounds check is dropped as dead code — the caller loop is provably `0 <= di < DIFFICULTY_COUNT`. Inlined as `kDifficultyAction[di]` at the sole call site.

`card_y_for` stays — it has two call sites (L67 and L79 in the original).

## Verification
- `cmake --build build` clean under `-Wall -Wextra -Werror`.
- `./build/shapeshifter_tests`: **All tests passed (3370 assertions in 963 test cases)**.
- Net: +11/-20 lines.
- Fabian Principle 1 still satisfied — table-driven dispatch, no switch; comment moves with the table.

Same single-call anon-ns cleanup theme as #1467 / #1471 / #1473 / #1475 / #1477 / #1479 / #1484 / #1485.