### PR TITLE
#1540 app/systems/game_state_end_screen_system.cpp: inline single-call `end_screen_input_ready` anon-ns helper

### DIFF
--- a/app/systems/game_state_end_screen_system.cpp
+++ b/app/systems/game_state_end_screen_system.cpp
@@ -5,30 +5,22 @@
 
 namespace {
 
-// Per Fabian's existential processing (issue #1202/#1204, PR G): the former
-// `gs.phase == GamePhase::X` checks dispatch on tag presence in `reg.ctx()`;
-// the former `gs.transition_pending = true; gs.next_phase = X` pair is now
-// `request_phase_transition<NextPhase*Tag>()`. `phase_timer` is read directly
-// from `GameState` because the input-delay clock is per-phase data, not a
-// control-flow discriminator.
-bool end_screen_input_ready(entt::registry& reg, const GameState& gs) {
-    const auto& ctx = reg.ctx();
-    const bool game_over_ready =
-        ctx.contains<GamePhaseGameOverTag>() && gs.phase_timer > constants::GAME_OVER_INPUT_DELAY;
-    const bool song_complete_ready =
-        ctx.contains<GamePhaseSongCompleteTag>() && gs.phase_timer > constants::SONG_COMPLETE_INPUT_DELAY;
-    return game_over_ready || song_complete_ready;
-}
-
 void erase_end_choice_tags(entt::registry& reg) {
     if (reg.ctx().find<EndChoiceRestart>())     reg.ctx().erase<EndChoiceRestart>();
     if (reg.ctx().find<EndChoiceLevelSelect>()) reg.ctx().erase<EndChoiceLevelSelect>();
     if (reg.ctx().find<EndChoiceMainMenu>())    reg.ctx().erase<EndChoiceMainMenu>();
 }
 
-// One transform per former enum value (Fabian's "transform per tag" mechanic).
-// Each is gated by tag presence AND the shared input-ready predicate, so a
-// choice latched during the input-delay window persists until the delay
+// One transform per former enum value (Fabian's "transform per tag" mechanic,
+// issue #1202/#1204, PR G). The former `gs.phase == GamePhase::X` checks now
+// dispatch on per-phase tag presence in `reg.ctx()`; the former
+// `gs.transition_pending = true; gs.next_phase = X` pair is now
+// `request_phase_transition<NextPhase*Tag>()`. `phase_timer` is read directly
+// from `GameState` because the input-delay clock is per-phase data, not a
+// control-flow discriminator.
+//
+// Each handler is gated by tag presence AND the inline input-ready predicate,
+// so a choice latched during the input-delay window persists until the delay
 // elapses — matching the pre-migration semantics. The handlers are mutually
 // exclusive in practice because input routing only ever emplaces one tag per
 // press; erase_end_choice_tags on consumption keeps that invariant explicit.
@@ -36,7 +28,12 @@ template <typename ChoiceTag, typename NextPhaseTag>
 void apply_end_choice(entt::registry& reg) {
     if (!reg.ctx().find<ChoiceTag>()) return;
     auto& gs = reg.ctx().get<GameState>();
-    if (!end_screen_input_ready(reg, gs)) return;
+    const auto& ctx = reg.ctx();
+    const bool game_over_ready =
+        ctx.contains<GamePhaseGameOverTag>() && gs.phase_timer > constants::GAME_OVER_INPUT_DELAY;
+    const bool song_complete_ready =
+        ctx.contains<GamePhaseSongCompleteTag>() && gs.phase_timer > constants::SONG_COMPLETE_INPUT_DELAY;
+    if (!(game_over_ready || song_complete_ready)) return;
     request_phase_transition<NextPhaseTag>(reg);
     erase_end_choice_tags(reg);
 }


### PR DESCRIPTION
Closes #1540.

`end_screen_input_ready` was an 8-LOC anonymous-namespace helper with a single call site at `apply_end_choice`. Same mechanical inline pattern as the recently-merged #1528 / #1530 / #1532 — single call site, no behavior change, semantics preserved.

Folded the Fabian-rationale comment block from the deleted helper into `apply_end_choice`'s leading comment so the per-phase tag dispatch rationale stays anchored to the code that performs the tag check (rather than orphaned on a deleted helper).

**Verification**

- `rg -n 'end_screen_input_ready' app/` → 0 hits
- `cmake --build build` → zero warnings
- `./build/shapeshifter_tests` → 3397 assertions in 964 test cases, all passing

**Acceptance criteria (from #1540)**

- [x] `rg -n 'end_screen_input_ready' app/` returns zero hits.
- [x] `apply_end_choice` keeps the same input-ready gate semantics (game-over and song-complete tags + their respective input-delay thresholds).
- [x] Build clean (zero warnings, `-Wall -Wextra -Werror`) and `ctest` green.
