### PR TITLE
#1517 game_phase_transition.cpp: inline single-call `update_web_title` anon-ns helper

### DIFF
--- a/app/systems/game_phase_transition.cpp
+++ b/app/systems/game_phase_transition.cpp
@@ -21,14 +21,18 @@ void set_web_title(const char* phase_name) {
         title.c_str());
 }
 
-// Per Fabian's existential processing (issue #1202/#1204, PR G): the former
-// eight-case `switch (phase)` over the WASM smoke title is replaced by per-tag
-// transforms on the `GamePhase*Tag` ctx mirror seeded by `enter_phase<...>()`.
-// The mirror invariant pinned by `tests/test_game_phase_tags.cpp` guarantees
-// that exactly one `GamePhase*Tag` is present at any time, so these eight
-// `if` blocks are mutually exclusive even without `else` chaining and
-// dispatch on tag presence rather than on an enum compare.
-void update_web_title(entt::registry& reg) {
+}  // namespace
+#endif
+
+void notify_phase_changed(entt::registry& reg) {
+#if defined(__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)
+    // Per Fabian's existential processing (issue #1202/#1204, PR G): the former
+    // eight-case `switch (phase)` over the WASM smoke title is replaced by per-tag
+    // transforms on the `GamePhase*Tag` ctx mirror seeded by `enter_phase<...>()`.
+    // The mirror invariant pinned by `tests/test_game_phase_tags.cpp` guarantees
+    // that exactly one `GamePhase*Tag` is present at any time, so these eight
+    // `if` blocks are mutually exclusive even without `else` chaining and
+    // dispatch on tag presence rather than on an enum compare.
     const auto& ctx = reg.ctx();
     if (ctx.contains<GamePhaseTitleTag>())        { set_web_title("Title"); }
     if (ctx.contains<GamePhaseLevelSelectTag>())  { set_web_title("LevelSelect"); }
@@ -38,14 +42,6 @@ void update_web_title(entt::registry& reg) {
     if (ctx.contains<GamePhaseSongCompleteTag>()) { set_web_title("SongComplete"); }
     if (ctx.contains<GamePhaseSettingsTag>())     { set_web_title("Settings"); }
     if (ctx.contains<GamePhaseTutorialTag>())     { set_web_title("Tutorial"); }
-}
-
-}  // namespace
-#endif
-
-void notify_phase_changed(entt::registry& reg) {
-#if defined(__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)
-    update_web_title(reg);
 #else
     (void)reg;
 #endif


### PR DESCRIPTION
Closes #1517.

## Summary

Inlines the single-call anonymous-namespace helper `update_web_title` in `app/systems/game_phase_transition.cpp` (previously lines 24–41) into its sole caller `notify_phase_changed`.

Before:

```cpp
// Per Fabian's existential processing (issue #1202/#1204, PR G): the former
// eight-case `switch (phase)` over the WASM smoke title is replaced by per-tag
// transforms on the `GamePhase*Tag` ctx mirror seeded by `enter_phase<...>()`.
// The mirror invariant pinned by `tests/test_game_phase_tags.cpp` guarantees
// that exactly one `GamePhase*Tag` is present at any time, so these eight
// `if` blocks are mutually exclusive even without `else` chaining and
// dispatch on tag presence rather than on an enum compare.
void update_web_title(entt::registry& reg) {
    const auto& ctx = reg.ctx();
    if (ctx.contains<GamePhaseTitleTag>())        { set_web_title("Title"); }
    if (ctx.contains<GamePhaseLevelSelectTag>())  { set_web_title("LevelSelect"); }
    // ...6 more rows...
}

}  // namespace
#endif

void notify_phase_changed(entt::registry& reg) {
#if defined(__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)
    update_web_title(reg);
#else
    (void)reg;
#endif
}
```

After:

```cpp
}  // namespace
#endif

void notify_phase_changed(entt::registry& reg) {
#if defined(__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)
    // Per Fabian's existential processing (issue #1202/#1204, PR G): the former
    // eight-case `switch (phase)` over the WASM smoke title is replaced by per-tag
    // transforms on the `GamePhase*Tag` ctx mirror seeded by `enter_phase<...>()`.
    // The mirror invariant pinned by `tests/test_game_phase_tags.cpp` guarantees
    // that exactly one `GamePhase*Tag` is present at any time, so these eight
    // `if` blocks are mutually exclusive even without `else` chaining and
    // dispatch on tag presence rather than on an enum compare.
    const auto& ctx = reg.ctx();
    if (ctx.contains<GamePhaseTitleTag>())        { set_web_title("Title"); }
    if (ctx.contains<GamePhaseLevelSelectTag>())  { set_web_title("LevelSelect"); }
    if (ctx.contains<GamePhasePlayingTag>())      { set_web_title("Playing"); }
    if (ctx.contains<GamePhasePausedTag>())       { set_web_title("Paused"); }
    if (ctx.contains<GamePhaseGameOverTag>())     { set_web_title("GameOver"); }
    if (ctx.contains<GamePhaseSongCompleteTag>()) { set_web_title("SongComplete"); }
    if (ctx.contains<GamePhaseSettingsTag>())     { set_web_title("Settings"); }
    if (ctx.contains<GamePhaseTutorialTag>())     { set_web_title("Tutorial"); }
#else
    (void)reg;
#endif
}
```

`grep -rn "\bupdate_web_title\b" app/ tests/` post-fix confirms zero remaining hits.

`set_web_title` stays in the anonymous namespace — it is the EM_ASM-wrapping utility called 8× by the inlined dispatch and is genuine reusable abstraction.

Mirrors the recently merged single-call inline drops: #1494/#1496, #1495/#1497, #1498/#1502, #1500/#1504, #1506/#1510, #1508/#1509, #1512/#1515, #1516/#1518.

## Diff shape

```
app/systems/game_phase_transition.cpp | 28 ++++++++++++----------------
1 file changed, 12 insertions(+), 16 deletions(-)
```

## Verification

- `cmake --build build` — zero warnings under `-Wall -Wextra -Werror`.
- `./build/shapeshifter_tests` — 3370 assertions in 963 test cases, all pass.
- Native build skips the `#if __EMSCRIPTEN__ && SHAPESHIFTER_WASM_SMOKE_MARKERS` blocks symmetrically (definition + caller both inlined together; no orphan helper warning).
- WASM build path produces identical `document.title` behaviour: same `set_web_title` call for each of the 8 `GamePhase*Tag` ctx slots.

## Non-goals (respected)

- `set_web_title` retained in the anonymous namespace (EM_ASM-wrapping utility, 8 callers post-inline; legitimate abstraction).
- The 8-row `if (ctx.contains<GamePhase*Tag>())` dispatch table preserved verbatim — per the existing Fabian-rationale comment, this is the intended structure; collapsing would re-introduce a `switch`.
- Non-WASM `(void)reg;` branch unchanged.
- No CLI / data / behavioural changes.
