### PR TITLE
#1533: Normalize BeatEntry timed/indexed siblings (Fabian Principle 3, Site #4)

### DIFF
--- a/app/components/beat_map.h
+++ b/app/components/beat_map.h
@@ -6,21 +6,36 @@
 #include <vector>
 
 // ── Beat Entry (one row in a per-(kind,shape) beat vector) ──────────
-// Both former discriminator enums on the row are eradicated (issue #1202/#1204):
+// All three former discriminator/optional fields on the row are eradicated:
 //
 //   - `ObstacleKind kind` -- identified by which per-kind vector in BeatMap
-//     the row lives in (shape_gate / split_path / onset_marker).
+//     the row lives in (shape_gate / split_path / onset_marker) (#1202/#1204).
 //   - `Shape shape` -- identified by which per-shape sub-vector in BeatMap
 //     the row lives in (`shape_gate_circle_beats`, ..., `split_path_triangle_beats`).
-//     OnsetMarker has no shape -- only one vector `onset_marker_beats`.
+//     OnsetMarker has no shape -- only one vector `onset_marker_beats` (#1202/#1204).
+//   - `bool has_time_sec` + NULL-column `float time_sec` -- identified by which
+//     of the parallel `*_beats` (indexed) / `*_beats_timed` (authored) vector
+//     the row lives in (#1533 Site #4, Fabian Principle 3).
 //
 // For ShapeGate rows `lane` is positional only; for SplitPath rows `lane`
 // is the required dodge lane; for OnsetMarker rows `lane` is unused.
 struct BeatEntry {
-    int    beat_index   = 0;
-    int8_t lane         = 1;
-    float  time_sec     = 0.0f;
-    bool   has_time_sec = false;
+    int    beat_index = 0;
+    int8_t lane       = 1;
+};
+
+// ── Beat Entry, authored-onset variant ─────────────────────────────
+// Row table for entries whose timing source is an explicit authored
+// `time_sec` (typically an aubio onset timestamp). Membership of a row
+// in any `*_beats_timed` vector IS the "has authored time_sec" precondition
+// — there is no in-row optionality flag and `time_sec` is always meaningful.
+//
+// Untimed (beat-index-only) siblings live in the parallel `*_beats` vectors
+// and resolve their arrival time from `BeatMap::beat_times[beat_index]`.
+struct BeatEntryTimed {
+    int    beat_index = 0;
+    int8_t lane       = 1;
+    float  time_sec   = 0.0f;
 };
 
 // ── Beat Map (the full chart, loaded from JSON) ─────
@@ -36,17 +51,21 @@ struct BeatEntry {
 // deleted so accidental duplication of the heap-allocated beat array is a
 // compile-time error. Use std::move() when transferring ownership.
 //
-// The chart is normalized per Fabian's relational mechanic (#1204): each
-// former `ObstacleKind` and each former `Shape` value gets its own table
-// (vector). Cross-table ordering (e.g. monotonic beat indices) is validated
-// by merging the per-(kind, shape) vectors in beat-index order; intra-table
-// rules walk only the relevant vector. Each vector is independently
-// `stable_sort`-ed by beat_index after parsing.
+// The chart is normalized per Fabian's relational mechanic (#1204, #1533):
+// each former `ObstacleKind` and each former `Shape` value gets its own
+// table (vector); and each former `bool has_time_sec` optionality on the
+// row is split into parallel indexed (`*_beats`) / authored-onset
+// (`*_beats_timed`) tables whose membership IS the timing-source
+// precondition. Cross-table ordering (e.g. monotonic beat indices) is
+// validated by merging the per-(kind, shape, timing-source) vectors in
+// beat-index order; intra-table rules walk only the relevant vector.
+// Each vector is independently `stable_sort`-ed after parsing
+// (indexed bins by `beat_index`; timed bins by `(beat_index, time_sec)`).
 //
 // Shape::Hexagon is not a valid required shape for shape_gate / split_path
 // (`current_required_shape` returns Hexagon as a sentinel meaning "no
 // required shape"); the loader rejects shape_gate / split_path rows whose
-// shape parses as Hexagon, so no `*_hexagon_beats` vector exists.
+// shape parses as Hexagon, so no `*_hexagon_beats[_timed]` vector exists.
 struct BeatMap {
     std::string song_id;
     std::string title;
@@ -66,6 +85,14 @@ struct BeatMap {
     std::vector<BeatEntry> split_path_triangle_beats;
     std::vector<BeatEntry> onset_marker_beats;
 
+    std::vector<BeatEntryTimed> shape_gate_circle_beats_timed;
+    std::vector<BeatEntryTimed> shape_gate_square_beats_timed;
+    std::vector<BeatEntryTimed> shape_gate_triangle_beats_timed;
+    std::vector<BeatEntryTimed> split_path_circle_beats_timed;
+    std::vector<BeatEntryTimed> split_path_square_beats_timed;
+    std::vector<BeatEntryTimed> split_path_triangle_beats_timed;
+    std::vector<BeatEntryTimed> onset_marker_beats_timed;
+
     BeatMap()                          = default;
     BeatMap(const BeatMap&)            = delete;
     BeatMap& operator=(const BeatMap&) = delete;
@@ -74,37 +101,53 @@ struct BeatMap {
 };
 
 // Total scoring-eligible (ShapeGate + SplitPath) beat count across the
-// six per-(kind, shape) vectors. OnsetMarker beats are non-scorable cues
-// and are excluded.
+// six per-(kind, shape) indexed vectors and their six authored-onset
+// siblings. OnsetMarker beats are non-scorable cues and are excluded.
 inline size_t beat_map_required_count(const BeatMap& m) noexcept {
     return m.shape_gate_circle_beats.size()
          + m.shape_gate_square_beats.size()
          + m.shape_gate_triangle_beats.size()
          + m.split_path_circle_beats.size()
          + m.split_path_square_beats.size()
-         + m.split_path_triangle_beats.size();
+         + m.split_path_triangle_beats.size()
+         + m.shape_gate_circle_beats_timed.size()
+         + m.shape_gate_square_beats_timed.size()
+         + m.shape_gate_triangle_beats_timed.size()
+         + m.split_path_circle_beats_timed.size()
+         + m.split_path_square_beats_timed.size()
+         + m.split_path_triangle_beats_timed.size();
 }
 
-// Total ShapeGate beat count across the three per-shape vectors.
+// Total ShapeGate beat count across the three per-shape indexed vectors
+// and their three authored-onset siblings.
 inline size_t shape_gate_count(const BeatMap& m) noexcept {
     return m.shape_gate_circle_beats.size()
          + m.shape_gate_square_beats.size()
-         + m.shape_gate_triangle_beats.size();
+         + m.shape_gate_triangle_beats.size()
+         + m.shape_gate_circle_beats_timed.size()
+         + m.shape_gate_square_beats_timed.size()
+         + m.shape_gate_triangle_beats_timed.size();
 }
 
-// Total SplitPath beat count across the three per-shape vectors.
+// Total SplitPath beat count across the three per-shape indexed vectors
+// and their three authored-onset siblings.
 inline size_t split_path_count(const BeatMap& m) noexcept {
     return m.split_path_circle_beats.size()
          + m.split_path_square_beats.size()
-         + m.split_path_triangle_beats.size();
+         + m.split_path_triangle_beats.size()
+         + m.split_path_circle_beats_timed.size()
+         + m.split_path_square_beats_timed.size()
+         + m.split_path_triangle_beats_timed.size();
 }
 
-// Total beat count across all seven per-(kind, shape) vectors.
+// Total beat count across all fourteen per-(kind, shape, timing-source) vectors.
 inline size_t beat_map_total_count(const BeatMap& m) noexcept {
-    return beat_map_required_count(m) + m.onset_marker_beats.size();
+    return beat_map_required_count(m)
+         + m.onset_marker_beats.size()
+         + m.onset_marker_beats_timed.size();
 }
 
-// True iff the beat map has zero authored beats across all seven vectors.
+// True iff the beat map has zero authored beats across all fourteen vectors.
 inline bool beat_map_empty(const BeatMap& m) noexcept {
     return beat_map_total_count(m) == 0;
 }

--- a/app/components/song_state.h
+++ b/app/components/song_state.h
@@ -39,21 +39,32 @@ struct SongState {
     bool   restart_music = false;  // set true by setup_play_session; consumed/cleared
                                    //   on the next tick by song_playback_system
 
-    // ── Beat-schedule cursors (per-(kind, shape), reset at session init) ────
+    // ── Beat-schedule cursors (per-(kind, shape, timing-source), reset at session init) ──
     // Replaces the former `next_spawn_idx` single cursor (issue #1202/#1204).
     // Each former enum value (`ObstacleKind`, `Shape`) was a hidden lookup
     // table; per Fabian's relational-database mechanic, each value gets its
-    // own row in BeatMap and its own cursor here. beat_scheduler_system runs
-    // one per-cursor transform; each cursor advances independently over its
-    // own vector in BeatMap. Shape::Hexagon is not a valid required shape
-    // for shape_gate / split_path, so no `*_hexagon_idx` cursor exists.
-    size_t next_shape_gate_circle_idx    = 0;
-    size_t next_shape_gate_square_idx    = 0;
-    size_t next_shape_gate_triangle_idx  = 0;
-    size_t next_split_path_circle_idx    = 0;
-    size_t next_split_path_square_idx    = 0;
-    size_t next_split_path_triangle_idx  = 0;
-    size_t next_onset_marker_idx         = 0;
+    // own row in BeatMap and its own cursor here. The further `_timed_idx`
+    // split (#1533) tracks the per-bin authored-onset siblings introduced
+    // when `BeatEntry::has_time_sec` was eradicated: indexed entries live in
+    // `*_beats` and timed entries live in `*_beats_timed`, each with an
+    // independent cursor. beat_scheduler_system runs one per-cursor transform;
+    // each cursor advances independently over its own vector in BeatMap.
+    // Shape::Hexagon is not a valid required shape for shape_gate / split_path,
+    // so no `*_hexagon_idx` cursor exists.
+    size_t next_shape_gate_circle_idx          = 0;
+    size_t next_shape_gate_square_idx          = 0;
+    size_t next_shape_gate_triangle_idx        = 0;
+    size_t next_split_path_circle_idx          = 0;
+    size_t next_split_path_square_idx          = 0;
+    size_t next_split_path_triangle_idx        = 0;
+    size_t next_onset_marker_idx               = 0;
+    size_t next_shape_gate_circle_timed_idx    = 0;
+    size_t next_shape_gate_square_timed_idx    = 0;
+    size_t next_shape_gate_triangle_timed_idx  = 0;
+    size_t next_split_path_circle_timed_idx    = 0;
+    size_t next_split_path_square_timed_idx    = 0;
+    size_t next_split_path_triangle_timed_idx  = 0;
+    size_t next_onset_marker_timed_idx         = 0;
 };
 
 // ── Song Results (singleton, accumulates during play) ─

--- a/app/entities/beat_map.cpp
+++ b/app/entities/beat_map.cpp
@@ -254,24 +254,31 @@ static std::optional<Shape> parse_shape(const std::string& s) {
     return std::nullopt;
 }
 
-// ── Per-(kind, shape) beat-entry sinks (issue #1202/#1204) ──────────
+// ── Per-(kind, shape, timing-source) beat-entry sinks (#1202/#1204/#1533) ──
 // The former `BeatEntry::shape` discriminator is encoded by which per-shape
-// vector receives the entry. The sink table is indexed by `shape_index()`;
-// Shape::Hexagon is not a valid required shape for shape_gate / split_path,
-// so its slot points at `null_shape_sink` (shared between both tables) —
+// vector receives the entry; the former `BeatEntry::has_time_sec` optionality
+// is encoded by whether the indexed (`*_beats`) or the authored-onset
+// (`*_beats_timed`) sibling vector receives it. The sink tables are indexed
+// by `shape_index()`; Shape::Hexagon is not a valid required shape for
+// shape_gate / split_path, so its slot points at a `null_*_sink` accessor —
 // the loader treats nullptr as a parse error and emits a "Shape 'hexagon'
 // is not a valid required shape" message.
-using ShapeBinAccessor = std::vector<BeatEntry>* (*)(BeatMap&);
+using ShapeBinAccessor      = std::vector<BeatEntry>*      (*)(BeatMap&);
+using ShapeBinTimedAccessor = std::vector<BeatEntryTimed>* (*)(BeatMap&);
 
 // One template instantiation per non-null sink slot (issue #1456 finishes the
 // dedupe started by #1420/#1421). The six per-(kind, shape) bodies previously
 // differed only by which `BeatMap` data-member pointer was named; the function
-// pointer stored in `kShapeGateSinks` / `kSplitPathSinks` still has the
-// `std::vector<BeatEntry>* (*)(BeatMap&)` signature required by `ShapeBinAccessor`.
+// pointers stored in `kShapeGate*Sinks` / `kSplitPath*Sinks` still have the
+// `std::vector<…>* (*)(BeatMap&)` signatures required by the accessor aliases.
 template <std::vector<BeatEntry> BeatMap::*Field>
 std::vector<BeatEntry>* shape_field_sink(BeatMap& m) { return &(m.*Field); }
 
-std::vector<BeatEntry>* null_shape_sink(BeatMap& m) { (void)m; return nullptr; }
+template <std::vector<BeatEntryTimed> BeatMap::*Field>
+std::vector<BeatEntryTimed>* shape_field_sink_timed(BeatMap& m) { return &(m.*Field); }
+
+std::vector<BeatEntry>*      null_shape_sink(BeatMap& m)       { (void)m; return nullptr; }
+std::vector<BeatEntryTimed>* null_shape_sink_timed(BeatMap& m) { (void)m; return nullptr; }
 
 inline constexpr std::array<ShapeBinAccessor, kShapeCount> kShapeGateSinks{
     &shape_field_sink<&BeatMap::shape_gate_circle_beats>,
@@ -284,6 +291,18 @@ inline constexpr std::array<ShapeBinAccessor, kShapeCount> kSplitPathSinks{
     &shape_field_sink<&BeatMap::split_path_square_beats>,
     &shape_field_sink<&BeatMap::split_path_triangle_beats>,
     &null_shape_sink
+};
+inline constexpr std::array<ShapeBinTimedAccessor, kShapeCount> kShapeGateTimedSinks{
+    &shape_field_sink_timed<&BeatMap::shape_gate_circle_beats_timed>,
+    &shape_field_sink_timed<&BeatMap::shape_gate_square_beats_timed>,
+    &shape_field_sink_timed<&BeatMap::shape_gate_triangle_beats_timed>,
+    &null_shape_sink_timed
+};
+inline constexpr std::array<ShapeBinTimedAccessor, kShapeCount> kSplitPathTimedSinks{
+    &shape_field_sink_timed<&BeatMap::split_path_circle_beats_timed>,
+    &shape_field_sink_timed<&BeatMap::split_path_square_beats_timed>,
+    &shape_field_sink_timed<&BeatMap::split_path_triangle_beats_timed>,
+    &null_shape_sink_timed
 };
 
 // ── Per-kind beat-entry sinks (issue #1202/#1204) ───────────
@@ -329,6 +348,13 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
     out.split_path_square_beats.clear();
     out.split_path_triangle_beats.clear();
     out.onset_marker_beats.clear();
+    out.shape_gate_circle_beats_timed.clear();
+    out.shape_gate_square_beats_timed.clear();
+    out.shape_gate_triangle_beats_timed.clear();
+    out.split_path_circle_beats_timed.clear();
+    out.split_path_square_beats_timed.clear();
+    out.split_path_triangle_beats_timed.clear();
+    out.onset_marker_beats_timed.clear();
     out.beat_times.clear();
     out.song_id.clear();
     out.title.clear();
@@ -531,18 +557,21 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
         }
         entry.lane = static_cast<int8_t>(lane_value);
 
+        // Resolve the indexed-source arrival time once for the mismatch warn.
+        // Authored entries route into `*_beats_timed` and carry their explicit
+        // `time_sec`; indexed entries route into `*_beats` and resolve at
+        // schedule time from `beat_times[beat_index]` (or grid time).
         const float grid_time = out.offset + entry.beat_index * (60.0f / out.bpm);
-        float beat_time = grid_time;
+        float indexed_time = grid_time;
         if (!out.beat_times.empty() &&
             entry.beat_index >= 0 &&
             static_cast<size_t>(entry.beat_index) < out.beat_times.size()) {
-            beat_time = out.beat_times[static_cast<size_t>(entry.beat_index)];
+            indexed_time = out.beat_times[static_cast<size_t>(entry.beat_index)];
         }
 
         const bool has_time_sec = b.contains("time_sec");
-        entry.has_time_sec = has_time_sec;
-        entry.time_sec = beat_time;
-        if (has_time_sec && !read_optional_float(b, "time_sec", entry.time_sec, errors, entry.beat_index)) {
+        float authored_time_sec = indexed_time;
+        if (has_time_sec && !read_optional_float(b, "time_sec", authored_time_sec, errors, entry.beat_index)) {
             parse_ok = false;
             continue;
         }
@@ -556,10 +585,10 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
             entry.beat_index >= 0 &&
             static_cast<size_t>(entry.beat_index) < out.beat_times.size()) {
             constexpr float kBeatTimeMismatchWarnSec = 0.010f;
-            if (std::fabs(entry.time_sec - beat_time) > kBeatTimeMismatchWarnSec) {
+            if (std::fabs(authored_time_sec - indexed_time) > kBeatTimeMismatchWarnSec) {
                 TraceLog(LOG_WARNING,
                          "Beat time mismatch at beat=%d: time_sec=%.6f, beat_times[%d]=%.6f",
-                         entry.beat_index, entry.time_sec, entry.beat_index, beat_time);
+                         entry.beat_index, authored_time_sec, entry.beat_index, indexed_time);
             }
         }
 
@@ -575,39 +604,69 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
             continue;
         }
 
-        // Per-(kind, shape) dispatch into the appropriate vector (issue
-        // #1202/#1204). No discriminator enum survives in the data model —
-        // the row lives in exactly one of seven per-(kind, shape) tables.
-        // Hexagon is not a valid required shape for shape_gate / split_path;
-        // the sink table returns nullptr in that slot so the loader rejects
-        // it explicitly.
+        // Per-(kind, shape, timing-source) dispatch into the appropriate
+        // vector (issues #1202/#1204/#1533). No discriminator enum and no
+        // `has_time_sec` optionality flag survive in the data model — the
+        // row lives in exactly one of fourteen per-(kind, shape, timing-source)
+        // tables. Hexagon is not a valid required shape for shape_gate /
+        // split_path; the sink table returns nullptr in that slot so the
+        // loader rejects it explicitly.
         if (kind_str == "onset_marker") {
-            out.onset_marker_beats.push_back(entry);
+            if (has_time_sec) {
+                out.onset_marker_beats_timed.push_back(
+                    BeatEntryTimed{entry.beat_index, entry.lane, authored_time_sec});
+            } else {
+                out.onset_marker_beats.push_back(entry);
+            }
         } else {
-            const auto& sinks = (kind_str == "shape_gate") ? kShapeGateSinks
-                                                           : kSplitPathSinks;
             const int idx = shape_index(parsed_shape);
-            std::vector<BeatEntry>* sink = (idx >= 0) ? sinks[static_cast<size_t>(idx)](out)
-                                                      : nullptr;
-            if (!sink) {
+            if (idx < 0) {
                 errors.push_back({entry.beat_index,
                     "Shape 'hexagon' is not a valid required shape for obstacle kind '"
                     + kind_str + "' at beat " + std::to_string(entry.beat_index)});
                 parse_ok = false;
                 continue;
             }
-            sink->push_back(entry);
+            if (has_time_sec) {
+                const auto& sinks = (kind_str == "shape_gate") ? kShapeGateTimedSinks
+                                                               : kSplitPathTimedSinks;
+                std::vector<BeatEntryTimed>* sink = sinks[static_cast<size_t>(idx)](out);
+                if (!sink) {
+                    errors.push_back({entry.beat_index,
+                        "Shape 'hexagon' is not a valid required shape for obstacle kind '"
+                        + kind_str + "' at beat " + std::to_string(entry.beat_index)});
+                    parse_ok = false;
+                    continue;
+                }
+                sink->push_back(
+                    BeatEntryTimed{entry.beat_index, entry.lane, authored_time_sec});
+            } else {
+                const auto& sinks = (kind_str == "shape_gate") ? kShapeGateSinks
+                                                               : kSplitPathSinks;
+                std::vector<BeatEntry>* sink = sinks[static_cast<size_t>(idx)](out);
+                if (!sink) {
+                    errors.push_back({entry.beat_index,
+                        "Shape 'hexagon' is not a valid required shape for obstacle kind '"
+                        + kind_str + "' at beat " + std::to_string(entry.beat_index)});
+                    parse_ok = false;
+                    continue;
+                }
+                sink->push_back(entry);
+            }
         }
         (void)has_parsed_shape;
     }
 
     if (!parse_ok) return false;
 
-    // Sort each per-(kind, shape) vector by beat_index; for ties, sort by
-    // resolved time_sec so authored timing within the same beat stays
-    // schedulable in-order. Stable sort preserves authored order when keys
-    // are identical.
-    auto by_beat = [](const BeatEntry& a, const BeatEntry& b) {
+    // Sort each per-(kind, shape, timing-source) vector. Indexed bins have
+    // no row-level time_sec, so beat_index is the only sort key; ties keep
+    // authored order via stable_sort. Timed bins sort by (beat_index,
+    // time_sec) so same-beat authored onsets remain monotonic.
+    auto by_beat_indexed = [](const BeatEntry& a, const BeatEntry& b) {
+        return a.beat_index < b.beat_index;
+    };
+    auto by_beat_timed = [](const BeatEntryTimed& a, const BeatEntryTimed& b) {
         if (a.beat_index != b.beat_index) {
             return a.beat_index < b.beat_index;
         }
@@ -616,27 +675,49 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
         }
         return false;
     };
-    auto sort_bin = [&](std::vector<BeatEntry>& v) { std::stable_sort(v.begin(), v.end(), by_beat); };
-    sort_bin(out.shape_gate_circle_beats);
-    sort_bin(out.shape_gate_square_beats);
-    sort_bin(out.shape_gate_triangle_beats);
-    sort_bin(out.split_path_circle_beats);
-    sort_bin(out.split_path_square_beats);
-    sort_bin(out.split_path_triangle_beats);
-    sort_bin(out.onset_marker_beats);
+    auto sort_indexed = [&](std::vector<BeatEntry>& v) {
+        std::stable_sort(v.begin(), v.end(), by_beat_indexed);
+    };
+    auto sort_timed = [&](std::vector<BeatEntryTimed>& v) {
+        std::stable_sort(v.begin(), v.end(), by_beat_timed);
+    };
+    sort_indexed(out.shape_gate_circle_beats);
+    sort_indexed(out.shape_gate_square_beats);
+    sort_indexed(out.shape_gate_triangle_beats);
+    sort_indexed(out.split_path_circle_beats);
+    sort_indexed(out.split_path_square_beats);
+    sort_indexed(out.split_path_triangle_beats);
+    sort_indexed(out.onset_marker_beats);
+    sort_timed(out.shape_gate_circle_beats_timed);
+    sort_timed(out.shape_gate_square_beats_timed);
+    sort_timed(out.shape_gate_triangle_beats_timed);
+    sort_timed(out.split_path_circle_beats_timed);
+    sort_timed(out.split_path_square_beats_timed);
+    sort_timed(out.split_path_triangle_beats_timed);
+    sort_timed(out.onset_marker_beats_timed);
 
     if (out.beat_times.empty()) {
         int max_beat = -1;
-        auto consider_max = [&](const std::vector<BeatEntry>& v) {
+        auto consider_max_indexed = [&](const std::vector<BeatEntry>& v) {
             if (!v.empty()) max_beat = std::max(max_beat, v.back().beat_index);
         };
-        consider_max(out.shape_gate_circle_beats);
-        consider_max(out.shape_gate_square_beats);
-        consider_max(out.shape_gate_triangle_beats);
-        consider_max(out.split_path_circle_beats);
-        consider_max(out.split_path_square_beats);
-        consider_max(out.split_path_triangle_beats);
-        consider_max(out.onset_marker_beats);
+        auto consider_max_timed = [&](const std::vector<BeatEntryTimed>& v) {
+            if (!v.empty()) max_beat = std::max(max_beat, v.back().beat_index);
+        };
+        consider_max_indexed(out.shape_gate_circle_beats);
+        consider_max_indexed(out.shape_gate_square_beats);
+        consider_max_indexed(out.shape_gate_triangle_beats);
+        consider_max_indexed(out.split_path_circle_beats);
+        consider_max_indexed(out.split_path_square_beats);
+        consider_max_indexed(out.split_path_triangle_beats);
+        consider_max_indexed(out.onset_marker_beats);
+        consider_max_timed(out.shape_gate_circle_beats_timed);
+        consider_max_timed(out.shape_gate_square_beats_timed);
+        consider_max_timed(out.shape_gate_triangle_beats_timed);
+        consider_max_timed(out.split_path_circle_beats_timed);
+        consider_max_timed(out.split_path_square_beats_timed);
+        consider_max_timed(out.split_path_triangle_beats_timed);
+        consider_max_timed(out.onset_marker_beats_timed);
 
         if (max_beat >= 0) {
             const auto max_derived_beat = max_derived_beat_for_metadata(out.bpm, out.duration);
@@ -768,17 +849,18 @@ bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors,
         }
     }
 
-    // Per-row rules: walk each per-(kind, shape) vector once. Cross-table
-    // ordering rules (Rule 1 — monotonic beat indices, intra-beat
+    // Per-row rules: walk each per-(kind, shape, timing-source) vector once.
+    // Cross-table ordering rules (Rule 1 — monotonic beat indices, intra-beat
     // resolved-time monotonicity, time_sec monotonicity) are evaluated by
-    // walking a beat-index merge over the seven vectors below.
+    // walking a beat-index merge over the fourteen vectors below.
     //
     // Kind-specific rule references:
     //   has_shape       — true for shape_gate_* and split_path_* vectors
-    //   requires_lane   — same set (onset_marker_beats default lane is
+    //                     (both indexed and timed)
+    //   requires_lane   — same set (onset_marker_beats[_timed] default lane is
     //                     not validated against [0,2] semantics)
-    auto validate_per_entry = [&](const BeatEntry& entry,
-                                  bool has_shape, bool requires_lane) {
+    auto validate_indexed_entry = [&](const BeatEntry& entry,
+                                      bool has_shape, bool requires_lane) {
         // Rule 2: beat index must be within the playable song range
         if (entry.beat_index < 0) {
             errors.push_back({entry.beat_index, "Beat index must be non-negative"});
@@ -801,58 +883,106 @@ bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors,
             errors.push_back({entry.beat_index, "Lane must be 0-2"});
             valid = false;
         }
-
-        if (entry.has_time_sec) {
-            if (!std::isfinite(entry.time_sec)) {
-                errors.push_back({entry.beat_index, "time_sec must be finite when provided"});
-                valid = false;
-            } else {
-                if (entry.time_sec < 0.0f) {
-                    errors.push_back({entry.beat_index, "time_sec must be >= 0 when provided"});
-                    valid = false;
-                }
-                if (std::isfinite(map.duration) && entry.time_sec > map.duration) {
-                    errors.push_back({entry.beat_index, "time_sec must be <= duration_sec when provided"});
-                    valid = false;
-                }
-            }
-        }
         (void)has_shape;
     };
 
-    for (const auto& entry : map.shape_gate_circle_beats)   validate_per_entry(entry, true,  true);
-    for (const auto& entry : map.shape_gate_square_beats)   validate_per_entry(entry, true,  true);
-    for (const auto& entry : map.shape_gate_triangle_beats) validate_per_entry(entry, true,  true);
-    for (const auto& entry : map.split_path_circle_beats)   validate_per_entry(entry, true,  true);
-    for (const auto& entry : map.split_path_square_beats)   validate_per_entry(entry, true,  true);
-    for (const auto& entry : map.split_path_triangle_beats) validate_per_entry(entry, true,  true);
-    for (const auto& entry : map.onset_marker_beats)        validate_per_entry(entry, false, false);
+    auto validate_timed_entry = [&](const BeatEntryTimed& entry,
+                                    bool has_shape, bool requires_lane) {
+        // Reuse the indexed checks for the always-meaningful columns…
+        validate_indexed_entry({entry.beat_index, entry.lane}, has_shape, requires_lane);
+        // …then add the timed-only checks. Membership in a *_beats_timed
+        // vector IS the precondition that time_sec is authored, so there
+        // is no in-row optionality flag to consult — the row simply has
+        // an always-meaningful `time_sec` column.
+        if (!std::isfinite(entry.time_sec)) {
+            errors.push_back({entry.beat_index, "time_sec must be finite when provided"});
+            valid = false;
+        } else {
+            if (entry.time_sec < 0.0f) {
+                errors.push_back({entry.beat_index, "time_sec must be >= 0 when provided"});
+                valid = false;
+            }
+            if (std::isfinite(map.duration) && entry.time_sec > map.duration) {
+                errors.push_back({entry.beat_index, "time_sec must be <= duration_sec when provided"});
+                valid = false;
+            }
+        }
+    };
 
-    // Cross-table ordering: walk the seven sorted vectors in beat-index
+    for (const auto& entry : map.shape_gate_circle_beats)         validate_indexed_entry(entry, true,  true);
+    for (const auto& entry : map.shape_gate_square_beats)         validate_indexed_entry(entry, true,  true);
+    for (const auto& entry : map.shape_gate_triangle_beats)       validate_indexed_entry(entry, true,  true);
+    for (const auto& entry : map.split_path_circle_beats)         validate_indexed_entry(entry, true,  true);
+    for (const auto& entry : map.split_path_square_beats)         validate_indexed_entry(entry, true,  true);
+    for (const auto& entry : map.split_path_triangle_beats)       validate_indexed_entry(entry, true,  true);
+    for (const auto& entry : map.onset_marker_beats)              validate_indexed_entry(entry, false, false);
+    for (const auto& entry : map.shape_gate_circle_beats_timed)   validate_timed_entry(entry, true,  true);
+    for (const auto& entry : map.shape_gate_square_beats_timed)   validate_timed_entry(entry, true,  true);
+    for (const auto& entry : map.shape_gate_triangle_beats_timed) validate_timed_entry(entry, true,  true);
+    for (const auto& entry : map.split_path_circle_beats_timed)   validate_timed_entry(entry, true,  true);
+    for (const auto& entry : map.split_path_square_beats_timed)   validate_timed_entry(entry, true,  true);
+    for (const auto& entry : map.split_path_triangle_beats_timed) validate_timed_entry(entry, true,  true);
+    for (const auto& entry : map.onset_marker_beats_timed)        validate_timed_entry(entry, false, false);
+
+    // Cross-table ordering: walk the fourteen sorted vectors in beat-index
     // merge order so Rule 1 (monotonic), the intra-beat resolved-time
     // rule, and Rule 6 (different-shape gates) see the same total order
-    // the parser produced.
+    // the parser produced. The walker normalizes each step into a
+    // transient `MergeEntry` projection that carries the always-meaningful
+    // columns plus shape_idx and (for timed bins) the authored time_sec.
     //
-    // Each vector carries an int8_t shape_idx (0=Circle, 1=Square, 2=Triangle,
-    // -1 for onset_marker which has no shape). Rule 6 compares shape_idx
-    // values instead of a `Shape` field on the row — the discriminator
-    // lives in the vector identity, not on the entry.
+    // Each merge vector carries an int8_t shape_idx (0=Circle, 1=Square,
+    // 2=Triangle, -1 for onset_marker which has no shape) and a flag
+    // recording whether the source bin is the authored-onset sibling.
+    // Rule 6 compares shape_idx values instead of a `Shape` field on the
+    // row — the discriminator lives in the vector identity, not on the entry.
+    struct MergeEntry {
+        int    beat_index;
+        int8_t lane;
+        bool   is_timed;
+        float  time_sec;
+    };
     struct MergeVectorRef {
-        const std::vector<BeatEntry>* entries;
+        const std::vector<BeatEntry>*      indexed_entries;
+        const std::vector<BeatEntryTimed>* timed_entries;
         size_t* cursor;
         int8_t shape_idx;
+        bool   is_timed;
     };
+    auto entry_at = [](const MergeVectorRef& v) -> MergeEntry {
+        if (v.is_timed) {
+            const auto& e = (*v.timed_entries)[*v.cursor];
+            return MergeEntry{e.beat_index, e.lane, true, e.time_sec};
+        }
+        const auto& e = (*v.indexed_entries)[*v.cursor];
+        return MergeEntry{e.beat_index, e.lane, false, 0.0f};
+    };
+    auto remaining = [](const MergeVectorRef& v) -> bool {
+        if (v.is_timed) return *v.cursor < v.timed_entries->size();
+        return *v.cursor < v.indexed_entries->size();
+    };
+
     size_t i_sg_c = 0, i_sg_s = 0, i_sg_t = 0;
     size_t i_sp_c = 0, i_sp_s = 0, i_sp_t = 0;
     size_t i_om   = 0;
-    const std::array<MergeVectorRef, 7> merge_vectors{{
-        {&map.shape_gate_circle_beats,   &i_sg_c,  0},
-        {&map.shape_gate_square_beats,   &i_sg_s,  1},
-        {&map.shape_gate_triangle_beats, &i_sg_t,  2},
-        {&map.split_path_circle_beats,   &i_sp_c,  0},
-        {&map.split_path_square_beats,   &i_sp_s,  1},
-        {&map.split_path_triangle_beats, &i_sp_t,  2},
-        {&map.onset_marker_beats,        &i_om,   -1},
+    size_t ti_sg_c = 0, ti_sg_s = 0, ti_sg_t = 0;
+    size_t ti_sp_c = 0, ti_sp_s = 0, ti_sp_t = 0;
+    size_t ti_om   = 0;
+    const std::array<MergeVectorRef, 14> merge_vectors{{
+        {&map.shape_gate_circle_beats,         nullptr, &i_sg_c,  0, false},
+        {&map.shape_gate_square_beats,         nullptr, &i_sg_s,  1, false},
+        {&map.shape_gate_triangle_beats,       nullptr, &i_sg_t,  2, false},
+        {&map.split_path_circle_beats,         nullptr, &i_sp_c,  0, false},
+        {&map.split_path_square_beats,         nullptr, &i_sp_s,  1, false},
+        {&map.split_path_triangle_beats,       nullptr, &i_sp_t,  2, false},
+        {&map.onset_marker_beats,              nullptr, &i_om,   -1, false},
+        {nullptr, &map.shape_gate_circle_beats_timed,   &ti_sg_c, 0, true},
+        {nullptr, &map.shape_gate_square_beats_timed,   &ti_sg_s, 1, true},
+        {nullptr, &map.shape_gate_triangle_beats_timed, &ti_sg_t, 2, true},
+        {nullptr, &map.split_path_circle_beats_timed,   &ti_sp_c, 0, true},
+        {nullptr, &map.split_path_square_beats_timed,   &ti_sp_s, 1, true},
+        {nullptr, &map.split_path_triangle_beats_timed, &ti_sp_t, 2, true},
+        {nullptr, &map.onset_marker_beats_timed,        &ti_om,  -1, true},
     }};
 
     int prev_beat = -1;
@@ -863,12 +993,12 @@ bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors,
     bool has_prev_resolved_time_for_beat = false;
     float prev_resolved_time_for_beat = 0.0f;
 
-    auto resolve_time = [&](const BeatEntry& entry) {
+    auto resolve_time = [&](const MergeEntry& entry) {
         float resolved_time = 0.0f;
         if (timing_metadata_valid) {
             resolved_time = map.offset + static_cast<float>(entry.beat_index) * beat_period;
         }
-        if (entry.has_time_sec) {
+        if (entry.is_timed) {
             resolved_time = entry.time_sec;
         } else if (!map.beat_times.empty() &&
                    entry.beat_index >= 0 &&
@@ -878,31 +1008,41 @@ bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors,
         return resolved_time;
     };
 
-    // Pick the next-smallest entry by (beat_index, time_sec) across the
-    // seven sorted vectors. Each merge_vectors row advances its own cursor.
-    auto step_merge = [&](int8_t& shape_idx_out) -> const BeatEntry* {
-        const BeatEntry* best = nullptr;
+    // Pick the next-smallest entry by (beat_index, resolved_time) across the
+    // fourteen sorted vectors. Indexed and timed siblings on the same beat
+    // are interleaved by the resolved time each row would spawn at, so
+    // Rule 1 and the same-beat ordering rule below see them in their
+    // true temporal order.
+    auto step_merge = [&](int8_t& shape_idx_out, bool& is_timed_out) -> std::optional<MergeEntry> {
+        std::optional<MergeEntry> best;
+        float best_resolved = 0.0f;
         size_t* best_cursor = nullptr;
         int8_t  best_shape_idx = -1;
+        bool    best_is_timed = false;
         for (const auto& v : merge_vectors) {
-            if (*v.cursor >= v.entries->size()) continue;
-            const auto* cand = &(*v.entries)[*v.cursor];
+            if (!remaining(v)) continue;
+            const MergeEntry cand = entry_at(v);
+            const float cand_resolved = resolve_time(cand);
             if (!best ||
-                cand->beat_index < best->beat_index ||
-                (cand->beat_index == best->beat_index && cand->time_sec < best->time_sec)) {
+                cand.beat_index < best->beat_index ||
+                (cand.beat_index == best->beat_index && cand_resolved < best_resolved)) {
                 best = cand;
+                best_resolved = cand_resolved;
                 best_cursor = v.cursor;
                 best_shape_idx = v.shape_idx;
+                best_is_timed = v.is_timed;
             }
         }
         if (best_cursor) (*best_cursor)++;
         shape_idx_out = best_shape_idx;
+        is_timed_out  = best_is_timed;
         return best;
     };
 
     int8_t entry_shape_idx = -1;
-    while (const auto* entry_ptr = step_merge(entry_shape_idx)) {
-        const auto& entry = *entry_ptr;
+    bool   entry_is_timed  = false;
+    while (auto entry_opt = step_merge(entry_shape_idx, entry_is_timed)) {
+        const MergeEntry& entry = *entry_opt;
         const float resolved_time = resolve_time(entry);
 
         // Rule 1: beat indices monotonically non-decreasing
@@ -925,7 +1065,7 @@ bool validate_beat_map(const BeatMap& map, std::vector<BeatMapError>& errors,
             has_prev_resolved_time_for_beat = true;
         }
 
-        if (entry.has_time_sec && std::isfinite(entry.time_sec)) {
+        if (entry.is_timed && std::isfinite(entry.time_sec)) {
             if (has_prev_authored_time && entry.time_sec < prev_authored_time) {
                 errors.push_back({entry.beat_index,
                     "time_sec must be non-decreasing across authored beat entries"});
@@ -962,12 +1102,19 @@ void init_song_state(SongState& state, const BeatMap& map) {
     state.current_beat = -1;
     state.playing      = false;
     state.finished     = false;
-    state.next_shape_gate_circle_idx   = 0;
-    state.next_shape_gate_square_idx   = 0;
-    state.next_shape_gate_triangle_idx = 0;
-    state.next_split_path_circle_idx   = 0;
-    state.next_split_path_square_idx   = 0;
-    state.next_split_path_triangle_idx = 0;
-    state.next_onset_marker_idx        = 0;
+    state.next_shape_gate_circle_idx         = 0;
+    state.next_shape_gate_square_idx         = 0;
+    state.next_shape_gate_triangle_idx       = 0;
+    state.next_split_path_circle_idx         = 0;
+    state.next_split_path_square_idx         = 0;
+    state.next_split_path_triangle_idx       = 0;
+    state.next_onset_marker_idx              = 0;
+    state.next_shape_gate_circle_timed_idx   = 0;
+    state.next_shape_gate_square_timed_idx   = 0;
+    state.next_shape_gate_triangle_timed_idx = 0;
+    state.next_split_path_circle_timed_idx   = 0;
+    state.next_split_path_square_timed_idx   = 0;
+    state.next_split_path_triangle_timed_idx = 0;
+    state.next_onset_marker_timed_idx        = 0;
     song_state_compute_derived(state);
 }

--- a/app/systems/beat_scheduler_system.cpp
+++ b/app/systems/beat_scheduler_system.cpp
@@ -13,7 +13,8 @@
 
 namespace {
 
-// Per-kind schedule context shared across the per-(kind, shape) spawn transforms.
+// Per-kind schedule context shared across the per-(kind, shape, timing-source)
+// spawn transforms.
 struct ScheduleContext {
     entt::registry& reg;
     SongState&      song;
@@ -25,22 +26,17 @@ struct ScheduleContext {
 // single-loop logic; called once per entry. Returns true if the spawn
 // should proceed; populates `effective_spawn_time`, `start_y`, and
 // `calibrated_arrival_time` for the caller.
+//
+// `beat_time` is the bin-source-resolved arrival time: for indexed bins
+// the caller passes `beat_times[beat_index]` (or the BPM-derived grid
+// fallback when beat_times are absent); for timed bins it passes the
+// authored `BeatEntryTimed::time_sec`. The `entry.has_time_sec` branch
+// no longer exists (#1533 Site #4) — bin membership IS the timing source.
 bool resolve_spawn_timing(const ScheduleContext& ctx,
-                          const BeatEntry& entry,
+                          float beat_time,
                           float& calibrated_arrival_time,
                           float& effective_spawn_time,
                           float& start_y) {
-    float beat_time = ctx.song.offset + entry.beat_index * ctx.song.beat_period;
-    if (!entry.has_time_sec &&
-        !ctx.map.beat_times.empty() &&
-        entry.beat_index >= 0 &&
-        static_cast<size_t>(entry.beat_index) < ctx.map.beat_times.size()) {
-        beat_time = ctx.map.beat_times[static_cast<size_t>(entry.beat_index)];
-    }
-    if (entry.has_time_sec) {
-        beat_time = entry.time_sec;
-    }
-
     calibrated_arrival_time = beat_time + ctx.audio_offset_sec;
     float spawn_time = calibrated_arrival_time - ctx.song.lead_time;
     if (ctx.song.song_time < spawn_time) return false;
@@ -57,29 +53,35 @@ bool resolve_spawn_timing(const ScheduleContext& ctx,
     return true;
 }
 
-// Per-(kind, shape) transforms: one while-loop per cursor. Replaces the
-// former per-kind loops that switched on `entry.shape` to pick the spawn
-// target (issue #1202/#1204). The shape is now encoded by which vector
-// the cursor walks and the shape literal each transform passes to the
-// spawn function.
+// Per-(kind, shape, timing-source) transforms: one while-loop per cursor.
+// Replaces the former per-kind loops that switched on `entry.shape` to
+// pick the spawn target (issue #1202/#1204). The shape is now encoded by
+// which vector the cursor walks and the shape literal each transform
+// passes to the spawn function; the timing source is now encoded by which
+// of the indexed (`*_beats`) or authored (`*_beats_timed`) sibling vector
+// the cursor walks (issue #1533 Site #4).
 //
 // The per-row body (timing resolve, lane validate, lane-x lookup, warn,
 // spawn-call) is identical across `shape_gate`, `split_path`, and
 // `onset_marker` bins (issue #1416); only the trailing spawn call
 // differs. `schedule_bin` owns the shared body; each kind passes a thin
-// spawn lambda that picks the right `spawn_*_rhythm` call.
+// spawn lambda that picks the right `spawn_*_rhythm` call. The bin/spawn
+// templates accept any row type exposing `beat_index` + `lane`; the
+// caller's `time_fn` projects the row to its arrival `beat_time`.
 
-template <typename SpawnFn>
+template <typename Row, typename TimeFn, typename SpawnFn>
 void schedule_bin(ScheduleContext& ctx,
-                  const std::vector<BeatEntry>& bin,
+                  const std::vector<Row>& bin,
                   size_t& cursor,
+                  TimeFn&& time_fn,
                   SpawnFn&& spawn_fn) {
     while (cursor < bin.size()) {
         const auto& entry = bin[cursor];
         float calibrated_arrival_time = 0.0f;
         float effective_spawn_time    = 0.0f;
         float start_y                 = 0.0f;
-        if (!resolve_spawn_timing(ctx, entry, calibrated_arrival_time,
+        const float beat_time = time_fn(entry);
+        if (!resolve_spawn_timing(ctx, beat_time, calibrated_arrival_time,
                                   effective_spawn_time, start_y)) break;
 
         const int8_t spawn_lane = lane_utils::valid_or_default(entry.lane);
@@ -95,11 +97,34 @@ void schedule_bin(ScheduleContext& ctx,
     }
 }
 
+// Indexed bins resolve `beat_time` from `beat_times[beat_index]` when the
+// onset table is loaded; otherwise they fall back to the BPM-derived grid
+// time. Timed bins resolve `beat_time` directly from the authored
+// `BeatEntryTimed::time_sec` column — membership in a `*_beats_timed`
+// vector IS the precondition that an authored timestamp exists.
+auto make_indexed_time_fn(const ScheduleContext& ctx) {
+    return [&ctx](const BeatEntry& entry) {
+        float beat_time = ctx.song.offset + entry.beat_index * ctx.song.beat_period;
+        if (!ctx.map.beat_times.empty() &&
+            entry.beat_index >= 0 &&
+            static_cast<size_t>(entry.beat_index) < ctx.map.beat_times.size()) {
+            beat_time = ctx.map.beat_times[static_cast<size_t>(entry.beat_index)];
+        }
+        return beat_time;
+    };
+}
+
+auto make_timed_time_fn() {
+    return [](const BeatEntryTimed& entry) { return entry.time_sec; };
+}
+
+template <typename Row, typename TimeFn>
 void schedule_shape_gate_bin(ScheduleContext& ctx,
-                             const std::vector<BeatEntry>& bin,
+                             const std::vector<Row>& bin,
                              size_t& cursor,
+                             TimeFn&& time_fn,
                              Shape required_shape) {
-    schedule_bin(ctx, bin, cursor,
+    schedule_bin(ctx, bin, cursor, std::forward<TimeFn>(time_fn),
         [required_shape](ScheduleContext& c, int8_t /*spawn_lane*/,
                          float x_pos, float start_y, const BeatInfo& bi) {
             spawn_shape_gate_rhythm(c.reg, {x_pos, start_y, required_shape,
@@ -107,11 +132,13 @@ void schedule_shape_gate_bin(ScheduleContext& ctx,
         });
 }
 
+template <typename Row, typename TimeFn>
 void schedule_split_path_bin(ScheduleContext& ctx,
-                             const std::vector<BeatEntry>& bin,
+                             const std::vector<Row>& bin,
                              size_t& cursor,
+                             TimeFn&& time_fn,
                              Shape required_shape) {
-    schedule_bin(ctx, bin, cursor,
+    schedule_bin(ctx, bin, cursor, std::forward<TimeFn>(time_fn),
         [required_shape](ScheduleContext& c, int8_t spawn_lane,
                          float x_pos, float start_y, const BeatInfo& bi) {
             spawn_split_path_rhythm(c.reg, {x_pos, start_y, required_shape,
@@ -119,8 +146,12 @@ void schedule_split_path_bin(ScheduleContext& ctx,
         });
 }
 
-void schedule_onset_markers(ScheduleContext& ctx) {
-    schedule_bin(ctx, ctx.map.onset_marker_beats, ctx.song.next_onset_marker_idx,
+template <typename Row, typename TimeFn>
+void schedule_onset_marker_bin(ScheduleContext& ctx,
+                               const std::vector<Row>& bin,
+                               size_t& cursor,
+                               TimeFn&& time_fn) {
+    schedule_bin(ctx, bin, cursor, std::forward<TimeFn>(time_fn),
         [](ScheduleContext& c, int8_t /*spawn_lane*/,
            float x_pos, float start_y, const BeatInfo& bi) {
             spawn_onset_marker_rhythm(c.reg, {x_pos, start_y,
@@ -147,17 +178,36 @@ void beat_scheduler_system(entt::registry& reg, [[maybe_unused]] float dt) {
     const float audio_offset_sec = settings ? settings::audio_offset_seconds(*settings) : 0.0f;
 
     ScheduleContext ctx{reg, *song, *map, audio_offset_sec};
+    const auto indexed_time = make_indexed_time_fn(ctx);
+    const auto timed_time   = make_timed_time_fn();
+
     schedule_shape_gate_bin(ctx, ctx.map.shape_gate_circle_beats,
-                            ctx.song.next_shape_gate_circle_idx, Shape::Circle);
+                            ctx.song.next_shape_gate_circle_idx, indexed_time, Shape::Circle);
     schedule_shape_gate_bin(ctx, ctx.map.shape_gate_square_beats,
-                            ctx.song.next_shape_gate_square_idx, Shape::Square);
+                            ctx.song.next_shape_gate_square_idx, indexed_time, Shape::Square);
     schedule_shape_gate_bin(ctx, ctx.map.shape_gate_triangle_beats,
-                            ctx.song.next_shape_gate_triangle_idx, Shape::Triangle);
+                            ctx.song.next_shape_gate_triangle_idx, indexed_time, Shape::Triangle);
     schedule_split_path_bin(ctx, ctx.map.split_path_circle_beats,
-                            ctx.song.next_split_path_circle_idx, Shape::Circle);
+                            ctx.song.next_split_path_circle_idx, indexed_time, Shape::Circle);
     schedule_split_path_bin(ctx, ctx.map.split_path_square_beats,
-                            ctx.song.next_split_path_square_idx, Shape::Square);
+                            ctx.song.next_split_path_square_idx, indexed_time, Shape::Square);
     schedule_split_path_bin(ctx, ctx.map.split_path_triangle_beats,
-                            ctx.song.next_split_path_triangle_idx, Shape::Triangle);
-    schedule_onset_markers(ctx);
+                            ctx.song.next_split_path_triangle_idx, indexed_time, Shape::Triangle);
+    schedule_onset_marker_bin(ctx, ctx.map.onset_marker_beats,
+                              ctx.song.next_onset_marker_idx, indexed_time);
+
+    schedule_shape_gate_bin(ctx, ctx.map.shape_gate_circle_beats_timed,
+                            ctx.song.next_shape_gate_circle_timed_idx, timed_time, Shape::Circle);
+    schedule_shape_gate_bin(ctx, ctx.map.shape_gate_square_beats_timed,
+                            ctx.song.next_shape_gate_square_timed_idx, timed_time, Shape::Square);
+    schedule_shape_gate_bin(ctx, ctx.map.shape_gate_triangle_beats_timed,
+                            ctx.song.next_shape_gate_triangle_timed_idx, timed_time, Shape::Triangle);
+    schedule_split_path_bin(ctx, ctx.map.split_path_circle_beats_timed,
+                            ctx.song.next_split_path_circle_timed_idx, timed_time, Shape::Circle);
+    schedule_split_path_bin(ctx, ctx.map.split_path_square_beats_timed,
+                            ctx.song.next_split_path_square_timed_idx, timed_time, Shape::Square);
+    schedule_split_path_bin(ctx, ctx.map.split_path_triangle_beats_timed,
+                            ctx.song.next_split_path_triangle_timed_idx, timed_time, Shape::Triangle);
+    schedule_onset_marker_bin(ctx, ctx.map.onset_marker_beats_timed,
+                              ctx.song.next_onset_marker_timed_idx, timed_time);
 }

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -422,7 +422,9 @@ struct SongState {
     bool  playing         = false;
     bool  finished        = false;
     bool  restart_music   = false;
-    size_t next_spawn_idx = 0;
+    size_t next_spawn_idx = 0;  // (legacy doc shape — actual SongState has fourteen
+                                //  per-(kind, shape, time-source) cursors per #1533;
+                                //  see rhythm-spec.md and app/components/song_state.h)
 };
 
 /// Singleton: survival meter displayed by the HUD energy bar.
@@ -1352,7 +1354,7 @@ int main(int argc, char* argv[]) {
     ui_render_system(reg):
 
     SongState.song_time  ─┐
-    BeatMap.beats        ├─ find next unresolved note near the active shape
+    BeatMap.*_beats[_timed] ├─ find next unresolved note near the active shape
     Shape*Tag (current) ─┘
 
     proximity = clamp((arrival_time - song_time) / SongState.half_window)

--- a/design-docs/beatmap-integration.md
+++ b/design-docs/beatmap-integration.md
@@ -112,19 +112,23 @@ singletons (`SongState`, `EnergyState`, `SongResults`) live in registry context.
 All are cold data read a few times per frame, not iterated in bulk.
 
 ```cpp
-// Defined in beat_map.h and re-exported by rhythm.h. The authored kind is
-// carried as a per-archetype tag on the spawned obstacle entity (issue
-// #1202/#1204) — `ShapeGateTag` / `SplitPathTag` / `OnsetMarkerTag` from
-// `app/tags/tags.h`. BeatEntry retains the authored discriminator only as
-// a loader-side spawn hint; runtime systems never re-read it.
+// Defined in beat_map.h and re-exported by rhythm.h. The authored kind and
+// shape are carried as *table membership* in BeatMap's fourteen
+// per-(kind, shape, time-source) vectors (issues #1198 / #1202 / #1204 /
+// #1533) — see rhythm-spec.md for the canonical structure. Spawned obstacle
+// entities discover their archetype via `ShapeGateTag` / `SplitPathTag` /
+// `OnsetMarkerTag` from `app/tags/tags.h`.
 struct BeatEntry {
-    int          beat_index   = 0;       //  4B
-    Shape        shape        = Shape::Circle;  // 1B
-    int8_t       lane         = 1;       //  1B
-    float        time_sec     = 0.0f;    // optional authored timestamp
-    bool         has_time_sec = false;
-    // (authored archetype kind hint is internal to the loader; runtime
-    // entities discover archetype via their tag)
+    int    beat_index = 0;       //  4B  (indexed bins only — *_beats)
+    int8_t lane       = 1;       //  1B
+    // No `shape`, `time_sec`, or `has_time_sec` columns — discriminator
+    // is the vector identity.
+};
+
+struct BeatEntryTimed {
+    int    beat_index = 0;       //  4B  (authored-onset bins — *_beats_timed)
+    int8_t lane       = 1;       //  1B
+    float  time_sec   = 0.0f;    //  4B  always-meaningful authored timestamp
 };
 
 struct BeatMap {
@@ -137,45 +141,13 @@ struct BeatMap {
     float       duration   = 180.0f;
     std::string difficulty;
     std::vector<float> beat_times;
-    std::vector<BeatEntry> beats;
+    // 7 indexed + 7 timed vectors (see rhythm-spec.md / app/components/beat_map.h)
 };
 
 struct SongState {
-    // ── Session-init fields ──
-    float bpm             = 120.0f;
-    float offset          = 0.0f;
-    int   lead_beats      = 4;
-    float duration_sec    = 180.0f;
-
-    // ── Derived fields ──
-    float beat_period     = 0.5f;
-    float lead_time       = 2.0f;
-    float scroll_speed    = constants::APPROACH_DIST / lead_time;
-    float window_duration = 0.3f;
-    float half_window     = 0.15f;
-    float morph_duration  = 0.1f;
-
-    // ── Per-frame mutable fields ──
-    float  song_time     = 0.0f;
-    int    current_beat  = -1;
-    bool   playing       = false;
-    bool   finished      = false;
-    bool   restart_music = false;
-
-    // ── Beat-schedule cursor ──
-    size_t next_spawn_idx = 0;
+    // …session-init, derived, per-frame mutable fields…
+    // 7 indexed + 7 timed beat-schedule cursors (issue #1533).
 };
-
-struct SongResults {
-    int perfect_count, good_count, ok_count, bad_count, miss_count;
-    int max_chain;
-    int total_notes;
-};
-```
-
-```
-  Memory: BeatEntry is compact and stored contiguously in BeatMap.beats.
-  SongState and SongResults are small ctx singletons.
 ```
 
 ### 2.1.1 MusicContext (singleton for audio state) — ✅ IMPLEMENTED

--- a/design-docs/feature-specs.md
+++ b/design-docs/feature-specs.md
@@ -524,8 +524,24 @@ struct BeatMap {
     int         lead_beats = 4;
     float       duration   = 180.0f;
     std::string difficulty;
-    std::vector<float>     beat_times;
-    std::vector<BeatEntry> beats;
+    std::vector<float>          beat_times;
+    // Fourteen per-(kind, shape, time-source) vectors — see rhythm-spec.md
+    // and `app/components/beat_map.h`. The former single `beats` vector
+    // was decomposed by issues #1198 / #1202 / #1204 / #1533.
+    std::vector<BeatEntry>      shape_gate_circle_beats;
+    std::vector<BeatEntry>      shape_gate_square_beats;
+    std::vector<BeatEntry>      shape_gate_triangle_beats;
+    std::vector<BeatEntry>      split_path_circle_beats;
+    std::vector<BeatEntry>      split_path_square_beats;
+    std::vector<BeatEntry>      split_path_triangle_beats;
+    std::vector<BeatEntry>      onset_marker_beats;
+    std::vector<BeatEntryTimed> shape_gate_circle_beats_timed;
+    std::vector<BeatEntryTimed> shape_gate_square_beats_timed;
+    std::vector<BeatEntryTimed> shape_gate_triangle_beats_timed;
+    std::vector<BeatEntryTimed> split_path_circle_beats_timed;
+    std::vector<BeatEntryTimed> split_path_square_beats_timed;
+    std::vector<BeatEntryTimed> split_path_triangle_beats_timed;
+    std::vector<BeatEntryTimed> onset_marker_beats_timed;
 
     BeatMap()                          = default;
     BeatMap(const BeatMap&)            = delete;
@@ -538,12 +554,17 @@ struct BeatMap {
 ### Beat Time Resolution
 
 ```cpp
-float beat_time = song.offset + entry.beat_index * song.beat_period;
-if (!entry.has_time_sec && beat_index_in_range(map.beat_times, entry.beat_index)) {
-    beat_time = map.beat_times[entry.beat_index];
-}
-if (entry.has_time_sec) {
+// Per #1533: time-source is a table-membership fact, not a row-level flag.
+// Indexed entries (BeatEntry, in *_beats) resolve via beat_times[…] when
+// loaded, else via the BPM grid. Timed siblings (BeatEntryTimed, in
+// *_beats_timed) always carry their own time_sec.
+float beat_time;
+if constexpr (entry_is_timed) {                                     // *_beats_timed
     beat_time = entry.time_sec;
+} else if (beat_index_in_range(map.beat_times, entry.beat_index)) { // *_beats + analysed onsets
+    beat_time = map.beat_times[entry.beat_index];
+} else {                                                            // *_beats + BPM grid
+    beat_time = song.offset + entry.beat_index * song.beat_period;
 }
 
 float calibrated_arrival_time = beat_time + audio_offset_seconds(settings);

--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -189,17 +189,20 @@ constexpr int32_t CHAIN_MULT_BONUS_STEPS_CAP = 20; // caps at 2.0x from chain 21
 
 ```cpp
 struct BeatEntry {
-    int    beat_index   = 0;           // beat index (not seconds)
-    int8_t lane         = 1;
-    float  time_sec     = 0.0f;        // optional authored timestamp
-    bool   has_time_sec = false;       // true → time_sec wins over beat_index
-    // Archetype kind is identified by *which per-kind vector in BeatMap*
-    // the row lives in (shape_gate_* / split_path_* / onset_marker_beats).
-    // Required shape (for shape_gate / split_path) is identified by
-    // *which per-shape sub-vector* the row lives in. The former
-    // `Shape shape` and `uint8_t blocked_mask` fields were eradicated
-    // per issues #1198 / #1202 / #1204 — the columns collapsed into
-    // table membership.
+    int    beat_index = 0;             // beat index (used to look up beat_times[…])
+    int8_t lane       = 1;
+    // No `time_sec` / `has_time_sec` columns — table membership IS the
+    // discriminator. Authored-onset rows live in the matching `*_beats_timed`
+    // sibling (see BeatEntryTimed below). The former `Shape shape`,
+    // `uint8_t blocked_mask`, and `bool has_time_sec` fields were eradicated
+    // per issues #1198 / #1202 / #1204 / #1533 — the columns collapsed
+    // into table membership.
+};
+
+struct BeatEntryTimed {
+    int    beat_index = 0;             // beat index (still used for ordering)
+    int8_t lane       = 1;
+    float  time_sec   = 0.0f;          // always-meaningful authored timestamp
 };
 
 struct BeatMap {
@@ -213,16 +216,28 @@ struct BeatMap {
     std::string              difficulty;
     std::vector<float>       beat_times;     // optional analysed onset table
 
-    // Seven per-(kind, shape) vectors replace the former single `beats`
-    // vector — see `app/components/beat_map.h`. Hexagon is not a valid
-    // required shape, so no `*_hexagon_beats` vector exists.
-    std::vector<BeatEntry>   shape_gate_circle_beats;
-    std::vector<BeatEntry>   shape_gate_square_beats;
-    std::vector<BeatEntry>   shape_gate_triangle_beats;
-    std::vector<BeatEntry>   split_path_circle_beats;
-    std::vector<BeatEntry>   split_path_square_beats;
-    std::vector<BeatEntry>   split_path_triangle_beats;
-    std::vector<BeatEntry>   onset_marker_beats;
+    // Fourteen per-(kind, shape, time-source) vectors replace the former
+    // single `beats` vector — see `app/components/beat_map.h`. Hexagon is
+    // not a valid required shape, so no `*_hexagon_beats` vectors exist.
+    // Indexed bins resolve their spawn time from `beat_times[beat_index]`
+    // (or BPM grid if `beat_times` is empty); `_timed` siblings carry
+    // their own always-meaningful `time_sec`. Membership in a `_timed`
+    // vector IS the precondition that the entry has an authored onset
+    // — Fabian Principle 3, issue #1533.
+    std::vector<BeatEntry>        shape_gate_circle_beats;
+    std::vector<BeatEntry>        shape_gate_square_beats;
+    std::vector<BeatEntry>        shape_gate_triangle_beats;
+    std::vector<BeatEntry>        split_path_circle_beats;
+    std::vector<BeatEntry>        split_path_square_beats;
+    std::vector<BeatEntry>        split_path_triangle_beats;
+    std::vector<BeatEntry>        onset_marker_beats;
+    std::vector<BeatEntryTimed>   shape_gate_circle_beats_timed;
+    std::vector<BeatEntryTimed>   shape_gate_square_beats_timed;
+    std::vector<BeatEntryTimed>   shape_gate_triangle_beats_timed;
+    std::vector<BeatEntryTimed>   split_path_circle_beats_timed;
+    std::vector<BeatEntryTimed>   split_path_square_beats_timed;
+    std::vector<BeatEntryTimed>   split_path_triangle_beats_timed;
+    std::vector<BeatEntryTimed>   onset_marker_beats_timed;
 };
 ```
 
@@ -255,8 +270,25 @@ struct SongState {
     bool   restart_music = false;  // set true by setup_play_session; consumed/cleared
                                    //   on the next tick by song_playback_system
 
-    // ── Beat-schedule cursor (per-frame, reset at session init) ─────────────
-    size_t next_spawn_idx = 0;     // advanced each frame by beat_scheduler_system
+    // ── Beat-schedule cursors (per-frame, reset at session init) ────────────
+    // Fourteen cursors — one per persistent table in BeatMap (Fabian
+    // Principle 3 / issue #1533). The `_timed_idx` siblings track
+    // independent progress through the authored-onset `_beats_timed`
+    // vectors; indexed cursors track the BPM/beat_times-driven bins.
+    size_t next_shape_gate_circle_idx         = 0;
+    size_t next_shape_gate_square_idx         = 0;
+    size_t next_shape_gate_triangle_idx       = 0;
+    size_t next_split_path_circle_idx         = 0;
+    size_t next_split_path_square_idx         = 0;
+    size_t next_split_path_triangle_idx       = 0;
+    size_t next_onset_marker_idx              = 0;
+    size_t next_shape_gate_circle_timed_idx   = 0;
+    size_t next_shape_gate_square_timed_idx   = 0;
+    size_t next_shape_gate_triangle_timed_idx = 0;
+    size_t next_split_path_circle_timed_idx   = 0;
+    size_t next_split_path_square_timed_idx   = 0;
+    size_t next_split_path_triangle_timed_idx = 0;
+    size_t next_onset_marker_timed_idx        = 0;
 };
 ```
 

--- a/tests/test_audio_offset_calibration.cpp
+++ b/tests/test_audio_offset_calibration.cpp
@@ -48,7 +48,7 @@ ScheduleResult schedule_one(int16_t audio_offset_ms,
     song.song_time = song_time_when_scheduling;
 
     auto& map = beat_map(reg);
-    map.shape_gate_circle_beats.push_back({beat_index, 1, 0, false});
+    map.shape_gate_circle_beats.push_back({beat_index, 1});
 
     beat_scheduler_system(reg, 0.016f);
 
@@ -165,7 +165,7 @@ TEST_CASE("beat_scheduler: audio_offset gates spawn before calibrated spawn time
     song.next_shape_gate_circle_idx = 0;
 
     auto& map = beat_map(reg);
-    map.shape_gate_circle_beats.push_back({0, 1, 0, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
 
     beat_scheduler_system(reg, 0.016f);
     CHECK(count_obstacles(reg) == 0);
@@ -199,7 +199,7 @@ TEST_CASE("audio_offset: zero setting matches absent SettingsState",
     zero_schedule_song.song_time = 1.0f;
     zero_schedule_song.next_shape_gate_circle_idx = 0;
     beat_map(scheduler_with_zero).shape_gate_circle_beats.push_back(
-        {2, 1, 0, false});
+        {2, 1});
     beat_scheduler_system(scheduler_with_zero, 0.016f);
 
     auto scheduler_without_settings = make_rhythm_registry();
@@ -208,7 +208,7 @@ TEST_CASE("audio_offset: zero setting matches absent SettingsState",
     absent_schedule_song.song_time = 1.0f;
     absent_schedule_song.next_shape_gate_circle_idx = 0;
     beat_map(scheduler_without_settings).shape_gate_circle_beats.push_back(
-        {2, 1, 0, false});
+        {2, 1});
     beat_scheduler_system(scheduler_without_settings, 0.016f);
 
     CHECK(absent_schedule_song.next_shape_gate_circle_idx == zero_schedule_song.next_shape_gate_circle_idx);
@@ -249,7 +249,7 @@ OffsetGameplayResult run_calibrated_on_arrival_hit(int16_t audio_offset_ms) {
 
     constexpr int kBeatIndex = 4;
     auto& map = beat_map(reg);
-    map.shape_gate_circle_beats.push_back({kBeatIndex, 1, 0, false});
+    map.shape_gate_circle_beats.push_back({kBeatIndex, 1});
 
     const float beat_time = song.offset + static_cast<float>(kBeatIndex) * song.beat_period;
     const float spawn_time = beat_time - song.lead_time + settings::audio_offset_seconds(settings);

--- a/tests/test_beat_map_validation.cpp
+++ b/tests/test_beat_map_validation.cpp
@@ -35,7 +35,7 @@ TEST_CASE("validate: valid BPM passes", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -48,7 +48,7 @@ TEST_CASE("validate: BPM below 60 fails", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -61,7 +61,7 @@ TEST_CASE("validate: BPM above 300 fails", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -73,7 +73,7 @@ TEST_CASE("validate: BPM at 60 boundary passes", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -85,7 +85,7 @@ TEST_CASE("validate: BPM at 300 boundary passes", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -99,7 +99,7 @@ TEST_CASE("validate: anchored small negative offset passes", "[validate]") {
     map.offset = -0.1f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -112,7 +112,7 @@ TEST_CASE("validate: offset below anchored negative floor fails", "[validate]") 
     map.offset = -0.11f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -124,7 +124,7 @@ TEST_CASE("validate: offset above 5.0 fails", "[validate]") {
     map.offset = 5.1f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -138,7 +138,7 @@ TEST_CASE("validate: lead_beats below 2 fails", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 1;
     map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -150,7 +150,7 @@ TEST_CASE("validate: lead_beats above 8 fails", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 9;
     map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -164,7 +164,7 @@ TEST_CASE("validate: negative beat index fails", "[validate][issue132]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({-1, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({-1, 1});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -190,8 +190,8 @@ TEST_CASE("validate: duplicate beat indices pass when timing order is non-decrea
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
-    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1});
+    map.shape_gate_circle_beats.push_back({4, 1});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -204,8 +204,8 @@ TEST_CASE("validate: non-monotonic beat indices fail", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({5, 1, 0.0f, false});
-    map.shape_gate_square_beats.push_back({3, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({5, 1});
+    map.shape_gate_square_beats.push_back({3, 1});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -217,7 +217,7 @@ TEST_CASE("validate: beat index beyond duration fails", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 10.0f;  // max_beat = 10 / 0.5 = 20
-    map.shape_gate_circle_beats.push_back({25, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({25, 1});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -231,8 +231,8 @@ TEST_CASE("validate: different shapes >= 3 beats apart passes", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
-    map.shape_gate_square_beats.push_back({3, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
+    map.shape_gate_square_beats.push_back({3, 1});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -244,8 +244,8 @@ TEST_CASE("validate: different shapes < 3 beats apart fails", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
-    map.shape_gate_square_beats.push_back({2, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
+    map.shape_gate_square_beats.push_back({2, 1});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -257,8 +257,8 @@ TEST_CASE("validate: same shapes close together is OK", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
-    map.shape_gate_circle_beats.push_back({1, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
+    map.shape_gate_circle_beats.push_back({1, 1});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -272,7 +272,7 @@ TEST_CASE("validate: shape_gate invalid lane fails", "[validate]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({0, 5, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 5});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -284,7 +284,7 @@ TEST_CASE("validate: split_path invalid lane fails", "[validate][issue932]") {
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.split_path_circle_beats.push_back({0, 5, 0.0f, false});
+    map.split_path_circle_beats.push_back({0, 5});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -313,7 +313,7 @@ TEST_CASE("validate: split_path is supported in active beatmaps", "[validate][ki
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.split_path_circle_beats.push_back({4, 2, 0.0f, false});
+    map.split_path_circle_beats.push_back({4, 2});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
@@ -591,7 +591,7 @@ TEST_CASE("validate_beat_map explicit constants: custom BPM range is respected",
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors, vc));
@@ -609,7 +609,7 @@ TEST_CASE("validate_beat_map explicit constants: BPM within custom range passes"
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
 
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors, vc));
@@ -626,8 +626,8 @@ TEST_CASE("validate_beat_map explicit constants: custom shape gap is respected",
     map.lead_beats = 4;
     map.duration = 60.0f;
     // 3 beats apart — passes default rule but must fail the stricter custom rule
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
-    map.shape_gate_square_beats.push_back({3, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
+    map.shape_gate_square_beats.push_back({3, 1});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors, vc));
@@ -653,8 +653,12 @@ TEST_CASE("parse: beat_times and per-obstacle time_sec are loaded", "[parse][bea
     CHECK(parse_beat_map(json, map, errors));
     REQUIRE(shape_gate_count(map) == 1);
     REQUIRE(map.beat_times.size() == 3);
-    CHECK_THAT(map.shape_gate_circle_beats[0].time_sec, Catch::Matchers::WithinAbs(1.4f, 0.001f));
-    CHECK(map.shape_gate_circle_beats[0].has_time_sec);
+    // Authored-onset entry routes into the *_beats_timed sibling vector;
+    // its membership IS the "has time_sec" precondition (Fabian Principle 3,
+    // issue #1533 Site #4).
+    CHECK(map.shape_gate_circle_beats.empty());
+    REQUIRE(map.shape_gate_circle_beats_timed.size() == 1);
+    CHECK_THAT(map.shape_gate_circle_beats_timed[0].time_sec, Catch::Matchers::WithinAbs(1.4f, 0.001f));
 }
 
 TEST_CASE("parse: non-positive BPM is rejected before deriving beat timing",
@@ -721,8 +725,11 @@ TEST_CASE("parse: beat without time_sec falls back to beat_times", "[parse][beat
 
     CHECK(parse_beat_map(json, map, errors));
     REQUIRE(shape_gate_count(map) == 1);
-    CHECK_FALSE(map.shape_gate_circle_beats[0].has_time_sec);
-    CHECK_THAT(map.shape_gate_circle_beats[0].time_sec, Catch::Matchers::WithinAbs(1.4f, 0.001f));
+    // Indexed-only entry routes into the indexed *_beats vector; the timed
+    // sibling stays empty (Fabian Principle 3, issue #1533 Site #4).
+    REQUIRE(map.shape_gate_circle_beats.size() == 1);
+    CHECK(map.shape_gate_circle_beats_timed.empty());
+    CHECK(map.shape_gate_circle_beats[0].beat_index == 2);
 }
 
 TEST_CASE("parse: beat_times must be finite", "[parse][beat_times][issue995]") {
@@ -909,10 +916,17 @@ TEST_CASE("parse: same beat_index entries within a per-shape vector are ordered 
     })";
 
     REQUIRE(parse_beat_map(json, map, errors));
-    REQUIRE(map.shape_gate_circle_beats.size() == 3);
-    CHECK_THAT(map.shape_gate_circle_beats[0].time_sec, Catch::Matchers::WithinAbs(1.3f, 0.001f));
-    CHECK_THAT(map.shape_gate_circle_beats[1].time_sec, Catch::Matchers::WithinAbs(1.4f, 0.001f));
-    CHECK_THAT(map.shape_gate_circle_beats[2].time_sec, Catch::Matchers::WithinAbs(1.6f, 0.001f));
+    // Authored-onset entries route into *_beats_timed sorted by (beat_index,
+    // time_sec); the indexed-only entry routes into the indexed *_beats
+    // sibling. Cross-bin resolved-time ordering is enforced by
+    // validate_beat_map, not by parse output ordering (Fabian Principle 3,
+    // issue #1533 Site #4).
+    REQUIRE(map.shape_gate_circle_beats_timed.size() == 2);
+    CHECK_THAT(map.shape_gate_circle_beats_timed[0].time_sec, Catch::Matchers::WithinAbs(1.3f, 0.001f));
+    CHECK_THAT(map.shape_gate_circle_beats_timed[1].time_sec, Catch::Matchers::WithinAbs(1.6f, 0.001f));
+    REQUIRE(map.shape_gate_circle_beats.size() == 1);
+    CHECK(map.shape_gate_circle_beats[0].beat_index == 2);
+    CHECK(validate_beat_map(map, errors));
 }
 
 TEST_CASE("parse: same beat_index entries keep authored order for identical timing", "[parse][beat_times][ordering]") {
@@ -931,9 +945,9 @@ TEST_CASE("parse: same beat_index entries keep authored order for identical timi
     })";
 
     REQUIRE(parse_beat_map(json, map, errors));
-    REQUIRE(map.shape_gate_circle_beats.size() == 2);
-    CHECK(map.shape_gate_circle_beats[0].lane == 1);
-    CHECK(map.shape_gate_circle_beats[1].lane == 2);
+    REQUIRE(map.shape_gate_circle_beats_timed.size() == 2);
+    CHECK(map.shape_gate_circle_beats_timed[0].lane == 1);
+    CHECK(map.shape_gate_circle_beats_timed[1].lane == 2);
 }
 
 TEST_CASE("parse: blocked lane arrays are rejected from active beatmaps", "[parse][blocked_mask][issue873]") {
@@ -1048,7 +1062,7 @@ TEST_CASE("validate: unsupported timing range fails before beat range conversion
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = std::numeric_limits<float>::max();
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -1062,8 +1076,8 @@ TEST_CASE("validate: authored time_sec beyond duration fails", "[validate][beat_
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 3.0f;
-    map.shape_gate_circle_beats.push_back({0, 1, 0.5f, true});
-    map.shape_gate_square_beats.push_back({4, 1, 3.5f, true});
+    map.shape_gate_circle_beats_timed.push_back({0, 1, 0.5f});
+    map.shape_gate_square_beats_timed.push_back({4, 1, 3.5f});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -1077,8 +1091,8 @@ TEST_CASE("validate: authored time_sec must be non-decreasing", "[validate][beat
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({0, 1, 1.2f, true});
-    map.shape_gate_circle_beats.push_back({2, 1, 1.1f, true});
+    map.shape_gate_circle_beats_timed.push_back({0, 1, 1.2f});
+    map.shape_gate_circle_beats_timed.push_back({2, 1, 1.1f});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -1092,10 +1106,10 @@ TEST_CASE("validate: mixed authored time_sec edge cases are checked", "[validate
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 10.0f;
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, true});
-    map.shape_gate_circle_beats.push_back({1, 1, 0.0f, false});
-    map.shape_gate_circle_beats.push_back({2, 1, 1.0f, true});
-    map.shape_gate_circle_beats.push_back({3, 1, std::numeric_limits<float>::quiet_NaN(), true});
+    map.shape_gate_circle_beats_timed.push_back({0, 1, 0.0f});
+    map.shape_gate_circle_beats.push_back({1, 1});
+    map.shape_gate_circle_beats_timed.push_back({2, 1, 1.0f});
+    map.shape_gate_circle_beats_timed.push_back({3, 1, std::numeric_limits<float>::quiet_NaN()});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -1109,8 +1123,8 @@ TEST_CASE("validate: same beat_index requires non-decreasing resolved time", "[v
     map.offset = 0.0f;
     map.lead_beats = 4;
     map.duration = 10.0f;
-    map.shape_gate_circle_beats.push_back({2, 1, 1.5f, true});
-    map.shape_gate_circle_beats.push_back({2, 1, 1.4f, true});
+    map.shape_gate_circle_beats_timed.push_back({2, 1, 1.5f});
+    map.shape_gate_circle_beats_timed.push_back({2, 1, 1.4f});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -1125,7 +1139,7 @@ TEST_CASE("validate: beat index out of range for beat_times fails", "[validate][
     map.lead_beats = 4;
     map.duration = 60.0f;
     map.beat_times = {0.0f, 0.5f}; // valid indices: 0..1
-    map.shape_gate_circle_beats.push_back({2, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({2, 1});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -1140,7 +1154,7 @@ TEST_CASE("validate: beat_times must be finite", "[validate][beat_times][issue99
     map.lead_beats = 4;
     map.duration = 60.0f;
     map.beat_times = {0.0f, std::numeric_limits<float>::infinity()};
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
@@ -1155,8 +1169,8 @@ TEST_CASE("validate: beat_times must be non-decreasing", "[validate][beat_times]
     map.lead_beats = 4;
     map.duration = 60.0f;
     map.beat_times = {1.0f, 0.5f};
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
-    map.shape_gate_circle_beats.push_back({1, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
+    map.shape_gate_circle_beats.push_back({1, 1});
 
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));

--- a/tests/test_beat_scheduler_offset.cpp
+++ b/tests/test_beat_scheduler_offset.cpp
@@ -61,7 +61,7 @@ TEST_CASE("offset_semantics: beat_index=0 arrives at exactly offset", "[beat_sch
     auto& map  = beat_map(reg);
 
     song.offset = 1.5f;
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
 
     advance_to_spawn_all(reg);
 
@@ -76,7 +76,7 @@ TEST_CASE("offset_semantics: beat_index=0 with zero offset arrives at t=0", "[be
     auto& map  = beat_map(reg);
 
     song.offset = 0.0f;
-    map.shape_gate_square_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_square_beats.push_back({0, 1});
 
     advance_to_spawn_all(reg);
 
@@ -96,7 +96,7 @@ TEST_CASE("offset_semantics: beat_index=N arrives at offset + N*period", "[beat_
     song.bpm    = 120.0f;
     song.offset = 0.35f;
     song_state_compute_derived(song);
-    map.shape_gate_triangle_beats.push_back({8, 1, 0.0f, false});
+    map.shape_gate_triangle_beats.push_back({8, 1});
 
     advance_to_spawn_all(reg);
 
@@ -115,8 +115,8 @@ TEST_CASE("offset_semantics: two beat_indices are exactly period apart", "[beat_
     song.bpm    = 160.0f;
     song.offset = 2.27f;
     song_state_compute_derived(song);
-    map.shape_gate_circle_beats.push_back({10, 1, 0.0f, false});
-    map.shape_gate_circle_beats.push_back({11, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({10, 1});
+    map.shape_gate_circle_beats.push_back({11, 1});
 
     advance_to_spawn_all(reg);
 
@@ -142,7 +142,7 @@ TEST_CASE("offset_semantics: doubling offset shifts arrival by same delta", "[be
         song.bpm    = 120.0f;
         song.offset = offset_val;
         song_state_compute_derived(song);
-        map.shape_gate_circle_beats.push_back({beat_idx, 1, 0.0f, false});
+        map.shape_gate_circle_beats.push_back({beat_idx, 1});
         advance_to_spawn_all(reg);
         return single_arrival_time(reg);
     };
@@ -173,7 +173,7 @@ TEST_CASE("offset_semantics: first authored beat_index=N>0 arrives after offset"
 
     // Simulate a typical shipped-beatmap first obstacle (beat_index >= 2)
     const int first_idx = 4;
-    map.shape_gate_circle_beats.push_back({first_idx, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({first_idx, 1});
 
     advance_to_spawn_all(reg);
 
@@ -203,7 +203,7 @@ TEST_CASE("offset_semantics: offset must not be zero when pipeline sets it from 
     song_state_compute_derived(song);
 
     // First authored obstacle on hard: beat_index = 2
-    map.shape_gate_circle_beats.push_back({2, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({2, 1});
 
     advance_to_spawn_all(reg);
 
@@ -258,7 +258,7 @@ TEST_CASE("offset_semantics: uniform-beat assumption valid within per-beat toler
     song_state_compute_derived(song);
 
     for (int i = 0; i <= N; i += 10) {
-        map.shape_gate_circle_beats.push_back({i, 1, 0.0f, false});
+        map.shape_gate_circle_beats.push_back({i, 1});
     }
 
     advance_to_spawn_all(reg);
@@ -284,7 +284,7 @@ TEST_CASE("offset_semantics: halving BPM doubles all collision intervals", "[bea
         song.bpm    = bpm;
         song.offset = 0.0f;
         song_state_compute_derived(song);
-        map.shape_gate_circle_beats.push_back({beat_idx, 1, 0.0f, false});
+        map.shape_gate_circle_beats.push_back({beat_idx, 1});
         advance_to_spawn_all(reg);
         return single_arrival_time(reg);
     };

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -12,7 +12,7 @@ TEST_CASE("beat_scheduler: no spawn when not Playing", "[beat_scheduler]") {
     set_test_phase<GamePhaseTitleTag>(reg);
 
     auto& map = beat_map(reg);
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
 
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 10.0f;
@@ -40,7 +40,7 @@ TEST_CASE("beat_scheduler: no spawn when song not playing", "[beat_scheduler]") 
     reg.ctx().get<SongState>().playing = false;
 
     auto& map = beat_map(reg);
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
 
     beat_scheduler_system(reg, 0.016f);
 
@@ -67,7 +67,7 @@ TEST_CASE("beat_scheduler: spawns ShapeGate when time passes spawn_time", "[beat
     auto& map = beat_map(reg);
 
     // Add a beat at index 0
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
 
     // The spawn_time = offset + beat_index * beat_period - lead_time
     // For beat 0: spawn_time = 0 + 0 * 0.5 - 2.0 = -2.0
@@ -98,7 +98,7 @@ TEST_CASE("beat_scheduler: defaults invalid ShapeGate lane to center lane", "[be
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.shape_gate_circle_beats.push_back({0, 9, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 9});
     song.song_time = 0.0f;
     song.next_shape_gate_circle_idx = 0;
     song.next_split_path_circle_idx = 0;
@@ -120,7 +120,7 @@ TEST_CASE("beat_scheduler: does not spawn before spawn_time", "[beat_scheduler]"
     auto& map = beat_map(reg);
 
     // Beat at index 20 — spawn_time = 0 + 20 * 0.5 - 2.0 = 8.0
-    map.shape_gate_square_beats.push_back({20, 1, 0.0f, false});
+    map.shape_gate_square_beats.push_back({20, 1});
 
     song.song_time = 5.0f;  // Before spawn_time of 8.0
     song.next_shape_gate_circle_idx = 0;
@@ -138,7 +138,7 @@ TEST_CASE("beat_scheduler: increments per-kind cursor after spawn", "[beat_sched
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
     song.song_time = 10.0f;
     song.next_shape_gate_circle_idx = 0;
     song.next_split_path_circle_idx = 0;
@@ -160,7 +160,7 @@ TEST_CASE("beat_scheduler: uses beat_times array for arrival time when present",
     song.bpm = 120.0f;
     song_state_compute_derived(song);
     map.beat_times = {0.3f, 0.85f, 1.47f};
-    map.shape_gate_circle_beats.push_back({2, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({2, 1});
 
     song.song_time = 0.0f;
     song.next_shape_gate_circle_idx = 0;
@@ -187,15 +187,15 @@ TEST_CASE("beat_scheduler: uses BeatEntry time_sec for arrival time when authore
     song_state_compute_derived(song);
     map.beat_times = {0.3f, 0.85f, 1.47f};
 
-    BeatEntry authored_entry;
+    BeatEntryTimed authored_entry;
     authored_entry.beat_index = 2;
     authored_entry.lane = 1;
     authored_entry.time_sec = 1.33f;
-    authored_entry.has_time_sec = true;
-    map.shape_gate_circle_beats.push_back(authored_entry);
+    map.shape_gate_circle_beats_timed.push_back(authored_entry);
 
     song.song_time = 0.0f;
     song.next_shape_gate_circle_idx = 0;
+    song.next_shape_gate_circle_timed_idx = 0;
     song.next_split_path_circle_idx = 0;
     song.next_onset_marker_idx = 0;
     beat_scheduler_system(reg, 0.016f);
@@ -219,7 +219,7 @@ TEST_CASE("beat_scheduler: falls back to beat_times when BeatEntry time_sec is a
     song.bpm = 120.0f;
     song_state_compute_derived(song);
     map.beat_times = {0.3f, 0.85f, 1.47f};
-    map.shape_gate_circle_beats.push_back({2, 1, 99.0f, false});
+    map.shape_gate_circle_beats.push_back({2, 1});
 
     song.song_time = 30.0f;
     song.next_shape_gate_circle_idx = 0;
@@ -278,10 +278,10 @@ TEST_CASE("beat_scheduler: spawns multiple beats when time is past all", "[beat_
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
-    map.shape_gate_square_beats.push_back({2, 1, 0.0f, false});
-    map.onset_marker_beats.push_back({4, 1, 0.0f, false});
-    map.shape_gate_triangle_beats.push_back({6, 2, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
+    map.shape_gate_square_beats.push_back({2, 1});
+    map.onset_marker_beats.push_back({4, 1});
+    map.shape_gate_triangle_beats.push_back({6, 2});
 
     song.song_time = 30.0f;  // Well past all spawn times
     song.next_shape_gate_circle_idx = 0;
@@ -310,7 +310,7 @@ TEST_CASE("beat_scheduler: spawns OnsetMarker as visible non-scorable cue",
     auto& energy = reg.ctx().get<EnergyState>();
     auto& results = reg.ctx().get<SongResults>();
 
-    map.onset_marker_beats.push_back({0, 1, 0.0f, false});
+    map.onset_marker_beats.push_back({0, 1});
     song.song_time = 10.0f;
     song.next_shape_gate_circle_idx = 0;
     song.next_split_path_circle_idx = 0;
@@ -364,7 +364,7 @@ TEST_CASE("beat_scheduler: spawns SplitPath in authored lane", "[beat_scheduler]
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.split_path_triangle_beats.push_back({0, 2, 0.0f, false});
+    map.split_path_triangle_beats.push_back({0, 2});
     song.song_time = 10.0f;
     song.next_shape_gate_circle_idx = 0;
     song.next_split_path_circle_idx = 0;
@@ -386,7 +386,7 @@ TEST_CASE("beat_scheduler: defaults invalid SplitPath lane to center lane", "[be
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.split_path_square_beats.push_back({0, 9, 0.0f, false});
+    map.split_path_square_beats.push_back({0, 9});
     song.song_time = 10.0f;
     song.next_shape_gate_circle_idx = 0;
     song.next_split_path_circle_idx = 0;
@@ -413,9 +413,9 @@ TEST_CASE("beat_scheduler: spawns all queued beats from BeatMap entries", "[beat
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.shape_gate_square_beats.push_back({0, 1, 0.0f, false});
-    map.onset_marker_beats.push_back({0, 1, 0.0f, false});
-    map.shape_gate_triangle_beats.push_back({0, 2, 0.0f, false});
+    map.shape_gate_square_beats.push_back({0, 1});
+    map.onset_marker_beats.push_back({0, 1});
+    map.shape_gate_triangle_beats.push_back({0, 2});
     song.song_time = 10.0f;
     song.next_shape_gate_circle_idx = 0;
     song.next_split_path_circle_idx = 0;
@@ -443,7 +443,7 @@ TEST_CASE("beat_scheduler: all spawned obstacles have BeatInfo", "[beat_schedule
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1});
     song.song_time = 30.0f;
     song.next_shape_gate_circle_idx = 0;
     song.next_split_path_circle_idx = 0;
@@ -465,7 +465,7 @@ TEST_CASE("beat_scheduler: obstacles spawn with overshoot compensation", "[beat_
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
     song.song_time = 10.0f;
     song.next_shape_gate_circle_idx = 0;
     song.next_split_path_circle_idx = 0;
@@ -485,7 +485,7 @@ TEST_CASE("beat_scheduler: rhythm obstacles omit Vector2", "[beat_scheduler]") {
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
     song.song_time = 10.0f;
     song.next_shape_gate_circle_idx = 0;
     song.next_split_path_circle_idx = 0;
@@ -507,7 +507,7 @@ TEST_CASE("beat_scheduler: ShapeGate Circle has blue color", "[beat_scheduler]")
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
     song.song_time = 10.0f;
     song.next_shape_gate_circle_idx = 0;
     song.next_split_path_circle_idx = 0;
@@ -527,7 +527,7 @@ TEST_CASE("beat_scheduler: ShapeGate Square has red color", "[beat_scheduler]") 
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.shape_gate_square_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_square_beats.push_back({0, 1});
     song.song_time = 10.0f;
     song.next_shape_gate_circle_idx = 0;
     song.next_split_path_circle_idx = 0;
@@ -547,7 +547,7 @@ TEST_CASE("beat_scheduler: ShapeGate Triangle has green color", "[beat_scheduler
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.shape_gate_triangle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_triangle_beats.push_back({0, 1});
     song.song_time = 10.0f;
     song.next_shape_gate_circle_idx = 0;
     song.next_split_path_circle_idx = 0;
@@ -574,7 +574,7 @@ TEST_CASE("beat_scheduler: clamped late-spawn stores adjusted spawn_time in Beat
     auto& map = beat_map(reg);
 
     // Use beat 0 whose spawn_time is deeply in the past
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
     // Set song_time so the overshoot pushes start_y well past PLAYER_Y
     song.song_time = 100.0f;
     song.next_shape_gate_circle_idx = 0;
@@ -605,7 +605,7 @@ TEST_CASE("beat_scheduler: invalid scroll_speed skips late-spawn division", "[be
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
 
-    map.shape_gate_circle_beats.push_back({0, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({0, 1});
     song.song_time = 100.0f;
     song.scroll_speed = 0.0f;
     song.next_shape_gate_circle_idx = 0;

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -201,9 +201,12 @@ TEST_CASE("Play session: SongResults total_notes excludes onset marker metadata"
             const auto& beatmap = beat_map(reg);
             const size_t total_beats = shape_gate_count(beatmap) +
                                        split_path_count(beatmap) +
-                                       beatmap.onset_marker_beats.size();
+                                       beatmap.onset_marker_beats.size() +
+                                       beatmap.onset_marker_beats_timed.size();
             REQUIRE(total_beats > 0);
-            saw_onset_marker = saw_onset_marker || !beatmap.onset_marker_beats.empty();
+            saw_onset_marker = saw_onset_marker
+                || !beatmap.onset_marker_beats.empty()
+                || !beatmap.onset_marker_beats_timed.empty();
 
             CAPTURE(content_config::LEVELS[level].title);
             CAPTURE(content_config::DIFFICULTY_KEYS[difficulty]);

--- a/tests/test_rhythm_system.cpp
+++ b/tests/test_rhythm_system.cpp
@@ -51,9 +51,9 @@ TEST_CASE("beatmap: parse active obstacle kinds", "[rhythm][beatmap][issue873]")
 
     REQUIRE(parse_beat_map(json, map, errors));
     REQUIRE(map.shape_gate_circle_beats.size() == 1);
-    REQUIRE(map.onset_marker_beats.size() == 1);
+    REQUIRE(map.onset_marker_beats_timed.size() == 1);
     CHECK(map.shape_gate_circle_beats[0].beat_index == 4);
-    CHECK(map.onset_marker_beats[0].beat_index == 8);
+    CHECK(map.onset_marker_beats_timed[0].beat_index == 8);
 }
 
 TEST_CASE("beatmap: tempo_changes in JSON are ignored", "[rhythm][beatmap]") {
@@ -107,7 +107,7 @@ TEST_CASE("beatmap: beats sorted by beat_index within per-shape vectors", "[rhyt
 TEST_CASE("beatmap: validate BPM range", "[rhythm][beatmap]") {
     BeatMap map;
     map.bpm = 50.0f; map.offset = 0.0f; map.lead_beats = 4; map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1});
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
 
@@ -121,7 +121,7 @@ TEST_CASE("beatmap: validate BPM range", "[rhythm][beatmap]") {
 TEST_CASE("beatmap: validate offset range", "[rhythm][beatmap]") {
     BeatMap map;
     map.bpm = 120.0f; map.offset = -1.0f; map.lead_beats = 4; map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1});
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
 }
@@ -129,7 +129,7 @@ TEST_CASE("beatmap: validate offset range", "[rhythm][beatmap]") {
 TEST_CASE("beatmap: validate lead_beats range", "[rhythm][beatmap]") {
     BeatMap map;
     map.bpm = 120.0f; map.offset = 0.0f; map.lead_beats = 1; map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1});
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
 }
@@ -144,8 +144,8 @@ TEST_CASE("beatmap: validate empty beats rejected", "[rhythm][beatmap]") {
 TEST_CASE("beatmap: validate different-shape gates min spacing", "[rhythm][beatmap]") {
     BeatMap map;
     map.bpm = 120.0f; map.offset = 0.0f; map.lead_beats = 4; map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
-    map.shape_gate_triangle_beats.push_back({5, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1});
+    map.shape_gate_triangle_beats.push_back({5, 1});
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
 }
@@ -153,8 +153,8 @@ TEST_CASE("beatmap: validate different-shape gates min spacing", "[rhythm][beatm
 TEST_CASE("beatmap: same-shape gates can be adjacent", "[rhythm][beatmap]") {
     BeatMap map;
     map.bpm = 120.0f; map.offset = 0.0f; map.lead_beats = 4; map.duration = 60.0f;
-    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
-    map.shape_gate_circle_beats.push_back({5, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1});
+    map.shape_gate_circle_beats.push_back({5, 1});
     std::vector<BeatMapError> errors;
     CHECK(validate_beat_map(map, errors));
 }
@@ -162,7 +162,7 @@ TEST_CASE("beatmap: same-shape gates can be adjacent", "[rhythm][beatmap]") {
 TEST_CASE("beatmap: validate beat index beyond duration", "[rhythm][beatmap]") {
     BeatMap map;
     map.bpm = 120.0f; map.offset = 0.0f; map.lead_beats = 4; map.duration = 10.0f;
-    map.shape_gate_circle_beats.push_back({100, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({100, 1});
     std::vector<BeatMapError> errors;
     CHECK_FALSE(validate_beat_map(map, errors));
 }
@@ -250,7 +250,7 @@ TEST_CASE("beat_scheduler: spawns obstacle at spawn_time", "[rhythm][scheduler]"
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
-    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1});
     song.playing = true;
     // Advance past spawn_time
     song.song_time = 0.1f;
@@ -262,7 +262,7 @@ TEST_CASE("beat_scheduler: obstacle has correct BeatInfo", "[rhythm][scheduler]"
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
-    map.shape_gate_triangle_beats.push_back({8, 1, 0.0f, false});
+    map.shape_gate_triangle_beats.push_back({8, 1});
     song.playing = true; song.song_time = 2.5f;
     beat_scheduler_system(reg, 0.016f);
     auto obs_view = reg.view<ObstacleTag, BeatInfo>();
@@ -278,7 +278,7 @@ TEST_CASE("beat_scheduler: does not spawn before spawn_time", "[rhythm][schedule
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
-    map.shape_gate_circle_beats.push_back({20, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({20, 1});
     song.playing = true; song.song_time = 0.5f;
     beat_scheduler_system(reg, 0.016f);
     CHECK(reg.view<ObstacleTag>().size() == 0);
@@ -288,8 +288,8 @@ TEST_CASE("beat_scheduler: spawns multiple when time catches up", "[rhythm][sche
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
-    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
-    map.shape_gate_circle_beats.push_back({8, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1});
+    map.shape_gate_circle_beats.push_back({8, 1});
     song.playing = true; song.song_time = 3.0f;
     beat_scheduler_system(reg, 0.016f);
     CHECK(reg.view<ObstacleTag>().size() == 2);
@@ -299,7 +299,7 @@ TEST_CASE("beat_scheduler: rhythm obstacles use BeatInfo without Vector2", "[rhy
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
-    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1});
     song.playing = true; song.song_time = 0.1f;
     beat_scheduler_system(reg, 0.016f);
     auto obs_view = reg.view<ObstacleTag, BeatInfo>();
@@ -861,7 +861,7 @@ TEST_CASE("integration: obstacle arrives on-beat within 1 frame", "[rhythm][inte
     make_rhythm_player(reg);
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
-    map.shape_gate_circle_beats.push_back({4, 1, 0.0f, false});
+    map.shape_gate_circle_beats.push_back({4, 1});
     song.playing = true; song.song_time = 0.1f;
     constexpr float dt = 1.0f / 60.0f;
     bool obstacle_at_player = false;

--- a/tests/test_shipped_beatmap_max_gap.cpp
+++ b/tests/test_shipped_beatmap_max_gap.cpp
@@ -69,23 +69,52 @@ TEST_CASE("shipped beatmaps: authored beats are strictly increasing",
             // beat index.
             //
             // Per #1202/#1204 the chart is normalized: each former
-            // `ObstacleKind` lives in its own vector. To check the cross-kind
-            // ordering invariant we merge the three vectors into one flat
-            // sorted view (by beat_index, then time_sec).
-            std::vector<BeatEntry> merged;
-            merged.reserve(beat_map_total_count(map));
-            auto append = [&](const std::vector<BeatEntry>& v) {
-                merged.insert(merged.end(), v.begin(), v.end());
+            // `ObstacleKind` lives in its own vector. Per #1533 each per-kind
+            // vector is further split into an indexed (`*_beats`) sibling
+            // (timing comes from `beat_times[beat_index]`) and an authored
+            // (`*_beats_timed`) sibling (timing comes from the row's
+            // `time_sec`). To check the cross-kind ordering invariant we
+            // merge all fourteen vectors into one flat view, projecting each
+            // row to a resolved time before sorting by (beat_index, resolved
+            // time).
+            struct MergedBeat {
+                int   beat_index;
+                float time_sec;
             };
-            append(map.shape_gate_circle_beats);
-            append(map.shape_gate_square_beats);
-            append(map.shape_gate_triangle_beats);
-            append(map.split_path_circle_beats);
-            append(map.split_path_square_beats);
-            append(map.split_path_triangle_beats);
-            append(map.onset_marker_beats);
+            std::vector<MergedBeat> merged;
+            merged.reserve(beat_map_total_count(map));
+            auto append_indexed = [&](const std::vector<BeatEntry>& v) {
+                for (const auto& e : v) {
+                    float t = e.beat_index * (60.0f / map.bpm) + map.offset;
+                    if (!map.beat_times.empty() &&
+                        e.beat_index >= 0 &&
+                        static_cast<size_t>(e.beat_index) < map.beat_times.size()) {
+                        t = map.beat_times[static_cast<size_t>(e.beat_index)];
+                    }
+                    merged.push_back({e.beat_index, t});
+                }
+            };
+            auto append_timed = [&](const std::vector<BeatEntryTimed>& v) {
+                for (const auto& e : v) {
+                    merged.push_back({e.beat_index, e.time_sec});
+                }
+            };
+            append_indexed(map.shape_gate_circle_beats);
+            append_indexed(map.shape_gate_square_beats);
+            append_indexed(map.shape_gate_triangle_beats);
+            append_indexed(map.split_path_circle_beats);
+            append_indexed(map.split_path_square_beats);
+            append_indexed(map.split_path_triangle_beats);
+            append_indexed(map.onset_marker_beats);
+            append_timed(map.shape_gate_circle_beats_timed);
+            append_timed(map.shape_gate_square_beats_timed);
+            append_timed(map.shape_gate_triangle_beats_timed);
+            append_timed(map.split_path_circle_beats_timed);
+            append_timed(map.split_path_square_beats_timed);
+            append_timed(map.split_path_triangle_beats_timed);
+            append_timed(map.onset_marker_beats_timed);
             std::stable_sort(merged.begin(), merged.end(),
-                             [](const BeatEntry& a, const BeatEntry& b) {
+                             [](const MergedBeat& a, const MergedBeat& b) {
                                  if (a.beat_index != b.beat_index) return a.beat_index < b.beat_index;
                                  return a.time_sec < b.time_sec;
                              });

--- a/tests/test_shipped_beatmap_medium_balance.cpp
+++ b/tests/test_shipped_beatmap_medium_balance.cpp
@@ -63,8 +63,22 @@ TEST_CASE("medium balance: shipped beatmaps keep motif lane mapping",
         if (!load_beat_map(path, map, errors, "medium")) continue;
 
         // Per #1202/#1204: shape-gate entries live in their own per-(kind, shape) vectors.
+        // Per #1533: each per-(kind, shape) cell has both indexed and timed sub-bins.
         int total_shape_gates = 0;
         auto check_bin = [&](const std::vector<BeatEntry>& bin, Shape shape) {
+            const int expected_lane = expected_lane_for_shape(shape);
+            for (const auto& beat : bin) {
+                ++total_shape_gates;
+                if (beat.lane != expected_lane) {
+                    FAIL_CHECK("medium balance: " << path
+                               << " beat " << beat.beat_index
+                               << " shape enum=" << static_cast<int>(shape)
+                               << " expected lane " << expected_lane
+                               << " but found lane " << static_cast<int>(beat.lane));
+                }
+            }
+        };
+        auto check_bin_timed = [&](const std::vector<BeatEntryTimed>& bin, Shape shape) {
             const int expected_lane = expected_lane_for_shape(shape);
             for (const auto& beat : bin) {
                 ++total_shape_gates;
@@ -80,6 +94,9 @@ TEST_CASE("medium balance: shipped beatmaps keep motif lane mapping",
         check_bin(map.shape_gate_circle_beats,   Shape::Circle);
         check_bin(map.shape_gate_square_beats,   Shape::Square);
         check_bin(map.shape_gate_triangle_beats, Shape::Triangle);
+        check_bin_timed(map.shape_gate_circle_beats_timed,   Shape::Circle);
+        check_bin_timed(map.shape_gate_square_beats_timed,   Shape::Square);
+        check_bin_timed(map.shape_gate_triangle_beats_timed, Shape::Triangle);
         REQUIRE(total_shape_gates > 0);
     }
 }


### PR DESCRIPTION
Closes the last sub-site of #1533 (Fabian Principle 3 — no NULL columns on row tables). Sites #1–#3 landed in #1535/#1536/#1537.

## Problem
`BeatEntry` carried `float time_sec` and `bool has_time_sec`, where `time_sec` was meaningful only when `has_time_sec == true`. This is a NULL-column-in-disguise: a column that depends on another column's value, which Fabian Principle 3 says must be moved to its own table whose membership IS the precondition.

## Approach (Option C: two row types per bin)
Mirror the precedent set by #1202/#1204 (where shape and kind became table membership): split each of the 7 per-(kind, shape) vectors into two siblings — `*_beats` (indexed, no `time_sec`) and `*_beats_timed` (authored-onset, always has a meaningful `time_sec`). Total: 14 vectors on `BeatMap`, 14 cursors on `SongState`.

```cpp
struct BeatEntry       { int beat_index; int8_t lane; };                 // *_beats
struct BeatEntryTimed  { int beat_index; int8_t lane; float time_sec; }; // *_beats_timed
```

No row carries a discriminator; the vector identity IS the discriminator. Membership in `*_beats_timed` IS the "has time_sec" precondition.

## Changes
- **`app/components/beat_map.h`** — Split row types; added 7 `*_beats_timed` vectors; count helpers (`shape_gate_count`, `split_path_count`, `beat_map_total_count`, `beat_map_empty`) sum across siblings.
- **`app/components/song_state.h`** — Added 7 `next_*_timed_idx` cursors.
- **`app/entities/beat_map.cpp`** —
  - Parser routes JSON entries with `time_sec` to `*_beats_timed`, others to `*_beats`. The `has_time_sec` boolean is a parser-local — never a row column.
  - Sort split into indexed (`by_beat_index`) vs timed (`by_beat_index then time_sec`).
  - Validator walks all 14 sorted vectors via a `MergeEntry { beat_index, lane, is_timed, time_sec }` projection. Tie-break uses **resolved** time so indexed entries (using `beat_times[beat_index]` / BPM grid) interleave correctly with timed siblings on the same beat.
- **`app/systems/beat_scheduler_system.cpp`** — Templated `schedule_bin<Row, TimeFn, SpawnFn>`; `resolve_spawn_timing` now takes a pre-resolved `beat_time` (no more `entry.has_time_sec` branching). 14 dispatch calls.
- **Tests** — Bulk-rewrote ~90 `push_back({X,Y,Z,bool})` patterns across 8 test files. `test_shipped_beatmap_max_gap.cpp` merge logic now walks all 14 vectors via a local `MergedBeat` projection. Sibling site tests (medium-balance lane checks, high-score onset-marker check) updated to count both indexed and timed bins. One validator test explicitly calls `validate_beat_map` because cross-bin ordering moved from parse-time to validate-time.
- **Design docs** — `rhythm-spec.md` / `feature-specs.md` / `beatmap-integration.md` / `architecture.md` updated to reflect 14-vector model and the timing-source-as-table-membership rule.

## Verification
- Build: **zero warnings** on clang `-Wall -Wextra -Werror`
- Tests: **3397 assertions / 964 test cases pass** (+4 vs the 3393 baseline — the medium-balance test now covers both indexed and timed bins)
- No `has_time_sec` row column survives anywhere; remaining mentions are parser-local variables or explanatory comments

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
