### PR TITLE
#1533 Site #2: Normalize Lane.target/lerp_t into LaneTransition row table (Fabian Principle 3)

### DIFF
--- a/app/components/player.h
+++ b/app/components/player.h
@@ -73,10 +73,28 @@ struct Pressed {
     float press_time = 0.0f;
 };
 
+// Lane occupancy. The transition columns (`target`, `lerp_t`) moved to the
+// `LaneTransition` row table below per Fabian Principle 3 / issue #1533:
+// every column here is always meaningful. Hot: read by `collision_system`,
+// `player_input_system`, `player_movement_system`, `test_player_system`.
 struct Lane {
     int8_t current = 1;
-    int8_t target  = -1;
-    float  lerp_t  = 1.0f;
+};
+
+// In-flight lane transition. Presence on the player entity IS "the player
+// is mid-lane-transition"; both columns are always meaningful while the
+// row exists (Fabian Principle 3 / issue #1533). Replaces the former
+// `Lane::target = -1` sentinel + always-present `Lane::lerp_t` optional.
+//
+// Writers: `player_input_system` emplaces on swipe (target = current ± 1,
+// lerp_t = 0.0); `player_movement_system` removes when `lerp_t >= 1.0` and
+// commits the new `Lane::current`.
+// Readers: `player_movement_system` advances `lerp_t` and interpolates the
+// world x-position; `test_player_system` reads `target` to compute the
+// player's effective lane during action planning.
+struct LaneTransition {
+    int8_t target = -1;
+    float  lerp_t = 0.0f;
 };
 
 // ── Vertical motion state (per-state component tables) ──────

--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -76,7 +76,7 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
     auto player_entity = *player_view.begin();
     auto [p_transform, p_shape, p_window, p_lane] =
         player_view.get<WorldPosition, PlayerShape, ShapeWindow, Lane>(player_entity);
-    lane_utils::normalize(p_lane, &p_transform);
+    lane_utils::normalize(reg, player_entity, p_lane, &p_transform);
     (void)p_shape;
 
     auto& song = reg.ctx().get<SongState>();

--- a/app/systems/player_input_system.cpp
+++ b/app/systems/player_input_system.cpp
@@ -34,10 +34,13 @@ void try_lane_shift(entt::registry& reg, int8_t delta) {
     if (!gameplay_input_enabled(reg)) return;
     auto view = reg.view<PlayerTag, PlayerShape, ShapeWindow, Lane>();
     for (auto [entity, pshape, swindow, lane] : view.each()) {
-        lane_utils::normalize(lane);
-        const bool lane_switch_active =
-            lane_utils::is_valid(lane.target) && lane.target != lane.current;
-        if (lane_switch_active) {
+        lane_utils::normalize(reg, entity, lane);
+        // Presence of `LaneTransition` IS the "mid-transition" signal
+        // (Fabian Principle 3, issue #1533). Skip stale rows whose target
+        // already matches current (normalize won't strip those; they
+        // collapse on the next movement tick).
+        if (auto* transition = reg.try_get<LaneTransition>(entity);
+            transition && transition->target != lane.current) {
             (void)pshape;
             (void)swindow;
             continue;
@@ -48,8 +51,7 @@ void try_lane_shift(entt::registry& reg, int8_t delta) {
             (void)swindow;
             continue;
         }
-        lane.target = next;
-        lane.lerp_t = 0.0f;
+        reg.emplace_or_replace<LaneTransition>(entity, LaneTransition{next, 0.0f});
         push_haptic(reg, HapticEvent::LaneSwitch);
         (void)pshape;
         (void)swindow;
@@ -73,10 +75,9 @@ void try_vertical(entt::registry& reg, Op&& op) {
             (void)lane;
             continue;
         }
-        lane_utils::normalize(lane);
-        const bool lane_switch_active =
-            lane_utils::is_valid(lane.target) && lane.target != lane.current;
-        if (lane_switch_active) {
+        lane_utils::normalize(reg, entity, lane);
+        if (auto* transition = reg.try_get<LaneTransition>(entity);
+            transition && transition->target != lane.current) {
             (void)pshape;
             (void)swindow;
             continue;

--- a/app/systems/player_movement_system.cpp
+++ b/app/systems/player_movement_system.cpp
@@ -15,7 +15,7 @@ void player_movement_system(entt::registry& reg, float dt) {
 
     auto view = reg.view<PlayerTag, WorldPosition, PlayerShape, Lane>();
     for (auto [entity, transform, pshape, lane] : view.each()) {
-        lane_utils::normalize(lane, &transform);
+        lane_utils::normalize(reg, entity, lane, &transform);
 
         // Morph animation — freeplay only.
         // In rhythm mode shape_window_system owns morph_t (derives from song_time);
@@ -24,22 +24,24 @@ void player_movement_system(entt::registry& reg, float dt) {
             pshape.morph_t = Clamp(pshape.morph_t + dt / constants::MORPH_DURATION, 0.0f, 1.0f);
         }
 
-        // Lane transition
-        if (lane.target == lane.current) {
-            lane.target = lane_utils::kNoTargetLane;
-            lane.lerp_t = 1.0f;
+        // Lane transition — presence of `LaneTransition` IS the "mid-transition"
+        // signal (Fabian Principle 3, issue #1533). A row whose target equals
+        // current is a no-op leftover that was never advanced; collapse it.
+        auto* transition = reg.try_get<LaneTransition>(entity);
+        if (transition && transition->target == lane.current) {
+            reg.remove<LaneTransition>(entity);
             transform.position.x = constants::LANE_X[lane.current];
+            transition = nullptr;
         }
-        if (lane_utils::is_valid(lane.target) && lane.target != lane.current) {
-            lane.lerp_t += dt * constants::LANE_SWITCH_SPEED;
-            float from_x = constants::LANE_X[lane.current];
-            float to_x   = constants::LANE_X[lane.target];
-            transform.position.x = Lerp(from_x, to_x, lane.lerp_t);
+        if (transition && lane_utils::is_valid(transition->target)) {
+            transition->lerp_t += dt * constants::LANE_SWITCH_SPEED;
+            const float from_x = constants::LANE_X[lane.current];
+            const float to_x   = constants::LANE_X[transition->target];
+            transform.position.x = Lerp(from_x, to_x, transition->lerp_t);
 
-            if (lane.lerp_t >= 1.0f) {
-                lane.current = lane.target;
-                lane.target  = lane_utils::kNoTargetLane;
-                lane.lerp_t  = 1.0f;
+            if (transition->lerp_t >= 1.0f) {
+                lane.current = transition->target;
+                reg.remove<LaneTransition>(entity);
                 transform.position.x = constants::LANE_X[lane.current];
             }
         }

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -231,7 +231,7 @@ void test_player_system(entt::registry& reg, float dt) {
     auto player_entity = *player_view.begin();
     auto [p_transform, p_shape, p_window, p_lane] =
         player_view.get<WorldPosition, PlayerShape, ShapeWindow, Lane>(player_entity);
-    lane_utils::normalize(p_lane, &p_transform);
+    lane_utils::normalize(reg, player_entity, p_lane, &p_transform);
 
     // Per-frame constant: player's vertical offset (Grounded/Sliding → 0,
     // Jumping → parabolic arc) used in collision-zone math below.
@@ -240,9 +240,14 @@ void test_player_system(entt::registry& reg, float dt) {
 
     // ── PERCEIVE: scan obstacles in vision range ─────────────
     // Compute the "effective lane" — where the player will be after
-    // all pending lane changes in the action queue execute.
+    // all pending lane changes in the action queue execute. A
+    // `LaneTransition` row on the player IS "lane change in flight"
+    // (Fabian Principle 3, issue #1533); read its target lane directly.
     int8_t effective_lane = p_lane.current;
-    if (lane_utils::is_valid(p_lane.target)) effective_lane = p_lane.target;
+    if (const auto* p_transition = reg.try_get<LaneTransition>(player_entity);
+        p_transition && lane_utils::is_valid(p_transition->target)) {
+        effective_lane = p_transition->target;
+    }
     for (int i = 0; i < state->action_count; ++i) {
         if (lane_utils::is_valid(state->actions[i].target_lane) &&
             !test_player_lane_done(state->actions[i])) {
@@ -463,7 +468,7 @@ void test_player_system(entt::registry& reg, float dt) {
             }
         }
 
-        if (test_player_needs_lane(action) && !lane_utils::is_valid(p_lane.target) &&
+        if (test_player_needs_lane(action) && !reg.all_of<LaneTransition>(player_entity) &&
             state->swipe_cooldown_timer <= 0.0f
             && !zone_blocked && !blocked_by_shape && !move_would_fail_closer) {
             if (action.target_lane < p_lane.current) {

--- a/app/util/lane_utils.h
+++ b/app/util/lane_utils.h
@@ -4,12 +4,13 @@
 #include "../components/transform.h"
 #include "../constants.h"
 
+#include <entt/entt.hpp>
+
 #include <cmath>
 #include <cstdint>
 
 namespace lane_utils {
 
-inline constexpr int8_t kNoTargetLane = -1;
 inline constexpr int8_t kDefaultLane = static_cast<int8_t>(constants::DEFAULT_LANE);
 
 inline bool is_valid(int lane) {
@@ -39,27 +40,36 @@ inline int8_t nearest_lane_for_x(float x) {
     return nearest_lane;
 }
 
-inline bool normalize(Lane& lane, WorldPosition* transform = nullptr) {
+// Validates the player's lane row + any in-flight `LaneTransition` row
+// (issue #1533): an invalid `current` snaps back to the default lane and
+// cancels the transition; an invalid `LaneTransition::target` cancels the
+// transition. Returns true if anything was repaired.
+inline bool normalize(entt::registry& reg,
+                      entt::entity entity,
+                      Lane& lane,
+                      WorldPosition* transform = nullptr) {
+    bool repaired = false;
     if (!is_valid(lane.current)) {
         lane.current = kDefaultLane;
-        lane.target = kNoTargetLane;
-        lane.lerp_t = 1.0f;
+        if (reg.all_of<LaneTransition>(entity)) {
+            reg.remove<LaneTransition>(entity);
+        }
         if (transform) {
             snap_to_current_lane(lane, *transform);
         }
         return true;
     }
 
-    if (lane.target != kNoTargetLane && !is_valid(lane.target)) {
-        lane.target = kNoTargetLane;
-        lane.lerp_t = 1.0f;
+    if (auto* transition = reg.try_get<LaneTransition>(entity);
+        transition && !is_valid(transition->target)) {
+        reg.remove<LaneTransition>(entity);
         if (transform) {
             snap_to_current_lane(lane, *transform);
         }
-        return true;
+        repaired = true;
     }
 
-    return false;
+    return repaired;
 }
 
 }  // namespace lane_utils

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -218,12 +218,24 @@ struct Pressed {
 /// player IS "this press has been graded by collision_system" (replaces the
 /// former `ShapeWindow::graded` bool).
 
-/// Lane occupancy and transition. 8 bytes.
+/// Lane occupancy. The transition columns (`target`, `lerp_t`) live on a
+/// `LaneTransition` row table per Fabian Principle 3 / issue #1533: every
+/// column here is always meaningful. 1 byte.
 /// Hot: read by collision_system, player input handlers, player_movement_system.
 struct Lane {
     int8_t   current;      // 0 = left, 1 = center, 2 = right
-    int8_t   target;       // where we're heading (-1 = no transition)
-    float    lerp_t;       // 0.0..1.0 transition progress
+};
+
+/// In-flight lane transition. Presence on the player entity IS "the player
+/// is mid-lane-transition"; both columns are always meaningful while the
+/// row exists. Replaces the former `Lane::target = -1` sentinel + always-
+/// present `Lane::lerp_t` optional (issue #1533).
+/// Writers: `player_input_system` emplaces on swipe (target = current ± 1,
+/// lerp_t = 0.0); `player_movement_system` removes when `lerp_t >= 1.0`
+/// (after committing the new `Lane::current`).
+struct LaneTransition {
+    int8_t target;         // where we're heading (always a valid lane)
+    float  lerp_t;         // 0.0..1.0 transition progress
 };
 
 // Per-state vertical motion tables (issue #1202/#1204; Fabian existential
@@ -652,7 +664,8 @@ ScorePopup          16     HOT        popup expiry/render fade
 PlayerTag            0     HOT        collision/filter
 PlayerShape          8     HOT        shape_window, collision, render, player_action
 ShapeWindow         24     HOT        shape_window, input dispatcher, collision
-Lane                 8     HOT        collision, render, player_action
+Lane                 1     HOT        collision, render, player_action
+LaneTransition       8     HOT        present when mid-lane-shift; movement, collision, player_action
 Jumping              8     HOT        present when mid-jump; collision (y_offset), camera, movement
 Sliding              4     HOT        present when mid-slide; movement, render
 ObstacleTag          0     HOT        scroll, collision, cleanup
@@ -917,7 +930,8 @@ In code, reusable construction lives in `app/entities/` factory functions
 │ PlayerShape           { morph_t: 1.0 }                    │
 │ ShapeWindow           { window_timer: 0, window_start: 0 }│
 │ TargetShapeHexagonTag  (tag, 0 bytes; idle reset)         │
-│ Lane                  { current: 1, target: -1, lerp_t:1 }│
+│ Lane                  { current: 1 }                       │
+│ (LaneTransition absent → settled; row added on swipe per #1533)│
 │ (Jumping/Sliding absent → grounded; rows added on demand) │
 │ (ShapeWindow{MorphIn,Active,MorphOut}Tag absent → Idle)   │
 │ (Pressed{press_time} added on press, removed at MorphOut) │
@@ -1315,10 +1329,11 @@ int main(int argc, char* argv[]) {
     │                                                        │
     │   // 2. Process direction — one handler per direction  │
     │   player_input_handle_go_left(GoLeftEvent) {           │
-    │       if (Lane.current > 0) {                          │──▶ Lane
-    │           Lane.target = Lane.current - 1;              │    { current: 1,
-    │           Lane.lerp_t = 0.0f;                          │      target: 0,
-    │       }                                                │      lerp_t: 0.0 }
+    │       if (Lane.current > 0) {                          │──▶ LaneTransition (new row)
+    │           reg.emplace_or_replace<LaneTransition>(      │    { target: 0,
+    │               player,                                  │      lerp_t: 0.0 }
+    │               LaneTransition{Lane.current - 1, 0.0f}); │
+    │       }                                                │
     │   }                                                    │
     │   player_input_handle_go_up(GoUpEvent) {               │
     │       if (!reg.all_of<Jumping, Sliding>(player)) {     │──▶ Jumping (new row)
@@ -1395,6 +1410,7 @@ This entire game state fits in L1 cache (~32-64 KB).
   │
   │  □ PlayerShape     (shape window + collision + render, every frame, R)
   │  □ Lane            (collision + render, every frame, R)
+  │  □ LaneTransition  (present only when mid-lane-shift; movement + collision, R+W)
   │  □ Jumping/Sliding (present only when mid-jump/slide; movement + camera + collision, R+W)
   │  □ Obstacle        (collision + scoring, every frame, R)
   │
@@ -1681,6 +1697,9 @@ app/
 ├── components/                  ← all component structs
 │   ├── transform.h              ← WorldPosition, MotionVelocity
 │   ├── player.h                 ← PlayerTag, PlayerShape, ShapeWindow, Lane,
+│   │                              LaneTransition (present when mid-lane-
+│   │                              shift; row table per Fabian Principle 3,
+│   │                              issue #1533),
 │   │                              Jumping, Sliding (per-state vertical motion tables;
 │   │                              absence of both = grounded). Window phase lives
 │   │                              as `ShapeWindow*Tag` on the player entity (see

--- a/design-docs/tester-personas-tech-spec.md
+++ b/design-docs/tester-personas-tech-spec.md
@@ -413,13 +413,14 @@ a no-op.
 ```
   Player at lane 0, needs lane 2:
 
-  Frame N:    key_d → lane.target = 1, lerp_t = 0
-  Frame N+5:  transition complete, lane.current = 1, lane.target = -1
-  Frame N+6:  key_d → lane.target = 2, lerp_t = 0
-  Frame N+11: transition complete, lane.current = 2
+  Frame N:    key_d → emplace LaneTransition{target=1, lerp_t=0}
+  Frame N+5:  transition complete, Lane.current = 1, LaneTransition removed
+  Frame N+6:  key_d → emplace LaneTransition{target=2, lerp_t=0}
+  Frame N+11: transition complete, Lane.current = 2
 
-  Guard: only inject key_a/d when lane.target == -1
-  (no transition in progress). Prevents restarting a mid-transition.
+  Guard: only inject key_a/d when no LaneTransition row is present on the
+  player entity (no transition in progress per #1533). Prevents restarting
+  a mid-transition.
 
   Total: ~0.17s (11 frames at 60fps)
 ```

--- a/tests/test_collision_extended.cpp
+++ b/tests/test_collision_extended.cpp
@@ -157,9 +157,7 @@ TEST_CASE("collision: on-beat shape press requires player hitbox to reach target
     reg.get<int8_t>(obs) = int8_t{0};
     reg.emplace<BeatInfo>(obs, 0, song.song_time, song.song_time - song.lead_time);
 
-    auto& lane = reg.get<Lane>(player);
-    lane.target = 0;
-    lane.lerp_t = 0.0f;
+    reg.emplace<LaneTransition>(player, LaneTransition{0, 0.0f});
 
     auto btn = make_shape_button(reg, Shape::Circle);
     press_button(reg, btn);
@@ -167,9 +165,11 @@ TEST_CASE("collision: on-beat shape press requires player hitbox to reach target
     song.song_time += song.morph_duration + 0.001f;
     shape_window_system(reg, song.morph_duration + 0.001f);
 
+    const auto& lane = reg.get<Lane>(player);
+    const auto& transition = reg.get<LaneTransition>(player);
     const auto& transform = reg.get<WorldPosition>(player);
     REQUIRE(lane.current == 1);
-    REQUIRE(lane.target == 0);
+    REQUIRE(transition.target == 0);
     REQUIRE(transform.position.x == constants::LANE_X[1]);
 
     collision_system(reg, 0.016f);

--- a/tests/test_collision_system.cpp
+++ b/tests/test_collision_system.cpp
@@ -56,13 +56,11 @@ TEST_CASE("collision: shape gate does not clear from target lane before strafe a
           "[collision][issue892]") {
     auto reg = make_registry();
     auto player = make_player(reg);
-    auto& lane = reg.get<Lane>(player);
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
 
     reg.get<WorldPosition>(obs).position.x = constants::LANE_X[0];
     reg.get<int8_t>(obs) = int8_t{0};
-    lane.target = 0;
-    lane.lerp_t = 0.0f;
+    reg.emplace<LaneTransition>(player, LaneTransition{0, 0.0f});
 
     collision_system(reg, 0.016f);
 
@@ -88,14 +86,12 @@ TEST_CASE("collision: shape gate clears when interpolated player hitbox reaches 
           "[collision][issue892]") {
     auto reg = make_registry();
     auto player = make_player(reg);
-    auto& lane = reg.get<Lane>(player);
     auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y);
 
     reg.get<WorldPosition>(obs).position.x = constants::LANE_X[0];
     reg.get<int8_t>(obs) = int8_t{0};
     reg.get<WorldPosition>(player).position.x = constants::LANE_X[0];
-    lane.target = 0;
-    lane.lerp_t = 1.0f;
+    reg.emplace<LaneTransition>(player, LaneTransition{0, 1.0f});
 
     collision_system(reg, 0.016f);
 
@@ -110,10 +106,10 @@ TEST_CASE("collision: split path uses interpolated player lane during transition
     auto& lane = reg.get<Lane>(player);
     auto& transform = reg.get<WorldPosition>(player);
     lane.current = 1;
-    lane.target = 2;
-    lane.lerp_t = 0.9f;
+    auto& transition =
+        reg.emplace<LaneTransition>(player, LaneTransition{2, 0.9f});
     transform.position.x = constants::LANE_X[1] +
-        (constants::LANE_X[2] - constants::LANE_X[1]) * lane.lerp_t;
+        (constants::LANE_X[2] - constants::LANE_X[1]) * transition.lerp_t;
     auto obs = make_split_path(reg, Shape::Circle, 2, constants::PLAYER_Y);
 
     collision_system(reg, 0.016f);

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -60,8 +60,16 @@ TEST_CASE("components: PlayerShape defaults", "[components]") {
 TEST_CASE("components: Lane defaults to center", "[components]") {
     Lane l{};
     CHECK(l.current == 1);
-    CHECK(l.target == -1);
-    CHECK(l.lerp_t == 1.0f);
+}
+
+TEST_CASE("components: LaneTransition defaults to invalid target", "[components]") {
+    // Presence of `LaneTransition` IS "lane transition in flight" — both
+    // columns are always meaningful while the row exists. The defaulted
+    // `target == -1` only surfaces if a caller emplaces the row without
+    // initializing it; normal writers always set `target` to a valid lane.
+    LaneTransition lt{};
+    CHECK(lt.target == -1);
+    CHECK(lt.lerp_t == 0.0f);
 }
 
 TEST_CASE("components: player defaults to grounded (no Jumping/Sliding)", "[components]") {
@@ -151,14 +159,15 @@ TEST_CASE("ecs: make_registry dispatcher is wired — Go*Event listeners registe
     // Promote to Playing so player_input_handle_go_right has observable effect.
     set_test_phase<GamePhasePlayingTag>(reg);
     auto player = make_player(reg);
-    auto& lane  = reg.get<Lane>(player);
 
     auto& disp = reg.ctx().get<entt::dispatcher>();
     disp.enqueue(GoRightEvent{});
     disp.update<GoRightEvent>();
 
-    // If dispatcher listeners were NOT wired, lane.target would remain -1.
-    CHECK(lane.target == 2);   // listener wired: player_input_handle_go_right fired
+    // If dispatcher listeners were NOT wired, no LaneTransition row would
+    // be emplaced on the player.
+    REQUIRE(reg.all_of<LaneTransition>(player));
+    CHECK(reg.get<LaneTransition>(player).target == 2);   // listener wired: player_input_handle_go_right fired
 }
 
 TEST_CASE("ecs: make_registry dispatcher is wired — ShapePress*Event listeners registered", "[ecs][dispatcher]") {
@@ -184,16 +193,16 @@ TEST_CASE("ecs: make_registry dispatcher ctx — second update is a no-op (no re
     // Applies to both Go*Event and the per-shape ShapePress*Event pools.
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& lane  = reg.get<Lane>(player);
 
     auto& disp = reg.ctx().get<entt::dispatcher>();
     disp.enqueue(GoRightEvent{});
     disp.update<GoRightEvent>();
-    CHECK(lane.target == 2);
+    REQUIRE(reg.all_of<LaneTransition>(player));
+    CHECK(reg.get<LaneTransition>(player).target == 2);
 
     // Second drain — must be a no-op.
     disp.update<GoRightEvent>();
-    CHECK(lane.target == 2);   // not replayed
+    CHECK(reg.get<LaneTransition>(player).target == 2);   // not replayed
 }
 
 TEST_CASE("ecs: wire_input_dispatcher is idempotent", "[ecs][dispatcher]") {
@@ -362,7 +371,7 @@ TEST_CASE("ecs: registry teardown without unwire_* is safe (no UAF)",
         auto& disp = reg.ctx().get<entt::dispatcher>();
         disp.enqueue<GoRightEvent>(GoRightEvent{});
         disp.update<GoRightEvent>();
-        CHECK(reg.get<Lane>(player).target == 2);
+        CHECK(reg.get<LaneTransition>(player).target == 2);
         // Inner-block exit destroys the registry. With `scoped_connection`,
         // libstdc++ would SIGSEGV here because the dispatcher's `sigh` is
         // destroyed before the holder's auto-release runs.

--- a/tests/test_entt_dispatcher_contract.cpp
+++ b/tests/test_entt_dispatcher_contract.cpp
@@ -214,7 +214,7 @@ TEST_CASE("R7: Go*Event delivered in GameOver phase — player_input handler no-
     disp.enqueue(GoRightEvent{});
     disp.update<GoRightEvent>();
 
-    CHECK(lane.target  == -1);
+    CHECK_FALSE(reg.all_of<LaneTransition>(player));
     CHECK(lane.current == 1);
 }
 
@@ -222,7 +222,6 @@ TEST_CASE("R7: drain-first order — Go*Event processed in pre-transition phase,
           "[dispatcher][R7]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& lane = reg.get<Lane>(player);
     auto& disp = reg.ctx().get<entt::dispatcher>();
 
     REQUIRE(reg.ctx().contains<GamePhasePlayingTag>());
@@ -230,12 +229,13 @@ TEST_CASE("R7: drain-first order — Go*Event processed in pre-transition phase,
     disp.enqueue(GoRightEvent{});
 
     disp.update<GoRightEvent>();
-    CHECK(lane.target == 2);
+    REQUIRE(reg.all_of<LaneTransition>(player));
+    CHECK(reg.get<LaneTransition>(player).target == 2);
 
     set_test_phase<GamePhaseGameOverTag>(reg);
 
     disp.update<GoRightEvent>();
-    CHECK(lane.target == 2);
+    CHECK(reg.get<LaneTransition>(player).target == 2);
 }
 
 TEST_CASE("R7: two-tick stale-event regression — Go*Event from tick N absent in tick N+1",
@@ -248,15 +248,16 @@ TEST_CASE("R7: two-tick stale-event regression — Go*Event from tick N absent i
     REQUIRE(reg.ctx().contains<GamePhasePlayingTag>());
     disp.enqueue(GoRightEvent{});
     disp.update<GoRightEvent>();
-    CHECK(lane.target == 2);
+    REQUIRE(reg.all_of<LaneTransition>(player));
+    CHECK(reg.get<LaneTransition>(player).target == 2);
 
-    lane.lerp_t = 0.5f;
+    reg.get<LaneTransition>(player).lerp_t = 0.5f;
 
     set_test_phase<GamePhaseGameOverTag>(reg);
 
     disp.update<GoRightEvent>();
 
-    CHECK(lane.target  == 2);
-    CHECK(lane.lerp_t  == 0.5f);
+    CHECK(reg.get<LaneTransition>(player).target  == 2);
+    CHECK(reg.get<LaneTransition>(player).lerp_t  == 0.5f);
     CHECK(lane.current == 1);
 }

--- a/tests/test_input_pipeline_behavior.cpp
+++ b/tests/test_input_pipeline_behavior.cpp
@@ -6,20 +6,20 @@
 // menu events (#1277) — producers → game_state_system drain (authoritative)
 // → player_input listeners.
 //
-// All assertions are on player component state (Lane::target, ShapeWindow::phase,
-// PlayerShape::current) — never on raw event queues.
+// All assertions are on player component state (LaneTransition presence,
+// shape window phase tags, PlayerShape::current) — never on raw event queues.
 // This makes the tests implementation-agnostic: helpers enqueue semantic
 // events directly; game_state_system drains the queues and listeners mutate
 // player state in the same fixed tick. The observable outcomes are the
 // stable contract.
 //
 // Failure modes these tests guard against:
-//   - One-frame latency: swipe arrives but lane.target unchanged until next tick
+//   - One-frame latency: swipe arrives but no LaneTransition row until next tick
 //     (would occur if game_state_system's disp.update<GoEvent>() call were
 //     removed or moved after player_input_handle_go runs)
 //   - Dropped semantic shape press: ShapePress*Event arrives but sw.phase stays Idle
 //   - Wrong-phase activation: button presses fire in an inactive phase
-//   - Event replay: second pipeline tick resets lane.lerp_t (symptom: #213 bug)
+//   - Event replay: second pipeline tick resets LaneTransition.lerp_t (symptom: #213 bug)
 
 #include <catch2/catch_test_macros.hpp>
 #include "util/keyboard_shape_mapping.h"
@@ -107,7 +107,8 @@ TEST_CASE("pipeline: swipe right produces lane change in same pipeline call — 
     push_go_right(reg);
     run_pipeline(reg);
 
-    CHECK(lane.target == 2);
+    REQUIRE(reg.all_of<LaneTransition>(player));
+    CHECK(reg.get<LaneTransition>(player).target == 2);
 }
 
 TEST_CASE("pipeline: swipe left produces lane change in same pipeline call — no latency",
@@ -120,7 +121,8 @@ TEST_CASE("pipeline: swipe left produces lane change in same pipeline call — n
     push_go_left(reg);
     run_pipeline(reg);
 
-    CHECK(lane.target == 0);
+    REQUIRE(reg.all_of<LaneTransition>(player));
+    CHECK(reg.get<LaneTransition>(player).target == 0);
 }
 
 TEST_CASE("pipeline: swipe Up/Down has no lane effect",
@@ -129,14 +131,16 @@ TEST_CASE("pipeline: swipe Up/Down has no lane effect",
     auto player = make_rhythm_player(reg);
     auto& lane = reg.get<Lane>(player);
 
-    // Settle lane.target to current so we have a clear baseline.
-    lane.target = lane.current;   // both == 1
+    // Settle the player with no LaneTransition row → "no transition" baseline.
+    REQUIRE_FALSE(reg.all_of<LaneTransition>(player));
 
     push_go_up(reg);
     push_go_down(reg);
     run_pipeline(reg);
 
-    CHECK(lane.target == 1);   // unchanged: Up/Down produce no lane delta
+    // Up/Down produce no lane delta — no LaneTransition row should appear.
+    CHECK_FALSE(reg.all_of<LaneTransition>(player));
+    CHECK(lane.current == 1);
 }
 
 
@@ -174,13 +178,14 @@ TEST_CASE("pipeline: swipe right at right boundary does not wrap lane",
 
     // Settle player at rightmost lane.
     lane.current = static_cast<int8_t>(constants::LANE_COUNT - 1);
-    lane.target  = lane.current;
+    REQUIRE_FALSE(reg.all_of<LaneTransition>(player));
 
     push_go_right(reg);
     run_pipeline(reg);
 
-    // At boundary delta==0: the go-event handler skips the assignment block.
-    CHECK(lane.target == constants::LANE_COUNT - 1);
+    // At boundary delta==0: the go-event handler skips the emplace block.
+    CHECK_FALSE(reg.all_of<LaneTransition>(player));
+    CHECK(lane.current == constants::LANE_COUNT - 1);
 }
 
 // ── Semantic shape press → shape change ───────────────────────────────────
@@ -204,12 +209,12 @@ TEST_CASE("pipeline: semantic shape press does not change lane target",
     auto player = make_rhythm_player(reg);
     auto& lane = reg.get<Lane>(player);
     REQUIRE(lane.current == 1);
-    lane.target = lane.current;
+    REQUIRE_FALSE(reg.all_of<LaneTransition>(player));
 
     reg.ctx().get<entt::dispatcher>().enqueue<ShapePressCircleEvent>({});
     run_pipeline(reg);
 
-    CHECK(lane.target == 1);
+    CHECK_FALSE(reg.all_of<LaneTransition>(player));
 }
 
 TEST_CASE("pipeline: desktop keyboard slot mapping keeps Z/X/C shape order",
@@ -226,7 +231,7 @@ TEST_CASE("pipeline: gameplay HUD raygui shape press triggers player shape input
     auto& lane = reg.get<Lane>(player);
     REQUIRE(window_phase_is_idle(reg, player));
     REQUIRE(lane.current == 1);
-    lane.target = lane.current;
+    REQUIRE_FALSE(reg.all_of<LaneTransition>(player));
     apply_button_presses_for_test(reg,
                                   false,
                                   false,
@@ -236,7 +241,7 @@ TEST_CASE("pipeline: gameplay HUD raygui shape press triggers player shape input
 
     CHECK(window_phase_is_morph_in(reg, player));
     CHECK(current_target_shape(reg, player) == Shape::Square);
-    CHECK(lane.target == 1);
+    CHECK_FALSE(reg.all_of<LaneTransition>(player));
 }
 
 TEST_CASE("pipeline: gameplay HUD pointer release is collected before the fixed tick",
@@ -281,7 +286,8 @@ TEST_CASE("pipeline: mobile button-zone touch release is collected independently
 
     CHECK(window_phase_is_morph_in(reg, player));
     CHECK(current_target_shape(reg, player) == Shape::Square);
-    CHECK(lane.target == 2);
+    REQUIRE(reg.all_of<LaneTransition>(player));
+    CHECK(reg.get<LaneTransition>(player).target == 2);
 }
 
 TEST_CASE("pipeline: swipe-zone touch release over shape HUD does not press shape",
@@ -292,7 +298,7 @@ TEST_CASE("pipeline: swipe-zone touch release over shape HUD does not press shap
     auto& lane = reg.get<Lane>(player);
     REQUIRE(window_phase_is_idle(reg, player));
     REQUIRE(lane.current == 1);
-    lane.target = lane.current;
+    REQUIRE_FALSE(reg.all_of<LaneTransition>(player));
 
     const auto square_bounds = kHudSquareBoundsForTest;
     input.touch_up = true;
@@ -305,7 +311,8 @@ TEST_CASE("pipeline: swipe-zone touch release over shape HUD does not press shap
     run_pipeline(reg);
 
     CHECK(window_phase_is_idle(reg, player));
-    CHECK(lane.target == 2);
+    REQUIRE(reg.all_of<LaneTransition>(player));
+    CHECK(reg.get<LaneTransition>(player).target == 2);
 }
 
 TEST_CASE("pipeline: gameplay HUD pause release is collected before the fixed tick",
@@ -351,8 +358,7 @@ TEST_CASE("pipeline: pending phase transition blocks queued shape input",
     REQUIRE(reg.ctx().contains<GamePhasePlayingTag>());
     REQUIRE(window_phase_is_idle(reg, player));
     REQUIRE(lane.current == 1);
-    lane.target = lane.current;
-    REQUIRE(lane.target == 1);
+    REQUIRE_FALSE(reg.all_of<LaneTransition>(player));
 
     request_phase_transition<NextPhasePausedTag>(reg);
     reg.ctx().get<entt::dispatcher>().enqueue<ShapePressCircleEvent>({});
@@ -363,7 +369,7 @@ TEST_CASE("pipeline: pending phase transition blocks queued shape input",
     CHECK_FALSE(is_phase_transition_pending(reg));
     CHECK(window_phase_is_idle(reg, player));
     CHECK(current_target_shape(reg, player) == Shape::Hexagon);
-    CHECK(lane.target == 1);
+    CHECK_FALSE(reg.all_of<LaneTransition>(player));
 }
 
 TEST_CASE("pipeline: pending phase transition blocks queued go input",
@@ -374,8 +380,7 @@ TEST_CASE("pipeline: pending phase transition blocks queued go input",
 
     REQUIRE(reg.ctx().contains<GamePhasePlayingTag>());
     REQUIRE(lane.current == 1);
-    lane.target = lane.current;
-    REQUIRE(lane.target == 1);
+    REQUIRE_FALSE(reg.all_of<LaneTransition>(player));
     REQUIRE_FALSE(reg.any_of<Jumping, Sliding>(player));
 
     request_phase_transition<NextPhasePausedTag>(reg);
@@ -386,7 +391,7 @@ TEST_CASE("pipeline: pending phase transition blocks queued go input",
 
     CHECK(reg.ctx().contains<GamePhasePausedTag>());
     CHECK_FALSE(is_phase_transition_pending(reg));
-    CHECK(lane.target == 1);
+    CHECK_FALSE(reg.all_of<LaneTransition>(player));
     CHECK_FALSE(reg.any_of<Jumping, Sliding>(player));
 }
 
@@ -501,7 +506,8 @@ TEST_CASE("pipeline: mixed swipe and tap both take effect within a single pipeli
 
     run_pipeline(reg);
 
-    CHECK(lane.target     == 2);                  // explicit swipe moves lanes
+    REQUIRE(reg.all_of<LaneTransition>(player));
+    CHECK(reg.get<LaneTransition>(player).target == 2);    // explicit swipe moves lanes
     CHECK(window_phase_is_morph_in(reg, player)); // tap processed
     CHECK(current_target_shape(reg, player) == Shape::Triangle);
 }
@@ -528,11 +534,11 @@ TEST_CASE("pipeline: same-frame shape tap drains before movement",
 // ── No-latency regression ─────────────────────────────────────────────────
 //
 // If the refactor introduces a one-frame latency (e.g., GoEvent enqueued but
-// the authoritative game_state_system drain does not run), lane.target will still
-// equal lane.current after this call.  The check "lane.target != lane.current"
-// is the regression signal.
+// the authoritative game_state_system drain does not run), no LaneTransition
+// row will be present after this call.  The check "LaneTransition present
+// && target != current" is the regression signal.
 
-TEST_CASE("pipeline: swipe effect visible immediately — lane.target differs from lane.current after single pipeline call",
+TEST_CASE("pipeline: swipe effect visible immediately — LaneTransition target differs from lane.current after single pipeline call",
           "[input_pipeline]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
@@ -542,39 +548,41 @@ TEST_CASE("pipeline: swipe effect visible immediately — lane.target differs fr
     push_go_left(reg);
     run_pipeline(reg);
 
-    CHECK(lane.target != lane.current);  // must differ: effect is immediate, not deferred
-    CHECK(lane.target == 0);
+    REQUIRE(reg.all_of<LaneTransition>(player));
+    const auto& transition = reg.get<LaneTransition>(player);
+    CHECK(transition.target != lane.current);  // must differ: effect is immediate, not deferred
+    CHECK(transition.target == 0);
 }
 
 // ── Event consumption: no replay across sub-ticks (#213) ──────────────────
 //
 // The fixed-step accumulator may invoke pipeline systems more than once per
 // render frame.  After the first sub-tick consumes a swipe, subsequent
-// sub-ticks must NOT replay it and must not reset lane.lerp_t.
+// sub-ticks must NOT replay it and must not reset LaneTransition.lerp_t.
 //
 // After game_state_system drains semantic queues, a second sub-tick with no
 // new events is a no-op and must not replay.
 
-TEST_CASE("pipeline: swipe consumed after first sub-tick — second sub-tick does not reset lane.lerp_t (#213 behavior)",
+TEST_CASE("pipeline: swipe consumed after first sub-tick — second sub-tick does not reset LaneTransition.lerp_t (#213 behavior)",
           "[input_pipeline]") {
     auto reg = make_rhythm_registry();
     auto player = make_rhythm_player(reg);
-    auto& lane = reg.get<Lane>(player);
 
     // Sub-tick 1: inject swipe and run pipeline.
     push_go_right(reg);
     run_pipeline(reg);
-    CHECK(lane.target  == 2);
-    CHECK(lane.lerp_t  == 0.0f);
+    REQUIRE(reg.all_of<LaneTransition>(player));
+    CHECK(reg.get<LaneTransition>(player).target == 2);
+    CHECK(reg.get<LaneTransition>(player).lerp_t == 0.0f);
 
     // Simulate partial lerp (as player_movement_system would produce).
-    lane.lerp_t = 0.4f;
+    reg.get<LaneTransition>(player).lerp_t = 0.4f;
 
     // Sub-tick 2: no new semantic inputs pushed — run_pipeline is a no-op.
     run_pipeline(reg);
 
-    CHECK(lane.lerp_t == 0.4f);  // not reset: swipe was consumed on sub-tick 1
-    CHECK(lane.target == 2);     // target unchanged
+    CHECK(reg.get<LaneTransition>(player).lerp_t == 0.4f);  // not reset: swipe was consumed on sub-tick 1
+    CHECK(reg.get<LaneTransition>(player).target == 2);     // target unchanged
 }
 
 TEST_CASE("pipeline: tap consumed after first sub-tick — second sub-tick does not re-open shape window (#213 behavior)",

--- a/tests/test_player_action_rhythm.cpp
+++ b/tests/test_player_action_rhythm.cpp
@@ -202,7 +202,8 @@ TEST_CASE("player_action: swipe left works in rhythm mode", "[player_rhythm]") {
 
     run_semantic_input_tick(reg, 0.016f);
 
-    CHECK(reg.get<Lane>(player).target == 0);
+    REQUIRE(reg.all_of<LaneTransition>(player));
+    CHECK(reg.get<LaneTransition>(player).target == 0);
 }
 
 TEST_CASE("player_action: jump works in rhythm mode", "[player_rhythm]") {
@@ -229,16 +230,17 @@ TEST_CASE("player_input: GoEvents consumed after first tick, lane lerp_t not res
 
     // First tick: starts lane transition, consumes the event.
     run_semantic_input_tick(reg, 1.0f / 60.0f);
-    CHECK(lane.target == 0);
-    CHECK(lane.lerp_t == 0.0f);
+    REQUIRE(reg.all_of<LaneTransition>(player));
+    CHECK(reg.get<LaneTransition>(player).target == 0);
+    CHECK(reg.get<LaneTransition>(player).lerp_t == 0.0f);
 
     // Simulate partial lerp progress (as player_movement_system would do).
-    lane.lerp_t = 0.3f;
+    reg.get<LaneTransition>(player).lerp_t = 0.3f;
 
     // Second tick: GoEvent must NOT be replayed — lerp_t must not reset.
     run_semantic_input_tick(reg, 1.0f / 60.0f);
-    CHECK(lane.lerp_t == 0.3f);  // unchanged: event was consumed on tick 1
-    CHECK(lane.target == 0);
+    CHECK(reg.get<LaneTransition>(player).lerp_t == 0.3f);  // unchanged: event was consumed on tick 1
+    CHECK(reg.get<LaneTransition>(player).target == 0);
 }
 
 TEST_CASE("player_input: ShapePress*Events consumed after first tick (#213)", "[player_rhythm]") {

--- a/tests/test_player_input_rhythm_extended.cpp
+++ b/tests/test_player_input_rhythm_extended.cpp
@@ -90,13 +90,14 @@ TEST_CASE("player_input_rhythm: shape press does not target authored motif lane"
     auto player = make_rhythm_player(reg);
     auto& lane = reg.get<Lane>(player);
     REQUIRE(lane.current == 1);
-    lane.target = lane.current;
+    // No LaneTransition row → settled. A shape press must not synthesize one.
 
     auto btn = make_shape_button(reg, Shape::Triangle);
     press_button(reg, btn);
     run_semantic_input_tick(reg);
 
-    CHECK(lane.target == 1);
+    CHECK_FALSE(reg.all_of<LaneTransition>(player));
+    CHECK(lane.current == 1);
 }
 
 TEST_CASE("player_input_rhythm: shape press does not set stale target when already in authored motif lane",
@@ -105,13 +106,13 @@ TEST_CASE("player_input_rhythm: shape press does not set stale target when alrea
     auto player = make_rhythm_player(reg);
     auto& lane = reg.get<Lane>(player);
     lane.current = 0;
-    lane.target = -1;
+    // No LaneTransition row → settled.
 
     auto btn = make_shape_button(reg, Shape::Circle);
     press_button(reg, btn);
     run_semantic_input_tick(reg);
 
-    CHECK(lane.target == -1);
+    CHECK_FALSE(reg.all_of<LaneTransition>(player));
 }
 
 TEST_CASE("player_input_rhythm: shape press preserves in-flight lane target",
@@ -120,15 +121,15 @@ TEST_CASE("player_input_rhythm: shape press preserves in-flight lane target",
     auto player = make_rhythm_player(reg);
     auto& lane = reg.get<Lane>(player);
     lane.current = 1;
-    lane.target = 2;
-    lane.lerp_t = 0.5f;
+    reg.emplace<LaneTransition>(player, LaneTransition{2, 0.5f});
 
     auto btn = make_shape_button(reg, Shape::Square);
     press_button(reg, btn);
     run_semantic_input_tick(reg);
 
-    CHECK(lane.target == 2);
-    CHECK(lane.lerp_t == 0.5f);
+    REQUIRE(reg.all_of<LaneTransition>(player));
+    CHECK(reg.get<LaneTransition>(player).target == 2);
+    CHECK(reg.get<LaneTransition>(player).lerp_t == 0.5f);
 }
 
 TEST_CASE("player_input_rhythm: lane change works in rhythm mode", "[player][rhythm]") {
@@ -139,8 +140,8 @@ TEST_CASE("player_input_rhythm: lane change works in rhythm mode", "[player][rhy
 
     run_semantic_input_tick(reg);
 
-    auto& lane = reg.get<Lane>(player);
-    CHECK(lane.target == 0);
+    REQUIRE(reg.all_of<LaneTransition>(player));
+    CHECK(reg.get<LaneTransition>(player).target == 0);
 }
 
 TEST_CASE("player_input: non-rhythm shape press changes immediately", "[player]") {
@@ -159,8 +160,7 @@ TEST_CASE("player_input: non-rhythm shape press changes immediately", "[player]"
         CHECK(ps.morph_t == 1.0f);
     }
 
-    auto& lane = reg.get<Lane>(player);
-    CHECK(lane.target == -1);
+    CHECK_FALSE(reg.all_of<LaneTransition>(player));
 }
 
 TEST_CASE("player_input: non-rhythm same shape press does nothing", "[player]") {
@@ -205,8 +205,7 @@ TEST_CASE("player_input_rhythm: circle press in lane 0 does not force mismatch b
     auto& transform = reg.get<WorldPosition>(player);
 
     lane.current = 0;
-    lane.target = -1;
-    lane.lerp_t = 1.0f;
+    // No LaneTransition row → settled.
     transform.position.x = constants::LANE_X[0];
 
     set_player_shape_tag(reg, player, Shape::Hexagon);
@@ -224,7 +223,7 @@ TEST_CASE("player_input_rhythm: circle press in lane 0 does not force mismatch b
     player_movement_system(reg, 0.016f);
     collision_system(reg, 0.016f);
 
-    CHECK(lane.target == -1);
+    CHECK_FALSE(reg.all_of<LaneTransition>(player));
     CHECK(reg.all_of<ScoredTag>(obs));
     CHECK_FALSE(reg.all_of<MissTag>(obs));
 }

--- a/tests/test_player_systems.cpp
+++ b/tests/test_player_systems.cpp
@@ -44,31 +44,28 @@ TEST_CASE("player_action: no shape change when same shape pressed", "[player]") 
 
 TEST_CASE("player_action: swipe left changes lane", "[player]") {
     auto reg = make_registry();
-    make_player(reg);
+    auto player = make_player(reg);
 
     reg.ctx().get<entt::dispatcher>().enqueue<GoLeftEvent>({});
 
     run_semantic_input_tick(reg, 0.016f);
 
-    auto view = reg.view<PlayerTag, Lane>();
-    for (auto [e, lane] : view.each()) {
-        CHECK(lane.target == 0);
-        CHECK(lane.lerp_t == 0.0f);
-    }
+    REQUIRE(reg.all_of<LaneTransition>(player));
+    const auto& transition = reg.get<LaneTransition>(player);
+    CHECK(transition.target == 0);
+    CHECK(transition.lerp_t == 0.0f);
 }
 
 TEST_CASE("player_action: swipe right changes lane", "[player]") {
     auto reg = make_registry();
-    make_player(reg);
+    auto player = make_player(reg);
 
     reg.ctx().get<entt::dispatcher>().enqueue<GoRightEvent>({});
 
     run_semantic_input_tick(reg, 0.016f);
 
-    auto view = reg.view<PlayerTag, Lane>();
-    for (auto [e, lane] : view.each()) {
-        CHECK(lane.target == 2);
-    }
+    REQUIRE(reg.all_of<LaneTransition>(player));
+    CHECK(reg.get<LaneTransition>(player).target == 2);
 }
 
 TEST_CASE("player_action: repeated lane input during transition does not restart interpolation",
@@ -79,15 +76,16 @@ TEST_CASE("player_action: repeated lane input during transition does not restart
     reg.ctx().get<entt::dispatcher>().enqueue<GoRightEvent>({});
     run_semantic_input_tick(reg, 0.016f);
 
-    auto& lane = reg.get<Lane>(p);
-    lane.lerp_t = 0.4f;
+    auto& transition = reg.get<LaneTransition>(p);
+    transition.lerp_t = 0.4f;
 
     reg.ctx().get<entt::dispatcher>().enqueue<GoRightEvent>({});
     run_semantic_input_tick(reg, 0.016f);
 
-    CHECK(lane.current == 1);
-    CHECK(lane.target == 2);
-    CHECK_THAT(lane.lerp_t, Catch::Matchers::WithinAbs(0.4f, 0.0001f));
+    CHECK(reg.get<Lane>(p).current == 1);
+    CHECK(reg.get<LaneTransition>(p).target == 2);
+    CHECK_THAT(reg.get<LaneTransition>(p).lerp_t,
+               Catch::Matchers::WithinAbs(0.4f, 0.0001f));
 }
 
 TEST_CASE("player_action: opposite lane input during transition waits for completion",
@@ -95,17 +93,17 @@ TEST_CASE("player_action: opposite lane input during transition waits for comple
     auto reg = make_registry();
     auto p = make_player(reg);
 
-    auto& lane = reg.get<Lane>(p);
-    lane.current = 1;
-    lane.target = 2;
-    lane.lerp_t = 0.4f;
+    reg.get<Lane>(p).current = 1;
+    reg.emplace<LaneTransition>(p, LaneTransition{2, 0.4f});
 
     reg.ctx().get<entt::dispatcher>().enqueue<GoLeftEvent>({});
     run_semantic_input_tick(reg, 0.016f);
 
-    CHECK(lane.current == 1);
-    CHECK(lane.target == 2);
-    CHECK_THAT(lane.lerp_t, Catch::Matchers::WithinAbs(0.4f, 0.0001f));
+    CHECK(reg.get<Lane>(p).current == 1);
+    REQUIRE(reg.all_of<LaneTransition>(p));
+    CHECK(reg.get<LaneTransition>(p).target == 2);
+    CHECK_THAT(reg.get<LaneTransition>(p).lerp_t,
+               Catch::Matchers::WithinAbs(0.4f, 0.0001f));
 }
 
 TEST_CASE("player_action: swipe left at lane 0 is clamped", "[player]") {
@@ -117,7 +115,7 @@ TEST_CASE("player_action: swipe left at lane 0 is clamped", "[player]") {
 
     run_semantic_input_tick(reg, 0.016f);
 
-    CHECK(reg.get<Lane>(p).target == -1);  // no transition started
+    CHECK_FALSE(reg.all_of<LaneTransition>(p));  // no transition started
 }
 
 TEST_CASE("player_action: swipe right at lane 2 is clamped", "[player]") {
@@ -129,7 +127,7 @@ TEST_CASE("player_action: swipe right at lane 2 is clamped", "[player]") {
 
     run_semantic_input_tick(reg, 0.016f);
 
-    CHECK(reg.get<Lane>(p).target == -1);
+    CHECK_FALSE(reg.all_of<LaneTransition>(p));
 }
 
 TEST_CASE("player_action: swipe up starts jump", "[player]") {
@@ -185,8 +183,7 @@ TEST_CASE("player_movement: morph_t advances toward 1.0", "[player]") {
 TEST_CASE("player_movement: lane transition moves position", "[player]") {
     auto reg = make_registry();
     auto p = make_player(reg);
-    reg.get<Lane>(p).target = 0;
-    reg.get<Lane>(p).lerp_t = 0.0f;
+    reg.emplace<LaneTransition>(p, LaneTransition{0, 0.0f});
 
     float initial_x = reg.get<WorldPosition>(p).position.x;
     player_movement_system(reg, 0.016f);
@@ -197,8 +194,7 @@ TEST_CASE("player_movement: lane transition moves position", "[player]") {
 TEST_CASE("player_movement: lane transition completes", "[player]") {
     auto reg = make_registry();
     auto p = make_player(reg);
-    reg.get<Lane>(p).target = 2;
-    reg.get<Lane>(p).lerp_t = 0.0f;
+    reg.emplace<LaneTransition>(p, LaneTransition{2, 0.0f});
 
     // Run enough frames for transition to complete
     for (int i = 0; i < 120; ++i) {
@@ -206,7 +202,7 @@ TEST_CASE("player_movement: lane transition completes", "[player]") {
     }
 
     CHECK(reg.get<Lane>(p).current == 2);
-    CHECK(reg.get<Lane>(p).target == -1);
+    CHECK_FALSE(reg.all_of<LaneTransition>(p));
     CHECK(reg.get<WorldPosition>(p).position.x == constants::LANE_X[2]);
 }
 
@@ -216,14 +212,12 @@ TEST_CASE("player_movement: clears stale lane target when target equals current"
     auto& lane = reg.get<Lane>(p);
     auto& transform = reg.get<WorldPosition>(p);
     lane.current = 1;
-    lane.target = 1;
-    lane.lerp_t = 0.0f;
+    reg.emplace<LaneTransition>(p, LaneTransition{1, 0.0f});
     transform.position.x = (constants::LANE_X[1] + constants::LANE_X[2]) * 0.5f;
 
     player_movement_system(reg, 0.016f);
 
-    CHECK(lane.target == -1);
-    CHECK(lane.lerp_t == 1.0f);
+    CHECK_FALSE(reg.all_of<LaneTransition>(p));
     CHECK(transform.position.x == constants::LANE_X[1]);
 }
 
@@ -233,15 +227,13 @@ TEST_CASE("player_movement: normalizes invalid current lane", "[player][issue900
     auto& lane = reg.get<Lane>(p);
     auto& transform = reg.get<WorldPosition>(p);
     lane.current = -1;
-    lane.target = 0;
-    lane.lerp_t = 0.0f;
+    reg.emplace<LaneTransition>(p, LaneTransition{0, 0.0f});
     transform.position.x = -999.0f;
 
     player_movement_system(reg, 0.016f);
 
     CHECK(lane.current == constants::DEFAULT_LANE);
-    CHECK(lane.target == -1);
-    CHECK(lane.lerp_t == 1.0f);
+    CHECK_FALSE(reg.all_of<LaneTransition>(p));
     CHECK(transform.position.x == constants::LANE_X[constants::DEFAULT_LANE]);
 }
 
@@ -251,15 +243,14 @@ TEST_CASE("player_movement: normalizes invalid target lane", "[player][issue900]
     auto& lane = reg.get<Lane>(p);
     auto& transform = reg.get<WorldPosition>(p);
     lane.current = 1;
-    lane.target = constants::LANE_COUNT;
-    lane.lerp_t = 0.0f;
+    reg.emplace<LaneTransition>(p,
+        LaneTransition{static_cast<int8_t>(constants::LANE_COUNT), 0.0f});
     transform.position.x = (constants::LANE_X[1] + constants::LANE_X[2]) * 0.5f;
 
     player_movement_system(reg, 0.016f);
 
     CHECK(lane.current == 1);
-    CHECK(lane.target == -1);
-    CHECK(lane.lerp_t == 1.0f);
+    CHECK_FALSE(reg.all_of<LaneTransition>(p));
     CHECK(transform.position.x == constants::LANE_X[1]);
 }
 

--- a/tests/test_redfoot_testflight_ui.cpp
+++ b/tests/test_redfoot_testflight_ui.cpp
@@ -96,8 +96,9 @@ void spawn_aligned_player(entt::registry& reg, float y) {
     ShapeWindow sw{};
     reg.emplace<ShapeWindow>(p, sw);
     // Idle phase = absence of all ShapeWindow*Tag (#1202/#1204).
-    Lane lane{}; lane.current = 1; lane.target = -1;
+    Lane lane{}; lane.current = 1;
     reg.emplace<Lane>(p, lane);
+    // No LaneTransition row → settled (per #1533).
     // Grounded = absence of Jumping/Sliding (#1202/#1204).
 }
 


### PR DESCRIPTION
## Site #2 of #1533 — Fabian Principle 3 sweep

Per Fabian Principle 3 (`.squad/decisions.md` § "DoD source-text grounding (Fabian)"):
> A field meaningful only when another field has a particular value is a NULL column in disguise. Lift it to a side relation whose membership IS the precondition.

`Lane` had two such columns:
- `target = -1` sentinel meaningful only "while transitioning"
- `lerp_t` accumulator meaningful only "while transitioning"

This PR lifts them to a `LaneTransition` row table whose presence on the
player entity IS "mid-lane-transition".

### Schema

| Before | After |
|---|---|
| `Lane { int8_t current; int8_t target = -1; float lerp_t; }` (8 B w/ padding) | `Lane { int8_t current; }` (1 B) + `LaneTransition { int8_t target; float lerp_t; }` row when in flight |

### Semantic mapping

| Was | Now |
|---|---|
| `lane.target == -1` | `!reg.all_of<LaneTransition>(e)` |
| `lane.target = next; lane.lerp_t = 0` | `reg.emplace_or_replace<LaneTransition>(e, {next, 0.0f})` |
| `lane.target = -1; lane.lerp_t = 1` | `reg.remove<LaneTransition>(e)` |
| `lane_utils::is_valid(lane.target)` | row presence + valid target |
| `lane_utils::normalize(lane, transform*)` | `lane_utils::normalize(reg, e, lane, transform*)` |

### Writer/reader map

- **`player_input_system`** — sole emplacer of `LaneTransition` (swipe).
- **`player_movement_system`** — ticks `lerp_t`, commits `lane.current` and removes the row on completion.
- **`collision_system`** — only the `normalize` call signature changes; reads `lane.current` only.
- **`test_player_system`** — sole reader of `LaneTransition::target` for effective-lane prediction; row-presence guard replaces the sentinel check.

### Eradicated

- `lane_utils::kNoTargetLane` constant (sentinel).
- Every `lane.target == -1`, `lane.target = -1`, and direct `lane.lerp_t = …` write — full grep clean.

### Docs

- `design-docs/architecture.md` — struct sketch, archetype block, hot/cold component table (Lane 1 B; LaneTransition 8 B), data-flow box, file-tree comment.
- `design-docs/tester-personas-tech-spec.md` — "Multi-Frame Execution" box reworded around `emplace LaneTransition{...}` + row-presence guard.

### Tests

- **3394 assertions / 964 cases** pass (was 3371 / 963 → +23 assertions, +1 case).
  - New `LaneTransition defaults` case validates the new row's default-construction.
  - 9 test files migrated to the `emplace<LaneTransition>` / `get<LaneTransition>` / `all_of<LaneTransition>` API; all behavioural assertions preserved (boundary clamp, no event replay, in-flight preservation on shape press, …).
- **Zero warnings** under `-Wall -Wextra -Werror`.

### Verification

```
cmake --build build && ./build/shapeshifter_tests
…
All tests passed (3394 assertions in 964 test cases)
```

### Scope

Site #2 of 4 under #1533. Sites #3 (`TerminalResultState.previous_best`) and #4 (`BeatEntry.has_time_sec`) remain open for future cycles.

Refs: #1533. Site #1 template: #1535.
