### PR TITLE
#1530 app/systems/play_session.cpp: inline single-call `is_runtime_allowed_validation_error` anon-ns helper

### DIFF
--- a/app/systems/play_session.cpp
+++ b/app/systems/play_session.cpp
@@ -27,10 +27,6 @@
 
 namespace {
 
-bool is_runtime_allowed_validation_error(const BeatMapError& error) {
-    return error.message == "Different-shape gates must be >= 3 beats apart";
-}
-
 bool load_runtime_beat_map(const char* path,
                            BeatMap& out,
                            std::vector<BeatMapError>& errors,
@@ -46,9 +42,12 @@ bool load_runtime_beat_map(const char* path,
         return true;
     }
 
+    // Runtime tolerates the "Different-shape gates must be >= 3 beats apart"
+    // validation error and treats it as a warning; any other validation error
+    // fails the load.
     bool only_allowed_errors = !validation_errors.empty();
     for (const BeatMapError& error : validation_errors) {
-        if (!is_runtime_allowed_validation_error(error)) {
+        if (error.message != "Different-shape gates must be >= 3 beats apart") {
             only_allowed_errors = false;
         }
         errors.push_back(error);


### PR DESCRIPTION
Continuation of the single-call anon-ns helper inline cleanup (#1519 / #1521 / #1523 / #1524 / #1528 / #1529).

`is_runtime_allowed_validation_error` was a 2-line wrapper around one string `==` comparison with one caller (`load_runtime_beat_map`). Folded the literal directly into the per-error classification loop, replacing `if (!is_runtime_allowed_validation_error(error))` with the `error.message != "Different-shape gates must be >= 3 beats apart"` comparison it wrapped. Added a one-line comment above the loop carrying the "runtime tolerates this one validation error" intent that the function name encoded.

Behaviour unchanged: same predicate, same per-error treatment, same warning/failure path. The tolerated-error string literal already appears verbatim in the validator that produces it (`app/entities/beat_map.cpp`) and the corresponding test fixture, so the spelling is single-source by data, not by code.

## Validation

- `cmake --build build` — zero warnings.
- All 963 tests / 3370 assertions pass (`./build/shapeshifter_tests`).

Closes #1530.