### PR TITLE
#1492 player_movement_system.cpp: inline 2 single-call anon-ns helpers (tick_jumping / tick_sliding)

### DIFF
--- a/app/systems/player_movement_system.cpp
+++ b/app/systems/player_movement_system.cpp
@@ -9,46 +9,6 @@
 #include "../util/lane_utils.h"
 #include <raymath.h>
 
-namespace {
-
-// Tick all jumping entities: advance the parabolic-arc timer, update
-// y_offset, and remove the Jumping component when the jump lands
-// (firing the JumpLand haptic). Per Fabian, this is the "Jumping"
-// table's per-row transform; entities without a Jumping row are not
-// touched.
-void tick_jumping(entt::registry& reg, float dt) {
-    auto view = reg.view<PlayerTag, Jumping>();
-    for (auto [entity, jump] : view.each()) {
-        jump.timer -= dt;
-        const float half = constants::JUMP_DURATION / 2.0f;
-        const float t = constants::JUMP_DURATION - jump.timer;
-        const float normalized = t / half - 1.0f;
-        jump.y_offset = -constants::JUMP_HEIGHT * (1.0f - normalized * normalized);
-
-        if (jump.timer <= 0.0f) {
-            if (auto* disp = reg.ctx().find<entt::dispatcher>()) {
-                disp->enqueue<PlayHapticEvent>({HapticEvent::JumpLand});
-            }
-            reg.remove<Jumping>(entity);
-        }
-    }
-}
-
-// Tick all sliding entities: advance the slide timer and remove the
-// Sliding component when the slide completes. Slide has no vertical
-// offset — the visual squash is applied by the render system.
-void tick_sliding(entt::registry& reg, float dt) {
-    auto view = reg.view<PlayerTag, Sliding>();
-    for (auto [entity, slide] : view.each()) {
-        slide.timer -= dt;
-        if (slide.timer <= 0.0f) {
-            reg.remove<Sliding>(entity);
-        }
-    }
-}
-
-}  // namespace
-
 void player_movement_system(entt::registry& reg, float dt) {
     auto* song = reg.ctx().find<SongState>();
     const bool rhythm_mode = (song != nullptr && (song->playing || song->finished));
@@ -89,6 +49,34 @@ void player_movement_system(entt::registry& reg, float dt) {
     // Per-state vertical-motion transforms (issue #1202/#1204).
     // Grounded entities have neither Jumping nor Sliding, so no transform
     // runs for them.
-    tick_jumping(reg, dt);
-    tick_sliding(reg, dt);
+
+    // Tick all jumping entities: advance the parabolic-arc timer, update
+    // y_offset, and remove the Jumping component when the jump lands
+    // (firing the JumpLand haptic). Per Fabian, this is the "Jumping"
+    // table's per-row transform; entities without a Jumping row are not
+    // touched.
+    for (auto [entity, jump] : reg.view<PlayerTag, Jumping>().each()) {
+        jump.timer -= dt;
+        const float half = constants::JUMP_DURATION / 2.0f;
+        const float t = constants::JUMP_DURATION - jump.timer;
+        const float normalized = t / half - 1.0f;
+        jump.y_offset = -constants::JUMP_HEIGHT * (1.0f - normalized * normalized);
+
+        if (jump.timer <= 0.0f) {
+            if (auto* disp = reg.ctx().find<entt::dispatcher>()) {
+                disp->enqueue<PlayHapticEvent>({HapticEvent::JumpLand});
+            }
+            reg.remove<Jumping>(entity);
+        }
+    }
+
+    // Tick all sliding entities: advance the slide timer and remove the
+    // Sliding component when the slide completes. Slide has no vertical
+    // offset — the visual squash is applied by the render system.
+    for (auto [entity, slide] : reg.view<PlayerTag, Sliding>().each()) {
+        slide.timer -= dt;
+        if (slide.timer <= 0.0f) {
+            reg.remove<Sliding>(entity);
+        }
+    }
 }


### PR DESCRIPTION
Closes #1492.

## What

Inlines the two single-call anon-namespace helpers in
`app/systems/player_movement_system.cpp`:

- `tick_jumping(reg, dt)` (def lines 19–35, sole call site at line 92)
- `tick_sliding(reg, dt)` (def lines 40–48, sole call site at line 93)

Both helpers wrapped a single `reg.view<PlayerTag, X>()` and operated
per-row. The inlined views remain at the same point in the function, so
Fabian's table-per-state dispatch is preserved — only the helper
boundary disappears. Doc comments move down with the bodies so the
"per-row transform on the Jumping/Sliding table" intent stays visible
at the call site.

The file's anonymous namespace was used only for these two helpers and
is removed.

## Why

Continues the single-call helper sweep (#1485, #1484, #1483, #1479,
#1477, #1476, #1475, #1473, #1472, #1490, #1491). One fewer indirection
in a tight per-frame system path; one fewer function boundary to keep
in sync with the registry views it wraps.

## Diff stats

```
app/systems/player_movement_system.cpp | 72 ++++++++-----------------
1 file changed, 30 insertions(+), 42 deletions(-)
```

95 → 82 lines.

## Acceptance (issue #1492)

- ✅ `cmake --build build` clean, zero warnings.
- ✅ `./build/shapeshifter_tests` — 3370 assertions in 963 test cases passed.
- ✅ `grep -c '\btick_jumping\b\|\btick_sliding\b' app/systems/player_movement_system.cpp` → 0.
- ✅ `grep -n 'namespace {' app/systems/player_movement_system.cpp` → no matches.
- ✅ `python3 tools/check_enum_allowlist.py` → ok.

## Out of scope

- No logic changes.
- No view re-ordering, no consolidation across `Jumping`/`Sliding`
  tables — they remain two distinct per-row transforms.
- Main lane/morph loop is untouched.
