### PR TITLE
#1569 game_state_system.cpp: inline single-call EMSCRIPTEN helper update_web_playing_lane_marker

### DIFF
--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -26,37 +26,6 @@ WasmSmokeLaneMarkerState& wasm_smoke_lane_marker_state(entt::registry& reg) {
     return reg.ctx().emplace<WasmSmokeLaneMarkerState>();
 }
 
-void update_web_playing_lane_marker(entt::registry& reg) {
-    auto& marker = wasm_smoke_lane_marker_state(reg);
-    if (!reg.ctx().contains<GamePhasePlayingTag>()) {
-        marker.last_lane = -1;
-        return;
-    }
-
-    auto player_view = reg.view<PlayerTag, Lane>();
-    if (player_view.begin() == player_view.end()) {
-        marker.last_lane = -1;
-        return;
-    }
-
-    const auto player_entity = *player_view.begin();
-    const int lane = static_cast<int>(player_view.get<Lane>(player_entity).current);
-    if (lane == marker.last_lane) {
-        return;
-    }
-    marker.last_lane = lane;
-
-    const std::string title = std::string("SHAPESHIFTER [Playing][Lane:")
-        + std::to_string(lane) + "]";
-    EM_ASM(
-        {
-            if (typeof document !== 'undefined') {
-                document.title = UTF8ToString($0);
-            }
-        },
-        title.c_str());
-}
-
 }  // namespace
 #endif
 
@@ -183,7 +152,34 @@ void game_state_system(entt::registry& reg, float dt) {
     }
 
 #if defined(__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)
-    update_web_playing_lane_marker(reg);
+    // Update browser tab title with current lane when in Playing phase, so
+    // WASM smoke tests can observe player state via document.title polling.
+    // Title is rewritten only on lane change; absence of player or non-Playing
+    // phase resets the cached lane to -1 so the next entry rewrites the title.
+    {
+        auto& marker = wasm_smoke_lane_marker_state(reg);
+        auto player_view = reg.view<PlayerTag, Lane>();
+        const bool playing = reg.ctx().contains<GamePhasePlayingTag>();
+        const bool has_player = player_view.begin() != player_view.end();
+        if (!playing || !has_player) {
+            marker.last_lane = -1;
+        } else {
+            const auto player_entity = *player_view.begin();
+            const int lane = static_cast<int>(player_view.get<Lane>(player_entity).current);
+            if (lane != marker.last_lane) {
+                marker.last_lane = lane;
+                const std::string title = std::string("SHAPESHIFTER [Playing][Lane:")
+                    + std::to_string(lane) + "]";
+                EM_ASM(
+                    {
+                        if (typeof document !== 'undefined') {
+                            document.title = UTF8ToString($0);
+                        }
+                    },
+                    title.c_str());
+            }
+        }
+    }
 #endif
     // Playing → SongComplete when song finishes (all obstacles cleared)
     if (reg.ctx().contains<GamePhasePlayingTag>()) {


### PR DESCRIPTION
Continuation of the single-call anon-ns inline cleanup train
(#1551 / #1559 / #1564 / #1566 / #1567 / #1568 / #1570). The
`update_web_playing_lane_marker` anon-ns helper (lines 29-58, behind
`__EMSCRIPTEN__ && SHAPESHIFTER_WASM_SMOKE_MARKERS`) had exactly one
caller (game_state_system:186).

Inline the body at the call site inside the same `#if` guard. The
companion ctx-singleton accessor `wasm_smoke_lane_marker_state` is
kept (separate find/emplace dance; not a single-call inline candidate).

Refactored the original 4 early-returns into a single 2-level if/else
branch consolidates the two ctx/view absence guards that previously set
`marker.last_lane = -1` and returned. Behaviour is bit-for-bit identical:

  - non-Playing phase or missing player -> last_lane = -1, no title write
  - same lane as cached -> no-op
  - lane change -> cache lane, EM_ASM rewrite document.title

A leading comment block preserves the semantic intent that the function
name carried.

Native build: zero-warning. Tests: 964 cases / 3369 assertions pass.
WASM build (Emscripten + SHAPESHIFTER_WASM_SMOKE_MARKERS path)
validated by CI.

Closes #1569.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
