### PR TITLE
#1563 sfx_bank.cpp: inline single-call anon-ns helper next_noise

### DIFF
--- a/app/systems/sfx_bank.cpp
+++ b/app/systems/sfx_bank.cpp
@@ -28,12 +28,6 @@ constexpr float kPi = 3.14159265358979323846f;
 constexpr int SAMPLE_RATE = 44100;
 constexpr int SFX_COUNT = static_cast<int>(SFX::Count);
 
-float next_noise(std::uint32_t& state) {
-    state = state * 1664525u + 1013904223u;
-    const auto sample = static_cast<int>((state >> 16u) & 0xffffu) - 32768;
-    return static_cast<float>(sample) / 32768.0f;
-}
-
 float sample_sine(const SfxSpec& spec, int frame, std::uint32_t& /*noise_state*/) {
     const float t = static_cast<float>(frame) / static_cast<float>(SAMPLE_RATE);
     const float phase = 2.0f * kPi * spec.frequency * t;
@@ -41,7 +35,9 @@ float sample_sine(const SfxSpec& spec, int frame, std::uint32_t& /*noise_state*/
 }
 
 float sample_noise(const SfxSpec& /*spec*/, int /*frame*/, std::uint32_t& noise_state) {
-    return next_noise(noise_state);
+    noise_state = noise_state * 1664525u + 1013904223u;
+    const auto sample = static_cast<int>((noise_state >> 16u) & 0xffffu) - 32768;
+    return static_cast<float>(sample) / 32768.0f;
 }
 
 constexpr std::array<SfxSpec, SFX_COUNT> SFX_SPECS{{


### PR DESCRIPTION
## Summary

Inline the single-call anon-ns helper `next_noise` in `app/systems/sfx_bank.cpp` per #1563. Same train as #1547 / #1551 / #1559.

`next_noise(state)` was a 4-line LCG step used by exactly one caller (`sample_noise`) and was never address-taken — only `sample_noise` participates in the `SFX_SPECS[].sample` function-pointer table. Inlining keeps the bit-for-bit output identical (same coefficients, same masking, same `int`→`float` divide).

## Diff

```
 1 file changed, 3 insertions(+), 7 deletions(-)
```

## Verification

- `cmake --build build`: zero-warning on macOS Clang.
- `./build/shapeshifter_tests -r compact`: All tests passed (3369 assertions in 964 test cases).

Closes #1563.
