### PR TITLE
#1539 README.md:135: rename `gameplay_hud_process_button_input` -> `ui_update_system` in System Pipeline diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ it identifies historical migration plans and the current authoritative runtime d
 ### System Pipeline (per frame)
 
 ```
-compute_screen_transform -> input_system -> gameplay_hud_process_button_input ->
+compute_screen_transform -> input_system -> ui_update_system ->
 test_player_system -> fixed timestep loop -> game_camera_system ->
 ui_camera_system -> game_render_system -> ui_render_system ->
 audio_system -> haptic_system


### PR DESCRIPTION
Closes #1539.

The "System Pipeline (per frame)" block in README.md still referenced the pre-#1501 name (`gameplay_hud_process_button_input`) for the per-frame HUD button input handler. The function was renamed to `ui_update_system` in #1501 and the old name no longer exists as a runtime symbol in `app/` — the two remaining `app/` references (`app/tags/tags.h:333`, `app/systems/ui_update_system.cpp:361`) are historical-attribution comments explicitly describing the "former" name.

This is the same drift class as #1501 / #1520 / #1526 — design-doc references to renamed/removed runtime symbols.

**Verification**

- `rg -n 'gameplay_hud_process_button_input' README.md` → 0 hits
- Doc-only change; build/tests untouched

**Acceptance criteria (from #1539)**

- [x] `rg -n 'gameplay_hud_process_button_input' README.md` returns zero hits.
- [x] The pipeline block at README.md:132-140 reads `compute_screen_transform -> input_system -> ui_update_system -> ...` (matching what `game_loop.cpp` actually runs at frame top).
- [x] No other documentation references the old name as a current symbol (historical-context refs in `app/` comments remain — they describe the former name and are intentional).
