### PR TITLE
#1500 game_render_system.cpp: drop single-call `draw_meshes`

### DIFF
--- a/app/systems/game_render_system.cpp
+++ b/app/systems/game_render_system.cpp
@@ -35,14 +35,6 @@ static void draw_pass(const entt::registry& reg, const camera::ShapeMeshes& sm) 
     }
 }
 
-static void draw_meshes(const entt::registry& reg) {
-    const auto* sm = reg.ctx().find<camera::ShapeMeshes>();
-    if (!sm) return;
-    draw_pass<TagWorldPass>(reg, *sm);
-    draw_pass<TagEffectsPass>(reg, *sm);
-}
-
-
 void game_render_system(const entt::registry& reg, float /*alpha*/) {
     auto& camera = game_camera(reg).cam;
 
@@ -55,11 +47,14 @@ void game_render_system(const entt::registry& reg, float /*alpha*/) {
     floor_render_system(reg);
 
     if (game_render_should_draw_world_meshes(reg)) {
-        rlDrawRenderBatchActive();
-        rlDisableDepthTest();
-        draw_meshes(reg);
-        rlDrawRenderBatchActive();
-        rlEnableDepthTest();
+        if (const auto* sm = reg.ctx().find<camera::ShapeMeshes>()) {
+            rlDrawRenderBatchActive();
+            rlDisableDepthTest();
+            draw_pass<TagWorldPass>(reg, *sm);
+            draw_pass<TagEffectsPass>(reg, *sm);
+            rlDrawRenderBatchActive();
+            rlEnableDepthTest();
+        }
     }
 
     EndMode3D();


### PR DESCRIPTION
Closes #1500.

## Change

Removes `static void draw_meshes` from `app/systems/game_render_system.cpp` and inlines the two `draw_pass<>` template calls at the sole call site. The `ShapeMeshes` lookup is hoisted into the outer `game_render_should_draw_world_meshes` guard so the early-out semantics are preserved.

Mirrors the single-call helper sweep: #1485, #1490, #1491, #1493, #1496, #1497, #1502.

## Verification

- `cmake --build build` — zero warnings.
- `./build/shapeshifter_tests` — All tests passed (3370 assertions in 963 test cases) — baseline preserved.