### PR TITLE
#1498 energy_system.cpp: inline single-call `request_energy_depleted_game_over`

### DIFF
--- a/app/systems/energy_system.cpp
+++ b/app/systems/energy_system.cpp
@@ -6,17 +6,6 @@
 #include "../constants.h"
 #include <raymath.h>
 
-namespace {
-
-void request_energy_depleted_game_over(entt::registry& reg) {
-    if (is_phase_transition_pending(reg)) return;
-
-    reg.ctx().insert_or_assign(EnergyDepletedDeath{});
-    request_phase_transition<NextPhaseGameOverTag>(reg);
-}
-
-}  // namespace
-
 void energy_system(entt::registry& reg, float dt) {
     if (!reg.ctx().contains<GamePhasePlayingTag>()) return;
     auto* energy = reg.ctx().find<EnergyState>();
@@ -41,8 +30,9 @@ void energy_system(entt::registry& reg, float dt) {
         pending.events.clear();
     }
 
-    if (song && energy->energy <= 0.0f) {
-        request_energy_depleted_game_over(reg);
+    if (song && energy->energy <= 0.0f && !is_phase_transition_pending(reg)) {
+        reg.ctx().insert_or_assign(EnergyDepletedDeath{});
+        request_phase_transition<NextPhaseGameOverTag>(reg);
     }
 
     // Smooth display toward actual energy


### PR DESCRIPTION
Closes #1498.

## Drift

`app/systems/energy_system.cpp` wrapped a 3-statement game-over-request sequence in an anonymous-namespace helper used at exactly one site — the same single-call helper pattern eradicated in #1490 / #1491 / #1493 / #1496 / #1497.

## Fix

Fold `request_energy_depleted_game_over`'s body (including its `is_phase_transition_pending` early-out) directly into the existing `if (song && energy->energy <= 0.0f)` block at the only call site. Drop the now-empty anonymous namespace.

```cpp
// Before
namespace {
void request_energy_depleted_game_over(entt::registry& reg) {
    if (is_phase_transition_pending(reg)) return;
    reg.ctx().insert_or_assign(EnergyDepletedDeath{});
    request_phase_transition<NextPhaseGameOverTag>(reg);
}
}  // namespace
...
if (song && energy->energy <= 0.0f) {
    request_energy_depleted_game_over(reg);
}

// After
if (song && energy->energy <= 0.0f && !is_phase_transition_pending(reg)) {
    reg.ctx().insert_or_assign(EnergyDepletedDeath{});
    request_phase_transition<NextPhaseGameOverTag>(reg);
}
```

Behavior is preserved: short-circuit evaluation makes the new predicate logically equivalent to the previous "call then early-return" structure.

## Validation

- `cmake --build build` — zero warnings.
- `./build/shapeshifter_tests` — 3370 assertions across 963 test cases pass (matches baseline).

## Acceptance criteria

- [x] `request_energy_depleted_game_over` is removed from `app/systems/energy_system.cpp`.
- [x] The (now empty) anonymous namespace is also removed.
- [x] Sole former call site does the work inline with the same observable effect.
- [x] `cmake --build build` succeeds with zero warnings.
- [x] `./build/shapeshifter_tests` passes (3370 assertions / 963 cases baseline).
