### PR TITLE
#1553 input_system.cpp: inline 3 single-call anon-ns helpers (find_free_touch_slot, set_input_source_mouse, set_input_source_touch)

### DIFF
--- a/app/systems/input.h
+++ b/app/systems/input.h
@@ -18,8 +18,9 @@
 //   • presence of `InputSourceMouse` ctx table  ⇔ Mouse owns the gesture
 //   • presence of `InputSourceTouch` ctx table  ⇔ Touch owns the gesture
 //   • absence of both                            ⇔ None
-// The mutex (at most one tag present) is enforced by the input_system
-// helpers `set_input_source_mouse / _touch` and `clear_input_source`.
+// The mutex (at most one tag present) is enforced inline at the two set
+// sites in input_system (insert one tag + erase the sibling) and via the
+// shared `clear_input_source` helper which drops both tags.
 struct InputSourceMouse {};
 struct InputSourceTouch {};
 

--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -97,15 +97,6 @@ int find_touch_slot(InputState& input, int touch_id) {
     return -1;
 }
 
-int find_free_touch_slot(InputState& input) {
-    for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
-        if (!input.touch_slots[i].active) {
-            return i;
-        }
-    }
-    return -1;
-}
-
 bool touch_id_is_current(int touch_id, int touch_point_count) {
     for (int touch_index = 0; touch_index < touch_point_count; ++touch_index) {
         if (GetTouchPointId(touch_index) == touch_id) {
@@ -147,28 +138,16 @@ void release_touch_slot(TouchSlot& slot,
     slot = TouchSlot{};
 }
 
-// ── Input-source ctx-tag mutex helpers (issues #1202 / #1204) ──────────────
+// ── Input-source ctx-tag mutex helper (issues #1202 / #1204) ──────────────
 // The former InputSource enum tracked which input device "owns" the
 // current gesture as a 3-state mutex on InputState. Per Fabian's
 // existential-processing canon, each former value is now its own ctx
 // table (InputSourceMouse / InputSourceTouch); absence of both = the
-// former `None`. These helpers maintain the mutex invariant so callers
-// don't have to duplicate the erase-the-other pattern.
-
-void set_input_source_mouse(entt::registry& reg) {
-    reg.ctx().insert_or_assign(InputSourceMouse{});
-    if (reg.ctx().find<InputSourceTouch>()) {
-        reg.ctx().erase<InputSourceTouch>();
-    }
-}
-
-void set_input_source_touch(entt::registry& reg) {
-    reg.ctx().insert_or_assign(InputSourceTouch{});
-    if (reg.ctx().find<InputSourceMouse>()) {
-        reg.ctx().erase<InputSourceMouse>();
-    }
-}
-
+// former `None`. The mutex invariant (at most one tag present) is
+// maintained inline at the two set sites in input_system below, which
+// insert one tag and erase the sibling. `clear_input_source` drops both
+// tags back to the former `None` state and has multiple callers, so it
+// stays as a helper.
 void clear_input_source(entt::registry& reg) {
     if (reg.ctx().find<InputSourceMouse>()) {
         reg.ctx().erase<InputSourceMouse>();
@@ -254,8 +233,9 @@ void input_system(entt::registry& reg, float raw_dt) {
     }
 
     // Read live each call — the mouse and touch blocks below mutate the
-    // mutex (set_input_source_mouse / _touch / clear_input_source) so a
-    // cached snapshot would race against the very same frame's writes.
+    // InputSourceMouse / InputSourceTouch ctx-tag mutex (inline sets +
+    // clear_input_source) so a cached snapshot would race against the
+    // very same frame's writes.
     const auto touch_owns_gesture = [&]() {
         return reg.ctx().find<InputSourceTouch>() != nullptr;
     };
@@ -269,7 +249,10 @@ void input_system(entt::registry& reg, float raw_dt) {
         !priv.suppress_mouse_release &&
         touch_point_count == 0 &&
         IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
-        set_input_source_mouse(reg);
+        reg.ctx().insert_or_assign(InputSourceMouse{});
+        if (reg.ctx().find<InputSourceTouch>()) {
+            reg.ctx().erase<InputSourceTouch>();
+        }
         priv.suppress_mouse_release = false;
     }
     if (allow_mouse_input &&
@@ -316,7 +299,12 @@ void input_system(entt::registry& reg, float raw_dt) {
                 if (has_active_touch_in_zone(input, button_zone)) {
                     continue;
                 }
-                slot_index = find_free_touch_slot(input);
+                for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
+                    if (!input.touch_slots[i].active) {
+                        slot_index = i;
+                        break;
+                    }
+                }
             }
             if (slot_index < 0) {
                 continue;
@@ -358,7 +346,10 @@ void input_system(entt::registry& reg, float raw_dt) {
             }
         }
         if (input.touching) {
-            set_input_source_touch(reg);
+            reg.ctx().insert_or_assign(InputSourceTouch{});
+            if (reg.ctx().find<InputSourceMouse>()) {
+                reg.ctx().erase<InputSourceMouse>();
+            }
         }
         input.duration = 0.0f;
         for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {

--- a/design-docs/feature-specs.md
+++ b/design-docs/feature-specs.md
@@ -103,8 +103,9 @@ The Input System translates raw touch / mouse / keyboard events into game action
 //   • presence of InputSourceMouse ⇔ Mouse owns the gesture
 //   • presence of InputSourceTouch ⇔ Touch owns the gesture
 //   • absence of both              ⇔ None
-// The mutex is maintained by input_system helpers
-// (set_input_source_mouse / _touch, clear_input_source).
+// The mutex is maintained inline at the two set sites in input_system
+// (insert one tag + erase the sibling) and via the shared
+// `clear_input_source` helper which drops both tags.
 struct InputSourceMouse {};
 struct InputSourceTouch {};
 


### PR DESCRIPTION
Resolves #1553.

Continuation of the single-call anon-ns inline cleanup series (#1519 / #1521 / #1523 / #1524 / #1528 / #1529 / #1531 / #1532 / #1540 / #1541 / #1543 / #1544 / #1547 / #1550 / #1557). Three sibling helpers in `app/systems/input_system.cpp` each had exactly one caller and are inlined here.

## Changes

| Helper | Caller (sole) | Inlined as |
| --- | --- | --- |
| `find_free_touch_slot(InputState&)` | `:319` (inside touch slot-assignment) | 5-line `for` loop |
| `set_input_source_mouse(entt::registry&)` | `:272` (mouse-down path) | 4-line `insert_or_assign` + guarded `erase` |
| `set_input_source_touch(entt::registry&)` | `:361` (touch-active path) | 4-line `insert_or_assign` + guarded `erase` |

`clear_input_source(entt::registry&)` is untouched — still has 3 callers (`:215`, `:281`, `:377`).

## Design-intent preservation

The ctx-tag mutex invariant (at most one of `InputSourceMouse` / `InputSourceTouch` present at a time) is the load-bearing contract documented in #1202 / #1204. Four doc sites were updated so the intent stays visible after the helpers vanish:

1. `app/systems/input_system.cpp` — the "Input-source ctx-tag mutex helpers" block comment is rewritten to live above the surviving `clear_input_source` and explains that the two set sites maintain the invariant inline.
2. `app/systems/input_system.cpp` — the in-function comment above `touch_owns_gesture` / `mouse_owns_gesture` lambdas (formerly referenced `set_input_source_mouse / _touch / clear_input_source` by name) now references the mutex tags + `clear_input_source` only.
3. `app/systems/input.h` — header doc above `InputSourceMouse` / `InputSourceTouch` no longer names the inlined helpers.
4. `design-docs/feature-specs.md` (Input section) — the matching doc block updated to match.

The `if (reg.ctx().find<Y>())` guard before `erase<Y>` is preserved (matches existing repo style; see `clear_input_source`).

## Verification

- `./run.sh test` → **977/977 tests pass, 0 failures** (1 platform smoke skipped)
- `cmake --build build` → **zero warnings** (`-Wall -Wextra -Werror`)
- `rg 'find_free_touch_slot|set_input_source_mouse|set_input_source_touch'` → no matches anywhere in repo
- `clear_input_source` left intact (3 call sites)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
