### PR TITLE
#1551 ui_update_system.cpp: inline single-call effective_debounce anon-ns helper

### DIFF
--- a/app/systems/ui_update_system.cpp
+++ b/app/systems/ui_update_system.cpp
@@ -283,13 +283,6 @@ constexpr std::array<PhaseDebounceRow, 2> kPhaseDebounceRows = {{
     {&phase_tag_present<GamePhaseSongCompleteTag>, constants::SONG_COMPLETE_INPUT_DELAY},
 }};
 
-float effective_debounce(const entt::registry& reg) {
-    for (const auto& row : kPhaseDebounceRows) {
-        if (row.phase_active(reg)) return row.seconds;
-    }
-    return constants::UI_ENTRY_DEBOUNCE;
-}
-
 // ── Lane button hit-test (issue #1297) ──────────────────────────────
 //
 // Per Fabian Principle 1, each (shape-tag, event) pairing is its own
@@ -336,9 +329,14 @@ void ui_update_system(entt::registry& reg) {
     // Debounce: ignore button presses inside the active phase's input-delay
     // window so a click that opened the phase does not also dismiss it,
     // and so end-screen prompts honour their longer settling time before
-    // accepting input.
+    // accepting input. The phase-row table picks the per-phase delay; any
+    // phase not listed falls through to the default `UI_ENTRY_DEBOUNCE`.
     const auto& gs = reg.ctx().get<GameState>();
-    if (gs.phase_timer <= effective_debounce(reg)) return;
+    float debounce_sec = constants::UI_ENTRY_DEBOUNCE;
+    for (const auto& row : kPhaseDebounceRows) {
+        if (row.phase_active(reg)) { debounce_sec = row.seconds; break; }
+    }
+    if (gs.phase_timer <= debounce_sec) return;
 
     // ── Pass D — Gameplay HUD lane buttons (issue #1297) ─────────────
     //


### PR DESCRIPTION
Closes #1551.

## Summary

Continues the single-call anon-ns helper inline cleanup
(#1519 / #1521 / #1523 / #1524 / #1528 / #1529 / #1531 / #1532 / #1540 /
#1541 / #1543 / #1544 / #1547 / #1550).

`effective_debounce` in `app/systems/ui_update_system.cpp` had exactly
one caller (`ui_update_system`). Removed the 5-line helper definition
and folded the per-phase debounce-table scan directly into the caller,
right after the existing rationale comment. The comment is expanded by
one sentence so the table-walk semantics are explicit in place.

## Diff

- Deleted `effective_debounce(const entt::registry&)` (5 lines) from the
  anonymous namespace.
- Inlined the table walk into `ui_update_system`: a `debounce_sec` local
  defaults to `constants::UI_ENTRY_DEBOUNCE` and is overwritten by the
  first matching `kPhaseDebounceRows` row.
- Extended the debounce-rationale comment to mention the fall-through.

Net: **+7 / -9** in one file.

## Behaviour

No change. Same per-phase delay selection (`GAME_OVER_INPUT_DELAY` for
`GamePhaseGameOverTag`, `SONG_COMPLETE_INPUT_DELAY` for
`GamePhaseSongCompleteTag`, `UI_ENTRY_DEBOUNCE` otherwise). The
`kPhaseDebounceRows` constexpr table is unchanged -- dispatch remains
data-driven (Fabian Principle 1).

## Verification

- `cmake --build build -j8` -- zero warnings.
- `./build/shapeshifter_tests` -- **All tests passed (3390 assertions
  in 964 test cases)**.
