### PR TITLE
#1501 design-docs: rename gameplay_hud_process_button_input -> ui_update_system

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -1077,7 +1077,7 @@ int main(int argc, char* argv[]) {
 
         // ── INPUT (once per frame, outside fixed loop) ──
         input_system(reg, raw_dt);
-        gameplay_hud_process_button_input(reg);
+        ui_update_system(reg);
         test_player_system(reg, raw_dt);
 
         // ── FIXED TIMESTEP LOOP ──────────────────────────────

--- a/design-docs/beatmap-integration.md
+++ b/design-docs/beatmap-integration.md
@@ -233,7 +233,7 @@ creates the standard runtime obstacle archetypes via the kind-specific
   │  PER-FRAME (variable dt — game_loop.cpp):                        │
   │  ✅ compute_screen_transform   (refresh letterbox + scale)      │
   │  ✅ input_system               (raylib → InputState + events)   │
-  │  ✅ gameplay_hud_process_button_input (HUD buttons → events)    │
+  │  ✅ ui_update_system                  (HUD buttons → events)    │
   │  ✅ test_player_system         (autoplay perception/planning)   │
   │       │                                                          │
   │       ▼  while (accumulator >= FIXED_DT) tick_fixed_systems(dt) │

--- a/design-docs/feature-specs.md
+++ b/design-docs/feature-specs.md
@@ -629,7 +629,7 @@ void obstacle_despawn_system(entt::registry& reg, float dt);
 Per-frame systems outside the fixed timestep:
 
 ```
-compute_screen_transform -> input_system -> gameplay_hud_process_button_input ->
+compute_screen_transform -> input_system -> ui_update_system ->
 test_player_system -> fixed timestep loop -> game_camera_system ->
 ui_camera_system -> game_render_system -> ui_render_system ->
 audio_system -> haptic_system

--- a/design-docs/tester-personas-tech-spec.md
+++ b/design-docs/tester-personas-tech-spec.md
@@ -105,7 +105,7 @@
 ```cpp
 // ── OUTSIDE fixed timestep (once per frame) ─────────
 input_system(reg, raw_dt);          // Phase 0: polls raylib
-gameplay_hud_process_button_input(reg);
+ui_update_system(reg);
 test_player_system(reg, raw_dt);    // Phase 0.5: ★ NEW — injects AI input
 
 // ── INSIDE fixed timestep loop ──────────────────────
@@ -126,7 +126,7 @@ while (accumulator >= FIXED_DT) {
 ## System Dependency Chain
 
 ```
-  input_system ──▶ gameplay_hud_process_button_input ──▶ test_player_system ──▶ game_state_system ──▶ player input handlers
+  input_system ──▶ ui_update_system ──▶ test_player_system ──▶ game_state_system ──▶ player input handlers
        │                │                      │
     clears           writes                 reads
     key_* flags      key_* flags           key_* flags


### PR DESCRIPTION
Closes #1501.

## Change

`gameplay_hud_process_button_input` no longer exists in `app/` — the HUD button-input path was folded into `ui_update_system` (`app/systems/ui_update_system.{h,cpp}`). This PR replaces the 5 stale references in `design-docs/` with the current name:

- `design-docs/feature-specs.md:632` — per-frame pipeline list
- `design-docs/architecture.md:1080` — main-loop code sketch
- `design-docs/beatmap-integration.md:236` — frame-pipeline ASCII box (padded to preserve right `│` border alignment at col 68, matching peer rows)
- `design-docs/tester-personas-tech-spec.md:108` — main-loop code sketch
- `design-docs/tester-personas-tech-spec.md:129` — system dependency chain (existing column markers / labels at lines 130-134 still align with the new shorter name)

The historical-context comments in `app/tags/tags.h:326` and `app/systems/ui_update_system.cpp:361` are intentionally left alone — they document the migration from the old name.

## Verification

- `grep -r 'gameplay_hud_process_button_input' design-docs/` — no matches.
- `grep -r 'ui_update_system' design-docs/` — includes the 5 updated locations alongside the pre-existing references.
- No code or test files modified, no new doc files created (diff stat: `4 files changed, 5 insertions(+), 5 deletions(-)`).