### PR TITLE
#1552 beat_scheduler_system.cpp: inline 2 single-call lambda-factory anon-ns helpers (make_indexed_time_fn, make_timed_time_fn)

### DIFF
--- a/app/systems/beat_scheduler_system.cpp
+++ b/app/systems/beat_scheduler_system.cpp
@@ -97,27 +97,6 @@ void schedule_bin(ScheduleContext& ctx,
     }
 }
 
-// Indexed bins resolve `beat_time` from `beat_times[beat_index]` when the
-// onset table is loaded; otherwise they fall back to the BPM-derived grid
-// time. Timed bins resolve `beat_time` directly from the authored
-// `BeatEntryTimed::time_sec` column — membership in a `*_beats_timed`
-// vector IS the precondition that an authored timestamp exists.
-auto make_indexed_time_fn(const ScheduleContext& ctx) {
-    return [&ctx](const BeatEntry& entry) {
-        float beat_time = ctx.song.offset + entry.beat_index * ctx.song.beat_period;
-        if (!ctx.map.beat_times.empty() &&
-            entry.beat_index >= 0 &&
-            static_cast<size_t>(entry.beat_index) < ctx.map.beat_times.size()) {
-            beat_time = ctx.map.beat_times[static_cast<size_t>(entry.beat_index)];
-        }
-        return beat_time;
-    };
-}
-
-auto make_timed_time_fn() {
-    return [](const BeatEntryTimed& entry) { return entry.time_sec; };
-}
-
 template <typename Row, typename TimeFn>
 void schedule_shape_gate_bin(ScheduleContext& ctx,
                              const std::vector<Row>& bin,
@@ -178,8 +157,21 @@ void beat_scheduler_system(entt::registry& reg, [[maybe_unused]] float dt) {
     const float audio_offset_sec = settings ? settings::audio_offset_seconds(*settings) : 0.0f;
 
     ScheduleContext ctx{reg, *song, *map, audio_offset_sec};
-    const auto indexed_time = make_indexed_time_fn(ctx);
-    const auto timed_time   = make_timed_time_fn();
+    // Indexed bins resolve `beat_time` from `beat_times[beat_index]` when the
+    // onset table is loaded; otherwise they fall back to the BPM-derived grid
+    // time. Timed bins resolve `beat_time` directly from the authored
+    // `BeatEntryTimed::time_sec` column — membership in a `*_beats_timed`
+    // vector IS the precondition that an authored timestamp exists.
+    const auto indexed_time = [&ctx](const BeatEntry& entry) {
+        float beat_time = ctx.song.offset + entry.beat_index * ctx.song.beat_period;
+        if (!ctx.map.beat_times.empty() &&
+            entry.beat_index >= 0 &&
+            static_cast<size_t>(entry.beat_index) < ctx.map.beat_times.size()) {
+            beat_time = ctx.map.beat_times[static_cast<size_t>(entry.beat_index)];
+        }
+        return beat_time;
+    };
+    const auto timed_time = [](const BeatEntryTimed& entry) { return entry.time_sec; };
 
     schedule_shape_gate_bin(ctx, ctx.map.shape_gate_circle_beats,
                             ctx.song.next_shape_gate_circle_idx, indexed_time, Shape::Circle);


### PR DESCRIPTION
Closes #1552.

## Summary

Continues the single-call anon-ns helper inline cleanup
(#1519 / #1521 / #1523 / #1524 / #1528 / #1529 / #1531 / #1532 / #1540 /
#1541 / #1543 / #1544 / #1547 / #1550 / #1551).

`make_indexed_time_fn(const ScheduleContext&)` and `make_timed_time_fn()`
in `app/systems/beat_scheduler_system.cpp` were lambda factories with
exactly one call site each. Both folded into direct `const auto` lambdas
at the existing call sites (inside `beat_scheduler_system`).

## Diff

- Deleted the two factory definitions (12 lines + 3 lines) from the
  anonymous namespace.
- Deleted the orphaned indexed-vs-timed rationale comment that lived
  above the factories.
- At the call site, `indexed_time` and `timed_time` are now direct
  lambdas; the rationale comment is placed adjacent to them.

Net: **+13 / -19** in one file.

## Behaviour

No change. Same closure captures (`&ctx` for indexed, none for timed),
same `BeatEntry` / `BeatEntryTimed` signatures, same return values. All
14 `schedule_*_bin(...)` calls (lines ~182-210) consume the lambdas
identically.

## Verification

- `cmake --build build -j8` -- zero warnings.
- `./build/shapeshifter_tests` -- **All tests passed (3390 assertions
  in 964 test cases)**.
