### PR TITLE
#1508 play_session.cpp: inline 2 single-call anon-ns helpers (spawn_session_player, count_result_notes)

### DIFF
--- a/app/systems/play_session.cpp
+++ b/app/systems/play_session.cpp
@@ -27,20 +27,8 @@
 
 namespace {
 
-// Session setup owns when a player is spawned; player_entity owns how.
-void spawn_session_player(entt::registry& reg) {
-    create_player_entity(reg);
-}
-
 bool is_runtime_allowed_validation_error(const BeatMapError& error) {
     return error.message == "Different-shape gates must be >= 3 beats apart";
-}
-
-int count_result_notes(const BeatMap& beatmap) {
-    // Per-(kind, shape) tables (#1202/#1204): result-counted notes are the
-    // scoring-eligible kinds — ShapeGate + SplitPath. OnsetMarker
-    // entries are non-scorable cues and don't contribute.
-    return static_cast<int>(beat_map_required_count(beatmap));
 }
 
 bool load_runtime_beat_map(const char* path,
@@ -254,7 +242,10 @@ void setup_play_session(entt::registry& reg) {
     assign_or_emplace_ctx(reg, EnergyState{});
     {
         SongResults results{};
-        results.total_notes = count_result_notes(beatmap);
+        // Per-(kind, shape) tables (#1202/#1204): result-counted notes are
+        // the scoring-eligible kinds — ShapeGate + SplitPath. OnsetMarker
+        // entries are non-scorable cues and don't contribute.
+        results.total_notes = static_cast<int>(beat_map_required_count(beatmap));
         assign_or_emplace_ctx(reg, results);
     }
     // Clear any death-cause and end-screen-choice tags carried over from a
@@ -272,7 +263,8 @@ void setup_play_session(entt::registry& reg) {
         current.value = session ? high_score::get_current_high_score(*hs, *session) : 0;
     }
 
-    spawn_session_player(reg);
+    // play_session owns when a player is spawned; player_entity owns how.
+    create_player_entity(reg);
     // Transition game state
     enter_phase<GamePhasePlayingTag>(reg);
 }


### PR DESCRIPTION
Closes #1508.

## What

Drop two single-call anonymous-namespace wrappers in
`app/systems/play_session.cpp` and inline their bodies at the unique
call sites:

- `spawn_session_player(entt::registry& reg)` → `create_player_entity(reg)`
- `count_result_notes(const BeatMap& beatmap)` → `static_cast<int>(beat_map_required_count(beatmap))`

Both wrappers were 1-line trampolines with exactly one call site each
(`grep -rn spawn_session_player\|count_result_notes app/ tests/`).

## Why

Same pattern as the recently merged single-call inline drops in the
recent cleanup wave:
- #1486 / #1489 (`test_player_session.cpp` — 2 helpers)
- #1487 / #1491 (`level_select_dynamic_spawn_system.cpp` — 2 helpers)
- #1488 / #1490 (`game_state_terminal_phase_system.cpp` — 3 helpers)
- #1492 / #1493 (`player_movement_system.cpp` — 2 helpers)
- #1494 / #1496, #1498 / #1502, #1499 / #1503, #1500 / #1504, #1505

Each removed an anon-ns indirection that no longer paid for itself.

## Diff shape

```
app/systems/play_session.cpp | 20 ++++++--------------
 1 file changed, 6 insertions(+), 14 deletions(-)
```

The explanatory comments stay attached to the data:

- "play_session owns when a player is spawned; player_entity owns how"
  moves to the `create_player_entity(reg)` call site.
- The per-(kind, shape) #1202/#1204 rationale ("result-counted notes
  are the scoring-eligible kinds — ShapeGate + SplitPath; OnsetMarker
  entries are non-scorable cues") moves to the
  `results.total_notes = ...` line so the design lineage stays bound
  to the value.

## Verification

- [x] Build warning-free under `-Wall -Wextra -Werror`.
- [x] Full test suite passes: 3370 assertions in 963 test cases.
- [x] No other call sites in `app/` or `tests/` reference the removed names.

## Non-goals

- Other anon-ns helpers in this TU (`is_runtime_allowed_validation_error`, `load_runtime_beat_map`, `assign_or_emplace_ctx`, `enter_phase`, …) are unchanged — they either have multiple call sites or aren't trivial wrappers.