### PR TITLE
#1528 app/game_loop.cpp: inline single-call `find_persistence_log_row` anon-ns helper

### DIFF
--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -121,17 +121,12 @@ constexpr PersistenceLogRow kPersistenceLogTable[] = {
     {persistence::Status::CorruptData, LOG_WARNING, "%s: corrupt data (defaults in use)"},
 };
 
-const PersistenceLogRow* find_persistence_log_row(persistence::Status status) {
-    for (const auto& row : kPersistenceLogTable) {
-        if (row.status == status) return &row;
-    }
-    return nullptr;
-}
-
 void log_persistence_result(const char* operation, const persistence::Result& result) {
-    if (const auto* row = find_persistence_log_row(result.status)) {
-        TraceLog(row->log_level, row->message_fmt, operation);
-        return;
+    for (const auto& row : kPersistenceLogTable) {
+        if (row.status == result.status) {
+            TraceLog(row.log_level, row.message_fmt, operation);
+            return;
+        }
     }
     // Fallback for statuses not in the table (any failure status that isn't
     // CorruptData) — stringify via persistence::status_name and include the


### PR DESCRIPTION
Continuation of the single-call anon-ns helper inline cleanup (#1519 / #1521 / #1523 / #1524).

`find_persistence_log_row` was a 6-line linear scan over `kPersistenceLogTable` with one caller (`log_persistence_result`). Folded the scan directly into `log_persistence_result` so the control flow reads as a single "scan-table-or-fall-through-to-fallback" loop instead of "helper-returns-pointer-then-check-pointer".

Behaviour unchanged: same table, same row matching, same `TraceLog` arguments on a hit, same `result.error` / `status_name` fallback when no row matches.

## Validation

- `cmake --build build` — zero warnings.
- All 963 tests / 3370 assertions pass (`./build/shapeshifter_tests`).

Closes #1528.