### PR TITLE
#1541 app/systems/settings_screen_bind_system.cpp: inline single-call `format_toggle` anon-ns helper

### DIFF
--- a/app/systems/settings_screen_bind_system.cpp
+++ b/app/systems/settings_screen_bind_system.cpp
@@ -39,16 +39,6 @@ struct SettingsBindContext {
     bool    motion_on;
 };
 
-void format_toggle(UiLabel& label, const char* name, bool on) {
-    // Two-cue ON/OFF (issue #390): icon-prefix `[X]` vs `[ ]` plus the
-    // explicit ON/OFF suffix. The colour cue lives in `ui_render_system`
-    // (`UiToggleTag` view selects the green/grey row).
-    char buf[32];
-    std::snprintf(buf, sizeof(buf), "[%s] %s: %s",
-                  on ? "X" : " ", name, on ? "ON" : "OFF");
-    ui_label_set(label, buf);
-}
-
 void bind_audio_offset(const SettingsBindContext& ctx, entt::registry& /*reg*/,
                        entt::entity /*e*/, UiLabel& label) {
     char buf[16];
@@ -64,7 +54,13 @@ void bind_audio_offset(const SettingsBindContext& ctx, entt::registry& /*reg*/,
 // without two byte-identical bodies.
 void bind_toggle_impl(entt::registry& reg, entt::entity e, UiLabel& label,
                       const char* name, bool on) {
-    format_toggle(label, name, on);
+    // Two-cue ON/OFF (issue #390): icon-prefix `[X]` vs `[ ]` plus the
+    // explicit ON/OFF suffix. The colour cue lives in `ui_render_system`
+    // (`UiToggleTag` view selects the green/grey row).
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "[%s] %s: %s",
+                  on ? "X" : " ", name, on ? "ON" : "OFF");
+    ui_label_set(label, buf);
     reg.emplace_or_replace<UiToggleState>(e, UiToggleState{on});
 }
 


### PR DESCRIPTION
Closes #1541.

`format_toggle` was a 9-LOC anonymous-namespace helper with a single call site at `bind_toggle_impl`. Same mechanical inline pattern as the recently-merged #1528 / #1530 / #1532 — single call site, no behavior change, visual format preserved exactly.

Folded the two-cue ON/OFF format comment (issue #390) from the deleted helper into `bind_toggle_impl` above the `snprintf` so the rationale stays anchored to the format string.

**Verification**

- `rg -n 'format_toggle\b' app/` → 0 hits
- `cmake --build build` → zero warnings
- `./build/shapeshifter_tests` → 3397 assertions in 964 test cases, all passing

**Acceptance criteria (from #1541)**

- [x] `rg -n 'format_toggle\b' app/` returns zero hits.
- [x] `bind_toggle_impl` keeps the same `[X] NAME: ON` / `[ ] NAME: OFF` label format (visual regression in `bind_haptics_toggle` / sibling toggle binder).
- [x] Build clean (zero warnings, `-Wall -Wextra -Werror`) and `ctest` green.
