### PR TITLE
#1549: Normalize PopupDisplay font-measurement cache into PopupTextMeasured row table (Fabian Principle 3)

### DIFF
--- a/app/components/popup.h
+++ b/app/components/popup.h
@@ -16,12 +16,27 @@ struct ScorePopup {
 };
 
 // Pre-computed popup display data. Static text/color are initialized at spawn;
-// ui_render_system lazily caches the text width once the active font is known.
+// the per-entity text-width cache lives in a sibling `PopupTextMeasured` row
+// table whose presence + key-match expresses cache validity (issue #1549,
+// Fabian Principle 3 — `.squad/decisions.md` § 9).
 struct PopupDisplay {
     char     text[16] = {};
     FontSize font_size = FontSize::Small;
     uint8_t  r = 255, g = 255, b = 255, a = 255;
-    float    text_half_width = 0.0f;
-    int      measured_font_base_size = -1;
-    unsigned int measured_font_texture_id = 0;
+};
+
+// Per-popup-entity text-measurement cache (row table). Emplaced/refreshed by
+// `ui_render_system` on the first frame the entity is rendered (and again
+// whenever the active font's identity changes, e.g. atlas reload). Membership
+// + key-match IS the precondition "`half_width` is valid for `(font_base_size,
+// font_texture_id)`"; absence forces a re-measurement.
+//
+// Replaces the prior `PopupDisplay { … float text_half_width; int
+// measured_font_base_size = -1; unsigned int measured_font_texture_id = 0; }`
+// shape (issue #1549) — the `-1` / `0` sentinels were NULL columns in disguise
+// per Fabian Principle 3.
+struct PopupTextMeasured {
+    int          font_base_size;
+    unsigned int font_texture_id;
+    float        half_width;
 };

--- a/app/systems/ui_render_system.cpp
+++ b/app/systems/ui_render_system.cpp
@@ -615,7 +615,6 @@ void ui_render_system(entt::registry& reg, float /*alpha*/) {
     {
         auto view = reg.view<PopupDisplay, ScreenPosition, TagHUDPass>();
         for (auto [entity, pd, sp] : view.each()) {
-            (void)entity;
             if (!text_ctx.loaded || pd.text[0] == '\0') {
                 continue;
             }
@@ -623,14 +622,27 @@ void ui_render_system(entt::registry& reg, float /*alpha*/) {
             const Font& font = popup_font_for_size(text_ctx, pd.font_size);
             const float font_size = static_cast<float>(font.baseSize);
             const float spacing = 1.0f;
-            if (pd.measured_font_base_size != font.baseSize ||
-                pd.measured_font_texture_id != font.texture.id) {
+
+            // PopupTextMeasured presence + key-match IS the cache-valid
+            // predicate (issue #1549, Fabian Principle 3). Absence or
+            // key-mismatch triggers a re-measurement that emplaces / replaces
+            // the row with the freshly observed `(font_base_size,
+            // font_texture_id, half_width)` tuple.
+            const auto* measured = reg.try_get<PopupTextMeasured>(entity);
+            float half_width;
+            if (measured != nullptr &&
+                measured->font_base_size == font.baseSize &&
+                measured->font_texture_id == font.texture.id) {
+                half_width = measured->half_width;
+            } else {
                 const Vector2 size = MeasureTextEx(font, pd.text, font_size, spacing);
-                pd.text_half_width = size.x / 2.0f;
-                pd.measured_font_base_size = font.baseSize;
-                pd.measured_font_texture_id = font.texture.id;
+                half_width = size.x / 2.0f;
+                reg.emplace_or_replace<PopupTextMeasured>(
+                    entity,
+                    PopupTextMeasured{font.baseSize, font.texture.id, half_width});
             }
-            DrawTextEx(font, pd.text, {sp.x - pd.text_half_width, sp.y},
+
+            DrawTextEx(font, pd.text, {sp.x - half_width, sp.y},
                        font_size, spacing, {pd.r, pd.g, pd.b, pd.a});
         }
     }

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -691,7 +691,8 @@ NonScorableTag       0     WARM       miss_detection/scoring exclusions, visual-
 OnsetMarkerTag       0     WARM       obstacle_render_entity, session_logger
 Color                4     COLD       render
 DrawSize             8     COLD       render
-PopupDisplay        36     COLD       popup_display (fade), ui_render
+PopupDisplay        24     COLD       popup_display (fade), ui_render
+PopupTextMeasured   12     COLD       ui_render (per-entity text-width cache; presence + key-match IS valid)
 ParticleTag          0     COLD       render (filter)
 EnergyBarTag         0     COLD       energy_bar_system (filter), gameplay_hud (filter)
 EnergyBarLayout     24     COLD       energy_bar_system (read), gameplay_hud (read)

--- a/tests/test_popup_display_system.cpp
+++ b/tests/test_popup_display_system.cpp
@@ -289,9 +289,6 @@ TEST_CASE("init_popup_display_perfect: formats PERFECT text + Medium font (#251)
     CHECK(pd.g == 20);
     CHECK(pd.b == 30);
     CHECK(pd.a == 200);
-    CHECK(pd.text_half_width == 0.0f);
-    CHECK(pd.measured_font_base_size == -1);
-    CHECK(pd.measured_font_texture_id == 0u);
 }
 
 TEST_CASE("init_popup_display_untimed: formats numeric value (#251)",
@@ -304,9 +301,6 @@ TEST_CASE("init_popup_display_untimed: formats numeric value (#251)",
 
     CHECK(std::strcmp(pd.text, "4242") == 0);
     CHECK(pd.font_size == FontSize::Small);
-    CHECK(pd.text_half_width == 0.0f);
-    CHECK(pd.measured_font_base_size == -1);
-    CHECK(pd.measured_font_texture_id == 0u);
 }
 
 // ── per-tier spawn_score_popup_*: entity factory contract (#349, #1202) ──────


### PR DESCRIPTION
## Summary

Closes #1549.

`PopupDisplay { … float text_half_width = 0.0f; int measured_font_base_size = -1; unsigned int measured_font_texture_id = 0; }` packed a three-column optional-style text-width cache directly into the display row. The `-1` / `0` defaults were sentinel discriminators meaning "no measurement yet" — a payload column (`text_half_width`) gated by paired discriminator columns whose meaning depends on the value of other columns in the same row. Per Fabian **Principle 3** (`.squad/decisions.md` § 9 — a field whose meaning depends on another field's value is a NULL column in disguise), eradicate by promoting the cache to a sibling per-entity row table whose presence + key-match **is** "we have a measurement for this font".

Same shape as the just-merged #1545 (`SongState::current_beat` + `SessionLog::last_logged_beat` → `BeatCursor` + `LastLoggedBeat`), #1537 (`TerminalResultState` → `NewBestRecord`), and the rest of the #1533 four-site sweep.

## Schema change (`app/components/popup.h`)

- `PopupDisplay`: drop `float text_half_width`, `int measured_font_base_size`, `unsigned int measured_font_texture_id`. Now `{char[16] text, FontSize font_size, uint8_t r,g,b,a}` — only the always-meaningful display payload. **24 bytes** (was 36).
- `PopupTextMeasured { int font_base_size; unsigned int font_texture_id; float half_width; }` — new per-entity row table. Membership + key-match **is** the precondition "`half_width` is valid for `(font_base_size, font_texture_id)`". **12 bytes.**

## Reader (`app/systems/ui_render_system.cpp:614-637`)

The popup-render loop now does a `try_get<PopupTextMeasured>(entity)` join, key-matches against the active font's `(baseSize, texture.id)`, and `emplace_or_replace` on a cache miss with the freshly measured half-width. The legacy "sentinel-vs-real" comparison branch becomes a presence + key-match check; the `-1` sentinel disappears.

## Tests (`tests/test_popup_display_system.cpp`)

The two `init_popup_display_*` unit tests that asserted the sentinel defaults (`text_half_width == 0.0f`, `measured_font_base_size == -1`, `measured_font_texture_id == 0u`) drop those checks — they were asserting the NULL columns we're eradicating. No new tests; the text-measurement cache hit/miss is a pure render-side optimization with no behavioural surface (verified via visual spot-check that the popup text remains centred after the rewrite).

## Docs (`design-docs/architecture.md`)

Component Summary Table: `PopupDisplay` size updated 36 → 24; new `PopupTextMeasured  12  COLD` row added with the presence + key-match contract.

## Verified

- **Zero warnings**: clean rebuild on Clang with `-Wall -Wextra -Werror`.
- **Tests**: `./build/shapeshifter_tests` 3390 assertions / 964 Catch2 cases pass (was 3396 — 6 sentinel-default assertions dropped as documented above, 3 per test × 2 tests). `ctest` 977/977 jobs pass.
