### PR TITLE
#1506 main.cpp: inline single-call `parse_level_arg` anon-ns helper

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -7,20 +7,6 @@
 
 namespace {
 
-int parse_level_arg(const char* value) {
-    if (value[0] >= '1' && value[0] < static_cast<char>('1' + content_config::LEVEL_COUNT)
-        && value[1] == '\0') {
-        return value[0] - '1';
-    }
-    for (int i = 0; i < content_config::LEVEL_COUNT; ++i) {
-        if (std::strcmp(value, content_config::LEVEL_KEYS[i]) == 0 ||
-            std::strcmp(value, content_config::LEVELS[i].title) == 0) {
-            return i;
-        }
-    }
-    return -1;
-}
-
 void print_level_help() {
     std::fprintf(stderr, "Known levels:");
     for (int i = 0; i < content_config::LEVEL_COUNT; ++i) {
@@ -80,7 +66,20 @@ int main(int argc, char* argv[]) {
                 return 1;
             }
             ++i;
-            selected_level = parse_level_arg(argv[i]);
+            const char* value = argv[i];
+            selected_level = -1;
+            if (value[0] >= '1' && value[0] < static_cast<char>('1' + content_config::LEVEL_COUNT)
+                && value[1] == '\0') {
+                selected_level = value[0] - '1';
+            } else {
+                for (int j = 0; j < content_config::LEVEL_COUNT; ++j) {
+                    if (std::strcmp(value, content_config::LEVEL_KEYS[j]) == 0 ||
+                        std::strcmp(value, content_config::LEVELS[j].title) == 0) {
+                        selected_level = j;
+                        break;
+                    }
+                }
+            }
             if (selected_level < 0) {
                 std::fprintf(stderr, "Unknown level: %s\n", argv[i]);
                 print_level_help();


### PR DESCRIPTION
Closes #1506.

## What

Drops the single-call anonymous-namespace wrapper `parse_level_arg` in `app/main.cpp` and folds its body inline at the unique call site inside the `--level` argv branch.

## Why

Same pattern as the recently merged single-call inline drops:
- #1494 / #1496 (`input_dispatcher.cpp`)
- #1495 / #1497 (`gameplay_hud_bind_system.cpp`)
- #1498 / #1502 (`energy_system.cpp`)
- #1499 / #1503 (`obstacle_render_entity.cpp`)
- #1500 / #1504 (`game_render_system.cpp`)
- #1508 / #1509 (`play_session.cpp`)

`grep -n parse_level_arg app/ tests/ -r` confirmed exactly one definition + one call site, both inside `app/main.cpp`.

## Diff shape

```
app/main.cpp | 29 ++++++++++++++---------------
 1 file changed, 14 insertions(+), 15 deletions(-)
```

The sibling helpers `print_level_help` (2 call sites) and `missing_option_value` (3 call sites) stay in the anon namespace.

## Verification

- [x] Build warning-free under `-Wall -Wextra -Werror`.
- [x] Full test suite passes: 3370 assertions in 963 test cases.
- [x] Smoke: `./build/shapeshifter --level NotALevel` still prints "Unknown level: NotALevel" + known-levels help and exits 1.
- [x] `grep` confirmed no other refs to `parse_level_arg` remain.

## Non-goals

- Do not touch `print_level_help` or `missing_option_value` (multiple callers each).
- No CLI semantic changes — error messages, exit codes, and argument parsing flow are preserved.