### PR TITLE
#1507 gameplay_hud_bind_system.cpp: drop stale `legacy controller` refs near chain thresholds

### DIFF
--- a/app/systems/gameplay_hud_bind_system.cpp
+++ b/app/systems/gameplay_hud_bind_system.cpp
@@ -33,11 +33,11 @@ constexpr float kChainAlphaRegular       = 0.7f;
 constexpr float kChainAlphaMeaningful    = 0.95f;
 constexpr float kEnergyLabelAlpha        = 0.8f;
 
-// Chain threshold: a "meaningful" chain is the explicit `>= 5` branch in
-// the legacy controller (drives the "!" suffix, the larger font, and the
-// background pulse halo).
+// "Meaningful" chain threshold: `chain >= 5` switches `bind_chain` to the
+// higher-tier font + alpha and adds the `ChainBgPulseTag` halo + "!" suffix.
 constexpr int kChainMeaningfulThreshold = 5;
-// Chain visibility threshold (legacy `score->chain_count >= 2`).
+// Chain visibility threshold: below `chain >= 2`, `bind_chain` clears the
+// label and drops the background-pulse tag.
 constexpr int kChainVisibleThreshold = 2;
 
 // Per-binder prefix (`GameplayHud*`) avoids an anonymous-namespace ODR


### PR DESCRIPTION
Closes #1507.

## What

Rewrites the two adjacent comments above `kChainMeaningfulThreshold` / `kChainVisibleThreshold` (lines 36-41) so they describe what each threshold drives in the current `bind_chain` binder, instead of attributing them to the pre-#1308 screen controller (whose files no longer exist).

```cpp
// before
// Chain threshold: a "meaningful" chain is the explicit `>= 5` branch in
// background pulse halo).
constexpr int kChainMeaningfulThreshold = 5;
// Chain visibility threshold (legacy `score->chain_count >= 2`).
constexpr int kChainVisibleThreshold = 2;

// after
// "Meaningful" chain threshold: `chain >= 5` switches `bind_chain` to the
constexpr int kChainMeaningfulThreshold = 5;
// Chain visibility threshold: below `chain >= 2`, `bind_chain` clears the
// label and drops the background-pulse tag.
constexpr int kChainVisibleThreshold = 2;
```

The numeric values (`5`, `2`) and constant names are unchanged.

## Why

Same pattern as the previously merged historical-attribution drops:
- #1442 / #1444 (5 app/ files)
- #1447 / #1450 (2 test files)
- #1457 / #1459 (4 files)
- #1460 / #1461 (2 files)
- #1464 / #1465 (3 files)
- #1468 / #1470 (4 files)

`app/ui/screen_controllers/` was deleted in #1308. `score->chain_count >= 2` is no longer a code path elsewhere — it lives in this binder.

## Diff shape

```
app/systems/gameplay_hud_bind_system.cpp | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)
```

## Verification

- [x] No "legacy controller" / "legacy \`…\`" wording on lines 36-41.
- [x] Comments describe the constants' effect in the current binder.
- [x] Numeric values and constant names unchanged.
- [x] Build warning-free under `-Wall -Wextra -Werror`.
- [x] Full test suite: 3370 assertions in 963 test cases.

## Non-goals

- Line 30 (`legacy \`GuiSetAlpha(…)\` overrides`) is left alone — that one refers to a raygui API, not the deleted screen controller. Different "legacy".
- No sibling `*_bind_system.{h,cpp}` files are touched in this issue; per the issue body, a separate triage pass decides whether each surviving "legacy controller" reference still serves as design rationale.