### PR TITLE
#1495 gameplay_hud_bind_system.cpp: drop single-call bind_pos_matches

### DIFF
--- a/app/systems/gameplay_hud_bind_system.cpp
+++ b/app/systems/gameplay_hud_bind_system.cpp
@@ -49,10 +49,6 @@ struct GameplayHudBindContext {
     const CurrentSongHighScore* current;
 };
 
-bool bind_pos_matches(float x, float y, float ex, float ey) noexcept {
-    return ex == x && ey == y;
-}
-
 void bind_score(const GameplayHudBindContext& ctx, entt::registry& reg, entt::entity e, UiLabel& label) {
     if (ctx.display == nullptr) {
         ui_label_set(label, "");
@@ -132,7 +128,7 @@ void gameplay_hud_bind_system(entt::registry& reg) {
         const auto& pos = view.get<UiPosition>(entity);
         auto& label     = view.get<UiLabel>(entity);
         for (const auto& row : kGameplayHudSlots) {
-            if (bind_pos_matches(row.x, row.y, pos.x, pos.y)) {
+            if (pos.x == row.x && pos.y == row.y) {
                 row.fn(ctx, reg, entity, label);
                 break;
             }


### PR DESCRIPTION
Closes #1495.

## What

Drops the 1-line `bind_pos_matches(float, float, float, float) noexcept` wrapper from the anonymous namespace of `app/systems/gameplay_hud_bind_system.cpp` and uses the natural inline expression at the sole call site.

## Why

`gameplay_hud_bind_system.cpp` was the only `*_bind_system.cpp` file using a single-call wrapper for the slot-match check. The three siblings already use the inline form:

- `app/systems/game_over_scoreboard_bind_system.cpp:120` — `if (pos.x == row.x && pos.y == row.y) {`
- `app/systems/song_complete_scoreboard_bind_system.cpp:127` — same
- `app/systems/settings_screen_bind_system.cpp:118` — same

After this PR, all four `*_bind_system.cpp` files use the same shape. Continues the single-call helper sweep: #1485 / #1484 / #1483 / #1479 / #1477 / #1476 / #1475 / #1473 / #1472 / #1490 / #1491 / #1493.

## Behavior

The operand order swaps from `ex == x && ey == y` to `pos.x == row.x && pos.y == row.y`, but `==` is commutative on `float` (no NaN sentinels involved) so the comparison is bit-identical.

## Verification

```
$ cmake --build build --target shapeshifter shapeshifter_tests
…
[100%] Built target shapeshifter
[100%] Built target shapeshifter_tests
$ ./build/shapeshifter_tests
All tests passed (3370 assertions in 963 test cases)
```

Zero warnings. 3370/3370 baseline preserved.

## Diff

```
app/systems/gameplay_hud_bind_system.cpp | 6 +-----
 1 file changed, 1 insertion(+), 5 deletions(-)
```
