### PR TITLE
#1560 HighScoreState: drop inline array column, walk HighScoreEntry row table (Fabian Principle 3)

### DIFF
--- a/app/components/high_score.h
+++ b/app/components/high_score.h
@@ -1,27 +1,33 @@
 #pragma once
 
-#include <array>
 #include <cstdint>
 #include <string>
 #include <entt/entt.hpp>
 
 #include "../systems/persistence_policy_system.h"
 
-// Compact fixed-size high-score table (durable, persisted to disk).
-// Max entries: LEVEL_COUNT x DIFFICULTY_COUNT = 9.
-// Flat array storage -- no heap nodes, O(N) linear scan (faster than
-// std::map for N <= 9 due to cache locality).
+// Constants for the durable high-score table. The struct itself carries no
+// instance state — entries live as `HighScoreEntry` rows in the registry,
+// one entity per stored score (Fabian Principle 3 / issue #1560 — the prior
+// `std::array<Entry, MAX_ENTRIES> entries + int32_t entry_count` shape was
+// a 1NF array column on a god-class component, structurally identical to
+// the `ObstacleChildren` array column eradicated in #1554).
+//
+// MAX_ENTRIES = LEVEL_COUNT (3) x DIFFICULTY_COUNT (3) survives as the
+// runtime overflow guard in set_score / ensure_entry / high_score_state_from_json.
 struct HighScoreState {
     static constexpr int32_t MAX_ENTRIES = 9;
     static constexpr int32_t KEY_CAP     = 32; // fits "song_id|difficulty\0"
+};
 
-    struct Entry {
-        char    key[KEY_CAP]{};
-        int32_t score{0};
-    };
-
-    std::array<Entry, MAX_ENTRIES> entries{};
-    int32_t entry_count{0};
+// Row component: one entity per stored high score. The printable `key` is
+// retained so JSON persistence preserves the on-disk schema bit-for-bit;
+// `key_hash` is cached at insert time so the hot `get_current_high_score`
+// lookup path doesn't rehash per row.
+struct HighScoreEntry {
+    char                           key[HighScoreState::KEY_CAP]{};
+    entt::hashed_string::hash_type key_hash{0};
+    int32_t                        score{0};
 };
 
 // Active-session pointer into the score table (transient, not persisted).

--- a/app/components/scoring.h
+++ b/app/components/scoring.h
@@ -31,10 +31,11 @@ struct ScoreDisplay {
 };
 
 // Best score for the currently loaded song+difficulty. Snapshotted from the
-// durable HighScoreState table at session load (in play_session) and bumped
-// at terminal phase if the current run exceeded it. Distinct from
-// HighScoreState (which spans every song+difficulty combo and persists to
-// disk) — this singleton is the single per-run best the HUD/end-screens read.
+// durable HighScoreEntry row table at session load (in play_session) and
+// bumped at terminal phase if the current run exceeded it. Distinct from
+// the HighScoreEntry table (which spans every song+difficulty combo and
+// persists to disk) — this singleton is the single per-run best the
+// HUD/end-screens read.
 struct CurrentSongHighScore {
     int32_t value = 0;
 };

--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -230,17 +230,18 @@ bool game_loop_init(entt::registry& reg,
     }
 
     // High scores — load from disk; defaults remain if file is missing/corrupt/path-invalid.
+    // Entries live as `HighScoreEntry` rows in the registry (Fabian Principle 3 /
+    // issue #1560); only the persistence bookkeeping + active-session pointer remain
+    // as ctx singletons.
     {
-        HighScoreState hs;
         HighScorePersistence persistence_state;
         if (path_result.ok()) {
             persistence_state.path = persistence_paths.high_scores_file.string();
-            persistence_state.last_load = high_score::load_high_scores(hs, persistence_paths.high_scores_file);
+            persistence_state.last_load = high_score::load_high_scores(reg, persistence_paths.high_scores_file);
         } else {
             persistence_state.last_load = path_result;
         }
         log_persistence_result("high score load", persistence_state.last_load);
-        reset_ctx_singleton<HighScoreState>(reg, hs);
         reset_ctx_singleton<HighScorePersistence>(reg, persistence_state);
         reset_ctx_singleton<HighScoreSession>(reg);
     }

--- a/app/systems/game_state_terminal_phase_system.cpp
+++ b/app/systems/game_state_terminal_phase_system.cpp
@@ -17,32 +17,28 @@ bool update_and_persist_high_score(entt::registry& reg) {
     const bool score_exceeds_high_score = (score.score > current.value);
     bool recorded_new_high_score = score_exceeds_high_score;
 
-    if (auto* hs = reg.ctx().find<HighScoreState>()) {
-        const auto* session = reg.ctx().find<HighScoreSession>();
-        const bool has_active_high_score_key = session && (session->key_hash != 0);
-        if (score_exceeds_high_score && has_active_high_score_key) {
-            recorded_new_high_score = high_score::update_if_higher(*hs, *session, score.score);
+    const auto* session = reg.ctx().find<HighScoreSession>();
+    const bool has_active_high_score_key = session && (session->key_hash != 0);
+    if (score_exceeds_high_score && has_active_high_score_key) {
+        recorded_new_high_score = high_score::update_if_higher(reg, *session, score.score);
+    }
+    if (score_exceeds_high_score && recorded_new_high_score) {
+        current.value = score.score;
+    }
+    if (auto* hp = reg.ctx().find<HighScorePersistence>()) {
+        if (score_exceeds_high_score && recorded_new_high_score && has_active_high_score_key) {
+            reg.ctx().emplace<HighScoreDirtyTag>();
         }
-        if (score_exceeds_high_score && recorded_new_high_score) {
-            current.value = score.score;
-        }
-        if (auto* hp = reg.ctx().find<HighScorePersistence>()) {
-            if (score_exceeds_high_score && recorded_new_high_score && has_active_high_score_key) {
-                reg.ctx().emplace<HighScoreDirtyTag>();
-            }
-            if (reg.ctx().contains<HighScoreDirtyTag>()) {
-                if (hp->path.empty()) {
-                    hp->last_save = persistence::Result{persistence::Status::PathUnavailable, {}};
-                } else {
-                    hp->last_save = high_score::save_high_scores(*hs, hp->path);
-                    if (hp->last_save.ok()) {
-                        reg.ctx().erase<HighScoreDirtyTag>();
-                    }
+        if (reg.ctx().contains<HighScoreDirtyTag>()) {
+            if (hp->path.empty()) {
+                hp->last_save = persistence::Result{persistence::Status::PathUnavailable, {}};
+            } else {
+                hp->last_save = high_score::save_high_scores(reg, hp->path);
+                if (hp->last_save.ok()) {
+                    reg.ctx().erase<HighScoreDirtyTag>();
                 }
             }
         }
-    } else if (score_exceeds_high_score) {
-        current.value = score.score;
     }
 
     if (recorded_new_high_score) {

--- a/app/systems/high_score_system.cpp
+++ b/app/systems/high_score_system.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <limits>
 #include <system_error>
+#include <vector>
 
 #include <raylib.h>
 
@@ -42,94 +43,126 @@ entt::hashed_string::hash_type make_key_hash(const char* song_id, const char* di
     return entt::hashed_string::value(static_cast<const char*>(buf));
 }
 
-int32_t get_score(const HighScoreState& state, const char* key) {
-    for (int32_t i = 0; i < state.entry_count; ++i) {
-        if (std::strncmp(state.entries[i].key, key, HighScoreState::KEY_CAP) == 0) {
-            return state.entries[i].score;
+namespace {
+
+// Linear scan over the HighScoreEntry row table; returns entt::null if no
+// matching row. The table caps at MAX_ENTRIES (9), so O(N) per lookup is
+// the dense-flat-array equivalent of the prior inline `std::array` scan.
+entt::entity find_entry_by_key(const entt::registry& reg, const char* key) {
+    auto view = reg.view<HighScoreEntry>();
+    for (auto entity : view) {
+        const auto& entry = view.get<HighScoreEntry>(entity);
+        if (std::strncmp(entry.key, key, HighScoreState::KEY_CAP) == 0) {
+            return entity;
         }
     }
-    return 0;
+    return entt::null;
 }
 
-int32_t get_score_by_hash(const HighScoreState& state, entt::hashed_string::hash_type hash) {
-    for (int32_t i = 0; i < state.entry_count; ++i) {
-        if (entt::hashed_string::value(static_cast<const char*>(state.entries[i].key)) == hash) {
-            return state.entries[i].score;
+entt::entity find_entry_by_hash(const entt::registry& reg, entt::hashed_string::hash_type hash) {
+    auto view = reg.view<HighScoreEntry>();
+    for (auto entity : view) {
+        if (view.get<HighScoreEntry>(entity).key_hash == hash) {
+            return entity;
         }
     }
-    return 0;
+    return entt::null;
 }
 
-bool set_score(HighScoreState& state, const char* key, int32_t score) {
-    for (int32_t i = 0; i < state.entry_count; ++i) {
-        if (std::strncmp(state.entries[i].key, key, HighScoreState::KEY_CAP) == 0) {
-            state.entries[i].score = score;
-            return true;
-        }
+void write_key(HighScoreEntry& entry, const char* key) {
+    std::strncpy(entry.key, key, HighScoreState::KEY_CAP - 1);
+    entry.key[HighScoreState::KEY_CAP - 1] = '\0';
+    entry.key_hash = entt::hashed_string::value(static_cast<const char*>(entry.key));
+}
+
+}  // namespace
+
+int32_t entry_count(const entt::registry& reg) {
+    return static_cast<int32_t>(reg.view<HighScoreEntry>().size());
+}
+
+int32_t get_score(const entt::registry& reg, const char* key) {
+    const auto entity = find_entry_by_key(reg, key);
+    if (entity == entt::null) return 0;
+    return reg.get<HighScoreEntry>(entity).score;
+}
+
+int32_t get_score_by_hash(const entt::registry& reg, entt::hashed_string::hash_type hash) {
+    const auto entity = find_entry_by_hash(reg, hash);
+    if (entity == entt::null) return 0;
+    return reg.get<HighScoreEntry>(entity).score;
+}
+
+bool set_score(entt::registry& reg, const char* key, int32_t score) {
+    if (const auto existing = find_entry_by_key(reg, key); existing != entt::null) {
+        reg.get<HighScoreEntry>(existing).score = score;
+        return true;
     }
-    if (state.entry_count < HighScoreState::MAX_ENTRIES) {
-        std::strncpy(state.entries[state.entry_count].key, key, HighScoreState::KEY_CAP - 1);
-        state.entries[state.entry_count].key[HighScoreState::KEY_CAP - 1] = '\0';
-        state.entries[state.entry_count].score = score;
-        ++state.entry_count;
+    if (entry_count(reg) < HighScoreState::MAX_ENTRIES) {
+        const auto entity = reg.create();
+        auto& entry = reg.emplace<HighScoreEntry>(entity);
+        write_key(entry, key);
+        entry.score = score;
         return true;
     }
     TraceLog(LOG_WARNING, "High score table full; dropping score for key '%s'", key);
     return false;
 }
 
-bool set_score_by_hash(HighScoreState& state, entt::hashed_string::hash_type hash, int32_t score) {
-    for (int32_t i = 0; i < state.entry_count; ++i) {
-        if (entt::hashed_string::value(static_cast<const char*>(state.entries[i].key)) == hash) {
-            state.entries[i].score = score;
-            return true;
-        }
+bool set_score_by_hash(entt::registry& reg, entt::hashed_string::hash_type hash, int32_t score) {
+    const auto entity = find_entry_by_hash(reg, hash);
+    if (entity == entt::null) {
+        TraceLog(LOG_WARNING, "High score entry hash %u not found; score update skipped",
+                 static_cast<unsigned int>(hash));
+        return false;
     }
-    TraceLog(LOG_WARNING, "High score entry hash %u not found; score update skipped",
-             static_cast<unsigned int>(hash));
-    return false;
+    reg.get<HighScoreEntry>(entity).score = score;
+    return true;
 }
 
-bool ensure_entry(HighScoreState& state, const char* key) {
-    for (int32_t i = 0; i < state.entry_count; ++i) {
-        if (std::strncmp(state.entries[i].key, key, HighScoreState::KEY_CAP) == 0) return true;
-    }
-    if (state.entry_count < HighScoreState::MAX_ENTRIES) {
-        std::strncpy(state.entries[state.entry_count].key, key, HighScoreState::KEY_CAP - 1);
-        state.entries[state.entry_count].key[HighScoreState::KEY_CAP - 1] = '\0';
-        state.entries[state.entry_count].score = 0;
-        ++state.entry_count;
+bool ensure_entry(entt::registry& reg, const char* key) {
+    if (find_entry_by_key(reg, key) != entt::null) return true;
+    if (entry_count(reg) < HighScoreState::MAX_ENTRIES) {
+        const auto entity = reg.create();
+        auto& entry = reg.emplace<HighScoreEntry>(entity);
+        write_key(entry, key);
+        entry.score = 0;
         return true;
     }
     TraceLog(LOG_WARNING, "High score table full; cannot create entry for key '%s'", key);
     return false;
 }
 
-int32_t get_current_high_score(const HighScoreState& state, const HighScoreSession& session) {
+int32_t get_current_high_score(const entt::registry& reg, const HighScoreSession& session) {
     if (session.key_hash == 0) return 0;
-    return get_score_by_hash(state, session.key_hash);
+    return get_score_by_hash(reg, session.key_hash);
 }
 
 namespace {
 
-nlohmann::json high_score_state_to_json(const HighScoreState& state) {
+nlohmann::json high_score_state_to_json(const entt::registry& reg) {
     nlohmann::json result;
     nlohmann::json scores_obj;
 
-    for (int32_t i = 0; i < state.entry_count; ++i) {
-        scores_obj[state.entries[i].key] = state.entries[i].score;
+    auto view = reg.view<HighScoreEntry>();
+    for (auto entity : view) {
+        const auto& entry = view.get<HighScoreEntry>(entity);
+        scores_obj[entry.key] = entry.score;
     }
 
     result["scores"] = scores_obj;
     return result;
 }
 
-bool high_score_state_from_json(const nlohmann::json& obj, HighScoreState& state) {
+bool high_score_state_from_json(const nlohmann::json& obj, entt::registry& reg) {
     if (!obj.is_object()) {
         return false;
     }
 
-    HighScoreState next;
+    // Stage into a local buffer first so a parse failure or overflow leaves
+    // the registry's existing rows untouched (atomic-on-success).
+    std::vector<HighScoreEntry> staged;
+    staged.reserve(HighScoreState::MAX_ENTRIES);
 
     if (obj.contains("scores")) {
         const auto& scores_obj = obj["scores"];
@@ -162,19 +195,30 @@ bool high_score_state_from_json(const nlohmann::json& obj, HighScoreState& state
                 raw = std::numeric_limits<std::int32_t>::max();
             }
 
-            if (!set_score(next, key.c_str(), static_cast<std::int32_t>(raw))) {
+            if (static_cast<int32_t>(staged.size()) >= HighScoreState::MAX_ENTRIES) {
                 return false;
             }
+
+            HighScoreEntry entry{};
+            write_key(entry, key.c_str());
+            entry.score = static_cast<std::int32_t>(raw);
+            staged.push_back(entry);
         }
     }
 
-    state = next;
+    // Commit: drop existing rows then emplace the staged set.
+    auto existing = reg.view<HighScoreEntry>();
+    reg.destroy(existing.begin(), existing.end());
+    for (const auto& entry : staged) {
+        const auto ent = reg.create();
+        reg.emplace<HighScoreEntry>(ent, entry);
+    }
     return true;
 }
 
 }  // namespace
 
-persistence::Result load_high_scores(HighScoreState& state, const std::filesystem::path& path) {
+persistence::Result load_high_scores(entt::registry& reg, const std::filesystem::path& path) {
     const auto prepare_result = persistence::prepare_for_persistence_read(path);
     if (!prepare_result.ok()) {
         return prepare_result;
@@ -200,7 +244,7 @@ persistence::Result load_high_scores(HighScoreState& state, const std::filesyste
         if (file.bad()) {
             return persistence::Result{persistence::Status::FileReadFailed, {}};
         }
-        if (!high_score_state_from_json(obj, state)) {
+        if (!high_score_state_from_json(obj, reg)) {
             return persistence::Result{persistence::Status::CorruptData, {}};
         }
         return persistence::Result{};
@@ -209,7 +253,7 @@ persistence::Result load_high_scores(HighScoreState& state, const std::filesyste
     }
 }
 
-persistence::Result save_high_scores(const HighScoreState& state, const std::filesystem::path& path) {
+persistence::Result save_high_scores(const entt::registry& reg, const std::filesystem::path& path) {
     const auto ensure_error = persistence::ensure_directory_exists(path.parent_path());
     if (ensure_error) {
         return persistence::Result{persistence::Status::DirectoryCreateFailed, ensure_error};
@@ -220,7 +264,7 @@ persistence::Result save_high_scores(const HighScoreState& state, const std::fil
         return persistence::Result{persistence::Status::FileOpenFailed, {}};
     }
 
-    nlohmann::json obj = high_score_state_to_json(state);
+    nlohmann::json obj = high_score_state_to_json(reg);
     file << obj.dump(2);
     file.flush();
     if (!file.good()) {
@@ -233,12 +277,12 @@ persistence::Result save_high_scores(const HighScoreState& state, const std::fil
     return persistence::flush_persistence_writes(path);
 }
 
-bool update_if_higher(HighScoreState& state, const HighScoreSession& session, int32_t new_score) {
+bool update_if_higher(entt::registry& reg, const HighScoreSession& session, int32_t new_score) {
     if (session.key_hash == 0) return false;
     if (new_score < 0) new_score = 0;
-    int32_t stored = get_score_by_hash(state, session.key_hash);
+    int32_t stored = get_score_by_hash(reg, session.key_hash);
     if (new_score > stored) {
-        return set_score_by_hash(state, session.key_hash, new_score);
+        return set_score_by_hash(reg, session.key_hash, new_score);
     }
     return true;
 }

--- a/app/systems/high_score_system.h
+++ b/app/systems/high_score_system.h
@@ -5,13 +5,14 @@
 
 namespace high_score {
 
-// Load high scores from JSON file.
+// Load high scores from JSON file into reg's HighScoreEntry table (atomic:
+// on parse failure existing rows are preserved).
 // Distinguishes missing/corrupt/path errors via structured status.
-persistence::Result load_high_scores(HighScoreState& state, const std::filesystem::path& path);
+persistence::Result load_high_scores(entt::registry& reg, const std::filesystem::path& path);
 
-// Save high scores to JSON file.
+// Save the current HighScoreEntry rows to JSON file.
 // Distinguishes path/open/write failures via structured status.
-persistence::Result save_high_scores(const HighScoreState& state, const std::filesystem::path& path);
+persistence::Result save_high_scores(const entt::registry& reg, const std::filesystem::path& path);
 
 // Resolve full high scores file path.
 // Returns structured failure and clears out_path when resolution fails.
@@ -21,8 +22,8 @@ persistence::Result get_high_scores_file_path(
 
 // Update the stored score for session.key_hash if new_score is strictly higher.
 // Negative new_score is clamped to 0. Returns false when no active key exists
-// or the active key is missing from the fixed entry table.
-bool update_if_higher(HighScoreState& state, const HighScoreSession& session, int32_t new_score);
+// or the active key is missing from the entry table.
+bool update_if_higher(entt::registry& reg, const HighScoreSession& session, int32_t new_score);
 
 // Build "song_id|difficulty" into caller-supplied buf (no heap allocation).
 // Returns snprintf-style char count (excluding NUL), or -1 if cap is invalid.
@@ -33,22 +34,25 @@ int32_t make_key_str(char* buf, int32_t cap, const char* song_id, const char* di
 entt::hashed_string::hash_type make_key_hash(const char* song_id, const char* difficulty);
 
 // Returns the stored score for key, or 0 if not found.
-int32_t get_score(const HighScoreState& state, const char* key);
+int32_t get_score(const entt::registry& reg, const char* key);
 
 // Returns the stored score for a hash -- used on the session current-key path.
-int32_t get_score_by_hash(const HighScoreState& state, entt::hashed_string::hash_type hash);
+int32_t get_score_by_hash(const entt::registry& reg, entt::hashed_string::hash_type hash);
 
 // Insert or update entry by string key. Returns false if the table is full.
-bool set_score(HighScoreState& state, const char* key, int32_t score);
+bool set_score(entt::registry& reg, const char* key, int32_t score);
 
 // Update an existing entry's score by hash. Returns false if hash is not found.
-bool set_score_by_hash(HighScoreState& state, entt::hashed_string::hash_type hash, int32_t score);
+bool set_score_by_hash(entt::registry& reg, entt::hashed_string::hash_type hash, int32_t score);
 
 // Ensure an entry exists for key with score 0 if not already present.
 // Returns false if the table is full.
-bool ensure_entry(HighScoreState& state, const char* key);
+bool ensure_entry(entt::registry& reg, const char* key);
 
 // Returns the stored score for the current session key, or 0 if no session active.
-int32_t get_current_high_score(const HighScoreState& state, const HighScoreSession& session);
+int32_t get_current_high_score(const entt::registry& reg, const HighScoreSession& session);
+
+// Count of stored entries (rows in the HighScoreEntry table).
+int32_t entry_count(const entt::registry& reg);
 
 } // namespace high_score

--- a/app/systems/play_session.cpp
+++ b/app/systems/play_session.cpp
@@ -24,6 +24,7 @@
 #include <filesystem>
 #include <raylib.h>
 #include <utility>
+#include <vector>
 
 namespace {
 
@@ -96,7 +97,25 @@ void setup_play_session(entt::registry& reg) {
         settings_was_dirty = dirty_view.begin() != dirty_view.end();
     }
 
+    // Snapshot the HighScoreEntry row table across the upcoming `reg.clear()`
+    // so durable scores survive the per-session entity wipe (Fabian Principle 3 /
+    // issue #1560: the row table replaces the prior ctx-singleton array column,
+    // and `reg.clear()` wipes entities but leaves ctx untouched).
+    std::vector<HighScoreEntry> saved_high_score_entries;
+    {
+        auto entry_view = reg.view<HighScoreEntry>();
+        saved_high_score_entries.reserve(entry_view.size());
+        for (auto entity : entry_view) {
+            saved_high_score_entries.push_back(entry_view.get<HighScoreEntry>(entity));
+        }
+    }
+
     reg.clear();
+
+    for (const auto& entry : saved_high_score_entries) {
+        const auto entity = reg.create();
+        reg.emplace<HighScoreEntry>(entity, entry);
+    }
 
     spawn_game_camera(reg);
     spawn_ui_camera(reg);
@@ -187,7 +206,9 @@ void setup_play_session(entt::registry& reg) {
     // Wire high score: derive song_id from beatmap filename and set HighScoreSession::key_hash.
     // The key string is built once in a stack buffer (no heap); ensure_entry pre-registers
     // the entry so update_if_higher can later update by hash without the key string.
-    if (auto* hs = reg.ctx().find<HighScoreState>()) {
+    // HighScoreEntry rows live in the registry (issue #1560), so the operations don't
+    // need a HighScoreState ctx-singleton gate any more.
+    {
         std::string stem = std::filesystem::path(beatmap_path).stem().string();
         static const std::string BEATMAP_SUFFIX = "_beatmap";
         if (stem.size() > BEATMAP_SUFFIX.size() &&
@@ -200,7 +221,7 @@ void setup_play_session(entt::registry& reg) {
         if (auto* session = reg.ctx().find<HighScoreSession>()) {
             session->key_hash = entt::hashed_string::value(static_cast<const char*>(key_buf));
         }
-        high_score::ensure_entry(*hs, key_buf);
+        high_score::ensure_entry(reg, key_buf);
     }
 
     // Init song state
@@ -261,10 +282,10 @@ void setup_play_session(entt::registry& reg) {
     erase_ctx_if_exists<EndChoiceMainMenu>(reg);
 
     // Load stored high score for this song+difficulty into CurrentSongHighScore
-    if (auto* hs = reg.ctx().find<HighScoreState>()) {
+    {
         auto& current = reg.ctx().get<CurrentSongHighScore>();
         const auto* session = reg.ctx().find<HighScoreSession>();
-        current.value = session ? high_score::get_current_high_score(*hs, *session) : 0;
+        current.value = session ? high_score::get_current_high_score(reg, *session) : 0;
     }
 
     // play_session owns when a player is spawned; player_entity owns how.

--- a/tests/test_component_boundary_wave2.cpp
+++ b/tests/test_component_boundary_wave2.cpp
@@ -16,13 +16,13 @@
 #include <type_traits>
 
 #include "test_helpers.h"        // HighScoreState (via high_score_system.h)
+#include "systems/high_score_system.h"
 
 // ── HighScoreState table constants ───────────────────────────────────────────
 //
 // MAX_ENTRIES == LEVEL_COUNT(3) × DIFFICULTY_COUNT(3) == 9.
-// Persistence serialises and deserialises up to this many entries by index; if
-// it changes without resizing the array the table silently drops or corrupts
-// entries.
+// `set_score` / `ensure_entry` / `load_high_scores` reject inserts past this
+// cap, so any change here must be paired with a persistence-format review.
 
 static_assert(HighScoreState::MAX_ENTRIES == 9,
     "HighScoreState::MAX_ENTRIES must equal LEVEL_COUNT(3) x DIFFICULTY_COUNT(3)=9; "
@@ -35,15 +35,22 @@ static_assert(HighScoreState::KEY_CAP == 32,
     "KEY_CAP must be >= 32 to fit all shipped 'song_id|difficulty' keys; "
     "longest is '3_mental_corruption|hard\\0' (26 chars)");
 
-// ── Runtime: HighScoreState default state ────────────────────────────────────
+// HighScoreState is now constants-only (Fabian Principle 3 / issue #1560):
+// the prior `std::array<Entry, MAX_ENTRIES> entries + int32_t entry_count`
+// was a god-class array column and has been normalized into a
+// `HighScoreEntry` row table walked via `view<HighScoreEntry>()`.
 
-TEST_CASE("HighScoreState: default-constructed is empty", "[boundary_wave2][high_score]") {
-    HighScoreState hs{};
-    CHECK(hs.entry_count == 0);
-    // All entry scores must be zero (no stale data)
-    for (int i = 0; i < HighScoreState::MAX_ENTRIES; ++i) {
-        CHECK(hs.entries[i].score == 0);
-    }
+static_assert(std::is_empty_v<HighScoreState>,
+    "HighScoreState must hold no instance state — entries live as HighScoreEntry rows "
+    "in the registry (issue #1560 / Fabian Principle 3)");
+
+// ── Runtime: HighScoreEntry row table ────────────────────────────────────────
+
+TEST_CASE("HighScoreEntry: default-constructed row is empty", "[boundary_wave2][high_score]") {
+    HighScoreEntry e{};
+    CHECK(e.key[0] == '\0');
+    CHECK(e.key_hash == 0u);
+    CHECK(e.score == 0);
 }
 
 TEST_CASE("HighScoreSession: default-constructed has zero key hash", "[boundary_wave2][high_score]") {
@@ -51,11 +58,11 @@ TEST_CASE("HighScoreSession: default-constructed has zero key hash", "[boundary_
     CHECK(session.key_hash == 0u);
 }
 
-TEST_CASE("HighScoreState: lives in ctx, not attached to entities", "[boundary_wave2][high_score]") {
+TEST_CASE("HighScoreEntry: rows live as registry entities, not in ctx", "[boundary_wave2][high_score]") {
     auto reg = make_registry();
-    // ctx singleton must be present and accessible
-    auto& hs = reg.ctx().get<HighScoreState>();
-    CHECK(hs.entry_count == 0);
-    // The type must never appear as an entity component — view must be empty
-    CHECK(reg.view<HighScoreState>().empty());
+    // Fresh registry starts with zero entry rows.
+    CHECK(high_score::entry_count(reg) == 0);
+    CHECK(reg.view<HighScoreEntry>().empty());
+    // HighScoreState is no longer a ctx singleton (constants-only struct).
+    CHECK_FALSE(reg.ctx().contains<HighScoreState>());
 }

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -142,7 +142,6 @@ TEST_CASE("ecs: make_registry creates all singletons", "[ecs]") {
     static_cast<void>(reg.ctx().get<EnergyState>());
     static_cast<void>(reg.ctx().get<SongResults>());
     // Scoring persistence / end-screen
-    static_cast<void>(reg.ctx().get<HighScoreState>());
     static_cast<void>(reg.ctx().get<HighScorePersistence>());
     SUCCEED("all required ctx singletons exist in registry context");
 }

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -57,7 +57,6 @@ inline entt::registry make_registry() {
     reg.ctx().emplace<SongState>();
     reg.ctx().emplace<EnergyState>();
     reg.ctx().emplace<SongResults>();
-    reg.ctx().emplace<HighScoreState>();
     reg.ctx().emplace<HighScorePersistence>();
     reg.ctx().emplace<HighScoreSession>();
     runtime_system_scratch_init(reg);

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -63,9 +63,8 @@ TEST_CASE("High score integration: setup_play_session loads selected song diffic
     lss.selected_level = 0;
     lss.selected_difficulty = 0;
 
-    auto& high_scores = reg.ctx().get<HighScoreState>();
-    high_score::set_score(high_scores, "1_stomper|easy", 1234);
-    high_score::set_score(high_scores, "1_stomper|hard", 9999);
+    high_score::set_score(reg, "1_stomper|easy", 1234);
+    high_score::set_score(reg, "1_stomper|hard", 9999);
 
     setup_play_session(reg);
 
@@ -119,8 +118,7 @@ TEST_CASE("Play session: missing selected beatmap returns to level select withou
           "[play_session][issue835]") {
     auto reg = make_registry();
     auto& lss = reg.ctx().get<LevelSelectState>();
-    auto& high_scores = reg.ctx().get<HighScoreState>();
-    high_score::set_score(high_scores, "1_stomper|medium", 4321);
+    high_score::set_score(reg, "1_stomper|medium", 4321);
     auto& session = reg.ctx().get<HighScoreSession>();
     session.key_hash = high_score::make_key_hash("1_stomper", "medium");
     reg.ctx().insert_or_assign(LevelSelectConfirmedTag{});
@@ -139,7 +137,7 @@ TEST_CASE("Play session: missing selected beatmap returns to level select withou
     CHECK(reg.view<PlayerTag>().empty());
     CHECK(reg.ctx().find<ScoreState>() == nullptr);
     CHECK(session.key_hash == 0);
-    CHECK(high_scores.entry_count == 1);
+    CHECK(high_score::entry_count(reg) == 1);
 
     reg.ctx().erase<PlaySessionContentOverride>();
     lss.selected_level = content_config::DEFAULT_LEVEL_INDEX;
@@ -172,9 +170,8 @@ TEST_CASE("Play session: high score key uses loaded fallback difficulty",
     })json");
 
     auto reg = make_registry();
-    auto& high_scores = reg.ctx().get<HighScoreState>();
-    high_score::set_score(high_scores, "shapeshifter_issue847|medium", 4321);
-    high_score::set_score(high_scores, "shapeshifter_issue847|hard", 9999);
+    high_score::set_score(reg, "shapeshifter_issue847|medium", 4321);
+    high_score::set_score(reg, "shapeshifter_issue847|hard", 9999);
     reg.ctx().emplace<PlaySessionContentOverride>(
         PlaySessionContentOverride{beatmap.path.string(), "hard"});
 
@@ -223,10 +220,9 @@ TEST_CASE("High score integration: new song-complete high score persists",
 
     auto reg = make_registry();
     reg.ctx().get<HighScorePersistence>().path = file.string();
-    auto& high_scores = reg.ctx().get<HighScoreState>();
-    high_score::ensure_entry(high_scores, "song_001|easy");
+    high_score::ensure_entry(reg, "song_001|easy");
     reg.ctx().get<HighScoreSession>().key_hash = high_score::make_key_hash("song_001", "easy");
-    high_score::set_score(high_scores, "song_001|easy", 1000);
+    high_score::set_score(reg, "song_001|easy", 1000);
 
     auto& score = reg.ctx().get<ScoreState>();
     auto& current = reg.ctx().get<CurrentSongHighScore>();
@@ -238,9 +234,9 @@ TEST_CASE("High score integration: new song-complete high score persists",
     game_state_system(reg, 0.016f);
 
     CHECK(current.value == 2500);
-    CHECK(high_score::get_score(high_scores, "song_001|easy") == 2500);
+    CHECK(high_score::get_score(reg, "song_001|easy") == 2500);
 
-    HighScoreState loaded;
+    entt::registry loaded;
     REQUIRE(high_score::load_high_scores(loaded, file).ok());
     CHECK(high_score::get_score(loaded, "song_001|easy") == 2500);
 
@@ -254,10 +250,9 @@ TEST_CASE("High score integration: lower game-over score does not overwrite pers
 
     auto reg = make_registry();
     reg.ctx().get<HighScorePersistence>().path = file.string();
-    auto& high_scores = reg.ctx().get<HighScoreState>();
-    high_score::ensure_entry(high_scores, "song_001|easy");
+    high_score::ensure_entry(reg, "song_001|easy");
     reg.ctx().get<HighScoreSession>().key_hash = high_score::make_key_hash("song_001", "easy");
-    high_score::set_score(high_scores, "song_001|easy", 3000);
+    high_score::set_score(reg, "song_001|easy", 3000);
 
     auto& score = reg.ctx().get<ScoreState>();
     auto& current = reg.ctx().get<CurrentSongHighScore>();
@@ -269,7 +264,7 @@ TEST_CASE("High score integration: lower game-over score does not overwrite pers
     game_state_system(reg, 0.016f);
 
     CHECK(current.value == 3000);
-    CHECK(high_score::get_score(high_scores, "song_001|easy") == 3000);
+    CHECK(high_score::get_score(reg, "song_001|easy") == 3000);
     CHECK_FALSE(std::filesystem::exists(file));
 
     remove_path(file);
@@ -278,10 +273,9 @@ TEST_CASE("High score integration: lower game-over score does not overwrite pers
 TEST_CASE("High score integration: missing active entry does not report new best",
           "[high_score][gamestate][issue1004]") {
     auto reg = make_registry();
-    auto& high_scores = reg.ctx().get<HighScoreState>();
     for (int32_t i = 0; i < HighScoreState::MAX_ENTRIES; ++i) {
         const std::string key = "song_" + std::to_string(i) + "|easy";
-        REQUIRE(high_score::set_score(high_scores, key.c_str(), i * 100));
+        REQUIRE(high_score::set_score(reg, key.c_str(), i * 100));
     }
     reg.ctx().get<HighScoreSession>().key_hash = high_score::make_key_hash("overflow", "hard");
 
@@ -297,7 +291,7 @@ TEST_CASE("High score integration: missing active entry does not report new best
     CHECK(current.value == 1000);
     CHECK_FALSE(reg.ctx().contains<NewBestRecord>());
     CHECK_FALSE(reg.ctx().contains<HighScoreDirtyTag>());
-    CHECK(high_score::get_score(high_scores, "overflow|hard") == 0);
+    CHECK(high_score::get_score(reg, "overflow|hard") == 0);
 }
 
 TEST_CASE("High score integration: failed save keeps dirty state for retry",
@@ -315,10 +309,9 @@ TEST_CASE("High score integration: failed save keeps dirty state for retry",
 
     auto reg = make_registry();
     reg.ctx().get<HighScorePersistence>().path = blocked_file.string();
-    auto& high_scores = reg.ctx().get<HighScoreState>();
-    high_score::ensure_entry(high_scores, "song_001|easy");
+    high_score::ensure_entry(reg, "song_001|easy");
     reg.ctx().get<HighScoreSession>().key_hash = high_score::make_key_hash("song_001", "easy");
-    high_score::set_score(high_scores, "song_001|easy", 1000);
+    high_score::set_score(reg, "song_001|easy", 1000);
 
     auto& score = reg.ctx().get<ScoreState>();
     auto& current = reg.ctx().get<CurrentSongHighScore>();
@@ -345,7 +338,7 @@ TEST_CASE("High score integration: failed save keeps dirty state for retry",
     CHECK_FALSE(reg.ctx().contains<HighScoreDirtyTag>());
     CHECK(retried_persistence.last_save.status == persistence::Status::Success);
 
-    HighScoreState loaded;
+    entt::registry loaded;
     REQUIRE(high_score::load_high_scores(loaded, retry_file).ok());
     CHECK(high_score::get_score(loaded, "song_001|easy") == 2500);
 
@@ -357,14 +350,12 @@ TEST_CASE("High score bootstrap: persistence path is populated for save call sit
     const auto file = temp_high_score_path("shapeshifter_issue_302_high_scores_bootstrap.json");
     remove_path(file);
 
-    HighScoreState seeded;
+    entt::registry seeded;
     high_score::set_score(seeded, "song_001|easy", 1000);
     REQUIRE(high_score::save_high_scores(seeded, file).ok());
 
     auto reg = make_registry();
-    HighScoreState loaded_at_bootstrap;
-    CHECK(high_score::load_high_scores(loaded_at_bootstrap, file).ok());
-    reg.ctx().get<HighScoreState>() = loaded_at_bootstrap;
+    CHECK(high_score::load_high_scores(reg, file).ok());
     reg.ctx().get<HighScorePersistence>() = HighScorePersistence{file.string()};
     reg.ctx().get<GameState>() = GameState{ 0.0f };
     sync_game_phase_tags<GamePhasePlayingTag>(reg);
@@ -374,8 +365,7 @@ TEST_CASE("High score bootstrap: persistence path is populated for save call sit
     current.value = 1000;
     score.score = 2500;
 
-    auto& high_scores = reg.ctx().get<HighScoreState>();
-    high_score::ensure_entry(high_scores, "song_001|easy");
+    high_score::ensure_entry(reg, "song_001|easy");
     reg.ctx().get<HighScoreSession>().key_hash = high_score::make_key_hash("song_001", "easy");
 
     const auto& persistence = reg.ctx().get<HighScorePersistence>();
@@ -384,7 +374,7 @@ TEST_CASE("High score bootstrap: persistence path is populated for save call sit
 
     game_state_system(reg, 0.016f);
 
-    HighScoreState loaded;
+    entt::registry loaded;
     REQUIRE(high_score::load_high_scores(loaded, file).ok());
     CHECK(high_score::get_score(loaded, "song_001|easy") == 2500);
 

--- a/tests/test_high_score_persistence.cpp
+++ b/tests/test_high_score_persistence.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <entt/entt.hpp>
 #include <filesystem>
 #include <fstream>
 #include <limits>
@@ -73,62 +74,62 @@ TEST_CASE("High score: no hash collisions across all 9 shipped song+difficulty k
 }
 
 TEST_CASE("High score: current score lookup and update never lowers stored score", "[high_score]") {
-    HighScoreState state;
+    entt::registry reg;
     HighScoreSession session;
-    CHECK(high_score::get_current_high_score(state, session) == 0);
+    CHECK(high_score::get_current_high_score(reg, session) == 0);
 
     // ensure_entry + session.key_hash mirrors the production setup_play_session path.
-    REQUIRE(high_score::ensure_entry(state, "song_001|easy"));
+    REQUIRE(high_score::ensure_entry(reg, "song_001|easy"));
     session.key_hash = high_score::make_key_hash("song_001", "easy");
-    CHECK(high_score::get_current_high_score(state, session) == 0);
+    CHECK(high_score::get_current_high_score(reg, session) == 0);
 
-    CHECK(high_score::update_if_higher(state, session, 5000));
-    CHECK(high_score::get_current_high_score(state, session) == 5000);
+    CHECK(high_score::update_if_higher(reg, session, 5000));
+    CHECK(high_score::get_current_high_score(reg, session) == 5000);
 
-    CHECK(high_score::update_if_higher(state, session, 1000));
-    CHECK(high_score::get_current_high_score(state, session) == 5000);
+    CHECK(high_score::update_if_higher(reg, session, 1000));
+    CHECK(high_score::get_current_high_score(reg, session) == 5000);
 }
 
 TEST_CASE("High score: saturated table reports insert and hash update failures", "[high_score][issue1004]") {
-    HighScoreState state;
+    entt::registry reg;
     HighScoreSession session;
     for (int32_t i = 0; i < HighScoreState::MAX_ENTRIES; ++i) {
         const std::string key = "song_" + std::to_string(i) + "|easy";
-        REQUIRE(high_score::set_score(state, key.c_str(), i * 100));
+        REQUIRE(high_score::set_score(reg, key.c_str(), i * 100));
     }
 
-    CHECK(state.entry_count == HighScoreState::MAX_ENTRIES);
-    CHECK_FALSE(high_score::set_score(state, "overflow|easy", 9000));
-    CHECK_FALSE(high_score::ensure_entry(state, "overflow|medium"));
+    CHECK(high_score::entry_count(reg) == HighScoreState::MAX_ENTRIES);
+    CHECK_FALSE(high_score::set_score(reg, "overflow|easy", 9000));
+    CHECK_FALSE(high_score::ensure_entry(reg, "overflow|medium"));
 
     session.key_hash = high_score::make_key_hash("overflow", "hard");
-    CHECK_FALSE(high_score::update_if_higher(state, session, 9000));
-    CHECK(high_score::get_score(state, "overflow|hard") == 0);
+    CHECK_FALSE(high_score::update_if_higher(reg, session, 9000));
+    CHECK(high_score::get_score(reg, "overflow|hard") == 0);
 
     session.key_hash = high_score::make_key_hash("song_0", "easy");
-    CHECK(high_score::update_if_higher(state, session, 9000));
-    CHECK(high_score::get_score(state, "song_0|easy") == 9000);
+    CHECK(high_score::update_if_higher(reg, session, 9000));
+    CHECK(high_score::get_score(reg, "song_0|easy") == 9000);
 }
 
 TEST_CASE("High score: tracks songs and difficulties independently", "[high_score]") {
-    HighScoreState state;
+    entt::registry reg;
     HighScoreSession session;
 
-    REQUIRE(high_score::ensure_entry(state, "song_001|easy"));
+    REQUIRE(high_score::ensure_entry(reg, "song_001|easy"));
     session.key_hash = high_score::make_key_hash("song_001", "easy");
-    CHECK(high_score::update_if_higher(state, session, 1000));
+    CHECK(high_score::update_if_higher(reg, session, 1000));
 
-    REQUIRE(high_score::ensure_entry(state, "song_001|hard"));
+    REQUIRE(high_score::ensure_entry(reg, "song_001|hard"));
     session.key_hash = high_score::make_key_hash("song_001", "hard");
-    CHECK(high_score::update_if_higher(state, session, 2000));
+    CHECK(high_score::update_if_higher(reg, session, 2000));
 
-    REQUIRE(high_score::ensure_entry(state, "song_002|easy"));
+    REQUIRE(high_score::ensure_entry(reg, "song_002|easy"));
     session.key_hash = high_score::make_key_hash("song_002", "easy");
-    CHECK(high_score::update_if_higher(state, session, 3000));
+    CHECK(high_score::update_if_higher(reg, session, 3000));
 
-    CHECK(high_score::get_score(state, "song_001|easy") == 1000);
-    CHECK(high_score::get_score(state, "song_001|hard") == 2000);
-    CHECK(high_score::get_score(state, "song_002|easy") == 3000);
+    CHECK(high_score::get_score(reg, "song_001|easy") == 1000);
+    CHECK(high_score::get_score(reg, "song_001|hard") == 2000);
+    CHECK(high_score::get_score(reg, "song_002|easy") == 3000);
 }
 
 TEST_CASE("High score persistence: round-trips score map", "[high_score]") {
@@ -136,14 +137,14 @@ TEST_CASE("High score persistence: round-trips score map", "[high_score]") {
     const auto file = dir / "high_scores.json";
     remove_path(dir);
 
-    HighScoreState original;
+    entt::registry original;
     high_score::set_score(original, "song_001|easy", 1000);
     high_score::set_score(original, "song_001|hard", 2000);
     high_score::set_score(original, "song_002|easy", 1500);
 
     REQUIRE(high_score::save_high_scores(original, file).ok());
 
-    HighScoreState loaded;
+    entt::registry loaded;
     REQUIRE(high_score::load_high_scores(loaded, file).ok());
     CHECK(high_score::get_score(loaded, "song_001|easy") == high_score::get_score(original, "song_001|easy"));
     CHECK(high_score::get_score(loaded, "song_001|hard") == high_score::get_score(original, "song_001|hard"));
@@ -156,12 +157,12 @@ TEST_CASE("High score persistence: supports current-directory files", "[high_sco
     const auto file = std::filesystem::path("high_scores_current_dir_tmp.json");
     remove_path(file);
 
-    HighScoreState original;
+    entt::registry original;
     high_score::set_score(original, "song_001|easy", 2000);
 
     REQUIRE(high_score::save_high_scores(original, file).ok());
 
-    HighScoreState loaded;
+    entt::registry loaded;
     REQUIRE(high_score::load_high_scores(loaded, file).ok());
     CHECK(high_score::get_score(loaded, "song_001|easy") == 2000);
 
@@ -172,12 +173,12 @@ TEST_CASE("High score persistence: missing file returns false and preserves stat
     const auto file = temp_high_score_path("missing_high_scores_xyz.json");
     remove_path(file);
 
-    HighScoreState state;
-    high_score::set_score(state, "song_001|easy", 500);
+    entt::registry reg;
+    high_score::set_score(reg, "song_001|easy", 500);
 
-    const auto result = high_score::load_high_scores(state, file);
+    const auto result = high_score::load_high_scores(reg, file);
     CHECK(result.status == persistence::Status::MissingFile);
-    CHECK(high_score::get_score(state, "song_001|easy") == 500);
+    CHECK(high_score::get_score(reg, "song_001|easy") == 500);
 }
 
 TEST_CASE("High score persistence: malformed JSON preserves state", "[high_score]") {
@@ -191,12 +192,12 @@ TEST_CASE("High score persistence: malformed JSON preserves state", "[high_score
         out << "{ invalid json }";
     }
 
-    HighScoreState state;
-    high_score::set_score(state, "song_001|easy", 500);
+    entt::registry reg;
+    high_score::set_score(reg, "song_001|easy", 500);
 
-    const auto result = high_score::load_high_scores(state, file);
+    const auto result = high_score::load_high_scores(reg, file);
     CHECK(result.status == persistence::Status::CorruptData);
-    CHECK(high_score::get_score(state, "song_001|easy") == 500);
+    CHECK(high_score::get_score(reg, "song_001|easy") == 500);
 
     remove_path(dir);
 }
@@ -212,19 +213,19 @@ TEST_CASE("High score persistence: invalid schema preserves state", "[high_score
         out << R"({"scores":["not","an","object"]})";
     }
 
-    HighScoreState state;
-    high_score::set_score(state, "song_001|easy", 500);
+    entt::registry reg;
+    high_score::set_score(reg, "song_001|easy", 500);
 
-    CHECK(high_score::load_high_scores(state, file).status == persistence::Status::CorruptData);
-    CHECK(high_score::get_score(state, "song_001|easy") == 500);
+    CHECK(high_score::load_high_scores(reg, file).status == persistence::Status::CorruptData);
+    CHECK(high_score::get_score(reg, "song_001|easy") == 500);
 
     {
         std::ofstream out(file);
         out << R"({"scores":{"song_001|easy":"not_a_number"}})";
     }
 
-    CHECK(high_score::load_high_scores(state, file).status == persistence::Status::CorruptData);
-    CHECK(high_score::get_score(state, "song_001|easy") == 500);
+    CHECK(high_score::load_high_scores(reg, file).status == persistence::Status::CorruptData);
+    CHECK(high_score::get_score(reg, "song_001|easy") == 500);
 
     remove_path(dir);
 }
@@ -245,11 +246,11 @@ TEST_CASE("High score persistence: oversized score map is corrupt", "[high_score
         out << "}}";
     }
 
-    HighScoreState state;
-    REQUIRE(high_score::set_score(state, "song_001|easy", 500));
+    entt::registry reg;
+    REQUIRE(high_score::set_score(reg, "song_001|easy", 500));
 
-    CHECK(high_score::load_high_scores(state, file).status == persistence::Status::CorruptData);
-    CHECK(high_score::get_score(state, "song_001|easy") == 500);
+    CHECK(high_score::load_high_scores(reg, file).status == persistence::Status::CorruptData);
+    CHECK(high_score::get_score(reg, "song_001|easy") == 500);
 
     remove_path(dir);
 }
@@ -265,27 +266,28 @@ TEST_CASE("High score persistence: clamps negative and oversized scores", "[high
         out << R"({"scores":{"negative|easy":-100,"huge|hard":999999999999}})";
     }
 
-    HighScoreState state;
-    REQUIRE(high_score::load_high_scores(state, file).ok());
-    CHECK(high_score::get_score(state, "negative|easy") == 0);
-    CHECK(high_score::get_score(state, "huge|hard") == std::numeric_limits<int32_t>::max());
+    entt::registry reg;
+    REQUIRE(high_score::load_high_scores(reg, file).ok());
+    CHECK(high_score::get_score(reg, "negative|easy") == 0);
+    CHECK(high_score::get_score(reg, "huge|hard") == std::numeric_limits<int32_t>::max());
 
     remove_path(dir);
 }
 
 TEST_CASE("High score persistence: load does not touch session key", "[high_score]") {
     // HighScoreSession is a separate ctx singleton (#1194/#1203) — load_high_scores
-    // takes only HighScoreState&, so it is structurally impossible to clobber the
-    // active session key. This regression test guards the API split.
+    // takes the registry but operates on HighScoreEntry rows only, so it is
+    // structurally impossible to clobber the active session key. This regression
+    // test guards the API split.
     const auto dir = temp_high_score_path("shapeshifter_high_score_current_key");
     const auto file = dir / "high_scores.json";
     remove_path(dir);
 
-    HighScoreState original;
+    entt::registry original;
     high_score::set_score(original, "song_001|easy", 1000);
     REQUIRE(high_score::save_high_scores(original, file).ok());
 
-    HighScoreState loaded;
+    entt::registry loaded;
     HighScoreSession session;
     // Simulate a session already active on song_002|hard before the load.
     const auto pre_load_hash = high_score::make_key_hash("song_002", "hard");
@@ -312,9 +314,9 @@ TEST_CASE("High score persistence: save reports unwritable parent path", "[high_
         out << "file blocks directory creation";
     }
 
-    HighScoreState state;
-    high_score::set_score(state, "song_001|easy", 1000);
-    const auto result = high_score::save_high_scores(state, file);
+    entt::registry reg;
+    high_score::set_score(reg, "song_001|easy", 1000);
+    const auto result = high_score::save_high_scores(reg, file);
     CHECK(result.status == persistence::Status::DirectoryCreateFailed);
 
     remove_path(root);
@@ -326,12 +328,12 @@ TEST_CASE("High score persistence: save creates nested parent directories",
     const auto file = root / "missing" / "parent" / "high_scores.json";
     remove_path(root);
 
-    HighScoreState original;
+    entt::registry original;
     high_score::set_score(original, "song_001|easy", 1000);
     REQUIRE(high_score::save_high_scores(original, file).ok());
     CHECK(std::filesystem::exists(file));
 
-    HighScoreState loaded;
+    entt::registry loaded;
     REQUIRE(high_score::load_high_scores(loaded, file).ok());
     CHECK(high_score::get_score(loaded, "song_001|easy") == 1000);
 


### PR DESCRIPTION
## What
Normalizes `HighScoreState`'s inline `std::array<Entry, MAX_ENTRIES>` array column + parallel `entry_count` cursor into a `HighScoreEntry` row table (one entity per stored score), matching the sibling pattern from #1554 (`ObstacleChildren` → `MeshChild` walked-by-parent).

## Why
Per `.squad/decisions.md` § 9 / Principle 3:
> **No array columns.** A `std::vector<X>` field is a 1NF violation. Each element becomes a row in its own table, with the parent's entity ID as the foreign key.

The same prohibition applies to fixed-size `std::array<X, N>` columns. `HighScoreState`'s inline 9-element entry array + cursor was structurally identical to the recently-eradicated `ObstacleChildren { entt::entity children[MAX]; int count; }`.

## How
- New row component: `HighScoreEntry { char key[KEY_CAP]; entt::hashed_string::hash_type key_hash; int32_t score; }`. Printable `key[]` retained so JSON persistence is bit-for-bit unchanged; `key_hash` cached so `get_current_high_score` doesn't rehash per row.
- `HighScoreState` reduced to constants-only (`MAX_ENTRIES`, `KEY_CAP`) — no longer a ctx singleton; `MAX_ENTRIES` survives as the runtime overflow guard.
- All `high_score::` APIs switched from `HighScoreState&` to `entt::registry&`. Linear `view<HighScoreEntry>` scans replace the old `for i < entry_count` loops (same O(N) shape, same dense-flat-array locality via EnTT's per-component packed storage).
- JSON loader stages into a local `std::vector<HighScoreEntry>` first, then commits atomically — parse failures or oversized maps still leave the registry's existing rows untouched.
- `setup_play_session` now snapshots `HighScoreEntry` rows around its `reg.clear()` (mirroring the existing settings save/restore pattern), since durable scores can no longer survive the wipe via a ctx singleton.
- `game_state_terminal_phase_system.cpp` drops the `find<HighScoreState>()` gate and the dead else-branch it guarded.

## Acceptance criteria (from #1560)
- [x] `HighScoreState` no longer carries `std::array<Entry, MAX_ENTRIES> entries` or `int32_t entry_count` — reduced to constants only.
- [x] New `HighScoreEntry { key_hash; score; (+ key) }` row component table replaces the inline array.
- [x] `get_score` / `set_score` / `ensure_entry` / `get_current_high_score` / `update_if_higher` updated to view the new table.
- [x] `high_score_state_to_json` / `_from_json` iterate the new storage; on-disk JSON schema preserved bit-for-bit.
- [x] All `MAX_ENTRIES` static asserts in `tests/test_component_boundary_wave2.cpp` still hold (recast to assert constants + row-table shape).
- [x] Zero-warning build; full suite passes (3369 assertions / 964 cases).

## Verification
- Clean rebuild of all touched files: zero warnings.
- `./build/shapeshifter_tests` → `All tests passed (3369 assertions in 964 test cases)`.
- `./build/shapeshifter_startup_shutdown_smoke` → exit 0.
- Fabian drift spot-check (folder layout, virtual/override/dynamic_cast, single tags header, enum allowlist): all clean.

Refs: `.squad/decisions.md` § 9 / Principle 3 · #1203 (doctrinal) · #1538 / #1545 / #1548 / #1550 / #1554 (sibling Principle 3 site cleanups).

Closes #1560
