### PR TITLE
#1546 app/systems/game_state_end_screen_system.cpp: inline single-call `erase_end_choice_tags` anon-ns helper

### DIFF
--- a/app/systems/game_state_end_screen_system.cpp
+++ b/app/systems/game_state_end_screen_system.cpp
@@ -5,12 +5,6 @@
 
 namespace {
 
-void erase_end_choice_tags(entt::registry& reg) {
-    if (reg.ctx().find<EndChoiceRestart>())     reg.ctx().erase<EndChoiceRestart>();
-    if (reg.ctx().find<EndChoiceLevelSelect>()) reg.ctx().erase<EndChoiceLevelSelect>();
-    if (reg.ctx().find<EndChoiceMainMenu>())    reg.ctx().erase<EndChoiceMainMenu>();
-}
-
 // One transform per former enum value (Fabian's "transform per tag" mechanic,
 // issue #1202/#1204, PR G). The former `gs.phase == GamePhase::X` checks now
 // dispatch on per-phase tag presence in `reg.ctx()`; the former
@@ -23,7 +17,8 @@ void erase_end_choice_tags(entt::registry& reg) {
 // so a choice latched during the input-delay window persists until the delay
 // elapses — matching the pre-migration semantics. The handlers are mutually
 // exclusive in practice because input routing only ever emplaces one tag per
-// press; erase_end_choice_tags on consumption keeps that invariant explicit.
+// press; erasing all three choice tags on consumption keeps that invariant
+// explicit.
 template <typename ChoiceTag, typename NextPhaseTag>
 void apply_end_choice(entt::registry& reg) {
     if (!reg.ctx().find<ChoiceTag>()) return;
@@ -35,7 +30,9 @@ void apply_end_choice(entt::registry& reg) {
         ctx.contains<GamePhaseSongCompleteTag>() && gs.phase_timer > constants::SONG_COMPLETE_INPUT_DELAY;
     if (!(game_over_ready || song_complete_ready)) return;
     request_phase_transition<NextPhaseTag>(reg);
-    erase_end_choice_tags(reg);
+    if (reg.ctx().find<EndChoiceRestart>())     reg.ctx().erase<EndChoiceRestart>();
+    if (reg.ctx().find<EndChoiceLevelSelect>()) reg.ctx().erase<EndChoiceLevelSelect>();
+    if (reg.ctx().find<EndChoiceMainMenu>())    reg.ctx().erase<EndChoiceMainMenu>();
 }
 
 }  // namespace


### PR DESCRIPTION
Closes #1546.

## Summary

Continues the single-call anon-ns inline train (#1519 / #1521 / #1523 / #1524 / #1528 / #1529 / #1531 / #1532 / #1540 / #1541 / #1543 / #1544). Removes the only call to `erase_end_choice_tags` by hoisting its three `ctx().erase<…>()` lines into its single caller, `apply_end_choice<ChoiceTag, NextPhaseTag>`.

## Diff

- Deleted the 5-line `erase_end_choice_tags(entt::registry&)` definition in `app/systems/game_state_end_screen_system.cpp`.
- Inlined the three `ctx().erase<…>()` checks into `apply_end_choice`, after `request_phase_transition<NextPhaseTag>(reg);`.
- Updated the explanatory comment to drop the helper name and describe the inline behavior directly.

Net: **+5 / −8** in a single file.

## Behavior

No change. Same three `EndChoiceRestart` / `EndChoiceLevelSelect` / `EndChoiceMainMenu` context-tag erases run in the same order on the same code path. The "consume the latched choice" semantic is preserved exactly.

## Verification

- `cmake --build build -j` — zero warnings.
- `ctest --test-dir build --output-on-failure -E "Bench:"` — **977 / 977 passing**, 0 failures.

Refs `.squad/decisions.md` § 9 / Principle 0 (single-call abstractions hide nothing; behavior dispatch belongs in the table, not in indirection).
