### PR TITLE
#1570 persistence_policy_system.cpp: inline single-call anon-ns helper resolve_root_dir

### DIFF
--- a/app/systems/persistence_policy_system.cpp
+++ b/app/systems/persistence_policy_system.cpp
@@ -95,33 +95,6 @@ bool path_uses_web_persistence(const std::filesystem::path& path) {
 }
 #endif
 
-std::filesystem::path resolve_root_dir(const std::filesystem::path& root_override) {
-    if (!root_override.empty()) {
-        return root_override;
-    }
-
-#ifdef _WIN32
-    const char* appdata = std::getenv("APPDATA");
-    if (appdata) return std::filesystem::path(appdata) / "shapeshifter";
-    return {};
-#elif defined(__EMSCRIPTEN__)
-    return std::filesystem::path(kWebPersistenceRoot);
-#else
-    const char* home = std::getenv("HOME");
-    if (!home) {
-        const passwd* pw = getpwuid(getuid());
-        if (pw) home = pw->pw_dir;
-    }
-    if (!home) return {};
-
-#if defined(__APPLE__) && defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
-    return std::filesystem::path(home) / "Library" / "Application Support" / "shapeshifter";
-#else
-    return std::filesystem::path(home) / ".shapeshifter";
-#endif
-#endif
-}
-
 }  // namespace
 
 std::error_code ensure_directory_exists(const std::filesystem::path& dir) {
@@ -153,7 +126,32 @@ Result resolve_paths(Paths& out_paths, const std::filesystem::path& root_overrid
     }
 #endif
 
-    const auto root_dir = resolve_root_dir(root_override);
+    const auto root_dir = [&]() -> std::filesystem::path {
+        if (!root_override.empty()) {
+            return root_override;
+        }
+
+#ifdef _WIN32
+        const char* appdata = std::getenv("APPDATA");
+        if (appdata) return std::filesystem::path(appdata) / "shapeshifter";
+        return {};
+#elif defined(__EMSCRIPTEN__)
+        return std::filesystem::path(kWebPersistenceRoot);
+#else
+        const char* home = std::getenv("HOME");
+        if (!home) {
+            const passwd* pw = getpwuid(getuid());
+            if (pw) home = pw->pw_dir;
+        }
+        if (!home) return {};
+
+#if defined(__APPLE__) && defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
+        return std::filesystem::path(home) / "Library" / "Application Support" / "shapeshifter";
+#else
+        return std::filesystem::path(home) / ".shapeshifter";
+#endif
+#endif
+    }();
     if (root_dir.empty()) {
         return Result{Status::PathUnavailable, {}};
     }


### PR DESCRIPTION
Continuation of the single-call anon-ns / file-static inline cleanup
train (#1551 / #1559 / #1564 / #1566 / #1567 / #1568). The anon-ns
helper `resolve_root_dir` had exactly one caller in the same file
(`resolve_paths`:156) and was not exported.

Inline the body into `resolve_paths` as an IIFE (immediately-invoked
lambda) to preserve the platform-conditional early-return structure
without restructuring the surrounding control flow. The lambda body
is bit-for-bit identical to the original function body.

Scope correction (out of issue scope): `ensure_directory_exists` was
initially listed in the cleanup pass but is EXPORTED via
`persistence_policy_system.h:36` and has two external callers
(`high_score_system.cpp:257`, `settings_system.cpp:211`). It stays
public; this change only inlines `resolve_root_dir`.

No behaviour change: same platform-conditional path resolution, same
`PathUnavailable` early-return, same downstream `ensure_directory_exists`
call.

Build: zero-warning. Tests: 964 cases / 3369 assertions pass.

Closes #1570.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
