### PR TITLE
#1516 game_state_system.cpp: inline single-call `reset_web_playing_lane_marker` anon-ns helper

### DIFF
--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -26,10 +26,6 @@ WasmSmokeLaneMarkerState& wasm_smoke_lane_marker_state(entt::registry& reg) {
     return reg.ctx().emplace<WasmSmokeLaneMarkerState>();
 }
 
-void reset_web_playing_lane_marker(entt::registry& reg) {
-    wasm_smoke_lane_marker_state(reg).last_lane = -1;
-}
-
 void update_web_playing_lane_marker(entt::registry& reg) {
     auto& marker = wasm_smoke_lane_marker_state(reg);
     if (!reg.ctx().contains<GamePhasePlayingTag>()) {
@@ -166,7 +162,7 @@ void game_state_system(entt::registry& reg, float dt) {
         clear_next_phase_tags(reg);
 #if defined(__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)
         if (!reg.ctx().contains<GamePhasePlayingTag>()) {
-            reset_web_playing_lane_marker(reg);
+            wasm_smoke_lane_marker_state(reg).last_lane = -1;
         }
 #endif
         return;


### PR DESCRIPTION
Closes #1516.

## Summary

Inlines the single-call anonymous-namespace helper `reset_web_playing_lane_marker` in `app/systems/game_state_system.cpp` (previously lines 29–31) into its sole caller at game_state_system, line 169.

Before:

```cpp
void reset_web_playing_lane_marker(entt::registry& reg) {
    wasm_smoke_lane_marker_state(reg).last_lane = -1;
}

// ... later, inside the WASM smoke-marker #if block:
if (!reg.ctx().contains<GamePhasePlayingTag>()) {
    reset_web_playing_lane_marker(reg);
}
```

After:

```cpp
if (!reg.ctx().contains<GamePhasePlayingTag>()) {
    wasm_smoke_lane_marker_state(reg).last_lane = -1;
}
```

`grep -rn "\breset_web_playing_lane_marker\b" app/ tests/` post-fix confirms zero remaining hits.

Mirrors the recently merged single-call inline drops: #1494/#1496, #1495/#1497, #1498/#1502, #1500/#1504, #1506/#1510, #1508/#1509, #1512/#1515.

## Diff shape

```
app/systems/game_state_system.cpp | 6 +-----
1 file changed, 1 insertion(+), 5 deletions(-)
```

## Verification

- `cmake --build build` — zero warnings under `-Wall -Wextra -Werror`.
- `./build/shapeshifter_tests` — 3370 assertions in 963 test cases, all pass.
- Native build skips the `#if __EMSCRIPTEN__ && SHAPESHIFTER_WASM_SMOKE_MARKERS` block; the WASM build path is symmetric (definition + call site both removed; the replacement uses the existing `wasm_smoke_lane_marker_state` shim already linked in the same file).

## Non-goals (respected)

- `wasm_smoke_lane_marker_state` retained (2 callers — `reset_*` inline path and `update_web_playing_lane_marker`; legitimate lookup-or-emplace shim).
- `update_web_playing_lane_marker` (sibling, ~30-line body with EM_ASM call) unchanged — substantive abstraction retained.
- No CLI / data / behavioural changes.
