### PR TITLE
#1533: Normalize TerminalResultState NULL columns into NewBestRecord row table (Fabian Principle 3, Site #3)

### DIFF
--- a/app/components/game_state.h
+++ b/app/components/game_state.h
@@ -29,11 +29,19 @@ struct LevelSelectState {
     int selected_difficulty  = 1;  // default medium
 };
 
-// ── Terminal Result Snapshot (singleton) ─────────────────────
-// Captured by game_state_terminal_phase_system at the moment of song
-// completion / game over.  Read by the Game Over / Song Complete screen
-// controllers (and high-score haptic feedback) to surface "new best" UI.
-struct TerminalResultState {
-    bool    new_best      = false;
+// ── New-Best Record (singleton row table) ─────────────────────
+// Emplaced by game_state_terminal_phase_system at the moment of song
+// completion / game over IFF the just-finished session set a new high
+// score for the active (song, difficulty) key. Read by the Game Over /
+// Song Complete screen controllers to surface the "NEW BEST!" / "PREV N"
+// lines.
+//
+// Per Fabian Principle 3 (issue #1533, site #3): the previous
+// `TerminalResultState { bool new_best; int32_t previous_best; }` shape
+// embedded a NULL column — `previous_best` was meaningful only when
+// `new_best == true`. The ctx-singleton's *membership* now expresses
+// the new-best precondition; the row carries only the always-meaningful
+// `previous_best` payload.
+struct NewBestRecord {
     int32_t previous_best = 0;
 };

--- a/app/components/scoring.h
+++ b/app/components/scoring.h
@@ -2,12 +2,13 @@
 
 #include <cstdint>
 
-// TerminalResultState relocated to game_state.h (it pairs with the
-// EnergyDepletedDeath ctx tag and the rest of the terminal-phase singletons).
-// ScorePopup / PopupDisplay relocated to popup.h (popup-entity data, distinct
-// from score-state singletons). Re-included here for source back-compat with
-// consumers that previously got them via scoring.h; new code should include
-// the canonical headers directly.
+// NewBestRecord (formerly TerminalResultState) relocated to game_state.h
+// (it pairs with the EnergyDepletedDeath ctx tag and the rest of the
+// terminal-phase singletons). ScorePopup / PopupDisplay relocated to
+// popup.h (popup-entity data, distinct from score-state singletons).
+// Re-included here for source back-compat with consumers that previously
+// got them via scoring.h; new code should include the canonical headers
+// directly.
 #include "game_state.h"
 #include "popup.h"
 

--- a/app/systems/game_over_scoreboard_bind_system.cpp
+++ b/app/systems/game_over_scoreboard_bind_system.cpp
@@ -12,10 +12,12 @@ namespace {
 
 // Bind context — owns the per-frame singleton reads so the per-slot
 // `bind_*` functions are pure transforms over their slot's `UiLabel`.
-// `TerminalResultState` may be absent during the Game Over debounce
-// window before `game_state_enter_terminal_phase_game_over` populates
-// it, so it is carried as a nullable pointer. `EnergyDepletedDeath`
-// is a presence-only ctx tag (no payload) so we carry a bool for it.
+// `NewBestRecord` is present-iff the just-finished session set a new
+// high score (Fabian Principle 3, issue #1533 site #3); its membership
+// in the ctx singleton table IS the "is_new_best" predicate, so we
+// carry a nullable pointer instead of a discriminator bool.
+// `EnergyDepletedDeath` is a presence-only ctx tag (no payload) so we
+// carry a bool for it.
 //
 // Per-binder prefix (`GameOver*`) avoids an anonymous-namespace ODR
 // collision with the sibling `*_bind_system.cpp` files when CMake Unity
@@ -23,14 +25,14 @@ namespace {
 struct GameOverBindContext {
     const ScoreState& score;
     const CurrentSongHighScore& current;
-    const TerminalResultState* result;
+    const NewBestRecord* new_best;
     bool energy_depleted;
 };
 
 using GameOverSlotBindFn = void (*)(const GameOverBindContext&, UiLabel&);
 
 bool is_new_best(const GameOverBindContext& ctx) {
-    return ctx.result != nullptr && ctx.result->new_best;
+    return ctx.new_best != nullptr;
 }
 
 void bind_score(const GameOverBindContext& ctx, UiLabel& label) {
@@ -51,7 +53,7 @@ void bind_prev_best(const GameOverBindContext& ctx, UiLabel& label) {
         return;
     }
     char buf[32];
-    std::snprintf(buf, sizeof(buf), "PREV %d", ctx.result->previous_best);
+    std::snprintf(buf, sizeof(buf), "PREV %d", ctx.new_best->previous_best);
     ui_label_set(label, buf);
 }
 
@@ -109,7 +111,7 @@ void game_over_scoreboard_bind_system(entt::registry& reg) {
     const GameOverBindContext ctx{
         reg.ctx().get<ScoreState>(),
         reg.ctx().get<CurrentSongHighScore>(),
-        reg.ctx().find<TerminalResultState>(),
+        reg.ctx().find<NewBestRecord>(),
         reg.ctx().find<EnergyDepletedDeath>() != nullptr,
     };
 

--- a/app/systems/game_over_scoreboard_bind_system.h
+++ b/app/systems/game_over_scoreboard_bind_system.h
@@ -13,9 +13,10 @@
 // (x, y, write fn) — no `switch` over a discriminator (Fabian Principle 1).
 //
 // The two reason slots (`ReasonSlot` at y=685 and `ReasonSlotNewBest` at
-// y=742) mirror the legacy controller's positional shift: when
-// `TerminalResultState.new_best` is set, the "ENERGY DEPLETED" reason moves
-// down to make room for the "NEW BEST!" + "PREV N" lines.
+// y=742) mirror the legacy controller's positional shift: when the
+// `NewBestRecord` ctx row is present (issue #1533 site #3), the
+// "ENERGY DEPLETED" reason moves down to make room for the "NEW BEST!"
+// + "PREV N" lines.
 //
 // Runs after `screen_lifecycle_system` so the GameOver entity set is
 // guaranteed to exist whenever `GamePhaseGameOverTag` is the active phase;

--- a/app/systems/game_state_terminal_phase_system.cpp
+++ b/app/systems/game_state_terminal_phase_system.cpp
@@ -45,10 +45,10 @@ bool update_and_persist_high_score(entt::registry& reg) {
         current.value = score.score;
     }
 
-    if (auto* result = reg.ctx().find<TerminalResultState>()) {
-        *result = TerminalResultState{recorded_new_high_score, previous_high_score};
-    } else {
-        reg.ctx().emplace<TerminalResultState>(TerminalResultState{recorded_new_high_score, previous_high_score});
+    if (recorded_new_high_score) {
+        reg.ctx().insert_or_assign(NewBestRecord{previous_high_score});
+    } else if (reg.ctx().contains<NewBestRecord>()) {
+        reg.ctx().erase<NewBestRecord>();
     }
 
     return recorded_new_high_score;

--- a/app/systems/song_complete_scoreboard_bind_system.cpp
+++ b/app/systems/song_complete_scoreboard_bind_system.cpp
@@ -14,10 +14,12 @@ namespace {
 
 // Bind context — owns the per-frame singleton reads so the per-slot
 // `bind_*` functions are pure transforms over their slot's `UiLabel`.
-// `SongResults`, `EnergyState`, and `TerminalResultState` may each be
-// absent during the Song Complete debounce window before
-// `game_state_enter_terminal_phase_song_complete` populates them, so
-// they are carried as nullable pointers.
+// `SongResults` and `EnergyState` may be absent during the Song Complete
+// debounce window before `game_state_enter_terminal_phase_song_complete`
+// populates them, so they are carried as nullable pointers. The
+// `NewBestRecord` ctx row is present-iff the just-finished session set a
+// new high score (Fabian Principle 3, issue #1533 site #3): we carry the
+// nullable pointer so the new-best precondition is just a null check.
 //
 // Per-binder prefix (`SongComplete*`) avoids an anonymous-namespace ODR
 // collision with the sibling `*_bind_system.cpp` files when CMake Unity
@@ -25,7 +27,7 @@ namespace {
 struct SongCompleteBindContext {
     const ScoreState& score;
     const CurrentSongHighScore& current;
-    const TerminalResultState* result;
+    const NewBestRecord* new_best;
     const SongResults* results;
     const EnergyState* energy;
 };
@@ -41,12 +43,12 @@ void bind_high_score(const SongCompleteBindContext& ctx, UiLabel& label) {
 }
 
 void bind_new_best(const SongCompleteBindContext& ctx, UiLabel& label) {
-    if (ctx.result == nullptr || !ctx.result->new_best) {
+    if (ctx.new_best == nullptr) {
         ui_label_set(label, "");
         return;
     }
     char buf[48];
-    std::snprintf(buf, sizeof(buf), "NEW BEST! PREV %d", ctx.result->previous_best);
+    std::snprintf(buf, sizeof(buf), "NEW BEST! PREV %d", ctx.new_best->previous_best);
     ui_label_set(label, buf);
 }
 
@@ -116,7 +118,7 @@ void song_complete_scoreboard_bind_system(entt::registry& reg) {
     const SongCompleteBindContext ctx{
         reg.ctx().get<ScoreState>(),
         reg.ctx().get<CurrentSongHighScore>(),
-        reg.ctx().find<TerminalResultState>(),
+        reg.ctx().find<NewBestRecord>(),
         reg.ctx().find<SongResults>(),
         reg.ctx().find<EnergyState>(),
     };

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -1715,8 +1715,11 @@ app/
 │   │                              Menu*Event, per-direction Go*Event
 │   │                              (in systems/, #1277/#1278/#1279)
 │   ├── game_state.h             ← GameState (phase_timer only), LevelSelectState,
-│   │                              TerminalResultState. Phase identity lives on
-│   │                              `GamePhase*Tag` ctx slots in `app/tags/tags.h`.
+│   │                              NewBestRecord (present iff terminal session
+│   │                              set a new high score; row table per Fabian
+│   │                              Principle 3, issue #1533). Phase identity
+│   │                              lives on `GamePhase*Tag` ctx slots in
+│   │                              `app/tags/tags.h`.
 │   ├── rendering.h              ← DrawSize, ScreenPosition; back-compat shim
 │   │                              for the camera/mesh splits (issue #1194)
 │   ├── particle.h               ← ParticleData, ParticleTag

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -103,9 +103,8 @@ TEST_CASE("game_state: enter_song_complete updates high score", "[gamestate]") {
 
     CHECK(current.value == 8000);
     CHECK(reg.ctx().contains<GamePhaseSongCompleteTag>());
-    const auto& terminal = reg.ctx().get<TerminalResultState>();
-    CHECK(terminal.new_best);
-    CHECK(terminal.previous_best == 5000);
+    REQUIRE(reg.ctx().contains<NewBestRecord>());
+    CHECK(reg.ctx().get<NewBestRecord>().previous_best == 5000);
 }
 
 TEST_CASE("game_state: enter_song_complete preserves higher high_score", "[gamestate]") {

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -292,7 +292,7 @@ TEST_CASE("High score integration: missing active entry does not report new best
     game_state_system(reg, 0.016f);
 
     CHECK(current.value == 1000);
-    CHECK_FALSE(reg.ctx().get<TerminalResultState>().new_best);
+    CHECK_FALSE(reg.ctx().contains<NewBestRecord>());
     CHECK_FALSE(reg.ctx().contains<HighScoreDirtyTag>());
     CHECK(high_score::get_score(high_scores, "overflow|hard") == 0);
 }

--- a/tests/test_ui_update_system.cpp
+++ b/tests/test_ui_update_system.cpp
@@ -446,7 +446,7 @@ TEST_CASE("song_complete_scoreboard_bind_system: writes score / high score / sta
     CHECK(resolve(120.0f, 684.0f) == "OK 2     BAD 1     MISS 0");
     CHECK(resolve(120.0f, 718.0f) == "MAX CHAIN 11");
     CHECK(resolve(120.0f, 752.0f) == "ENERGY 75%");
-    // NEW BEST line is empty when no TerminalResultState is present.
+    // NEW BEST line is empty when no NewBestRecord ctx row is present.
     CHECK(resolve(120.0f, 620.0f).empty());
 }
 
@@ -456,7 +456,7 @@ TEST_CASE("song_complete_scoreboard_bind_system: writes NEW BEST line when termi
     entt::registry reg = make_registry();
     prime_song_complete_entry(reg);
 
-    reg.ctx().insert_or_assign(TerminalResultState{true, 4242});
+    reg.ctx().insert_or_assign(NewBestRecord{4242});
 
     song_complete_scoreboard_bind_system(reg);
 
@@ -620,7 +620,7 @@ TEST_CASE("game_over_scoreboard_bind_system: writes score / high-score into slot
 
     CHECK(resolve_game_over_slot(reg, 210.0f, 540.0f) == "12345");
     CHECK(resolve_game_over_slot(reg, 210.0f, 634.0f) == "9000");
-    // No TerminalResultState / EnergyDepletedDeath — all dynamic reason /
+    // No NewBestRecord / EnergyDepletedDeath — all dynamic reason /
     // best slots empty.
     CHECK(resolve_game_over_slot(reg, 110.0f, 665.0f).empty());
     CHECK(resolve_game_over_slot(reg, 110.0f, 712.0f).empty());
@@ -649,7 +649,7 @@ TEST_CASE("game_over_scoreboard_bind_system: ENERGY DEPLETED shifts to y=742 + N
     prime_game_over_entry(reg);
 
     reg.ctx().insert_or_assign(EnergyDepletedDeath{});
-    reg.ctx().insert_or_assign(TerminalResultState{true, 3000});
+    reg.ctx().insert_or_assign(NewBestRecord{3000});
 
     game_over_scoreboard_bind_system(reg);
 
@@ -666,7 +666,7 @@ TEST_CASE("game_over_scoreboard_bind_system: NEW BEST/PREV without death cause l
           "[ui][game_over_scoreboard_bind_system][issue1293]") {
     entt::registry reg = make_registry();
     prime_game_over_entry(reg);
-    reg.ctx().insert_or_assign(TerminalResultState{true, 4242});
+    reg.ctx().insert_or_assign(NewBestRecord{4242});
 
     game_over_scoreboard_bind_system(reg);
 

--- a/tests/test_world_systems.cpp
+++ b/tests/test_world_systems.cpp
@@ -258,9 +258,8 @@ TEST_CASE("game_state: enter_game_over updates high score", "[gamestate]") {
 
     CHECK(current.value == 5000);
     CHECK(reg.ctx().contains<GamePhaseGameOverTag>());
-    const auto& terminal = reg.ctx().get<TerminalResultState>();
-    CHECK(terminal.new_best);
-    CHECK(terminal.previous_best == 3000);
+    REQUIRE(reg.ctx().contains<NewBestRecord>());
+    CHECK(reg.ctx().get<NewBestRecord>().previous_best == 3000);
 }
 
 TEST_CASE("game_state: enter_game_over pushes Crash SFX", "[gamestate]") {
@@ -288,9 +287,7 @@ TEST_CASE("game_state: enter_game_over preserves high score if lower", "[gamesta
     game_state_system(reg, 0.016f);
 
     CHECK(current.value == 5000);
-    const auto& terminal = reg.ctx().get<TerminalResultState>();
-    CHECK_FALSE(terminal.new_best);
-    CHECK(terminal.previous_best == 5000);
+    CHECK_FALSE(reg.ctx().contains<NewBestRecord>());
 }
 
 TEST_CASE("game_state: paused to playing on touch", "[gamestate]") {


### PR DESCRIPTION
Closes the third drift sub-site of #1533. Sites #1 (`ShapeWindow.press_time` → `Pressed`) and #2 (`Lane.target` → `LaneTransition`) are already merged on `main` (#1535, #1536).

## Drift site

```cpp
struct TerminalResultState {
    bool    new_best      = false;
    int32_t previous_best = 0;
};
```

`previous_best` is meaningful only when `new_best == true` — a classic NULL-column-in-disguise per Fabian Principle 3 (.squad/decisions.md § 9):

> A field whose meaning depends on another field's value is a NULL column in disguise. Move it to its own table whose membership IS the precondition.

## Normalization

```cpp
struct NewBestRecord {
    int32_t previous_best = 0;
};
```

Membership of `NewBestRecord` in the registry's ctx singleton table IS the "this terminal session set a new high score" predicate. `previous_best` is the always-meaningful payload of the present case.

## Writer

`app/systems/game_state_terminal_phase_system.cpp`:

```cpp
if (recorded_new_high_score) {
    reg.ctx().insert_or_assign(NewBestRecord{previous_high_score});
} else if (reg.ctx().contains<NewBestRecord>()) {
    reg.ctx().erase<NewBestRecord>();
}
```

Semantics-preserving swap: the previous code always wrote a fresh row holding both fields; the new code emplaces on new best and erases any stale row on not-new-best so the readers see the same ground truth.

## Readers

- `game_over_scoreboard_bind_system` — `is_new_best(ctx)` collapses to `ctx.new_best != nullptr`; `bind_prev_best` reads `ctx.new_best->previous_best` only inside the present-branch (no NULL access).
- `song_complete_scoreboard_bind_system` —

## Tests

Migrated 5 test sites across `test_game_state_extended`, `test_world_systems`, `test_high_score_integration`, and `test_ui_update_system`:

- Presence/payload assertions become `REQUIRE(contains<NewBestRecord>())` + `get<NewBestRecord>().previous_best == N`.
- Absence assertions become `CHECK_FALSE(contains<NewBestRecord>())`.
- One previously-meaningless assertion (`previous_best == 5000` in the not-new-best path) is dropped — it was asserting that the writer always wrote into the NULL column we're eradicating.

3393 assertions / 964 test cases pass; zero warnings.

## Doc updates

- `design-docs/architecture.md` — game_state.h tree entry updated.
- `app/components/scoring.h` / `app/systems/game_over_scoreboard_bind_system.h` — comment refresh.

## Remaining sub-site under #1533

- Site #4 — `BeatEntry.has_time_sec` optional-flag → split timed/untimed sub-types or side relation (cold-asset chart row, principle-purity drift).