### PR TITLE
#1554 ObstacleChildren: drop inline array column, walk MeshChild by parent (Fabian Principle 3)

### DIFF
--- a/.squad/skills/entt-ecs-audit/SKILL.md
+++ b/.squad/skills/entt-ecs-audit/SKILL.md
@@ -50,7 +50,7 @@ Per EnTT guide §"What is allowed and what is not":
 - [ ] Reactive storage: disconnected from observed pools before storage is destroyed
 
 ### 9. Hierarchy / child ownership
-- [ ] Parent–child entity relationships use a component (e.g., `ObstacleChildren`) — not raw pointers
+- [ ] Parent–child entity relationships are modeled as a row table on the *child* side (e.g., `MeshChild { entt::entity parent }`) — not as an inline array column on the parent, and not raw pointers. Walk children with `view<ChildRow>` filtered by `parent == X` (Fabian Principle 3 / issue #1554).
 - [ ] Destruction order: child storage pool must be initialized before parent signal is connected (lower pool index = destroyed last in reverse-order teardown)
 
 ---

--- a/app/components/obstacle.h
+++ b/app/components/obstacle.h
@@ -37,12 +37,15 @@ struct Obstacle {
 // future obstacle archetype must not emplace a raw `int8_t` on the same
 // entity — give them their own per-archetype component table instead.
 
-// Owned mesh children for a logical obstacle entity. destroy_obstacle_with_children
-// in app/entities/obstacle_render_entity.cpp cleans up in O(count). Relocated out
-// of app/components/rendering.h (issue #1194 SPLIT) — child-ownership is an
-// obstacle-archetype concern, not a generic render concept.
+// Sizing constant for obstacle mesh-child fan-out. Per Fabian Principle 3
+// (issue #1554), the inline `children[MAX] + count` array column was
+// normalized away: each child entity carries its own `MeshChild { parent }`
+// row, and "the children of obstacle X" is now `view<MeshChild>` filtered by
+// `parent == X`. The `MAX` cap survives as a hard limit enforced by the
+// obstacle mesh factory (`require_child_capacity` in
+// app/entities/obstacle_render_entity.cpp) and as a worst-case fan-out
+// estimate for `MeshChildCleanupScratch` (see
+// app/systems/runtime_system_scratch.cpp).
 struct ObstacleChildren {
     static constexpr int MAX = 8;
-    entt::entity children[MAX]{};
-    int count = 0;
 };

--- a/app/entities/obstacle_render_entity.cpp
+++ b/app/entities/obstacle_render_entity.cpp
@@ -38,20 +38,20 @@ struct PendingEntity {
 };
 }
 
-static void append_child(entt::registry& reg, entt::entity parent, entt::entity child) {
-    auto& children = reg.get_or_emplace<ObstacleChildren>(parent);
-    if (children.count >= ObstacleChildren::MAX) {
-        throw std::logic_error("ObstacleChildren capacity exceeded");
+static int count_mesh_children_of(entt::registry& reg, entt::entity parent) {
+    int count = 0;
+    for (auto [child, mc] : reg.view<MeshChild>().each()) {
+        (void)child;
+        if (mc.parent == parent) ++count;
     }
-    children.children[children.count++] = child;
+    return count;
 }
 
 // ObstacleChildren::MAX is the hard cap for mesh children owned by one
 // logical obstacle. Factory helpers reserve a slot before reg.create() so an
 // overflow cannot leave an unregistered MeshChild entity behind.
 static void require_child_capacity(entt::registry& reg, entt::entity parent) {
-    auto& children = reg.get_or_emplace<ObstacleChildren>(parent);
-    if (children.count >= ObstacleChildren::MAX) {
+    if (count_mesh_children_of(reg, parent) >= ObstacleChildren::MAX) {
         throw std::logic_error("ObstacleChildren capacity exceeded");
     }
 }
@@ -64,7 +64,6 @@ static entt::entity add_slab_child(entt::registry& reg, entt::entity parent,
     reg.emplace<MeshChild>(e, MeshChild{parent, x, 0.0f, w, d, h, tint});
     reg.emplace<MeshKindSlab>(e);
     reg.emplace<TagWorldPass>(e);
-    append_child(reg, parent, e);
     pending.release();
     return e;
 }
@@ -78,7 +77,6 @@ static entt::entity add_shape_child(entt::registry& reg, entt::entity parent,
     reg.emplace<MeshChild>(e, MeshChild{parent, cx, z_offset, size, 0.0f, 0.0f, tint});
     reg.emplace<MeshKindShape>(e, MeshKindShape{mesh_index});
     reg.emplace<TagWorldPass>(e);
-    append_child(reg, parent, e);
     pending.release();
     return e;
 }
@@ -139,14 +137,18 @@ void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical) {
 
 
 void destroy_obstacle_mesh_children(entt::registry& reg, entt::entity parent) {
-    auto* oc = reg.try_get<ObstacleChildren>(parent);
-    if (!oc) return;
-    for (int i = 0; i < oc->count; ++i) {
-        if (reg.valid(oc->children[i]))
-            reg.destroy(oc->children[i]);
-        oc->children[i] = entt::null;
+    // Collect first then destroy: removing entities mid-iteration would
+    // invalidate the MeshChild view's packed-storage iterator.
+    entt::entity to_destroy[ObstacleChildren::MAX];
+    int destroy_count = 0;
+    for (auto [child, mc] : reg.view<MeshChild>().each()) {
+        if (mc.parent != parent) continue;
+        if (destroy_count >= ObstacleChildren::MAX) break;
+        to_destroy[destroy_count++] = child;
     }
-    oc->count = 0;
+    for (int i = 0; i < destroy_count; ++i) {
+        if (reg.valid(to_destroy[i])) reg.destroy(to_destroy[i]);
+    }
 }
 
 void destroy_obstacle_with_children(entt::registry& reg, entt::entity parent) {

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -327,12 +327,14 @@ struct Obstacle {
     int16_t base_points = 200;
 };
 
-// Owned mesh children for a logical obstacle entity. destroy_obstacle_with_children
-// cleans up in O(count). Lives on the parent obstacle entity.
+// Sizing constant for obstacle mesh-child fan-out. Per Fabian Principle 3
+// (issue #1554), child-ownership is a row table: each child entity carries
+// `MeshChild { parent }`, and "the children of obstacle X" is
+// `view<MeshChild>` filtered by `parent == X`. `MAX` survives only as the
+// hard cap enforced by `require_child_capacity` and as the worst-case
+// fan-out used to size `MeshChildCleanupScratch`.
 struct ObstacleChildren {
     static constexpr int MAX = 8;
-    entt::entity children[MAX]{};
-    int          count = 0;
 };
 ```
 

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -318,23 +318,30 @@ TEST_CASE("beat_scheduler: spawns OnsetMarker as visible non-scorable cue",
     beat_scheduler_system(reg, 0.016f);
 
     auto view = reg.view<ObstacleTag, OnsetMarkerTag, NonScorableTag, Obstacle,
-                         BeatInfo, WorldPosition, ObstacleChildren>();
+                         BeatInfo, WorldPosition>();
     REQUIRE(view.size_hint() == 1);
 
     entt::entity cue = entt::null;
-    for (auto [e, obstacle, beat, wt, children] : view.each()) {
+    for (auto [e, obstacle, beat, wt] : view.each()) {
         (void)beat;
         cue = e;
         CHECK(obstacle.base_points == int16_t{0});
         CHECK_FALSE(has_required_shape_tag(reg, e));
         CHECK_FALSE(reg.all_of<uint8_t>(e));
         CHECK_FALSE(reg.all_of<SplitPathTag>(e));
-        REQUIRE(children.count == 1);
-        const auto child = children.children[0];
-        REQUIRE(reg.valid(child));
-        REQUIRE(reg.all_of<MeshChild>(child));
-        CHECK(reg.all_of<MeshKindSlab>(child));
-        const auto& mesh = reg.get<MeshChild>(child);
+
+        int child_count = 0;
+        entt::entity first_child = entt::null;
+        for (auto [child, mc] : reg.view<MeshChild>().each()) {
+            if (mc.parent != e) continue;
+            if (first_child == entt::null) first_child = child;
+            ++child_count;
+        }
+        REQUIRE(child_count == 1);
+        REQUIRE(reg.valid(first_child));
+        REQUIRE(reg.all_of<MeshChild>(first_child));
+        CHECK(reg.all_of<MeshKindSlab>(first_child));
+        const auto& mesh = reg.get<MeshChild>(first_child);
         CHECK_THAT(mesh.width, Catch::Matchers::WithinAbs(constants::SCREEN_W_F, 0.01f));
 
         wt.position.y = constants::DESTROY_Y + 10.0f;
@@ -393,17 +400,21 @@ TEST_CASE("beat_scheduler: defaults invalid SplitPath lane to center lane", "[be
     song.next_onset_marker_idx = 0;
     CHECK_NOTHROW(beat_scheduler_system(reg, 0.016f));
 
-    auto view = reg.view<ObstacleTag, WorldPosition, SplitPathTag, int8_t, ObstacleChildren>();
+    auto view = reg.view<ObstacleTag, WorldPosition, SplitPathTag, int8_t>();
     REQUIRE(view.size_hint() == 1);
-    for (auto [e, wt, lane, children] : view.each()) {
+    for (auto [e, wt, lane] : view.each()) {
         CHECK_THAT(wt.position.x, Catch::Matchers::WithinAbs(constants::LANE_X[1], 0.01f));
         CHECK(current_required_shape(reg, e) == Shape::Square);
         CHECK(lane == int8_t{1});
-        REQUIRE(children.count == 3);
-        for (int i = 0; i < children.count; ++i) {
-            REQUIRE(reg.valid(children.children[i]));
-            CHECK(reg.all_of<MeshChild>(children.children[i]));
+
+        int child_count = 0;
+        for (auto [child, mc] : reg.view<MeshChild>().each()) {
+            if (mc.parent != e) continue;
+            ++child_count;
+            REQUIRE(reg.valid(child));
+            CHECK(reg.all_of<MeshChild>(child));
         }
+        REQUIRE(child_count == 3);
     }
     CHECK(song.next_split_path_square_idx == 1);
 }

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -45,11 +45,7 @@ TEST_CASE("components: rendering components are safely default constructible",
     CHECK(child.tint.b == 255);
     CHECK(child.tint.a == 255);
 
-    ObstacleChildren children{};
-    CHECK(children.count == 0);
-    for (const auto entity : children.children) {
-        CHECK(entity == entt::entity{});
-    }
+    static_assert(ObstacleChildren::MAX > 0);
 }
 
 TEST_CASE("components: PlayerShape defaults", "[components]") {

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -95,10 +95,10 @@ TEST_CASE("Play session: restart clears obstacle mesh children without stale lis
           "[play_session][issue957]") {
     auto reg = make_registry();
     auto obstacle = spawn_shape_gate_obstacle(reg, {360.0f, -120.0f, Shape::Circle});
-    REQUIRE(reg.all_of<ObstacleChildren>(obstacle));
-    const auto children = reg.get<ObstacleChildren>(obstacle);
-    REQUIRE(children.count > 0);
-    const entt::entity first_child = children.children[0];
+    entt::entity first_child = entt::null;
+    for (auto [child, mc] : reg.view<MeshChild>().each()) {
+        if (mc.parent == obstacle) { first_child = child; break; }
+    }
     REQUIRE(reg.valid(first_child));
 
     setup_play_session(reg);

--- a/tests/test_obstacle_archetypes.cpp
+++ b/tests/test_obstacle_archetypes.cpp
@@ -41,10 +41,8 @@ entt::entity make_mesh_factory_obstacle(entt::registry& reg) {
 }
 
 void check_no_mesh_children(entt::registry& reg, entt::entity parent) {
+    (void)parent;
     CHECK(count_mesh_children(reg) == 0);
-    if (auto* children = reg.try_get<ObstacleChildren>(parent)) {
-        CHECK(children->count == 0);
-    }
 }
 }
 
@@ -84,13 +82,14 @@ TEST_CASE("entity: obstacle roots and mesh children declare world render pass", 
     auto e = spawn_shape_gate_obstacle(reg, {360.0f, -120.0f, Shape::Circle});
 
     CHECK(reg.all_of<TagWorldPass>(e));
-    REQUIRE(reg.all_of<ObstacleChildren>(e));
-    const auto& children = reg.get<ObstacleChildren>(e);
-    REQUIRE(children.count > 0);
-    for (int i = 0; i < children.count; ++i) {
-        CHECK(reg.all_of<MeshChild>(children.children[i]));
-        CHECK(reg.all_of<TagWorldPass>(children.children[i]));
+    int child_count = 0;
+    for (auto [child, mc] : reg.view<MeshChild>().each()) {
+        if (mc.parent != e) continue;
+        ++child_count;
+        CHECK(reg.all_of<MeshChild>(child));
+        CHECK(reg.all_of<TagWorldPass>(child));
     }
+    REQUIRE(child_count > 0);
 }
 
 TEST_CASE("entity: obstacle mesh overflow does not create orphan MeshChild", "[archetype][render][cleanup]") {
@@ -103,7 +102,6 @@ TEST_CASE("entity: obstacle mesh overflow does not create orphan MeshChild", "[a
     reg.emplace<Color>(parent, Color{80, 200, 255, 255});
     set_required_shape_tag(reg, parent, Shape::Circle);
 
-    auto& children = reg.emplace<ObstacleChildren>(parent);
     for (int i = 0; i < ObstacleChildren::MAX; ++i) {
         auto child = reg.create();
         reg.emplace<MeshChild>(child, MeshChild{
@@ -111,7 +109,6 @@ TEST_CASE("entity: obstacle mesh overflow does not create orphan MeshChild", "[a
             Color{255, 255, 255, 255}
         });
         reg.emplace<MeshKindSlab>(child);
-        children.children[children.count++] = child;
     }
     reg.emplace<ObstacleTag>(parent);
     reg.emplace<ShapeGateTag>(parent);
@@ -119,7 +116,6 @@ TEST_CASE("entity: obstacle mesh overflow does not create orphan MeshChild", "[a
     CHECK(count_mesh_children(reg) == ObstacleChildren::MAX);
     CHECK_THROWS_AS(spawn_obstacle_meshes(reg, parent), std::logic_error);
     CHECK(count_mesh_children(reg) == ObstacleChildren::MAX);
-    CHECK(reg.get<ObstacleChildren>(parent).count == ObstacleChildren::MAX);
 
     destroy_obstacle_with_children(reg, parent);
 

--- a/tests/test_perspective.cpp
+++ b/tests/test_perspective.cpp
@@ -142,10 +142,10 @@ TEST_CASE("game_camera_system drops mesh children for destroyed logical obstacle
     reg.ctx().emplace<ShapeMeshConfig>();
     reg.ctx().emplace<FloorParams>();
     auto parent = spawn_shape_gate_obstacle(reg, {360.0f, -120.0f, Shape::Circle});
-    REQUIRE(reg.all_of<ObstacleChildren>(parent));
-    const auto children = reg.get<ObstacleChildren>(parent);
-    REQUIRE(children.count > 0);
-    const entt::entity child = children.children[0];
+    entt::entity child = entt::null;
+    for (auto [c, mc] : reg.view<MeshChild>().each()) {
+        if (mc.parent == parent) { child = c; break; }
+    }
     REQUIRE(reg.valid(child));
 
     reg.destroy(parent);

--- a/tests/test_pr43_regression.cpp
+++ b/tests/test_pr43_regression.cpp
@@ -141,19 +141,23 @@ TEST_CASE("MeshChild: ShapeGate renders shape-only (no side slabs)",
 // ═══════════════════════════════════════════════════════════════════════
 // Theme 6 – obstacle mesh lifetime must only destroy children whose parent
 //           is the entity being destroyed, not other obstacles' children.
-// Explicit cleanup follows ObstacleChildren ownership directly, so it does not
-// depend on ObstacleTag pool insertion order.
+// Explicit cleanup walks the MeshChild row table filtered by parent, so it
+// does not depend on ObstacleTag pool insertion order.
 // ═══════════════════════════════════════════════════════════════════════
 
-// Helper: create an obstacle with an ObstacleChildren list.
+// Helper: create an obstacle and attach `kids` as MeshChild rows pointing at it.
 static entt::entity make_obstacle(entt::registry& reg,
                                    std::initializer_list<entt::entity> kids) {
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
-    auto& oc = reg.emplace<ObstacleChildren>(obs);
+    int attached = 0;
     for (auto k : kids) {
-        REQUIRE(oc.count < ObstacleChildren::MAX);
-        oc.children[oc.count++] = k;
+        REQUIRE(attached < ObstacleChildren::MAX);
+        reg.emplace<MeshChild>(k, MeshChild{
+            obs, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f,
+            Color{255, 255, 255, 255}
+        });
+        ++attached;
     }
     return obs;
 }


### PR DESCRIPTION
Closes #1554.

## Problem

`ObstacleChildren { entt::entity children[MAX]; int count; }` on the parent obstacle entity is a fixed-size inline-array column — a 1NF violation per Fabian Principle 3, structurally identical to the `std::array`/`std::vector` denormalizations cleaned up in #1535/#1536/#1537/#1538/#1548/#1550.

## Fix

Each child entity already carries `MeshChild { parent, ... }` — the FK back to the obstacle is the existing `parent` field. So the parent-side array column is fully redundant and the children of obstacle X are just `view<MeshChild>` filtered by `mc.parent == X`. The `MAX = 8` cap survives as a `constexpr` on the now-empty struct, shared with `MeshChildCleanupScratch` sizing.

### Production changes
- `app/components/obstacle.h` — `ObstacleChildren` reduced to constants only (`static constexpr int MAX = 8`).
- `app/entities/obstacle_render_entity.cpp` — `append_child` deleted; `require_child_capacity` and `destroy_obstacle_mesh_children` now walk `view<MeshChild>` filtered by parent. The teardown collects into a fixed-size `entt::entity[MAX]` buffer before destroying so the view iterator can't be invalidated mid-walk.

### Tests rewired to the same view-by-parent pattern
- `tests/test_obstacle_archetypes.cpp`
- `tests/test_beat_scheduler_system.cpp`
- `tests/test_high_score_integration.cpp`
- `tests/test_perspective.cpp`
- `tests/test_pr43_regression.cpp` (`make_obstacle` helper now emplaces `MeshChild { obs, … }` on each child)
- `tests/test_components.cpp` (default-construct test for removed fields dropped; `static_assert(MAX > 0)` retained)

### Docs
- `design-docs/architecture.md` — refresh struct snippet.
- `.squad/skills/entt-ecs-audit/SKILL.md` §9 — recast hierarchy audit bullet around the child-row-table pattern (parent FK on the child side, walk via filtered view) instead of pointing at the now-deleted `ObstacleChildren` array.

## Verification
- Zero-warning clean build (`-Wall -Wextra -Werror`).
- Full test suite: **3375 assertions in 964 test cases passed**, unchanged case count.

## Acceptance criteria
- [x] `ObstacleChildren` struct reduced to the `MAX` constant only.
- [x] Per-child parent FK reuses the existing `MeshChild::parent` column instead of introducing a duplicate `ObstacleChild { parent }` row (3NF — one column for the same fact).
- [x] `append_child` / `require_child_capacity` updated.
- [x] `destroy_obstacle_with_children` walks the `MeshChild` view filtered by parent.
- [x] `runtime_system_scratch.cpp:54` capacity calc unchanged — `ObstacleChildren::MAX` survives.
- [x] Build zero-warning; full test suite passes.