### PR TITLE
#1545: Normalize SongState.current_beat + SessionLog.last_logged_beat into BeatCursor + LastLoggedBeat row tables (Fabian Principle 3)

### DIFF
--- a/app/components/song_state.h
+++ b/app/components/song_state.h
@@ -31,8 +31,11 @@ struct SongState {
     float morph_duration  = 0.1f;   // shape-morph animation length in seconds
 
     // ── Per-frame mutable fields ─────────────────────────────────────────────
+    // The former `int current_beat = -1` sentinel migrated to the
+    // `BeatCursor` ctx-singleton row table below (Fabian Principle 3 /
+    // issue #1545): membership IS "at least one beat has been crossed",
+    // and `last_crossed` is always meaningful while the row exists.
     float  song_time     = 0.0f;   // mutated every frame by song_playback_system
-    int    current_beat  = -1;     // mutated every frame by song_playback_system
     bool   playing       = false;  // set true by setup_play_session; cleared by
                                    //   song_playback_system or terminal GameOver entry
     bool   finished      = false;  // set true by song_playback_system or terminal GameOver entry
@@ -76,4 +79,19 @@ struct SongResults {
     int   miss_count    = 0;
     int   max_chain     = 0;
     int   total_notes   = 0;
+};
+
+// ── Beat Cursor (singleton row table, lives in registry context) ─────────────
+// Presence in `reg.ctx()` IS "at least one beat has been crossed for the
+// current session"; `last_crossed` is the highest beat index that has been
+// crossed, always meaningful while the row exists. Per Fabian Principle 3
+// (.squad/decisions.md § 9 / issue #1545): the former
+// `SongState::current_beat = -1` sentinel was a NULL column in disguise
+// (a value whose meaning depended on whether it equalled the absent-beat
+// marker). Writers: `song_playback_system` emplaces on first crossing and
+// mutates `last_crossed` on subsequent crossings. Readers: `beat_log_system`
+// and `camera_system` join on presence and read `last_crossed`.
+// Reset path: `setup_play_session` erases any prior row at session init.
+struct BeatCursor {
+    int last_crossed = 0;
 };

--- a/app/entities/beat_map.cpp
+++ b/app/entities/beat_map.cpp
@@ -1099,7 +1099,10 @@ void init_song_state(SongState& state, const BeatMap& map) {
     state.lead_beats   = map.lead_beats;
     state.duration_sec = map.duration;
     state.song_time    = 0.0f;
-    state.current_beat = -1;
+    // Beat cursor lives in `reg.ctx()` as a `BeatCursor` row table whose
+    // membership IS "at least one beat has been crossed" (issue #1545 /
+    // Fabian Principle 3). `setup_play_session` erases any prior row at
+    // session init, so this function intentionally does not touch it.
     state.playing      = false;
     state.finished     = false;
     state.next_shape_gate_circle_idx         = 0;

--- a/app/systems/beat_log_system.cpp
+++ b/app/systems/beat_log_system.cpp
@@ -3,26 +3,40 @@
 #include "../entities/beat_map.h"
 #include "../components/game_state.h"
 #include "../components/rhythm.h"
+#include "../components/song_state.h"
 
-// Observes SongState::current_beat and emits BEAT log entries.
-// Keeps last_logged_beat in SessionLog so playback has no logging branch.
+// Observes BeatCursor and emits BEAT log entries.
+// Keeps LastLoggedBeat in registry context so playback has no logging branch.
+// Both singletons follow Fabian Principle 3 (issue #1545): membership IS the
+// precondition that any beat has been crossed / emitted, so there is no
+// `-1` sentinel discriminator in the read path.
 void beat_log_system(entt::registry& reg, [[maybe_unused]] float dt) {
-    auto* log = reg.ctx().find<SessionLog>();
+    auto& ctx = reg.ctx();
+    auto* log = ctx.find<SessionLog>();
     if (!log || !log->file) return;
 
-    auto* song = reg.ctx().find<SongState>();
-    auto* map = find_beat_map(reg);
+    auto* song = ctx.find<SongState>();
     if (!song || !song->playing || song->finished) return;
 
-    if (song->current_beat > log->last_logged_beat) {
-        for (int b = log->last_logged_beat + 1; b <= song->current_beat; ++b) {
-            float expected = song->offset + b * song->beat_period;
-            if (map && b >= 0 && static_cast<size_t>(b) < map->beat_times.size()) {
-                expected = map->beat_times[static_cast<size_t>(b)];
-            }
-            session_log_write(*log, song->song_time, "GAME",
-                "BEAT %d expected=%.3f", b, expected);
+    const auto* cursor = ctx.find<BeatCursor>();
+    if (!cursor) return;  // no beat crossed yet → nothing to log
+
+    auto* last_logged = ctx.find<LastLoggedBeat>();
+    const int last = last_logged ? last_logged->beat : -1;
+    if (cursor->last_crossed <= last) return;
+
+    auto* map = find_beat_map(reg);
+    for (int b = last + 1; b <= cursor->last_crossed; ++b) {
+        float expected = song->offset + b * song->beat_period;
+        if (map && b >= 0 && static_cast<size_t>(b) < map->beat_times.size()) {
+            expected = map->beat_times[static_cast<size_t>(b)];
         }
-        log->last_logged_beat = song->current_beat;
+        session_log_write(*log, song->song_time, "GAME",
+            "BEAT %d expected=%.3f", b, expected);
+    }
+    if (last_logged) {
+        last_logged->beat = cursor->last_crossed;
+    } else {
+        ctx.emplace<LastLoggedBeat>(LastLoggedBeat{cursor->last_crossed});
     }
 }

--- a/app/systems/camera_system.cpp
+++ b/app/systems/camera_system.cpp
@@ -332,10 +332,11 @@ void game_camera_system(entt::registry& reg, [[maybe_unused]] float dt) {
         auto* map = find_beat_map(reg);
         const auto* settings = find_settings_state(reg);
         const float audio_offset_sec = settings ? settings::audio_offset_seconds(*settings) : 0.0f;
+        const auto* cursor = reg.ctx().find<BeatCursor>();
         float pulse = 0.0f;
-        if (song && song->playing && song->beat_period > 0.0f && song->current_beat >= 0) {
-            float beat_time = song->offset + static_cast<float>(song->current_beat) * song->beat_period;
-            const auto beat_index = static_cast<size_t>(song->current_beat);
+        if (song && song->playing && song->beat_period > 0.0f && cursor) {
+            float beat_time = song->offset + static_cast<float>(cursor->last_crossed) * song->beat_period;
+            const auto beat_index = static_cast<size_t>(cursor->last_crossed);
             if (map && beat_index < map->beat_times.size()) {
                 beat_time = map->beat_times[beat_index];
             }

--- a/app/systems/play_session.cpp
+++ b/app/systems/play_session.cpp
@@ -166,6 +166,7 @@ void setup_play_session(entt::registry& reg) {
         erase_ctx_if_exists<ScoreDisplay>(reg);
         erase_ctx_if_exists<CurrentSongHighScore>(reg);
         erase_ctx_if_exists<SongState>(reg);
+        erase_ctx_if_exists<BeatCursor>(reg);
         erase_ctx_if_exists<EnergyState>(reg);
         erase_ctx_if_exists<SongResults>(reg);
         erase_ctx_if_exists<EnergyDepletedDeath>(reg);
@@ -204,6 +205,10 @@ void setup_play_session(entt::registry& reg) {
 
     // Init song state
     auto& song = assign_or_emplace_ctx(reg, SongState{});
+    // Reset the BeatCursor row table (Fabian Principle 3 / issue #1545):
+    // membership IS "at least one beat has been crossed", so erase any
+    // carry-over from a prior session before the new session begins.
+    erase_ctx_if_exists<BeatCursor>(reg);
     if (!beat_map_empty(beatmap)) {
         init_song_state(song, beatmap);
     } else {

--- a/app/systems/session_logger_system.cpp
+++ b/app/systems/session_logger_system.cpp
@@ -16,8 +16,7 @@
 SessionLog::SessionLog(SessionLog&& other) noexcept
     : file{other.file},
       frame{other.frame},
-      buffer{std::move(other.buffer)},
-      last_logged_beat{other.last_logged_beat}
+      buffer{std::move(other.buffer)}
 {
     other.file = nullptr;
     if (buffer.capacity() < kMaxLogBufferBytes) {
@@ -31,7 +30,6 @@ SessionLog& SessionLog::operator=(SessionLog&& other) noexcept {
         file = other.file;
         frame = other.frame;
         buffer = std::move(other.buffer);
-        last_logged_beat = other.last_logged_beat;
         other.file = nullptr;
         if (buffer.capacity() < kMaxLogBufferBytes) {
             buffer.reserve(kMaxLogBufferBytes);

--- a/app/systems/session_logger_system.h
+++ b/app/systems/session_logger_system.h
@@ -20,7 +20,11 @@ struct SessionLog {
     FILE*       file  = nullptr;
     uint32_t    frame = 0;
     std::string buffer;        // buffered log lines, flushed once per frame
-    int         last_logged_beat = -1;  // beat_log_system tracks last emitted beat
+    // The former `int last_logged_beat = -1` cursor migrated to the
+    // `LastLoggedBeat` ctx-singleton row table below (Fabian Principle 3 /
+    // issue #1545): membership IS "at least one beat has been emitted",
+    // and `beat` is always meaningful while the row exists. Reset path:
+    // test_player_session erases any prior row when re-opening the log.
 
     SessionLog() { buffer.reserve(kMaxLogBufferBytes); }
     SessionLog(const SessionLog&) = delete;
@@ -30,6 +34,19 @@ struct SessionLog {
     ~SessionLog();
 
     void release();
+};
+
+// ── Last Logged Beat (singleton row table, lives in registry context) ────────
+// Presence in `reg.ctx()` IS "at least one beat has been emitted to the
+// session log for the current session"; `beat` is the highest beat index
+// emitted, always meaningful while the row exists. Per Fabian Principle 3
+// (.squad/decisions.md § 9 / issue #1545): the former
+// `SessionLog::last_logged_beat = -1` sentinel was a NULL column in
+// disguise. Producer/consumer with `BeatCursor` (see song_state.h):
+// beat_log_system advances `LastLoggedBeat::beat` toward
+// `BeatCursor::last_crossed`, emitting a `BEAT` line per integer step.
+struct LastLoggedBeat {
+    int beat = 0;
 };
 
 // ── Free functions ───────────────────────────────────────────

--- a/app/systems/song_playback_system.cpp
+++ b/app/systems/song_playback_system.cpp
@@ -87,19 +87,30 @@ void song_playback_system(entt::registry& reg, float dt) {
     const auto* settings = find_settings_state(reg);
     const float audio_offset_sec = settings ? settings::audio_offset_seconds(*settings) : 0.0f;
 
-    // Current beat (non-decreasing)
+    // Current beat (non-decreasing). The `BeatCursor` ctx-singleton row
+    // (issue #1545 / Fabian Principle 3) is absent until the first beat
+    // is crossed; absence == -1 in the local int below so the index
+    // arithmetic stays identical to the legacy sentinel form.
+    auto* cursor = ctx.find<BeatCursor>();
+    int current = cursor ? cursor->last_crossed : -1;
     if (map && !map->beat_times.empty()) {
-        while ((song->current_beat + 1) >= 0 &&
-               static_cast<size_t>(song->current_beat + 1) < map->beat_times.size() &&
+        while (static_cast<size_t>(current + 1) < map->beat_times.size() &&
                song->song_time >=
-                   map->beat_times[static_cast<size_t>(song->current_beat + 1)] + audio_offset_sec) {
-            ++song->current_beat;
+                   map->beat_times[static_cast<size_t>(current + 1)] + audio_offset_sec) {
+            ++current;
         }
     } else if (song->beat_period > 0.0f && song->song_time >= song->offset + audio_offset_sec) {
         int beat = static_cast<int>(
             (song->song_time - (song->offset + audio_offset_sec)) / song->beat_period);
-        if (beat > song->current_beat) {
-            song->current_beat = beat;
+        if (beat > current) {
+            current = beat;
+        }
+    }
+    if (current >= 0) {
+        if (cursor) {
+            cursor->last_crossed = current;
+        } else {
+            ctx.emplace<BeatCursor>(BeatCursor{current});
         }
     }
 

--- a/app/systems/test_player_session.cpp
+++ b/app/systems/test_player_session.cpp
@@ -59,6 +59,12 @@ void test_player_init(entt::registry& reg, SkillConfig skill,
     auto& slog = reg.ctx().get<SessionLog>();
     session_log_close(slog);
     slog = SessionLog{};
+    // Reset the LastLoggedBeat row table (Fabian Principle 3 / issue #1545):
+    // membership IS "at least one beat has been emitted", so erase any
+    // carry-over from a prior test session before the new log opens.
+    if (reg.ctx().contains<LastLoggedBeat>()) {
+        reg.ctx().erase<LastLoggedBeat>();
+    }
     const double runtime_seconds = GetTime();
     const auto runtime_millis = static_cast<unsigned long long>(runtime_seconds * 1000.0);
     const uint32_t sequence = ++session_state->log_sequence;

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -418,13 +418,21 @@ struct SongState {
     float half_window     = 0.15f;
     float morph_duration  = 0.1f;
     float song_time       = 0.0f;
-    int   current_beat    = -1;
     bool  playing         = false;
     bool  finished        = false;
     bool  restart_music   = false;
     size_t next_spawn_idx = 0;  // (legacy doc shape — actual SongState has fourteen
                                 //  per-(kind, shape, time-source) cursors per #1533;
                                 //  see rhythm-spec.md and app/components/song_state.h)
+};
+
+/// Singleton row table: presence in `reg.ctx()` IS "at least one beat
+/// has been crossed for the current session". The legacy
+/// `SongState::current_beat = -1` sentinel was a NULL column in disguise
+/// (Fabian Principle 3 / issue #1545); membership now expresses
+/// "any beat crossed yet" while `last_crossed` is always meaningful.
+struct BeatCursor {
+    int last_crossed = 0;
 };
 
 /// Singleton: survival meter displayed by the HUD energy bar.
@@ -756,7 +764,7 @@ system in the same frame (unidirectional data flow).
  │  ┌─ PHASE 3: PLAYBACK + PLAYING TICK ────────────────────┐
  │  │                                                        │
  │  │  5. song_playback_system  Advance SongState.song_time  │
- │  │                           and current_beat from music. │
+ │  │                           and BeatCursor from music.   │
  │  │                                                        │
  │  │  6. tick_playing_systems  Runs only in Playing phase:  │
  │  │                                                        │
@@ -1727,7 +1735,7 @@ app/
 │   ├── particle.h               ← ParticleData, ParticleTag
 │   ├── rhythm.h                 ← BeatInfo, TimingGrade (precision only;
 │   │                              tier is a `Timing*Tag` from `tags.h`)
-│   └── song_state.h             ← SongState
+│   └── song_state.h             ← SongState, BeatCursor (row table, issue #1545)
 │
 ├── systems/                     ← all system free functions
 │   ├── input.h                  ← InputState, TouchSlot, InputSourceMouse, InputSourceTouch (singleton hardware-capture state)

--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -262,8 +262,12 @@ struct SongState {
     float morph_duration  = 0.1f;   // shape-morph animation length in seconds
 
     // ── Per-frame mutable fields ─────────────────────────────────────────────
+    // The former `int current_beat = -1` sentinel migrated to the
+    // `BeatCursor { int last_crossed; }` ctx-singleton row table (Fabian
+    // Principle 3 / issue #1545): membership IS "at least one beat has
+    // been crossed", and `last_crossed` is always meaningful while the
+    // row exists.
     float  song_time     = 0.0f;   // mutated every frame by song_playback_system
-    int    current_beat  = -1;     // mutated every frame by song_playback_system
     bool   playing       = false;  // set true by setup_play_session; cleared by
                                    //   song_playback_system or terminal GameOver entry
     bool   finished      = false;  // set true by song_playback_system or terminal GameOver entry

--- a/design-docs/tester-personas-tech-spec.md
+++ b/design-docs/tester-personas-tech-spec.md
@@ -259,9 +259,12 @@ runtime beat telemetry comes from `beat_log_system`.
 The runtime struct lives in `app/systems/session_logger_system.h` — see that header for
 the authoritative definition. Beyond `FILE* file` and `uint32_t frame`, it
 also owns a per-frame `std::string buffer` (pre-reserved at
-`kMaxLogBufferBytes = 4096`, so the hot write path never reallocates) and a
-`last_logged_beat` cursor used by `beat_log_system`. The struct is move-only
-with an explicit destructor / `release()` that closes the file handle.
+`kMaxLogBufferBytes = 4096`, so the hot write path never reallocates). The
+beat-log cursor that used to live on `SessionLog::last_logged_beat = -1`
+migrated to the `LastLoggedBeat { int beat; }` ctx-singleton row table in
+the same header (Fabian Principle 3 / issue #1545); membership IS "at
+least one beat has been emitted". The struct is move-only with an
+explicit destructor / `release()` that closes the file handle.
 
 Helper functions are free functions, not methods. The write entry point is
 `session_log_write`, paired with `session_log_open` / `session_log_close` /

--- a/tests/test_audio_offset_calibration.cpp
+++ b/tests/test_audio_offset_calibration.cpp
@@ -124,16 +124,16 @@ TEST_CASE("song_playback: positive audio_offset delays beat crossing",
 
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 0.0f;
-    song.current_beat = -1;
+    set_beat_cursor(reg, -1);
 
     auto& map = beat_map(reg);
     map.beat_times = {1.0f};
 
     song_playback_system(reg, 1.1f);
-    CHECK(song.current_beat == -1);
+    CHECK(beat_cursor_value(reg) == -1);
 
     song_playback_system(reg, 0.1f);
-    CHECK(song.current_beat == 0);
+    CHECK(beat_cursor_value(reg) == 0);
 }
 
 TEST_CASE("song_playback: negative audio_offset advances beat crossing",
@@ -144,13 +144,13 @@ TEST_CASE("song_playback: negative audio_offset advances beat crossing",
 
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 0.0f;
-    song.current_beat = -1;
+    set_beat_cursor(reg, -1);
 
     auto& map = beat_map(reg);
     map.beat_times = {1.0f};
 
     song_playback_system(reg, 0.85f);
-    CHECK(song.current_beat == 0);
+    CHECK(beat_cursor_value(reg) == 0);
 }
 
 TEST_CASE("beat_scheduler: audio_offset gates spawn before calibrated spawn time",
@@ -180,7 +180,7 @@ TEST_CASE("audio_offset: zero setting matches absent SettingsState",
     auto playback_with_zero = make_rhythm_registry();
     auto& zero_song = playback_with_zero.ctx().get<SongState>();
     zero_song.song_time = 0.0f;
-    zero_song.current_beat = -1;
+    set_beat_cursor(playback_with_zero, -1);
     beat_map(playback_with_zero).beat_times = {0.4f, 0.9f, 1.6f};
     song_playback_system(playback_with_zero, 1.0f);
 
@@ -188,11 +188,12 @@ TEST_CASE("audio_offset: zero setting matches absent SettingsState",
     destroy_settings_entity(playback_without_settings);
     auto& absent_song = playback_without_settings.ctx().get<SongState>();
     absent_song.song_time = 0.0f;
-    absent_song.current_beat = -1;
+    set_beat_cursor(playback_without_settings, -1);
     beat_map(playback_without_settings).beat_times = {0.4f, 0.9f, 1.6f};
     song_playback_system(playback_without_settings, 1.0f);
 
-    CHECK(absent_song.current_beat == zero_song.current_beat);
+    CHECK(beat_cursor_value(playback_without_settings) ==
+          beat_cursor_value(playback_with_zero));
 
     auto scheduler_with_zero = make_rhythm_registry();
     auto& zero_schedule_song = scheduler_with_zero.ctx().get<SongState>();
@@ -366,7 +367,7 @@ TEST_CASE("game camera floor pulse honors audio_offset_ms",
 
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 1.25f;
-    song.current_beat = 0;
+    set_beat_cursor(reg, 0);
     song.playing = true;
 
     auto& map = beat_map(reg);

--- a/tests/test_beat_log_system.cpp
+++ b/tests/test_beat_log_system.cpp
@@ -12,7 +12,6 @@ static SessionLog make_open_log() {
     log.file  = std::fopen("/dev/null", "w");
 #endif
     log.frame = 0;
-    log.last_logged_beat = -1;
     return log;
 }
 
@@ -40,7 +39,7 @@ TEST_CASE("beat_log: no-op when SessionLog absent", "[beat_log]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 0.6f;
-    song.current_beat = 1;
+    set_beat_cursor(reg, 1);
 
     // No SessionLog in context — must not crash
     beat_log_system(reg, 0.0f);
@@ -49,68 +48,63 @@ TEST_CASE("beat_log: no-op when SessionLog absent", "[beat_log]") {
 
 TEST_CASE("beat_log: no-op when log file is null", "[beat_log]") {
     auto reg = make_rhythm_registry();
-    auto& song = reg.ctx().get<SongState>();
-    song.current_beat = 3;
+    set_beat_cursor(reg, 3);
 
     SessionLog log;  // file = nullptr
     reg.ctx().emplace<SessionLog>(std::move(log));
 
     beat_log_system(reg, 0.0f);
-    auto& stored = reg.ctx().get<SessionLog>();
-    // last_logged_beat must not have advanced when file is null
-    CHECK(stored.last_logged_beat == -1);
+    // LastLoggedBeat must not have been emplaced when file is null
+    CHECK(last_logged_beat_value(reg) == -1);
 }
 
 TEST_CASE("beat_log: no-op when not in Playing phase", "[beat_log]") {
     auto reg = make_rhythm_registry();
     set_test_phase<GamePhaseTitleTag>(reg);
-    auto& song = reg.ctx().get<SongState>();
-    song.current_beat = 2;
+    set_beat_cursor(reg, 2);
 
     auto slog = make_open_log();
     reg.ctx().emplace<SessionLog>(std::move(slog));
 
     tick_playing_systems(reg, 0.0f);
-    CHECK(reg.ctx().get<SessionLog>().last_logged_beat == -1);
+    CHECK(last_logged_beat_value(reg) == -1);
 }
 
 TEST_CASE("beat_log: no-op when song not playing", "[beat_log]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     song.playing = false;
-    song.current_beat = 2;
+    set_beat_cursor(reg, 2);
 
     auto slog = make_open_log();
     reg.ctx().emplace<SessionLog>(std::move(slog));
 
     beat_log_system(reg, 0.0f);
-    CHECK(reg.ctx().get<SessionLog>().last_logged_beat == -1);
+    CHECK(last_logged_beat_value(reg) == -1);
 }
 
-// ── beat_log_system: advances last_logged_beat ───────────────
+// ── beat_log_system: advances LastLoggedBeat ─────────────────
 
-TEST_CASE("beat_log: logs new beat and advances last_logged_beat", "[beat_log]") {
+TEST_CASE("beat_log: logs new beat and advances LastLoggedBeat", "[beat_log]") {
     auto reg = make_rhythm_registry();
-    auto& song = reg.ctx().get<SongState>();
-    song.current_beat = 1;
+    set_beat_cursor(reg, 1);
 
     auto slog = make_open_log();
     reg.ctx().emplace<SessionLog>(std::move(slog));
 
     beat_log_system(reg, 0.0f);
-    CHECK(reg.ctx().get<SessionLog>().last_logged_beat == 1);
+    CHECK(last_logged_beat_value(reg) == 1);
 }
 
 TEST_CASE("beat_log: catches up multiple beats in one call", "[beat_log]") {
     auto reg = make_rhythm_registry();
-    auto& song = reg.ctx().get<SongState>();
-    song.current_beat = 5;  // jumped ahead 6 beats from -1
+    set_beat_cursor(reg, 5);  // jumped ahead 6 beats from absent cursor
 
     auto slog = make_open_log();
     reg.ctx().emplace<SessionLog>(std::move(slog));
 
     beat_log_system(reg, 0.0f);
-    CHECK(reg.ctx().get<SessionLog>().last_logged_beat == 5);
+    CHECK(last_logged_beat_value(reg) == 5);
 }
 
 TEST_CASE("beat_log: falls back when authored beat_times are shorter than current beat", "[beat_log]") {
@@ -119,7 +113,7 @@ TEST_CASE("beat_log: falls back when authored beat_times are shorter than curren
     song.offset = 0.25f;
     song.beat_period = 0.5f;
     song.song_time = 1.75f;
-    song.current_beat = 3;
+    set_beat_cursor(reg, 3);
 
     auto& map = beat_map(reg);
     map.beat_times = {0.25f};
@@ -130,23 +124,22 @@ TEST_CASE("beat_log: falls back when authored beat_times are shorter than curren
     beat_log_system(reg, 0.0f);
 
     auto& stored = reg.ctx().get<SessionLog>();
-    CHECK(stored.last_logged_beat == 3);
+    CHECK(last_logged_beat_value(reg) == 3);
     CHECK(stored.buffer.find("BEAT 0 expected=0.250") != std::string::npos);
     CHECK(stored.buffer.find("BEAT 3 expected=1.750") != std::string::npos);
 }
 
 TEST_CASE("beat_log: does not re-log already-logged beats", "[beat_log]") {
     auto reg = make_rhythm_registry();
-    auto& song = reg.ctx().get<SongState>();
-    song.current_beat = 3;
+    set_beat_cursor(reg, 3);
 
     auto slog = make_open_log();
-    slog.last_logged_beat = 3;  // already logged
     reg.ctx().emplace<SessionLog>(std::move(slog));
+    set_last_logged_beat(reg, 3);  // already logged
 
     beat_log_system(reg, 0.0f);
-    // last_logged_beat must remain 3 (no spurious advance)
-    CHECK(reg.ctx().get<SessionLog>().last_logged_beat == 3);
+    // LastLoggedBeat must remain 3 (no spurious advance)
+    CHECK(last_logged_beat_value(reg) == 3);
 }
 
 // ── song_playback_system: no logging dependency ───────────────
@@ -155,36 +148,36 @@ TEST_CASE("song_playback: does not write to SessionLog", "[song_playback][beat_l
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 0.0f;
-    song.current_beat = -1;
+    set_beat_cursor(reg, -1);
 
     // Place a SessionLog with open file so any accidental write would be detectable
     auto slog = make_open_log();
-    slog.last_logged_beat = -1;
     reg.ctx().emplace<SessionLog>(std::move(slog));
+    set_last_logged_beat(reg, -1);
 
     // Advance past two beats
     song_playback_system(reg, 1.1f);
 
-    // Playback advanced current_beat
-    CHECK(song.current_beat >= 1);
-    // But last_logged_beat must remain -1 — playback didn't touch the log
-    CHECK(reg.ctx().get<SessionLog>().last_logged_beat == -1);
+    // Playback advanced the beat cursor
+    CHECK(beat_cursor_value(reg) >= 1);
+    // But LastLoggedBeat must remain absent — playback didn't touch the log
+    CHECK(last_logged_beat_value(reg) == -1);
 }
 
-TEST_CASE("beat_log: last_logged_beat advances after beat_log_system runs", "[beat_log]") {
+TEST_CASE("beat_log: LastLoggedBeat advances after beat_log_system runs", "[beat_log]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 0.0f;
-    song.current_beat = -1;
+    set_beat_cursor(reg, -1);
 
     auto slog = make_open_log();
     reg.ctx().emplace<SessionLog>(std::move(slog));
 
     song_playback_system(reg, 1.1f);
     // Still not logged yet (beat_log hasn't run)
-    CHECK(reg.ctx().get<SessionLog>().last_logged_beat == -1);
+    CHECK(last_logged_beat_value(reg) == -1);
 
     beat_log_system(reg, 0.0f);
     // Now it matches
-    CHECK(reg.ctx().get<SessionLog>().last_logged_beat == song.current_beat);
+    CHECK(last_logged_beat_value(reg) == beat_cursor_value(reg));
 }

--- a/tests/test_beat_map_validation.cpp
+++ b/tests/test_beat_map_validation.cpp
@@ -346,7 +346,6 @@ TEST_CASE("init_song_state: resets playback state", "[init_song]") {
 
     SongState state;
     state.song_time = 50.0f;
-    state.current_beat = 10;
     state.playing = true;
     state.finished = true;
     state.next_shape_gate_circle_idx = 5;
@@ -356,7 +355,9 @@ TEST_CASE("init_song_state: resets playback state", "[init_song]") {
     init_song_state(state, map);
 
     CHECK(state.song_time == 0.0f);
-    CHECK(state.current_beat == -1);
+    // BeatCursor lives in `reg.ctx()` (issue #1545); init_song_state operates
+    // on the plain `SongState` value alone and intentionally does not touch
+    // the cursor — `setup_play_session` owns the per-session cursor reset.
     CHECK_FALSE(state.playing);
     CHECK_FALSE(state.finished);
     CHECK(state.next_shape_gate_circle_idx == 0);

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -29,6 +29,8 @@
 #include "systems/runtime_systems.h"
 #include "systems/input_routing.h"
 #include "systems/input_system_private.h"
+#include "systems/session_logger_system.h"
+#include "components/song_state.h"
 
 // Sets up a registry with all singletons in their default state.
 //
@@ -308,6 +310,44 @@ inline entt::registry make_rhythm_registry() {
     reg.ctx().get<EnergyState>() = EnergyState{};
     reg.ctx().get<SongResults>() = SongResults{};
     return reg;
+}
+
+// ── BeatCursor / LastLoggedBeat helpers (issue #1545) ─────────────────────
+// The legacy `SongState::current_beat = -1` and
+// `SessionLog::last_logged_beat = -1` sentinels migrated to ctx-singleton
+// row tables (Fabian Principle 3). These helpers preserve the legacy
+// `song.current_beat = N` / `log.last_logged_beat = N` ergonomic in tests:
+//   - N >= 0 → row exists with that value;
+//   - N <  0 → row absent (legacy "fresh-session" semantics).
+
+inline void set_beat_cursor(entt::registry& reg, int beat) {
+    if (beat < 0) {
+        if (reg.ctx().contains<BeatCursor>()) {
+            reg.ctx().erase<BeatCursor>();
+        }
+    } else {
+        reg.ctx().insert_or_assign(BeatCursor{beat});
+    }
+}
+
+inline int beat_cursor_value(const entt::registry& reg) {
+    const auto* c = reg.ctx().find<BeatCursor>();
+    return c ? c->last_crossed : -1;
+}
+
+inline void set_last_logged_beat(entt::registry& reg, int beat) {
+    if (beat < 0) {
+        if (reg.ctx().contains<LastLoggedBeat>()) {
+            reg.ctx().erase<LastLoggedBeat>();
+        }
+    } else {
+        reg.ctx().insert_or_assign(LastLoggedBeat{beat});
+    }
+}
+
+inline int last_logged_beat_value(const entt::registry& reg) {
+    const auto* l = reg.ctx().find<LastLoggedBeat>();
+    return l ? l->beat : -1;
 }
 
 // Creates a player entity in lane 1 (center) with default shape (Circle)

--- a/tests/test_rhythm_system.cpp
+++ b/tests/test_rhythm_system.cpp
@@ -224,7 +224,7 @@ TEST_CASE("song_playback: increments current_beat", "[rhythm][playback]") {
     auto& song = reg.ctx().get<SongState>();
     song.playing = true; song.offset = 0.0f; song.song_time = 0.0f;
     song_playback_system(reg, 0.5f);
-    CHECK(song.current_beat >= 1);
+    CHECK(beat_cursor_value(reg) >= 1);
 }
 
 TEST_CASE("song_playback: detects song end", "[rhythm][playback]") {

--- a/tests/test_song_playback_extended.cpp
+++ b/tests/test_song_playback_extended.cpp
@@ -8,13 +8,13 @@ TEST_CASE("song_playback: beat advances when song_time crosses beat boundary", "
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 0.0f;
-    song.current_beat = -1;
+    set_beat_cursor(reg, -1);
     song.offset = 0.0f;
 
     // Advance past first beat (beat_period = 0.5 at 120 BPM)
     song_playback_system(reg, 0.6f);
 
-    CHECK(song.current_beat >= 0);
+    CHECK(beat_cursor_value(reg) >= 0);
     CHECK_THAT(song.song_time, Catch::Matchers::WithinAbs(0.6f, 0.01f));
 }
 
@@ -22,13 +22,13 @@ TEST_CASE("song_playback: multiple beats advance correctly", "[song_playback]") 
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 0.0f;
-    song.current_beat = -1;
+    set_beat_cursor(reg, -1);
     song.offset = 0.0f;
 
     // Advance by 2.5 seconds at 120 BPM (0.5s per beat) → 5 beats
     song_playback_system(reg, 2.5f);
 
-    CHECK(song.current_beat >= 4);
+    CHECK(beat_cursor_value(reg) >= 4);
 }
 
 TEST_CASE("song_playback: song ends when duration exceeded", "[song_playback]") {
@@ -80,28 +80,29 @@ TEST_CASE("song_playback: offset delays beat counting", "[song_playback]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 0.0f;
-    song.current_beat = -1;
+    set_beat_cursor(reg, -1);
     song.offset = 1.0f;
 
     // song_time = 0.5, before offset → no beat yet
     song_playback_system(reg, 0.5f);
-    CHECK(song.current_beat == -1);
+    CHECK(beat_cursor_value(reg) == -1);
 
     // song_time = 1.5, past offset → beat counting starts
     song_playback_system(reg, 1.0f);
-    CHECK(song.current_beat >= 0);
+    CHECK(beat_cursor_value(reg) >= 0);
 }
 
 TEST_CASE("song_playback: current_beat is non-decreasing", "[song_playback]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 0.0f;
-    song.current_beat = -1;
+    set_beat_cursor(reg, -1);
 
     int prev_beat = -1;
     for (int i = 0; i < 20; ++i) {
         song_playback_system(reg, 0.1f);
-        CHECK(song.current_beat >= prev_beat);
-        prev_beat = song.current_beat;
+        const int current = beat_cursor_value(reg);
+        CHECK(current >= prev_beat);
+        prev_beat = current;
     }
 }

--- a/tests/test_song_playback_system.cpp
+++ b/tests/test_song_playback_system.cpp
@@ -84,7 +84,7 @@ TEST_CASE("song_playback: current_beat updates correctly", "[song_playback]") {
     // Advance to 0.6s — should be beat 1 (0.6 / 0.5 = 1.2 → beat 1)
     song_playback_system(reg, 0.6f);
 
-    CHECK(song.current_beat == 1);
+    CHECK(beat_cursor_value(reg) == 1);
 }
 
 TEST_CASE("song_playback: current_beat starts at -1 before offset", "[song_playback]") {
@@ -95,7 +95,7 @@ TEST_CASE("song_playback: current_beat starts at -1 before offset", "[song_playb
 
     song_playback_system(reg, 0.1f);  // song_time = -0.9, still before offset
 
-    CHECK(song.current_beat == -1);
+    CHECK(beat_cursor_value(reg) == -1);
 }
 
 TEST_CASE("song_playback: current_beat advances with offset", "[song_playback]") {
@@ -108,7 +108,7 @@ TEST_CASE("song_playback: current_beat advances with offset", "[song_playback]")
 
     song_playback_system(reg, 1.6f);
 
-    CHECK(song.current_beat == 1);
+    CHECK(beat_cursor_value(reg) == 1);
 }
 
 TEST_CASE("song_playback: current_beat follows beat_times array when present", "[song_playback]") {
@@ -116,14 +116,14 @@ TEST_CASE("song_playback: current_beat follows beat_times array when present", "
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
     song.song_time = 0.0f;
-    song.current_beat = -1;
+    set_beat_cursor(reg, -1);
     map.beat_times = {0.4f, 0.9f, 1.6f};
 
     song_playback_system(reg, 1.0f);
-    CHECK(song.current_beat == 1);
+    CHECK(beat_cursor_value(reg) == 1);
 
     song_playback_system(reg, 0.7f);
-    CHECK(song.current_beat == 2);
+    CHECK(beat_cursor_value(reg) == 2);
 }
 
 // ── song_playback_system: song end ───────────────────────────
@@ -175,14 +175,14 @@ TEST_CASE("song_playback: finished song stays latched and does not restart on la
     REQUIRE(song.finished);
     REQUIRE_FALSE(song.playing);
     const float finished_time = song.song_time;
-    const int finished_beat = song.current_beat;
+    const int finished_beat = beat_cursor_value(reg);
 
     song_playback_system(reg, 1.5f);
 
     CHECK(song.finished);
     CHECK_FALSE(song.playing);
     CHECK(song.song_time > finished_time);
-    CHECK(song.current_beat == finished_beat);
+    CHECK(beat_cursor_value(reg) == finished_beat);
     CHECK_FALSE(song.restart_music);
 }
 
@@ -253,24 +253,24 @@ TEST_CASE("song_playback: beat does not go backwards", "[song_playback]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 2.0f;
-    song.current_beat = 3;
+    set_beat_cursor(reg, 3);
 
     // Small advancement that doesn't cross a new beat
     song_playback_system(reg, 0.01f);
 
-    CHECK(song.current_beat >= 3);
+    CHECK(beat_cursor_value(reg) >= 3);
 }
 
 TEST_CASE("song_playback: multiple beats can be crossed in one frame", "[song_playback]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 0.0f;
-    song.current_beat = -1;
+    set_beat_cursor(reg, -1);
 
     // Advance 3 seconds at 120 BPM (beat_period=0.5) = 6 beats
     song_playback_system(reg, 3.0f);
 
-    CHECK(song.current_beat == 6);
+    CHECK(beat_cursor_value(reg) == 6);
 }
 
 TEST_CASE("song_playback: zero beat_period handled safely", "[song_playback]") {


### PR DESCRIPTION
## Summary

Eradicates two coupled `int sentinel = -1` NULL columns per Fabian Principle 3 (`.squad/decisions.md` § 9 — a field whose meaning depends on another field's value is a NULL column in disguise). Closes #1545.

- `SongState::current_beat = -1` → `BeatCursor { int last_crossed }` ctx-singleton row table in `app/components/song_state.h`. Presence IS "at least one beat crossed".
- `SessionLog::last_logged_beat = -1` → `LastLoggedBeat { int beat }` ctx-singleton row table in `app/systems/session_logger_system.h`. Presence IS "at least one beat emitted".

These two are the producer (`song_playback_system`) and consumer (`beat_log_system`) of the same conceptual cursor; the predicate at `beat_log_system.cpp:17` spans both fields, so the sentinel discipline must change in lock-step. Normalizing only one would be a half-migration (as noted in the filed issue).

## Hot-path changes

- `song_playback_system`: emplaces `BeatCursor` on first crossed beat, mutates `last_crossed` on subsequent crossings. The legacy `(current_beat + 1) >= 0` underflow guard becomes unnecessary — the local `int current = cursor ? cursor->last_crossed : -1` derivation matches the legacy semantics exactly while only assigning the row when `current >= 0`.
- `beat_log_system`: short-circuits when `BeatCursor` is absent (nothing crossed → nothing to log), then advances `LastLoggedBeat` toward `BeatCursor::last_crossed`, emplacing on first emission.
- `camera_system` floor-pulse: `song->current_beat >= 0` gate becomes a `BeatCursor` presence check.

## Reset paths

- `setup_play_session`: erases prior `BeatCursor` on session init + load-failure cleanup (joins the existing `erase_ctx_if_exists<…>` cluster).
- `test_player_session`: erases prior `LastLoggedBeat` when re-opening the per-session log (matches legacy `slog = SessionLog{}` semantics).
- `init_song_state`: drops `state.current_beat = -1` — cursor lives in `reg.ctx()` now.

## Tests

- 4 new helpers in `tests/test_helpers.h`: `set_beat_cursor` / `beat_cursor_value` / `set_last_logged_beat` / `last_logged_beat_value` preserve the legacy `song.current_beat = N` / `log.last_logged_beat = N` ergonomic (N < 0 erases the row; N >= 0 inserts-or-assigns).
- Mechanical rewrite across 6 test files: `test_beat_log_system`, `test_song_playback_system`, `test_song_playback_extended`, `test_audio_offset_calibration`, `test_rhythm_system`, `test_beat_map_validation`. Test-case titles describing "current_beat" semantics are intentionally preserved — the behaviour (non-decreasing beat tracking) is unchanged; only the storage layout moved.
- One previously-meaningless `CHECK(state.current_beat == -1)` in `test_beat_map_validation::"init_song_state: resets playback state"` was dropped — it was asserting the absent NULL column we're eradicating.

## Docs

- `design-docs/architecture.md`: SongState code block, song_playback_system tick-list comment, and `song_state.h` tree-entry refreshed.
- `design-docs/rhythm-spec.md`: SongState code block refreshed.
- `design-docs/tester-personas-tech-spec.md`: SessionLog paragraph points at `LastLoggedBeat`.

## Verified

- Zero warnings: clean rebuild on Clang with `-Wall -Wextra -Werror`.
- Tests: `./build/shapeshifter_tests` 3396 assertions / 964 Catch2 cases pass (was 3397 — one assertion dropped as documented above). `ctest` 977/977 jobs pass.

## Prior art

This is the same canonical row-table fix shape as the four sites filed in #1533 and merged in #1535 / #1536 / #1537 / #1538. Issue #1545 was filed as the producer/consumer follow-up to those four (audit found one more sentinel-int pair in the same family that the prior sweep did not cover).

Closes #1545.
