### PR TITLE
#1555 Drop 5 stale 'legacy controller' historical-attribution refs (mirrors #1507 / #1513)

### DIFF
--- a/app/systems/approach_ring_envelope_system.cpp
+++ b/app/systems/approach_ring_envelope_system.cpp
@@ -18,9 +18,9 @@ namespace {
 
 constexpr float kApproachRingMaxRadiusScale = 2.0f;
 
-// Lane button is sized 140×100 in `content/ui/screens/gameplay.rgl`; the
-// legacy controller computed `btn_radius = circle_bounds.width / 2.8f`,
-// which preserves the visual size after migration.
+// Lane button is sized 140×100 in `content/ui/screens/gameplay.rgl`;
+// dividing the width by 2.8 sizes the approach-ring radius to the
+// visual scale the gameplay HUD is designed around.
 constexpr float kLaneButtonRadiusDivisor = 2.8f;
 
 template <typename ShapeTag>

--- a/app/systems/game_over_scoreboard_bind_system.h
+++ b/app/systems/game_over_scoreboard_bind_system.h
@@ -13,10 +13,9 @@
 // (x, y, write fn) — no `switch` over a discriminator (Fabian Principle 1).
 //
 // The two reason slots (`ReasonSlot` at y=685 and `ReasonSlotNewBest` at
-// y=742) mirror the legacy controller's positional shift: when the
-// `NewBestRecord` ctx row is present (issue #1533 site #3), the
-// "ENERGY DEPLETED" reason moves down to make room for the "NEW BEST!"
-// + "PREV N" lines.
+// y=742) implement a positional shift: when the `NewBestRecord` ctx row
+// is present (issue #1533 site #3), the "ENERGY DEPLETED" reason moves
+// down to make room for the "NEW BEST!" + "PREV N" lines.
 //
 // Runs after `screen_lifecycle_system` so the GameOver entity set is
 // guaranteed to exist whenever `GamePhaseGameOverTag` is the active phase;

--- a/app/systems/gameplay_hud_bind_system.h
+++ b/app/systems/gameplay_hud_bind_system.h
@@ -15,8 +15,7 @@
 //
 // Each slot also writes `UiLabelFontSize` + `UiLabelAlpha` so the
 // generic label render pass picks the per-slot typography (the .rgl has
-// no per-slot font-size field; these are screen-specific styling that
-// the legacy controller hard-coded). Matches the position-keyed pattern
-// established by `settings_screen_bind_system` and
-// `game_over_scoreboard_bind_system`.
+// no per-slot font-size field; these are screen-specific styling owned
+// by the binder). Matches the position-keyed pattern established by
+// `settings_screen_bind_system` and `game_over_scoreboard_bind_system`.
 void gameplay_hud_bind_system(entt::registry& reg);

--- a/app/systems/settings_screen_bind_system.cpp
+++ b/app/systems/settings_screen_bind_system.cpp
@@ -35,7 +35,7 @@ struct SettingsBindContext {
     int16_t audio_offset_ms;
     bool    haptics_on;
     // Display-side inversion: the visible toggle reads "MOTION: ON" when
-    // motion is NOT reduced. Matches the legacy controller (#1295 spec).
+    // motion is NOT reduced (#1295 spec).
     bool    motion_on;
 };
 

--- a/app/systems/ui_update_system.cpp
+++ b/app/systems/ui_update_system.cpp
@@ -132,8 +132,8 @@ void settings_button_action(entt::registry& reg, entt::entity /*entity*/) {
 // back to Title (no other screen currently emits ActionId::CloseButton).
 // HapticsToggle / ReduceMotionToggle flip their respective bool and
 // persist via `settings::mark_dirty_and_save`. Enabling haptics also
-// warms up the platform backend (latency-sensitive first vibration,
-// matches legacy controller).
+// warms up the platform backend so the first vibration after enable is
+// not latency-bound.
 
 void audio_offset_step_action(entt::registry& reg, int delta) {
     auto* st = find_settings_state(reg);


### PR DESCRIPTION
Closes #1555.

## Summary

Continues the historical-attribution cleanup pattern (#1442 / #1447 /
#1457 / #1460 / #1464 / #1468 / #1507 / #1513). The screen-controller
files (`app/ui/screen_controllers/`) were deleted in #1308; any
surviving "legacy controller" / "matches legacy controller" justification
comment in `app/` is historical-attribution to dead code -- the current
binder / system IS the source of truth.

While preparing the fix, a fifth site surfaced
(`app/systems/gameplay_hud_bind_system.h:19`) that the original triage
missed but matches the exact pattern (`"the legacy controller
hard-coded"`); included it here for symmetry with the four cited in
#1555.

## Sites rewritten

| File | Line | Before fragment | After fragment |
|---|---|---|---|
| `app/systems/approach_ring_envelope_system.cpp` | 22 | "the legacy controller computed `btn_radius = circle_bounds.width / 2.8f`, which preserves the visual size after migration" | "dividing the width by 2.8 sizes the approach-ring radius to the visual scale the gameplay HUD is designed around" |
| `app/systems/game_over_scoreboard_bind_system.h` | 16 | "mirror the legacy controller's positional shift: when the `NewBestRecord` ctx row is present..." | "implement a positional shift: when the `NewBestRecord` ctx row is present..." |
| `app/systems/gameplay_hud_bind_system.h` | 19 | "these are screen-specific styling that the legacy controller hard-coded" | "these are screen-specific styling owned by the binder" |
| `app/systems/settings_screen_bind_system.cpp` | 38 | "Matches the legacy controller (#1295 spec)" | "(#1295 spec)" |
| `app/systems/ui_update_system.cpp` | 136 | "warms up the platform backend (latency-sensitive first vibration, matches legacy controller)" | "warms up the platform backend so the first vibration after enable is not latency-bound" |

All design-decision issue references (`#1295`, `#1297`, `#1533`) are
preserved.

## Non-goals (intentionally untouched)

- `app/components/obstacle.h:16` (`RequiredShape` (formerly...)`) --
  valid forwarding comment pointing to the per-shape tags.
- `app/components/scoring.h:5` (`NewBestRecord (formerly
  TerminalResultState) relocated to game_state.h`) -- valid relocation
  forwarding comment.
- `app/systems/gameplay_hud_bind_system.cpp:30`
  (`legacy \`GuiSetAlpha(...)\` overrides`) -- refers to a *raygui API*,
  not the deleted screen controller (called out as non-goal in #1507).

## Verification

- `grep -rn 'legacy controller' app/` -> 0 hits (was 5).
- `cmake --build build -j8` -- zero warnings.
- `./build/shapeshifter_tests` -- **All tests passed (3390 assertions
  in 964 test cases)**.
- Comments only; no code, no constants, no API surface changed.
