### PR TITLE
#1526 design-docs/architecture.md: eradicate residual ShapeWindow.phase / target_shape / PlayerShape.current refs

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -162,17 +162,28 @@ struct PlayerShape {
     float    morph_t = 1.0f;           // 0.0 = morph just started, 1.0 = settled
 };
 
-/// Rhythm-mode timing window state for the player. 24 bytes.
+/// Rhythm-mode timing window state for the player. 16 bytes
+/// (1 bool + 3 floats; the former `target_shape` and `WindowPhase phase`
+/// fields are now per-tag rows — see migration notes below).
 /// Hot: read/written by shape_window_system and input dispatcher callbacks;
 /// read by collision_system. Lives on the player entity alongside PlayerShape.
 ///
 /// Relationship to PlayerShape:
-///   - `target_shape`     is the shape the player is morphing toward when a
-///                        ButtonPressEvent or test-player event lands in or
-///                        near the active window.
-///   - When `phase == MorphIn` completes, shape_window_activation_system
-///                        promotes `target_shape` into `PlayerShape.current`
-///                        and resets the morph animation.
+///   - The active `TargetShape*Tag` (Circle/Square/Triangle/Hexagon) on the
+///                        player encodes which shape the press is morphing
+///                        toward when a ButtonPressEvent or test-player event
+///                        lands in or near the active window (issue
+///                        #1202/#1204 — replaces the former `target_shape`
+///                        field).
+///   - When the `ShapeWindowMorphInTag` → `ShapeWindowActiveTag` transition
+///                        fires, `shape_window_system` swaps the player's
+///                        current `Shape*Tag` to match the `TargetShape*Tag`
+///                        and resets the morph animation (replaces the
+///                        former MorphIn-completion path that promoted the
+///                        legacy target field into the legacy current-shape
+///                        field — eradicated per #1202/#1204; see
+///                        `app/systems/shape_window_system.cpp` for the
+///                        canonical transitions).
 ///   - `press_time`       feeds timing-grade computation when an obstacle
 ///                        resolves (collision_system compares it against
 ///                        BeatInfo.arrival_time).
@@ -892,17 +903,26 @@ In code, reusable construction lives in `app/entities/` factory functions
 
 ```
 ┌─ Player ──────────────────────────────────────────────────┐
-│ PlayerTag          (tag, 0 bytes)                         │
-│ WorldPosition     { position: {360.0, 920.0} }          │
-│ PlayerShape        { current: Hexagon, morph_t: 1.0 }     │
-│ ShapeWindow        { target: Hexagon, phase: Idle, ... }  │
-│ Lane               { current: 1, target: -1, lerp_t: 1 } │
+│ PlayerTag              (tag, 0 bytes)                     │
+│ WorldPosition         { position: {360.0, 920.0} }        │
+│ ShapeHexagonTag        (tag, 0 bytes; current shape)      │
+│ PlayerShape           { morph_t: 1.0 }                    │
+│ ShapeWindow           { graded: 0, window_timer: 0,       │
+│                         window_start: 0, press_time: -1 } │
+│ TargetShapeHexagonTag  (tag, 0 bytes; idle reset)         │
+│ Lane                  { current: 1, target: -1, lerp_t:1 }│
 │ (Jumping/Sliding absent → grounded; rows added on demand) │
-│ Color              { r: 80, g: 180, b: 255, a: 255 }     │
-│ DrawSize           { w: 64, h: 64 }                       │
-│ TagWorldPass       (tag, 0 bytes)                         │
+│ (ShapeWindow{MorphIn,Active,MorphOut}Tag absent → Idle)   │
+│ Color                 { r: 80, g: 180, b: 255, a: 255 }   │
+│ DrawSize              { w: 64, h: 64 }                    │
+│ TagWorldPass           (tag, 0 bytes)                     │
 └───────────────────────────────────────────────────────────┘
-Total: ~97 bytes per entity (1 entity)
+Total: ~48 bytes of component data per entity (1 entity).
+The current shape and shape-window phase are zero-byte tag rows
+(`Shape*Tag` / `ShapeWindow*Tag` / `TargetShape*Tag`) per issue
+#1202/#1204 — the former `PlayerShape::current`, `ShapeWindow::phase`
+(`WindowPhase` enum), and `ShapeWindow::target_shape` fields are
+eradicated.
 ```
 
 ### 5.2 Shape Gate Entity
@@ -1307,7 +1327,7 @@ int main(int argc, char* argv[]) {
 
     SongState.song_time  ─┐
     BeatMap.beats        ├─ find next unresolved note near the active shape
-    PlayerShape.current ─┘
+    Shape*Tag (current) ─┘
 
     proximity = clamp((arrival_time - song_time) / SongState.half_window)
     draw ring around the corresponding shape button:


### PR DESCRIPTION
Closes #1526.

Follow-up to #1520 / #1525. The earlier sweep used the grep pattern `ShapeWindow\.phase|ShapeWindow::phase`, which missed sites that referenced the eradicated fields in other shapes. This PR cleans up the survivors.

## Sites changed (4)

1. **§2.2 ShapeWindow doc comment (lines 169-187)** — the relationship-to-PlayerShape bullets referenced `target_shape`, `phase == MorphIn`, and `PlayerShape.current` (three eradicated artifacts in one sentence). Rewrote in tag terms: the active `TargetShape*Tag` encodes the morph target, and the `ShapeWindowMorphInTag` → `ShapeWindowActiveTag` transition driven by `shape_window_system` is what swaps the player's current `Shape*Tag`. Cites #1202/#1204 and points at the canonical `app/systems/shape_window_system.cpp`.
2. **§2.2 ShapeWindow size header** — claimed *24 bytes*, but the post-eradication struct (`bool + 3 floats`) is **16 bytes**. Updated.
3. **§5.1 Player Entity table (line 898)** — listed `PlayerShape { current: Hexagon, morph_t: 1.0 }` and `ShapeWindow { target: Hexagon, phase: Idle, ... }`. Replaced with the actual per-tag layout that `create_player_entity` builds (`app/entities/player_entity.cpp`):
   - `ShapeHexagonTag` (tag, 0 bytes; current shape)
   - `PlayerShape { morph_t: 1.0 }`
   - `ShapeWindow { graded, window_timer, window_start, press_time }`
   - `TargetShapeHexagonTag` (tag, 0 bytes; idle reset)
   - explicit note that `ShapeWindow{MorphIn,Active,MorphOut}Tag` absent ⇒ Idle.
   Also re-verified the byte total from the actual struct sizes (issue acceptance step): `8 (WorldPosition) + 4 (PlayerShape) + 16 (ShapeWindow) + 8 (Lane) + 4 (Color) + 8 (DrawSize) = 48 bytes` of component data — the legacy *~97 bytes* number was inflated by the now-eradicated fields. Added a brief migration footer summarising what's tag-rowed now.
4. **§7.3 Proximity Ring diagram (was line 1310)** — `PlayerShape.current ─┘` replaced with `Shape*Tag (current) ─┘`. `ui_render_system.cpp:424-427` reads `reg.all_of<ShapeCircleTag>(entity)` etc., never `PlayerShape.current`, so the diagram now matches the code. This was a tightly-coupled sibling drift not listed in the issue body (same eradicated field as site 1); included per the *"directly caused by or tightly coupled"* allowance.

## Acceptance criteria mapping

- [x] Update line 173-175 to tag-based phrasing — done (now lines 169-187).
- [x] Update line 898 (table) to reflect per-tag layout, with `TargetShape*Tag` / `ShapeWindow*Tag` notes.
- [x] Adjacent byte-count claim re-verified — `~48 bytes` (was `~97`).
- [x] Cite #1202/#1204 in updated lines — done at all three primary sites plus the new migration footer.
- [x] No code changes; docs-only.

## Verification

```bash
$ grep -rEn 'phase == MorphIn|phase: (Idle|MorphIn|MorphOut|Active)|target: (Circle|Square|Triangle|Hexagon)' design-docs/architecture.md
(no output)
$ grep -nE 'PlayerShape\.current|ShapeWindow\.target_shape|ShapeWindow\.phase' design-docs/architecture.md
(no output)
```

Build/tests unchanged (no source touched).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>