### PR TITLE
#1533: Normalize ShapeWindow.press_time/graded NULL columns (Fabian Principle 3, Site #1)

### DIFF
--- a/app/components/player.h
+++ b/app/components/player.h
@@ -52,11 +52,25 @@ struct PlayerShape {
 // The target shape the press is morphing toward lives as one of
 // `TargetShapeCircleTag` / `TargetShapeSquareTag` / `TargetShapeTriangleTag` /
 // `TargetShapeHexagonTag` on the same entity (issue #1202/#1204).
+//
+// Fabian Principle 3 (issue #1533): every column is always meaningful while
+// `ShapeWindow` exists. The former `press_time = -1.0f` sentinel migrated to
+// the `Pressed` row table (presence == "the window has a recorded press");
+// the former `bool graded` migrated to the `WindowGraded` zero-column tag
+// in `app/tags/tags.h` (presence == "this press has been graded").
 struct ShapeWindow {
-    bool        graded        = false;
     float       window_timer  = 0.0f;
     float       window_start  = 0.0f;
-    float       press_time    = -1.0f;
+};
+
+// Recorded press for the current shape window. Presence on the player entity
+// IS "the window has a press"; the `press_time` column is always meaningful
+// while the row exists (Fabian Principle 3 / issue #1533). Writers:
+// `player_input_system` emplaces on every shape press;
+// `shape_window_system` removes on MorphOut → Idle. Readers: `collision_system`
+// joins on `Pressed` to gate shape-timing grading and read the press time.
+struct Pressed {
+    float press_time = 0.0f;
 };
 
 struct Lane {

--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -23,8 +23,11 @@ bool shape_row_match(entt::registry& reg,
     if (!reg.all_of<RequiredTag>(obstacle_entity)) return false;
     if (rhythm_mode) {
         if (reg.all_of<ShapeWindowMorphInTag>(player_entity)) {
-            auto& sw = reg.get<ShapeWindow>(player_entity);
-            return sw.press_time >= 0.0f && reg.all_of<TargetTag>(player_entity);
+            // Pressed presence == "the window has a press" (Fabian Principle 3,
+            // issue #1533) — replaces the former `sw.press_time >= 0.0f`
+            // sentinel comparison.
+            return reg.all_of<Pressed>(player_entity)
+                && reg.all_of<TargetTag>(player_entity);
         }
         if (reg.all_of<ShapeWindowActiveTag>(player_entity)) {
             return reg.any_of<ShapeTag, TargetTag>(player_entity);
@@ -104,17 +107,22 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
         reg.get_or_emplace<ScoredTag>(entity);
     };
 
+    const auto* pressed = reg.try_get<Pressed>(player_entity);
     const bool can_grade_shape =
-        song.half_window > 0.0f && p_window.press_time >= 0.0f;
+        song.half_window > 0.0f && pressed != nullptr;
     auto grade_shape_timing = [&](entt::entity entity, float arrival_time) {
-        float delta_seconds = std::abs(p_window.press_time - arrival_time);
+        // can_grade_shape gates entry, so `pressed` is non-null here.
+        float delta_seconds = std::abs(pressed->press_time - arrival_time);
         float precision = 1.0f - (delta_seconds / kTimingOkSeconds);
         if (precision < 0.0f) precision = 0.0f;
         if (precision > 1.0f) precision = 1.0f;
         reg.emplace_or_replace<TimingGrade>(entity, TimingGrade{precision});
         emplace_timing_tier_tag_for_delta_abs(reg, entity, delta_seconds);
 
-        if (!p_window.graded) {
+        // WindowGraded presence == "this press has been graded" (Fabian
+        // Principle 3, issue #1533) — replaces the former `p_window.graded`
+        // bool.
+        if (!reg.all_of<WindowGraded>(player_entity)) {
             float scale = window_scale_from_delta_abs(delta_seconds);
             const float active_elapsed = song.song_time - p_window.window_start;
             float remaining = song.window_duration - active_elapsed;
@@ -126,7 +134,7 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
                 // shape_window_system on the next frame.
                 p_window.window_start -= remaining * (1.0f - scale);
             }
-            p_window.graded = true;
+            reg.emplace_or_replace<WindowGraded>(player_entity);
         }
     };
 

--- a/app/systems/player_input_system.cpp
+++ b/app/systems/player_input_system.cpp
@@ -123,9 +123,11 @@ void player_input_handle_shape_press_impl(entt::registry& reg, Shape pressed_sha
         set_target_shape_tag(reg, entity, pressed_shape);
         sw.window_timer = 0.0f;
         sw.window_start = song->song_time;
-        sw.press_time = song->song_time;
+        // Pressed row table presence == "this window has a press"; new press
+        // also clears any prior grading flag (Fabian Principle 3, issue #1533).
+        reg.emplace_or_replace<Pressed>(entity, Pressed{song->song_time});
         ps.morph_t = 0.0f;
-        sw.graded = false;
+        reg.remove<WindowGraded>(entity);
         // Phase transition: any previous phase → MorphIn (#1202/#1204).
         reg.remove<ShapeWindowActiveTag>(entity);
         reg.remove<ShapeWindowMorphOutTag>(entity);

--- a/app/systems/shape_window_system.cpp
+++ b/app/systems/shape_window_system.cpp
@@ -110,8 +110,8 @@ void advance_morph_out(entt::registry& reg,
         set_player_shape_tag(reg, entity, Shape::Hexagon);
         set_target_shape_tag(reg, entity, Shape::Hexagon);
         swindow.window_timer = 0.0f;
-        swindow.press_time = -1.0f;
-        swindow.graded = false;
+        reg.remove<Pressed>(entity);
+        reg.remove<WindowGraded>(entity);
         apply_shape_color(reg, entity, Shape::Hexagon);
         transition_to_idle<ShapeWindowMorphOutTag>(reg, entity);
         return;
@@ -122,8 +122,8 @@ void advance_morph_out(entt::registry& reg,
         set_player_shape_tag(reg, entity, Shape::Hexagon);
         set_target_shape_tag(reg, entity, Shape::Hexagon);
         swindow.window_timer = 0.0f;
-        swindow.press_time = -1.0f;
-        swindow.graded = false;
+        reg.remove<Pressed>(entity);
+        reg.remove<WindowGraded>(entity);
         apply_shape_color(reg, entity, Shape::Hexagon);
         transition_to_idle<ShapeWindowMorphOutTag>(reg, entity);
     }

--- a/app/tags/tags.h
+++ b/app/tags/tags.h
@@ -13,6 +13,13 @@
 // ── Player ───────────────────────────────────────────────────
 struct PlayerTag {};
 
+// Presence on the player entity IS "the current shape-window press has been
+// graded by collision_system" — replaces the former `ShapeWindow::graded`
+// bool (Fabian Principle 3 / issue #1533). collision_system emplaces on
+// first grading per window; shape_window_system removes on MorphOut → Idle;
+// player_input_system removes whenever a new press opens a window.
+struct WindowGraded {};
+
 // ── Player current shape (per-tag table; exactly one per player entity) ──
 // Replaces the former `PlayerShape::current` Shape-typed field (issue
 // #1202/#1204). Per Fabian's existential processing, each former enum value

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -204,11 +204,19 @@ struct PlayerShape {
 /// no `switch`. See `app/systems/shape_window_system.cpp` for the
 /// canonical transitions.
 struct ShapeWindow {
-    bool  graded       = false;  // a TimingGrade has already been emitted
     float window_timer = 0.0f;   // seconds into the current phase
     float window_start = 0.0f;   // song_time when the current window opened
-    float press_time   = -1.0f;  // song_time of the latest valid press (-1 = none)
 };
+
+/// Recorded press for the current shape window. Presence on the player
+/// entity IS "the window has a recorded press"; `press_time` is always
+/// meaningful while the row exists (Fabian Principle 3 / issue #1533).
+struct Pressed {
+    float press_time = 0.0f;     // song_time of the latest valid press
+};
+/// Marker tag (`WindowGraded`) lives in `app/tags/tags.h`: presence on the
+/// player IS "this press has been graded by collision_system" (replaces the
+/// former `ShapeWindow::graded` bool).
 
 /// Lane occupancy and transition. 8 bytes.
 /// Hot: read by collision_system, player input handlers, player_movement_system.
@@ -907,22 +915,25 @@ In code, reusable construction lives in `app/entities/` factory functions
 │ WorldPosition         { position: {360.0, 920.0} }        │
 │ ShapeHexagonTag        (tag, 0 bytes; current shape)      │
 │ PlayerShape           { morph_t: 1.0 }                    │
-│ ShapeWindow           { graded: 0, window_timer: 0,       │
-│                         window_start: 0, press_time: -1 } │
+│ ShapeWindow           { window_timer: 0, window_start: 0 }│
 │ TargetShapeHexagonTag  (tag, 0 bytes; idle reset)         │
 │ Lane                  { current: 1, target: -1, lerp_t:1 }│
 │ (Jumping/Sliding absent → grounded; rows added on demand) │
 │ (ShapeWindow{MorphIn,Active,MorphOut}Tag absent → Idle)   │
+│ (Pressed{press_time} added on press, removed at MorphOut) │
+│ (WindowGraded tag added when collision_system grades)     │
 │ Color                 { r: 80, g: 180, b: 255, a: 255 }   │
 │ DrawSize              { w: 64, h: 64 }                    │
 │ TagWorldPass           (tag, 0 bytes)                     │
 └───────────────────────────────────────────────────────────┘
-Total: ~48 bytes of component data per entity (1 entity).
+Total: ~40 bytes of component data per entity (1 entity).
 The current shape and shape-window phase are zero-byte tag rows
 (`Shape*Tag` / `ShapeWindow*Tag` / `TargetShape*Tag`) per issue
 #1202/#1204 — the former `PlayerShape::current`, `ShapeWindow::phase`
 (`WindowPhase` enum), and `ShapeWindow::target_shape` fields are
-eradicated.
+eradicated. Per #1533, the former `ShapeWindow::press_time` sentinel and
+`ShapeWindow::graded` bool migrated to the `Pressed` row table and the
+`WindowGraded` zero-column tag respectively (Fabian Principle 3).
 ```
 
 ### 5.2 Shape Gate Entity

--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -278,11 +278,14 @@ struct PlayerShape {
 };
 
 struct ShapeWindow {
-    bool  graded       = false;   // window already graded this cycle
     float window_timer = 0.0f;    // seconds in current phase/window
     float window_start = 0.0f;    // absolute song_time of window start
-    float press_time   = -1.0f;   // absolute song_time of input
 };
+// `Pressed { float press_time; }` lives in `app/components/player.h`.
+// `WindowGraded` lives in `app/tags/tags.h`. Presence of each row IS the
+// data (Fabian Principle 3 / issue #1533) — the former
+// `ShapeWindow::press_time = -1.0f` sentinel and `bool graded` flag are
+// eradicated.
 ```
 
 ## BeatInfo (per obstacle entity)
@@ -364,8 +367,10 @@ struct SongResults {
   │ collision_system                               [MOD]       │
   │   → checks shape match at obstacle arrival                 │
   │   → computes TimingGrade from BeatInfo.arrival_time        │
-  │     against ShapeWindow.press_time                         │
-  │   → on HIT: applies window_scale shortening if !graded     │
+  │     against Pressed.press_time (Fabian #1533: presence     │
+  │     of the Pressed row on the player IS "has a press")     │
+  │   → on HIT: applies window_scale shortening unless the     │
+  │     player already carries the WindowGraded tag            │
   │   → on MISS: drain EnergyState; GameOver only at energy=0  │
   │   → emplaces ScoredTag on both HIT and MISS paths          │
   │                                                            │
@@ -757,8 +762,10 @@ if (!song) return;  // no rhythm context — skip
 ## Phase 3 — Shape window (DONE)
 ```
   • shape_window_system: Idle→MorphIn→Active→MorphOut→Idle
-  • player_input_system handlers: trigger window, reset graded
-  • ShapeWindow: owns graded field; collision_system applies window_scale_for_tier on hit
+  • player_input_system handlers: trigger window, clear WindowGraded tag
+  • Pressed + WindowGraded tag (Fabian #1533): presence on the player
+    drives "has a press" / "press is graded"; collision_system applies
+    window_scale_for_tier on hit
   • collision_system: window scaling on GOOD/PERFECT
 ```
 

--- a/tests/test_audio_offset_calibration.cpp
+++ b/tests/test_audio_offset_calibration.cpp
@@ -238,10 +238,9 @@ OffsetGameplayResult run_calibrated_on_arrival_hit(int16_t audio_offset_ms) {
     settings.audio_offset_ms = audio_offset_ms;
 
     auto player = make_rhythm_player(reg);
-    auto& sw = reg.get<ShapeWindow>(player);
     set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
-    sw.graded = false;
+    reg.remove<WindowGraded>(player);
 
     auto& song = reg.ctx().get<SongState>();
     song.bpm    = 120.0f;
@@ -266,7 +265,7 @@ OffsetGameplayResult run_calibrated_on_arrival_hit(int16_t audio_offset_ms) {
     auto& wt = reg.get<WorldPosition>(obstacle);
     wt.position.y = constants::PLAYER_Y;
 
-    sw.press_time = info.spawn_time + song.lead_time;
+    reg.emplace_or_replace<Pressed>(player, Pressed{info.spawn_time + song.lead_time});
 
     collision_system(reg, 0.016f);
     REQUIRE(reg.all_of<ScoredTag>(obstacle));

--- a/tests/test_collision_extended.cpp
+++ b/tests/test_collision_extended.cpp
@@ -19,14 +19,13 @@ struct ScoredTimingResult {
 ScoredTimingResult score_rhythm_shape_hit_at_offset(float arrival_offset_seconds) {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
     song.song_time = 5.0f;
     set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
-    sw.graded = false;
-    sw.press_time = song.song_time;
+    reg.remove<WindowGraded>(player);
+    reg.emplace_or_replace<Pressed>(player, Pressed{song.song_time});
 
     const float arrival_time = song.song_time + arrival_offset_seconds;
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
@@ -106,11 +105,11 @@ TEST_CASE("collision: rhythm mode assigns Perfect for on-time hit", "[collision]
 
     set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
-    sw.graded = false;
+    reg.remove<WindowGraded>(player);
     sw.window_start = song.song_time;
-    sw.press_time = song.song_time;
+    reg.emplace_or_replace<Pressed>(player, Pressed{song.song_time});
 
-    // obstacle arrives right at press_time (perfect)
+    // obstacle arrives right at press time (perfect)
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<BeatInfo>(obs, 0, song.song_time, song.song_time - song.lead_time);
 
@@ -188,11 +187,11 @@ TEST_CASE("collision: rhythm mode assigns Bad for far-off hit", "[collision][rhy
 
     set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
-    sw.graded = false;
+    reg.remove<WindowGraded>(player);
     sw.window_start = song.song_time;
-    sw.press_time = song.song_time;
+    reg.emplace_or_replace<Pressed>(player, Pressed{song.song_time});
 
-    // obstacle arrival time far from press_time -> Bad
+    // obstacle arrival time far from press time -> Bad
     float bad_arrival = song.song_time + song.half_window * 1.2f;
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<BeatInfo>(obs, 0, bad_arrival, bad_arrival - song.lead_time);
@@ -207,14 +206,13 @@ TEST_CASE("collision: rhythm shape gate only matches during Active window",
           "[collision][rhythm][issue765]") {
     auto active_reg = make_rhythm_registry();
     auto active_player = make_rhythm_player(active_reg);
-    auto& active_window = active_reg.get<ShapeWindow>(active_player);
     auto& active_song = active_reg.ctx().get<SongState>();
 
     active_song.song_time = 5.0f;
     set_player_shape_tag(active_reg, active_player, Shape::Circle);
     set_target_shape_tag(active_reg, active_player, Shape::Circle);
     set_window_phase_active(active_reg, active_player);
-    active_window.press_time = active_song.song_time;
+    active_reg.emplace_or_replace<Pressed>(active_player, Pressed{active_song.song_time});
 
     auto active_obs = make_shape_gate(active_reg, Shape::Circle, constants::PLAYER_Y);
     active_reg.emplace<BeatInfo>(active_obs, 0, active_song.song_time,
@@ -228,14 +226,15 @@ TEST_CASE("collision: rhythm shape gate only matches during Active window",
 
     auto morphout_reg = make_rhythm_registry();
     auto morphout_player = make_rhythm_player(morphout_reg);
-    auto& morphout_window = morphout_reg.get<ShapeWindow>(morphout_player);
     auto& morphout_song = morphout_reg.ctx().get<SongState>();
 
     morphout_song.song_time = 5.0f;
     set_player_shape_tag(morphout_reg, morphout_player, Shape::Circle);
     set_target_shape_tag(morphout_reg, morphout_player, Shape::Circle);
     set_window_phase_morph_out(morphout_reg, morphout_player);
-    morphout_window.press_time = morphout_song.song_time - morphout_song.window_duration;
+    morphout_reg.emplace_or_replace<Pressed>(
+        morphout_player,
+        Pressed{morphout_song.song_time - morphout_song.window_duration});
 
     auto morphout_obs = make_shape_gate(morphout_reg, Shape::Circle, constants::PLAYER_Y);
     morphout_reg.emplace<BeatInfo>(morphout_obs, 0, morphout_song.song_time,
@@ -270,7 +269,6 @@ TEST_CASE("collision: finished song still requires active shape window",
 
     auto active_reg = make_rhythm_registry();
     auto active_player = make_rhythm_player(active_reg);
-    auto& active_window = active_reg.get<ShapeWindow>(active_player);
     auto& active_song = active_reg.ctx().get<SongState>();
 
     active_song.playing = false;
@@ -279,7 +277,7 @@ TEST_CASE("collision: finished song still requires active shape window",
     set_player_shape_tag(active_reg, active_player, Shape::Circle);
     set_target_shape_tag(active_reg, active_player, Shape::Circle);
     set_window_phase_active(active_reg, active_player);
-    active_window.press_time = active_song.song_time;
+    active_reg.emplace_or_replace<Pressed>(active_player, Pressed{active_song.song_time});
 
     auto active_obs = make_shape_gate(active_reg, Shape::Circle, constants::PLAYER_Y);
     active_reg.emplace<BeatInfo>(active_obs, 0, active_song.song_time,
@@ -309,13 +307,12 @@ TEST_CASE("collision: rhythm miss increments miss_count in SongResults", "[colli
 TEST_CASE("collision: rhythm perfect increments perfect_count in SongResults", "[collision][rhythm]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
     set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
-    sw.graded = false;
-    sw.press_time = song.song_time;
+    reg.remove<WindowGraded>(player);
+    reg.emplace_or_replace<Pressed>(player, Pressed{song.song_time});
 
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<BeatInfo>(obs, 0, song.song_time, song.song_time - song.lead_time);
@@ -445,13 +442,12 @@ TEST_CASE("collision: Hexagon fails split path even when shape and lane match", 
 TEST_CASE("scoring: collision_system alone does not mutate SongResults counts", "[scoring][collision]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
     set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
-    sw.graded = false;
-    sw.press_time = song.song_time;
+    reg.remove<WindowGraded>(player);
+    reg.emplace_or_replace<Pressed>(player, Pressed{song.song_time});
 
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<BeatInfo>(obs, 0, song.song_time, song.song_time - song.lead_time);

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -282,12 +282,12 @@ TEST_CASE("collision: BAD timing does not adjust window_start", "[collision][rhy
     // Put player in Active phase
     set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
-    sw.graded = false;
+    reg.remove<WindowGraded>(player);
     sw.window_timer = 0.0f;
     sw.window_start = song.song_time;
 
-    // press_time anchors grading. Set arrival_time far enough so it's BAD.
-    sw.press_time = song.song_time;
+    // Pressed presence anchors grading. Set arrival_time far enough so it's BAD.
+    reg.emplace_or_replace<Pressed>(player, Pressed{song.song_time});
     float bad_arrival = song.song_time - song.half_window * 1.2f;
 
     // Spawn an obstacle at the player's position
@@ -302,7 +302,7 @@ TEST_CASE("collision: BAD timing does not adjust window_start", "[collision][rhy
     // window_timer should remain unchanged by collision_system
     CHECK(sw.window_timer == 0.0f);
     // graded flag must be set
-    CHECK(sw.graded);
+    CHECK(reg.all_of<WindowGraded>(player));
 }
 
 TEST_CASE("collision: Perfect timing shrinks window via window_start adjustment", "[collision][rhythm]") {
@@ -315,12 +315,12 @@ TEST_CASE("collision: Perfect timing shrinks window via window_start adjustment"
 
     set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
-    sw.graded = false;
+    reg.remove<WindowGraded>(player);
     sw.window_timer = 0.0f;
     sw.window_start = song.song_time;
 
-    // Set press_time to right now so the hit is perfect.
-    sw.press_time = song.song_time;
+    // Pressed at song_time so the hit is perfect.
+    reg.emplace_or_replace<Pressed>(player, Pressed{song.song_time});
 
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<BeatInfo>(obs, 0, song.song_time, song.song_time - song.lead_time);
@@ -333,5 +333,5 @@ TEST_CASE("collision: Perfect timing shrinks window via window_start adjustment"
     float remaining = song.window_duration - 0.0f;
     float expected_shift = remaining * 0.50f;
     CHECK_THAT(sw.window_start, Catch::Matchers::WithinAbs(original_window_start - expected_shift, 0.0001f));
-    CHECK(sw.graded);
+    CHECK(reg.all_of<WindowGraded>(player));
 }

--- a/tests/test_phase_runner.cpp
+++ b/tests/test_phase_runner.cpp
@@ -70,8 +70,8 @@ TEST_CASE("tick_playing_systems: collision resolves before active window expiry"
     set_window_phase_active(reg, player);
     sw.window_start = 10.0f;
     sw.window_timer = 0.0f;
-    sw.press_time = song.song_time;
-    sw.graded = false;
+    reg.emplace_or_replace<Pressed>(player, Pressed{song.song_time});
+    reg.remove<WindowGraded>(player);
 
     auto obstacle = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<BeatInfo>(obstacle, 0, song.song_time, song.song_time - song.lead_time);
@@ -95,8 +95,8 @@ TEST_CASE("tick_playing_systems: shape window activates before collision", "[pha
     set_window_phase_morph_in(reg, player);
     sw.window_start = song.song_time - song.morph_duration - 0.01f;
     sw.window_timer = 0.0f;
-    sw.press_time = song.song_time;
-    sw.graded = false;
+    reg.emplace_or_replace<Pressed>(player, Pressed{song.song_time});
+    reg.remove<WindowGraded>(player);
 
     auto obstacle = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<BeatInfo>(obstacle, 0, song.song_time, song.song_time - song.lead_time);

--- a/tests/test_player_action_rhythm.cpp
+++ b/tests/test_player_action_rhythm.cpp
@@ -22,7 +22,7 @@ TEST_CASE("player_action: rhythm mode starts MorphIn on button press from Idle",
     CHECK(reg.all_of<ShapeHexagonTag>(player));
     CHECK(ps.morph_t == 0.0f);
     CHECK(sw.window_start == 5.0f);
-    CHECK(sw.graded == false);
+    CHECK_FALSE(reg.all_of<WindowGraded>(player));
 
     song.song_time += song.morph_duration + 0.01f;
     shape_window_system(reg, song.morph_duration + 0.01f);
@@ -52,7 +52,7 @@ TEST_CASE("player_action: post-song rhythm context still starts window for trail
     CHECK(reg.all_of<TargetShapeSquareTag>(player));
     CHECK(window_phase_is_morph_in(reg, player));
     CHECK(sw.window_start == song.song_time);
-    CHECK(sw.press_time == song.song_time);
+    CHECK(reg.get<Pressed>(player).press_time == song.song_time);
 }
 
 TEST_CASE("player_action: rhythm mode treats same shape during Active as no-op", "[player_rhythm]") {
@@ -63,12 +63,12 @@ TEST_CASE("player_action: rhythm mode treats same shape during Active as no-op",
     set_player_shape_tag(reg, player, Shape::Square);
     sw.window_timer = 0.1f;
     sw.window_start = 1.0f;
-    sw.press_time = 1.0f;
-    sw.graded = true;
+    reg.emplace_or_replace<Pressed>(player, Pressed{1.0f});
+    reg.emplace_or_replace<WindowGraded>(player);
 
     const float initial_window_start = sw.window_start;
     const float initial_window_timer = sw.window_timer;
-    const float initial_press_time = sw.press_time;
+    const float initial_press_time   = reg.get<Pressed>(player).press_time;
 
     auto btn = make_shape_button(reg, Shape::Square);
     press_button(reg, btn);
@@ -78,8 +78,8 @@ TEST_CASE("player_action: rhythm mode treats same shape during Active as no-op",
     CHECK(window_phase_is_active(reg, player));
     CHECK(sw.window_start == initial_window_start);
     CHECK(sw.window_timer == initial_window_timer);
-    CHECK(sw.press_time == initial_press_time);
-    CHECK(sw.graded);
+    CHECK(reg.get<Pressed>(player).press_time == initial_press_time);
+    CHECK(reg.all_of<WindowGraded>(player));
 }
 
 TEST_CASE("player_action: rhythm mode interrupts Active with different shape", "[player_rhythm]") {
@@ -103,7 +103,7 @@ TEST_CASE("player_action: rhythm mode interrupts Active with different shape", "
     CHECK(sw.window_timer == 0.0f);
     CHECK(ps.morph_t == 0.0f);
     CHECK(sw.window_start == 8.0f);
-    CHECK(sw.graded == false);
+    CHECK_FALSE(reg.all_of<WindowGraded>(player));
 }
 
 TEST_CASE("player_action: rhythm mode no action when no tap in queue", "[player_rhythm]") {
@@ -158,7 +158,7 @@ TEST_CASE("player_action: rhythm mode ACCEPTS button press during MorphOut (#209
     CHECK(sw.window_timer == 0.0f);
     CHECK(ps.morph_t == 0.0f);
     CHECK(sw.window_start == 15.0f);
-    CHECK(sw.graded == false);
+    CHECK_FALSE(reg.all_of<WindowGraded>(player));
     CHECK(drain_sfx_events(reg).count > 0);
 }
 

--- a/tests/test_player_input_rhythm_extended.cpp
+++ b/tests/test_player_input_rhythm_extended.cpp
@@ -52,12 +52,12 @@ TEST_CASE("player_input_rhythm: same shape in Active is no-op", "[player][rhythm
     set_window_phase_active(reg, player);
     sw.window_start = song.song_time - 0.5f;
     sw.window_timer = 0.5f;
-    sw.press_time = song.song_time - 0.5f;
-    sw.graded = true;  // was previously graded
+    reg.emplace_or_replace<Pressed>(player, Pressed{song.song_time - 0.5f});
+    reg.emplace_or_replace<WindowGraded>(player);  // was previously graded
 
     const float initial_window_start = sw.window_start;
     const float initial_window_timer = sw.window_timer;
-    const float initial_press_time = sw.press_time;
+    const float initial_press_time   = reg.get<Pressed>(player).press_time;
 
     auto btn = make_shape_button(reg, Shape::Circle);
     press_button(reg, btn);
@@ -67,8 +67,8 @@ TEST_CASE("player_input_rhythm: same shape in Active is no-op", "[player][rhythm
     CHECK(window_phase_is_active(reg, player));
     CHECK(sw.window_start == initial_window_start);
     CHECK(sw.window_timer == initial_window_timer);
-    CHECK(sw.press_time == initial_press_time);
-    CHECK(sw.graded);
+    CHECK(reg.get<Pressed>(player).press_time == initial_press_time);
+    CHECK(reg.all_of<WindowGraded>(player));
 }
 
 TEST_CASE("player_input_rhythm: shape change pushes ShapeShift SFX", "[player][rhythm]") {

--- a/tests/test_rhythm_system.cpp
+++ b/tests/test_rhythm_system.cpp
@@ -404,8 +404,8 @@ TEST_CASE("player_action: press_time recorded correctly", "[rhythm][action]") {
     auto btn = make_shape_button(reg, Shape::Circle);
     press_button(reg, btn);
     run_semantic_input_tick(reg, 0.016f);
-    auto& sw = reg.get<ShapeWindow>(player);
-    CHECK_THAT(sw.press_time, WithinAbs(5.0f, 0.001f));
+    REQUIRE(reg.all_of<Pressed>(player));
+    CHECK_THAT(reg.get<Pressed>(player).press_time, WithinAbs(5.0f, 0.001f));
 }
 
 TEST_CASE("player_action: same shape during active is ignored", "[rhythm][action]") {
@@ -481,13 +481,13 @@ TEST_CASE("collision: MISS drains energy", "[rhythm][collision]") {
 TEST_CASE("collision: timing grade PERFECT on press-at-arrival", "[rhythm][collision]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
     set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
-    song.song_time = 5.0f; sw.press_time = 5.0f;
+    song.song_time = 5.0f;
+    reg.emplace_or_replace<Pressed>(player, Pressed{5.0f});
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
-    // arrival_time == press_time -> Perfect
+    // arrival_time == press time -> Perfect
     reg.emplace<BeatInfo>(obs, 0, 5.0f, 5.0f - song.lead_time);
     collision_system(reg, 0.016f);
     REQUIRE(reg.all_of<ScoredTag>(obs));
@@ -498,7 +498,6 @@ TEST_CASE("collision: timing grade PERFECT on press-at-arrival", "[rhythm][colli
 TEST_CASE("collision: HUD perfect cue distance maps to PERFECT timing", "[rhythm][collision][hud]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
 
     const float cue_dist = gameplay_hud_perfect_distance(&song);
@@ -511,8 +510,8 @@ TEST_CASE("collision: HUD perfect cue distance maps to PERFECT timing", "[rhythm
 
     set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
-    sw.press_time = 5.0f;
-    song.song_time = sw.press_time + cue_lead_seconds;
+    reg.emplace_or_replace<Pressed>(player, Pressed{5.0f});
+    song.song_time = reg.get<Pressed>(player).press_time + cue_lead_seconds;
 
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<BeatInfo>(obs, 0, song.song_time, song.song_time - song.lead_time);
@@ -527,11 +526,11 @@ TEST_CASE("collision: HUD perfect cue distance maps to PERFECT timing", "[rhythm
 TEST_CASE("collision: timing grade GOOD at 50pct", "[rhythm][collision]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
     set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
-    song.song_time = 5.0f; sw.press_time = 5.0f;
+    song.song_time = 5.0f;
+    reg.emplace_or_replace<Pressed>(player, Pressed{5.0f});
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     // arrival_time offset by 50% of half_window (~75ms) -> Good
     reg.emplace<BeatInfo>(obs, 0, 5.0f + song.half_window * 0.5f, 0.0f);
@@ -543,11 +542,11 @@ TEST_CASE("collision: timing grade GOOD at 50pct", "[rhythm][collision]") {
 TEST_CASE("collision: timing grade OK at 80pct", "[rhythm][collision]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
     set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
-    song.song_time = 5.0f; sw.press_time = 5.0f;
+    song.song_time = 5.0f;
+    reg.emplace_or_replace<Pressed>(player, Pressed{5.0f});
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     // arrival_time offset by 80% of half_window (~120ms) -> Ok
     reg.emplace<BeatInfo>(obs, 0, 5.0f + song.half_window * 0.8f, 0.0f);
@@ -559,11 +558,11 @@ TEST_CASE("collision: timing grade OK at 80pct", "[rhythm][collision]") {
 TEST_CASE("collision: timing grade BAD beyond window", "[rhythm][collision]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
     set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
-    song.song_time = 5.0f; sw.press_time = 5.0f;
+    song.song_time = 5.0f;
+    reg.emplace_or_replace<Pressed>(player, Pressed{5.0f});
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     // arrival_time offset by 120% of half_window (>150ms) -> Bad
     reg.emplace<BeatInfo>(obs, 0, 5.0f + song.half_window * 1.2f, 0.0f);
@@ -583,9 +582,9 @@ TEST_CASE("collision: stale press from previous beat does not get Perfect", "[rh
     // Player pressed Circle at song_time 2.0.
     set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
-    sw.press_time = 2.0f;
+    reg.emplace_or_replace<Pressed>(player, Pressed{2.0f});
     sw.window_start = 2.0f;
-    sw.graded = false;
+    reg.remove<WindowGraded>(player);
 
     // Now it's beat N+2 (time 3.5 at 120 BPM = 0.5s per beat)
     song.song_time = 3.5f;
@@ -597,18 +596,18 @@ TEST_CASE("collision: stale press from previous beat does not get Perfect", "[rh
     collision_system(reg, 0.016f);
 
     REQUIRE(has_any_timing_tier_tag(reg, obs));
-    // press_time (2.0) is far from arrival (3.5) -> not Perfect
+    // press time (2.0) is far from arrival (3.5) -> not Perfect
     CHECK_FALSE(reg.all_of<TimingPerfectTag>(obs));
 }
 
 TEST_CASE("collision: PERFECT clears obstacle without game over", "[rhythm][collision]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
     set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
-    song.song_time = 5.0f; sw.press_time = 5.0f;
+    song.song_time = 5.0f;
+    reg.emplace_or_replace<Pressed>(player, Pressed{5.0f});
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<BeatInfo>(obs, 0, 5.0f, 5.0f - song.lead_time);
     collision_system(reg, 0.016f);
@@ -619,11 +618,11 @@ TEST_CASE("collision: PERFECT clears obstacle without game over", "[rhythm][coll
 TEST_CASE("collision: SongResults updated", "[rhythm][collision]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
     set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_active(reg, player);
-    song.song_time = 5.0f; sw.press_time = 5.0f;
+    song.song_time = 5.0f;
+    reg.emplace_or_replace<Pressed>(player, Pressed{5.0f});
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<BeatInfo>(obs, 0, 5.0f, 5.0f - song.lead_time);
     collision_system(reg, 0.016f);
@@ -712,7 +711,7 @@ TEST_CASE("window_scaling: PERFECT grade shortens remaining window", "[rhythm][w
     set_window_phase_active(reg, player);
     sw.window_timer = song.window_duration * 0.5f; // halfway through
     song.song_time = 5.0f;
-    sw.press_time = 5.0f; // PERFECT timing
+    reg.emplace_or_replace<Pressed>(player, Pressed{5.0f}); // PERFECT timing
     sw.window_start = song.song_time - sw.window_timer;
 
     float start_before = sw.window_start;
@@ -721,7 +720,7 @@ TEST_CASE("window_scaling: PERFECT grade shortens remaining window", "[rhythm][w
     reg.emplace<BeatInfo>(obs, 0, 5.0f, 5.0f - song.lead_time);
     collision_system(reg, 0.016f);
 
-    CHECK(sw.graded);
+    CHECK(reg.all_of<WindowGraded>(player));
     // Post-#223: Perfect scale = 0.50 (shrinks remaining window by 50%)
     // window_start moved backward so remaining Active window expires at 50%
     float remaining = song.window_duration - timer_before;
@@ -741,7 +740,7 @@ TEST_CASE("window_scaling: GOOD grade shortens window slightly", "[rhythm][windo
     set_window_phase_active(reg, player);
     sw.window_timer = song.window_duration * 0.4f;
     song.song_time = 5.0f;
-    sw.press_time = 5.0f;
+    reg.emplace_or_replace<Pressed>(player, Pressed{5.0f});
     sw.window_start = song.song_time - sw.window_timer;
 
     float start_before = sw.window_start;
@@ -751,7 +750,7 @@ TEST_CASE("window_scaling: GOOD grade shortens window slightly", "[rhythm][windo
     reg.emplace<BeatInfo>(obs, 0, 5.0f + song.half_window * 0.5f, 0.0f);
     collision_system(reg, 0.016f);
 
-    CHECK(sw.graded);
+    CHECK(reg.all_of<WindowGraded>(player));
     // Post-#223: Good scale = 0.75 (shrinks remaining window by 25%)
     float remaining = song.window_duration - timer_before;
     float expected_shift = remaining * 0.25f;
@@ -771,7 +770,7 @@ TEST_CASE("window_scaling: OK grade keeps window unchanged", "[rhythm][window_sc
     sw.window_timer = song.window_duration * 0.3f;
     // Keep window_start consistent with song_time and window_timer
     sw.window_start = song.song_time - sw.window_timer;
-    sw.press_time = 5.0f;
+    reg.emplace_or_replace<Pressed>(player, Pressed{5.0f});
 
     float start_before = sw.window_start;
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
@@ -779,7 +778,7 @@ TEST_CASE("window_scaling: OK grade keeps window unchanged", "[rhythm][window_sc
     reg.emplace<BeatInfo>(obs, 0, 5.0f + song.half_window * 0.8f, 0.0f);
     collision_system(reg, 0.016f);
 
-    CHECK(sw.graded);
+    CHECK(reg.all_of<WindowGraded>(player));
     // Post-#223: Ok scale = 1.0 → no window adjustment
     CHECK_THAT(sw.window_start, WithinAbs(start_before, 0.001f));
     // window_timer must NOT be changed by collision_system
@@ -798,7 +797,7 @@ TEST_CASE("window_scaling: BAD grade keeps window unchanged", "[rhythm][window_s
     sw.window_timer = song.window_duration * 0.2f;
     // Keep window_start consistent with song_time and window_timer
     sw.window_start = song.song_time - sw.window_timer;
-    sw.press_time = 5.0f;
+    reg.emplace_or_replace<Pressed>(player, Pressed{5.0f});
 
     float start_before = sw.window_start;
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
@@ -806,7 +805,7 @@ TEST_CASE("window_scaling: BAD grade keeps window unchanged", "[rhythm][window_s
     reg.emplace<BeatInfo>(obs, 0, 5.0f + song.half_window * 1.2f, 0.0f);
     collision_system(reg, 0.016f);
 
-    CHECK(sw.graded);
+    CHECK(reg.all_of<WindowGraded>(player));
     // Post-#223: Bad scale = 1.0 → no window adjustment
     CHECK_THAT(sw.window_start, WithinAbs(start_before, 0.001f));
     // window_timer must NOT be changed by collision_system
@@ -823,14 +822,14 @@ TEST_CASE("window_scaling: second obstacle does not re-scale", "[rhythm][window_
     set_window_phase_active(reg, player);
     sw.window_timer = song.window_duration * 0.4f;
     song.song_time = 5.0f;
-    sw.press_time = 5.0f;
+    reg.emplace_or_replace<Pressed>(player, Pressed{5.0f});
 
     // First obstacle grades PERFECT, jumps timer
     auto obs1 = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
     reg.emplace<BeatInfo>(obs1, 0, 5.0f, 5.0f - song.lead_time);
     collision_system(reg, 0.016f);
     float timer_after_first = sw.window_timer;
-    CHECK(sw.graded);
+    CHECK(reg.all_of<WindowGraded>(player));
 
     // Second obstacle should NOT jump timer again
     auto obs2 = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
@@ -842,10 +841,9 @@ TEST_CASE("window_scaling: second obstacle does not re-scale", "[rhythm][window_
 TEST_CASE("window_scaling: graded resets on new window", "[rhythm][window_scaling]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& sw = reg.get<ShapeWindow>(player);
 
     // Simulate a graded window
-    sw.graded = true;
+    reg.emplace_or_replace<WindowGraded>(player);
 
     // Start a new window via semantic input drain
     auto btn = make_shape_button(reg, Shape::Triangle);
@@ -853,7 +851,7 @@ TEST_CASE("window_scaling: graded resets on new window", "[rhythm][window_scalin
     set_window_phase_idle(reg, player);
     run_semantic_input_tick(reg, 0.016f);
 
-    CHECK_FALSE(sw.graded);
+    CHECK_FALSE(reg.all_of<WindowGraded>(player));
 }
 
 // Integration: obstacle arrives on-beat

--- a/tests/test_shape_window_extended.cpp
+++ b/tests/test_shape_window_extended.cpp
@@ -76,7 +76,7 @@ TEST_CASE("shape_window: MorphOut returns to Idle with Hexagon", "[shape_window]
     set_player_shape_tag(reg, player, Shape::Circle);
     set_window_phase_morph_out(reg, player);
     sw.window_start = song.song_time;
-    sw.press_time = song.song_time - 0.25f;
+    reg.emplace_or_replace<Pressed>(player, Pressed{song.song_time - 0.25f});
     ps.morph_t = 0.0f;
 
     // Advance past morph_duration
@@ -86,8 +86,8 @@ TEST_CASE("shape_window: MorphOut returns to Idle with Hexagon", "[shape_window]
     CHECK(window_phase_is_idle(reg, player));
     CHECK(reg.all_of<ShapeHexagonTag>(player));
     CHECK(reg.all_of<TargetShapeHexagonTag>(player));
-    CHECK(sw.press_time == -1.0f);
-    CHECK_FALSE(sw.graded);
+    CHECK_FALSE(reg.all_of<Pressed>(player));
+    CHECK_FALSE(reg.all_of<WindowGraded>(player));
 }
 
 TEST_CASE("shape_window: Idle phase does nothing", "[shape_window][rhythm]") {


### PR DESCRIPTION
Fixes part of #1533 — Site #1 (`ShapeWindow.press_time` + `ShapeWindow.graded`).

## Problem (issue #1533, Principle 3)

`ShapeWindow.press_time = -1.0f` is a sentinel meaning "no press recorded" — read at `collision_system.cpp:27` and `:108` as the literal "is there a press?" predicate. `ShapeWindow.graded` is a boolean discriminator gating downstream scoring eligibility. Both are NULL columns in disguise: meaningful only conditionally.

## Solution

- New `struct Pressed { float press_time; }` (`app/components/player.h`) — presence on the player entity IS "the current window has a recorded press"; `press_time` is always meaningful while the row exists.
- New `struct WindowGraded {}` (`app/tags/tags.h`) — presence IS "this press has been graded by collision_system".
- `ShapeWindow` reduces to the always-meaningful `window_timer` + `window_start`.

## Lifecycle

| Event | Before | After |
| --- | --- | --- |
| Shape press (`player_input_system`) | `sw.press_time = t; sw.graded = false` | `reg.emplace_or_replace<Pressed>(p, {t}); reg.remove<WindowGraded>(p)` |
| Collision grading (`collision_system`) | `if (!p_window.graded) { ...; p_window.graded = true; }` | `if (!reg.all_of<WindowGraded>(p)) { ...; reg.emplace_or_replace<WindowGraded>(p); }` |
| MorphOut -> Idle (`shape_window_system`) | `sw.press_time = -1.0f; sw.graded = false` | `reg.remove<Pressed>(p); reg.remove<WindowGraded>(p)` |
| MorphIn shape match | `sw.press_time >= 0.0f && all_of<TargetTag>` | `all_of<Pressed> && all_of<TargetTag>` |
| Grade timing | `std::abs(p_window.press_time - arrival_time)` | `std::abs(pressed->press_time - arrival_time)` (single `try_get` per call) |

## Tests / docs

- ~50 test sites updated mechanically (read sites switch to `reg.get<Pressed>(player).press_time` or `reg.all_of<WindowGraded>(player)`).
- `design-docs/architecture.md` and `design-docs/rhythm-spec.md` updated to describe the new component layout.

## Verification

- `cmake --build build` clean (zero warnings, `-Wall -Wextra -Werror`).
- `./build/shapeshifter_tests` — **3371 assertions in 963 test cases pass** (was 3370 — added a `REQUIRE(reg.all_of<Pressed>)` guard before the press-time read in `test_rhythm_system.cpp:407`).

## Scope

Sites #2 (`Lane.target` sentinel), #3 (`TerminalResultState.previous_best`), and #4 (`BeatEntry.has_time_sec`) from #1533 remain filed and will be addressed in subsequent cycles per the issue's "PRs in priority order" recommendation.

Refs: `.squad/decisions.md` § 9 / Principle 3 · prior art #1288 / #1306 / #1309.
