### PR TITLE
#1564 camera_system.cpp: inline 2 single-call helpers (build_shape_meshes, unload_shape_meshes)

### DIFF
--- a/app/systems/camera_system.cpp
+++ b/app/systems/camera_system.cpp
@@ -71,39 +71,17 @@ static const char* MESH_FS =
     "}\n";
 #endif
 
-static ShapeMeshes build_shape_meshes(const ShapeMeshConfig& config) {
-    ShapeMeshes sm = {};
-
-    sm.shapes[0] = GenMeshCylinder(1.0f, config.props[0].height_ratio, 12);
-    sm.shapes[1] = GenMeshCube(2.0f, config.props[1].height_ratio, 2.0f);
-    sm.shapes[2] = GenMeshCylinder(1.0f, config.props[2].height_ratio, 3);
-    sm.shapes[3] = GenMeshCylinder(1.0f, config.props[3].height_ratio, 6);
-    sm.slab = GenMeshCube(1.0f, 1.0f, 1.0f);
-    sm.quad = GenMeshPlane(1.0f, 1.0f, 1, 1);
-
-    Shader shader = LoadShaderFromMemory(MESH_VS, MESH_FS);
-    sm.material = LoadMaterialDefault();
-    sm.material.shader = shader;
-
-    sm.owned = true;
-    return sm;
-}
-
-static void unload_shape_meshes(ShapeMeshes& sm) {
-    for (int i = 0; i < 4; ++i)
-        UnloadMesh(sm.shapes[i]);
-    UnloadMesh(sm.slab);
-    UnloadMesh(sm.quad);
-    // raylib's UnloadMaterial() owns material.shader; unloading it separately
-    // double-frees the shader's location array.
-    UnloadMaterial(sm.material);
-}
-
 // ── ShapeMeshes RAII member definitions ─────────────────────────────────────
 
 void ShapeMeshes::release() {
     if (!owned) return;
-    unload_shape_meshes(*this);
+    for (int i = 0; i < 4; ++i)
+        UnloadMesh(shapes[i]);
+    UnloadMesh(slab);
+    UnloadMesh(quad);
+    // raylib's UnloadMaterial() owns material.shader; unloading it separately
+    // double-frees the shader's location array.
+    UnloadMaterial(material);
     for (int i = 0; i < 4; ++i) shapes[i] = {};
     slab = {}; quad = {}; material = {};
     owned = false;
@@ -154,7 +132,21 @@ void init(entt::registry& reg) {
     reg.ctx().emplace<ScreenTransform>();
     reg.ctx().emplace<FloorParams>();
     const auto& mesh_config = reg.ctx().emplace<ShapeMeshConfig>();
-    reg.ctx().emplace<ShapeMeshes>(build_shape_meshes(mesh_config));
+
+    ShapeMeshes sm = {};
+    sm.shapes[0] = GenMeshCylinder(1.0f, mesh_config.props[0].height_ratio, 12);
+    sm.shapes[1] = GenMeshCube(2.0f, mesh_config.props[1].height_ratio, 2.0f);
+    sm.shapes[2] = GenMeshCylinder(1.0f, mesh_config.props[2].height_ratio, 3);
+    sm.shapes[3] = GenMeshCylinder(1.0f, mesh_config.props[3].height_ratio, 6);
+    sm.slab = GenMeshCube(1.0f, 1.0f, 1.0f);
+    sm.quad = GenMeshPlane(1.0f, 1.0f, 1, 1);
+
+    Shader shader = LoadShaderFromMemory(MESH_VS, MESH_FS);
+    sm.material = LoadMaterialDefault();
+    sm.material.shader = shader;
+
+    sm.owned = true;
+    reg.ctx().emplace<ShapeMeshes>(std::move(sm));
 }
 
 void shutdown(entt::registry& reg) {


### PR DESCRIPTION
## Summary

Inline the 2 single-call namespace-static helpers `build_shape_meshes` and `unload_shape_meshes` in `app/systems/camera_system.cpp` per #1564. Same train as #1547 / #1551 / #1559.

Both helpers form a paired construct/destroy RAII pair for `ShapeMeshes`. Each had exactly one caller, no function-pointer-table use, no header re-export.

- `build_shape_meshes` → only caller: `camera::init` (line 157). Inlined; the local `sm` is still `std::move`'d into the ctx so the old NRVO/move-into-emplace behaviour is preserved bit-for-bit.
- `unload_shape_meshes` → only caller: `ShapeMeshes::release` (line 106). Inlined; the raylib double-free comment about `UnloadMaterial` owning `material.shader` is kept at the `UnloadMaterial(material)` call site.

No behaviour change: same GPU resource ownership, same `owned=true` late-set, same idempotent `release()`, same `camera::shutdown` early release path.

## Diff

```
 1 file changed, 22 insertions(+), 30 deletions(-)
```

## Verification

- `cmake --build build`: zero-warning on macOS Clang.
- `./build/shapeshifter_tests -r compact`: All tests passed (3369 assertions in 964 test cases).

Closes #1564.
