### PR TITLE
design-docs: replace ShapeWindow.phase field refs with per-phase tag refs (3 sites)

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -1273,13 +1273,13 @@ int main(int argc, char* argv[]) {
     │   // 1. Process shape button (rhythm mode)             │
     │   player_input_handle_press_square(                    │
     │       ShapePressSquareEvent) {                         │
-    │       ShapeWindow.target_shape = Shape::Square;        │──▶ ShapeWindow
-    │       ShapeWindow.phase        = MorphIn;              │    { target: Square,
-    │       PlayerShape.morph_t      = 0.0f;                 │      phase: MorphIn }
-    │       disp.enqueue(PlaySfxEvent{ShapeShift});          │
-    │       // PlayerShape.current is promoted to            │──▶ PlayerShape
-    │       // target_shape once MorphIn completes           │    { current: Square,
-    │       // (shape_window_activation_system).             │      morph_t: 1.0 }
+    │       set_target_shape_tag(reg, player, Square);       │──▶ player rows:
+    │       reg.emplace<ShapeWindowMorphInTag>(player);      │    +TargetShapeSquareTag
+    │       PlayerShape.morph_t      = 0.0f;                 │    +ShapeWindowMorphInTag
+    │       disp.enqueue(PlaySfxEvent{ShapeShift});          │    (per #1202/#1204)
+    │       // player's current Shape*Tag is swapped to the  │──▶ PlayerShape
+    │       // TargetShape*Tag once MorphIn->Active fires    │    { morph_t: 1.0 }
+    │       // (shape_window_activation_system).             │
     │   }                                                    │
     │                                                        │
     │   // 2. Process direction — one handler per direction  │

--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -348,7 +348,7 @@ struct SongResults {
   │ shape_window_activation_system                ★ NEW        │
   │   → ticks the MorphIn phase before collision so the player │
   │     finishes morphing (MorphIn → Active) before            │
-  │     collision_system reads ShapeWindow.phase               │
+  │     collision_system checks ShapeWindow*Tag (#1202/#1204)  │
   │   → guarded by SongState existing (not song->playing)      │
   └────────────────────────────────────────────────────────────┘
            ↓

--- a/design-docs/tester-personas-tech-spec.md
+++ b/design-docs/tester-personas-tech-spec.md
@@ -327,7 +327,8 @@ multiple events per frame; the constraint lives entirely inside test_player.
 test_player runs OUTSIDE the fixed timestep, so a single enqueue may flow
 through two fixed-step iterations within one render frame. Verified safe:
 each `ButtonPressEvent` fires once (the dispatcher drains its queue per
-pump), and `player_input_system` checks the current `ShapeWindow.phase`
+pump), and `player_input_system` checks for `ShapeWindowMorphInTag` /
+`ShapeWindowActiveTag` / `ShapeWindowMorphOutTag` presence (#1202/#1204)
 before mutating — re-entry on a window that is already MorphIn / Active is
 a no-op.
 


### PR DESCRIPTION
Closes #1520.

The `ShapeWindow::phase` field and its `WindowPhase` enum were eradicated by #1202/#1204 (Fabian existential processing). Phase identity now lives as a per-phase tag on the player entity:

- `ShapeWindowMorphInTag`
- `ShapeWindowActiveTag`
- `ShapeWindowMorphOutTag`
- Idle = absence of all three

Three design-docs sites still referenced the dead `.phase` field:

1. **`design-docs/architecture.md:1276-1278`** (§ 7.2 ASCII dispatcher diagram) — the `player_input_handle_press_square` body showed `ShapeWindow.target_shape = Shape::Square;` and `ShapeWindow.phase = MorphIn;` writes, plus the resulting struct annotation `{ target: Square, phase: MorphIn }`. Both fields were eradicated by the same #1202/#1204 migration, so the in-diagram code block is rewritten together to match `app/systems/player_input_system.cpp:122-137`:

   ```
   set_target_shape_tag(reg, player, Square);
   reg.emplace<ShapeWindowMorphInTag>(player);
   ```

   Box content widths preserved (56-char interior, 62-char total). Same line count (12 box rows) so surrounding diagram blocks are unaffected.

2. **`design-docs/tester-personas-tech-spec.md:330`** (§ Fixed Timestep Idempotency) — "`player_input_system` checks the current `ShapeWindow.phase` before mutating" now reads "checks for `ShapeWindowMorphInTag` / `ShapeWindowActiveTag` / `ShapeWindowMorphOutTag` presence (#1202/#1204) before mutating", mirroring the phrasing in `app/components/player.h:47-54` and the actual check at `player_input_system.cpp:142-146`.

3. **`design-docs/rhythm-spec.md:351`** (§ rhythm-engine pipeline diagram) — the bullet "collision_system reads ShapeWindow.phase" now reads "collision_system checks ShapeWindow*Tag (#1202/#1204)", consistent with the per-tag dispatch at `collision_system.cpp:25-38`. Box width preserved (64 chars).

Note: the architecture.md edit also rewrites the adjacent `ShapeWindow.target_shape = Shape::Square;` line (1276) and its `{ target: Square, … }` annotation — that field was eradicated by the same migration and the diagram block is inseparable, so leaving it partially-stale would break diagram coherence.

## Verification

- `grep -rn "ShapeWindow\.phase\|ShapeWindow::phase" design-docs/ app/` — **0 hits** (was 3).
- `cmake --build build` — zero warnings (sanity check; docs-only change).
- `./build/shapeshifter_tests` — all 963 tests / 3370 assertions pass.
- ASCII box widths verified via Python `len()` (counts characters, not bytes — `→` & `─` are multi-byte but single-char): rhythm-spec.md interior=64 chars; architecture.md interior=62 chars.

Follow-up to #1501 / #1332 (same docs-drift pattern, different symbol).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>