### PR TITLE
app/game_loop.cpp: inline single-call `unload_text_fonts` anon-ns helper

### DIFF
--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -104,10 +104,6 @@ bool load_default_text_fonts(TextContext& ctx) {
     return false;
 }
 
-void unload_text_fonts(TextContext& ctx) {
-    ctx.release();
-}
-
 // Status → (log_level, message_template) lookup table. Per Fabian's
 // existential processing (issue #1277), behavior dispatch on the `Status`
 // discriminator is replaced with a value→data lookup — same shape as the
@@ -398,7 +394,7 @@ void game_loop_shutdown(entt::registry& reg) {
     }
     camera::shutdown(reg);
     if (auto* text_ctx = reg.ctx().find<TextContext>()) {
-        unload_text_fonts(*text_ctx);
+        text_ctx->release();
     }
     sfx_bank_unload(reg);
     platform::haptics::shutdown(reg);


### PR DESCRIPTION
Closes #1521.

The anon-ns `unload_text_fonts(TextContext&)` was a single-statement passthrough to `TextContext::release()` with one call site at `game_loop_shutdown`. Inlined the call (`text_ctx->release();`) and deleted the helper.

Mirrors the recent single-call-helper cleanup pattern: #1517 / #1516 / #1512 / #1506 / #1508 / #1494 / #1495.

## Validation
- `cmake --build build` — zero warnings.
- All 963 tests / 3370 assertions pass (`./build/shapeshifter_tests`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>