### PR TITLE
#1565 obstacle_render_entity.cpp: inline single-call static helper count_mesh_children_of

### DIFF
--- a/app/entities/obstacle_render_entity.cpp
+++ b/app/entities/obstacle_render_entity.cpp
@@ -38,20 +38,16 @@ struct PendingEntity {
 };
 }
 
-static int count_mesh_children_of(entt::registry& reg, entt::entity parent) {
+// ObstacleChildren::MAX is the hard cap for mesh children owned by one
+// logical obstacle. Factory helpers reserve a slot before reg.create() so an
+// overflow cannot leave an unregistered MeshChild entity behind.
+static void require_child_capacity(entt::registry& reg, entt::entity parent) {
     int count = 0;
     for (auto [child, mc] : reg.view<MeshChild>().each()) {
         (void)child;
         if (mc.parent == parent) ++count;
     }
-    return count;
-}
-
-// ObstacleChildren::MAX is the hard cap for mesh children owned by one
-// logical obstacle. Factory helpers reserve a slot before reg.create() so an
-// overflow cannot leave an unregistered MeshChild entity behind.
-static void require_child_capacity(entt::registry& reg, entt::entity parent) {
-    if (count_mesh_children_of(reg, parent) >= ObstacleChildren::MAX) {
+    if (count >= ObstacleChildren::MAX) {
         throw std::logic_error("ObstacleChildren capacity exceeded");
     }
 }


### PR DESCRIPTION
## Summary

Inline the single-call file-static helper `count_mesh_children_of` in `app/entities/obstacle_render_entity.cpp` per #1565. Same train as #1547 / #1551 / #1559.

`count_mesh_children_of` was a tiny `view<MeshChild>().each()` linear count whose only caller was the capacity guard `require_child_capacity`. No address-taken use anywhere in the repo (`rg '\bcount_mesh_children_of\b'` returns exactly 2 hits, both in this file).

Semantics preserved: same cap (`ObstacleChildren::MAX`), same exception text.

## Diff

```
 1 file changed, 5 insertions(+), 9 deletions(-)
```

## Verification

- `cmake --build build`: zero-warning on macOS Clang.
- `./build/shapeshifter_tests -r compact`: All tests passed (3369 assertions in 964 test cases).

Closes #1565.
