### PR TITLE
#1513 scoreboard bind comments: drop stale "legacy controller" historical-attribution clause

### DIFF
--- a/app/systems/game_over_scoreboard_bind_system.cpp
+++ b/app/systems/game_over_scoreboard_bind_system.cpp
@@ -11,12 +11,11 @@
 namespace {
 
 // Bind context — owns the per-frame singleton reads so the per-slot
-// `bind_*` functions are pure transforms over their slot's `UiLabel`. The
-// optional pointer mirrors the legacy controller's `ctx().find<...>()`
-// semantics: a `TerminalResultState` may be absent during the Game Over
-// debounce window before `game_state_enter_terminal_phase_game_over`
-// populates it. `EnergyDepletedDeath` is a presence-only ctx tag (no
-// payload) so we carry a bool for it.
+// `bind_*` functions are pure transforms over their slot's `UiLabel`.
+// `TerminalResultState` may be absent during the Game Over debounce
+// window before `game_state_enter_terminal_phase_game_over` populates
+// it, so it is carried as a nullable pointer. `EnergyDepletedDeath`
+// is a presence-only ctx tag (no payload) so we carry a bool for it.
 //
 // Per-binder prefix (`GameOver*`) avoids an anonymous-namespace ODR
 // collision with the sibling `*_bind_system.cpp` files when CMake Unity

--- a/app/systems/song_complete_scoreboard_bind_system.cpp
+++ b/app/systems/song_complete_scoreboard_bind_system.cpp
@@ -13,11 +13,11 @@
 namespace {
 
 // Bind context — owns the per-frame singleton reads so the per-slot
-// `bind_*` functions are pure transforms over their slot's `UiLabel`. The
-// optional pointers mirror the legacy controller's `ctx().find<...>()`
-// semantics: a SongResults / EnergyState / TerminalResultState may be
+// `bind_*` functions are pure transforms over their slot's `UiLabel`.
+// `SongResults`, `EnergyState`, and `TerminalResultState` may each be
 // absent during the Song Complete debounce window before
-// `game_state_enter_terminal_phase_song_complete` populates them.
+// `game_state_enter_terminal_phase_song_complete` populates them, so
+// they are carried as nullable pointers.
 //
 // Per-binder prefix (`SongComplete*`) avoids an anonymous-namespace ODR
 // collision with the sibling `*_bind_system.cpp` files when CMake Unity


### PR DESCRIPTION
Closes #1513.

## Summary

Drops the stale "legacy controller's `ctx().find<...>()` semantics" historical-attribution clause from the two scoreboard bind-context comments in:

- `app/systems/song_complete_scoreboard_bind_system.cpp` (lines 13–24)
- `app/systems/game_over_scoreboard_bind_system.cpp` (lines 13–19)

The pre-#1308 screen controller no longer exists; `ctx().find<...>()` is not a code path in this repo anymore. The surviving invariant ("nullable during the debounce window") is the relevant fact for readers and is retained unchanged.

Mirrors the recently merged historical-attribution drops: #1442 / #1444, #1447 / #1450, #1457 / #1459, #1460 / #1461, #1464 / #1465, #1468 / #1470, #1507 / #1511.

## Diff shape

```
app/systems/game_over_scoreboard_bind_system.cpp     | 11 +++++------
app/systems/song_complete_scoreboard_bind_system.cpp |  8 ++++----
```

## Verification

- `cmake --build build` — zero warnings under `-Wall -Wextra -Werror`.
- `./build/shapeshifter_tests` — 3370 assertions in 963 test cases, all pass.
- Surrounding ODR / Unity prefix comment block (issue #1329) and per-binder prefix rationale stay intact.
- `SongCompleteBindContext` / `GameOverBindContext` struct layouts unchanged.

## Non-goals (respected)

- Per-binder anon-namespace ODR/Unity prefix comment is unchanged.
- No struct-layout, behavioural, or runtime changes.
- Other `legacy controller` references elsewhere in `app/` are out of scope per the issue.
