### PR TITLE
#1494 input_dispatcher.cpp: inline single-call warm_dispatcher_event_queues

### DIFF
--- a/app/systems/input_dispatcher.cpp
+++ b/app/systems/input_dispatcher.cpp
@@ -70,35 +70,6 @@ struct InputDispatcherConnections {
     }
 };
 
-void warm_dispatcher_event_queues(entt::dispatcher& disp) {
-    // Move first vector allocation out of the first gameplay input frame.
-    disp.enqueue<GoUpEvent>(GoUpEvent{});
-    disp.enqueue<GoDownEvent>(GoDownEvent{});
-    disp.enqueue<GoLeftEvent>(GoLeftEvent{});
-    disp.enqueue<GoRightEvent>(GoRightEvent{});
-    disp.enqueue<ShapePressCircleEvent>(ShapePressCircleEvent{});
-    disp.enqueue<ShapePressSquareEvent>(ShapePressSquareEvent{});
-    disp.enqueue<ShapePressTriangleEvent>(ShapePressTriangleEvent{});
-    disp.enqueue<MenuConfirmEvent>(MenuConfirmEvent{});
-    disp.enqueue<MenuRestartEvent>(MenuRestartEvent{});
-    disp.enqueue<MenuGoLevelSelectEvent>(MenuGoLevelSelectEvent{});
-    disp.enqueue<MenuGoMainMenuEvent>(MenuGoMainMenuEvent{});
-    disp.enqueue<MenuSelectLevelEvent>(MenuSelectLevelEvent{});
-    disp.enqueue<MenuSelectDiffEvent>(MenuSelectDiffEvent{});
-    disp.clear<GoUpEvent>();
-    disp.clear<GoDownEvent>();
-    disp.clear<GoLeftEvent>();
-    disp.clear<GoRightEvent>();
-    disp.clear<ShapePressCircleEvent>();
-    disp.clear<ShapePressSquareEvent>();
-    disp.clear<ShapePressTriangleEvent>();
-    disp.clear<MenuConfirmEvent>();
-    disp.clear<MenuRestartEvent>();
-    disp.clear<MenuGoLevelSelectEvent>();
-    disp.clear<MenuGoMainMenuEvent>();
-    disp.clear<MenuSelectLevelEvent>();
-    disp.clear<MenuSelectDiffEvent>();
-}
 }
 
 // game_state_system owns the fixed-step drain of the per-direction Go*Event
@@ -177,7 +148,33 @@ void wire_input_dispatcher(entt::registry& reg) {
     state->menu_go_main_menu_game_state =
         disp->sink<MenuGoMainMenuEvent>().connect<&game_state_handle_go_main_menu>(reg);
 
-    warm_dispatcher_event_queues(*disp);
+    // Move first vector allocation out of the first gameplay input frame.
+    disp->enqueue<GoUpEvent>(GoUpEvent{});
+    disp->enqueue<GoDownEvent>(GoDownEvent{});
+    disp->enqueue<GoLeftEvent>(GoLeftEvent{});
+    disp->enqueue<GoRightEvent>(GoRightEvent{});
+    disp->enqueue<ShapePressCircleEvent>(ShapePressCircleEvent{});
+    disp->enqueue<ShapePressSquareEvent>(ShapePressSquareEvent{});
+    disp->enqueue<ShapePressTriangleEvent>(ShapePressTriangleEvent{});
+    disp->enqueue<MenuConfirmEvent>(MenuConfirmEvent{});
+    disp->enqueue<MenuRestartEvent>(MenuRestartEvent{});
+    disp->enqueue<MenuGoLevelSelectEvent>(MenuGoLevelSelectEvent{});
+    disp->enqueue<MenuGoMainMenuEvent>(MenuGoMainMenuEvent{});
+    disp->enqueue<MenuSelectLevelEvent>(MenuSelectLevelEvent{});
+    disp->enqueue<MenuSelectDiffEvent>(MenuSelectDiffEvent{});
+    disp->clear<GoUpEvent>();
+    disp->clear<GoDownEvent>();
+    disp->clear<GoLeftEvent>();
+    disp->clear<GoRightEvent>();
+    disp->clear<ShapePressCircleEvent>();
+    disp->clear<ShapePressSquareEvent>();
+    disp->clear<ShapePressTriangleEvent>();
+    disp->clear<MenuConfirmEvent>();
+    disp->clear<MenuRestartEvent>();
+    disp->clear<MenuGoLevelSelectEvent>();
+    disp->clear<MenuGoMainMenuEvent>();
+    disp->clear<MenuSelectLevelEvent>();
+    disp->clear<MenuSelectDiffEvent>();
 }
 
 void unwire_input_dispatcher(entt::registry& reg) {


### PR DESCRIPTION
Closes #1494.

## What

Drops the 28-line `warm_dispatcher_event_queues(entt::dispatcher&)` helper from the anonymous namespace of `app/systems/input_dispatcher.cpp` (called from exactly one site — `wire_input_dispatcher`) and inlines its 13 enqueue + 13 clear calls at the call site, preserving the original intent comment. The `disp.` member access switches to `disp->` because the call site holds the dispatcher as an `entt::dispatcher*`.

The anonymous namespace stays — `InputDispatcherConnections` still lives there.

## Why

Exact mirror of #1485 (`warm_audio_haptic_dispatcher` in `audio_dispatcher.cpp`). Continues the single-call helper sweep: #1485 / #1484 / #1483 / #1479 / #1477 / #1476 / #1475 / #1473 / #1472 / #1490 / #1491 / #1493.

## Verification

```
$ cmake --build build --target shapeshifter shapeshifter_tests
…
[100%] Built target shapeshifter
[100%] Built target shapeshifter_tests
$ ./build/shapeshifter_tests
All tests passed (3370 assertions in 963 test cases)
```

Zero warnings. 3370/3370 baseline preserved.

## Diff

```
app/systems/input_dispatcher.cpp | 57 +++++++++++++------------------------
 1 file changed, 27 insertions(+), 30 deletions(-)
```
