### PR TITLE
#1512 settings_screen_bind_system.cpp: inline single-call `format_offset` anon-ns helper

### DIFF
--- a/app/systems/settings_screen_bind_system.cpp
+++ b/app/systems/settings_screen_bind_system.cpp
@@ -39,12 +39,6 @@ struct SettingsBindContext {
     bool    motion_on;
 };
 
-void format_offset(int16_t offset_ms, UiLabel& label) {
-    char buf[16];
-    std::snprintf(buf, sizeof(buf), "%+d ms", static_cast<int>(offset_ms));
-    ui_label_set(label, buf);
-}
-
 void format_toggle(UiLabel& label, const char* name, bool on) {
     // Two-cue ON/OFF (issue #390): icon-prefix `[X]` vs `[ ]` plus the
     // explicit ON/OFF suffix. The colour cue lives in `ui_render_system`
@@ -57,7 +51,10 @@ void format_toggle(UiLabel& label, const char* name, bool on) {
 
 void bind_audio_offset(const SettingsBindContext& ctx, entt::registry& /*reg*/,
                        entt::entity /*e*/, UiLabel& label) {
-    format_offset(ctx.audio_offset_ms, label);
+    char buf[16];
+    std::snprintf(buf, sizeof(buf), "%+d ms",
+                  static_cast<int>(ctx.audio_offset_ms));
+    ui_label_set(label, buf);
 }
 
 // Shared body for the two toggle binders below. Differs across the two


### PR DESCRIPTION
Closes #1512.

## Summary

Inlines the single-call anonymous-namespace helper `format_offset` in `app/systems/settings_screen_bind_system.cpp` (previously lines 42–46) into its sole caller `bind_audio_offset`.

Before:

```cpp
void format_offset(int16_t offset_ms, UiLabel& label) {
    char buf[16];
    std::snprintf(buf, sizeof(buf), "%+d ms", static_cast<int>(offset_ms));
    ui_label_set(label, buf);
}

void bind_audio_offset(const SettingsBindContext& ctx, entt::registry& /*reg*/,
                       entt::entity /*e*/, UiLabel& label) {
    format_offset(ctx.audio_offset_ms, label);
}
```

After:

```cpp
void bind_audio_offset(const SettingsBindContext& ctx, entt::registry& /*reg*/,
                       entt::entity /*e*/, UiLabel& label) {
    char buf[16];
    std::snprintf(buf, sizeof(buf), "%+d ms",
                  static_cast<int>(ctx.audio_offset_ms));
    ui_label_set(label, buf);
}
```

`grep -rn "\bformat_offset\b" app/ tests/` post-fix confirms zero remaining hits.

Mirrors the recently merged single-call inline drops: #1494 / #1496, #1495 / #1497, #1498 / #1502, #1499 / #1503, #1500 / #1504, #1508 / #1509, #1506 / #1510.

## Diff shape

```
app/systems/settings_screen_bind_system.cpp | 11 ++++-------
1 file changed, 4 insertions(+), 7 deletions(-)
```

## Verification

- `cmake --build build` — zero warnings under `-Wall -Wextra -Werror`.
- `./build/shapeshifter_tests` — 3370 assertions in 963 test cases, all pass.
- Settings screen "AUDIO OFFSET: +X ms" / "-X ms" rendering unchanged at runtime (same `snprintf` format string + same `ui_label_set` call, just inlined).

## Non-goals (respected)

- `format_toggle` (sibling helper, also single-call) retained — its body carries the issue-#390 two-cue ON/OFF comment that warrants a separate evaluation pass.
- `bind_toggle_impl` (called from 2 binders) unchanged.
- No CLI / data / behavioural changes.
