### PR TITLE
#1532 app/game_loop.cpp: inline single-call `load_default_text_fonts` anon-ns helper

### DIFF
--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -85,25 +85,6 @@ bool load_text_fonts(TextContext& ctx, const char* font_path) {
     return true;
 }
 
-bool load_default_text_fonts(TextContext& ctx) {
-    std::string exe_font = util::join_app_dir(
-        GetApplicationDirectory(), "content/fonts/LiberationMono-Regular.ttf");
-    const char* font_paths[] = {
-        exe_font.c_str(),
-        "content/fonts/LiberationMono-Regular.ttf",
-        "/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf",
-        "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
-    };
-    for (const char* path : font_paths) {
-        if (load_text_fonts(ctx, path)) {
-            TraceLog(LOG_INFO, "Loaded font: %s", path);
-            return true;
-        }
-    }
-    TraceLog(LOG_ERROR, "Could not load any TTF font");
-    return false;
-}
-
 // Status → (log_level, message_template) lookup table. Per Fabian's
 // existential processing (issue #1277), behavior dispatch on the `Status`
 // discriminator is replaced with a value→data lookup — same shape as the
@@ -182,10 +163,31 @@ bool game_loop_init(entt::registry& reg,
     sfx_bank_init(reg);
     TraceLog(LOG_INFO, "SHAPESHIFTER v%s", SHAPESHIFTER_VERSION);
 
-    // Text rendering
+    // Text rendering — fall back through bundled, repo-relative, and OS
+    // system font paths in order; the first one `load_text_fonts` accepts
+    // wins. `load_text_fonts` itself remains the anon-ns helper because
+    // its cleanup-on-partial-load logic warrants the abstraction.
     {
         auto& text_ctx = reset_ctx_singleton<TextContext>(reg);
-        load_default_text_fonts(text_ctx);
+        std::string exe_font = util::join_app_dir(
+            GetApplicationDirectory(), "content/fonts/LiberationMono-Regular.ttf");
+        const char* font_paths[] = {
+            exe_font.c_str(),
+            "content/fonts/LiberationMono-Regular.ttf",
+            "/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf",
+            "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
+        };
+        bool loaded = false;
+        for (const char* path : font_paths) {
+            if (load_text_fonts(text_ctx, path)) {
+                TraceLog(LOG_INFO, "Loaded font: %s", path);
+                loaded = true;
+                break;
+            }
+        }
+        if (!loaded) {
+            TraceLog(LOG_ERROR, "Could not load any TTF font");
+        }
     }
 
     // Core singletons


### PR DESCRIPTION
Continuation of the single-call anon-ns helper inline cleanup (#1519 / #1521 / #1523 / #1524 / #1528 / #1529 / #1531).

`load_default_text_fonts` was a 17-line wrapper around a 4-entry font-path fallback list with one caller (the `run_game()` "Text rendering" setup block). Folded the path table and the for-loop directly into the setup block, calling `load_text_fonts(text_ctx, path)` inside the inlined loop.

`load_text_fonts` itself **stays** as the anon-ns helper — its body is ~30 lines and includes cleanup-on-partial-load (UnloadFont + zero-init on size==0 failures) that warrants the abstraction. Inlining it into the for-loop would obscure the setup block. Per the issue acceptance criteria, this change touches `load_default_text_fonts` only.

Behaviour unchanged: same fallback order (bundled exe-dir → repo-relative → liberation system path → dejavu system path), same per-path `LoadFontEx`-then-validate path, same INFO log on success and ERROR log on full fallback exhaustion.

## Validation

- `cmake --build build` — zero warnings.
- All 963 tests / 3370 assertions pass (`./build/shapeshifter_tests`).

Closes #1532.
