### PR TITLE
#1573 play_session.h: drop stale 'GamePhase::Playing' enum ref in comment

### DIFF
--- a/app/systems/play_session.h
+++ b/app/systems/play_session.h
@@ -9,6 +9,6 @@ struct PlaySessionContentOverride {
 };
 
 // Sets up a fresh play session: clears entities, resets singletons,
-// creates the player entity. Called by game_state_system on transition
-// to GamePhase::Playing.
+// creates the player entity. Called by game_state_system on the
+// transition into GamePhasePlayingTag (see app/tags/tags.h).
 void setup_play_session(entt::registry& reg);


### PR DESCRIPTION
Closes #1573.

The `GamePhase` enum was eradicated by #1202/#1204 (Fabian existential processing); phase identity lives as `GamePhase*Tag` rows in `app/tags/tags.h`. The `play_session.h` header comment was the lone present-tense use of the deleted enum value (the sibling `.cpp` comments in `game_state_system.cpp`, `game_state_routing.cpp`, `test_player_system.cpp`, `game_state_end_screen_system.cpp`, and `song_playback_system.cpp` all correctly mark these as "former").

Replace `GamePhase::Playing` with `GamePhasePlayingTag` and cite the tag header.

## Verification

- `grep -n 'GamePhase::Playing' app/systems/play_session.h` → no hits.
- `cmake --build build` → zero warnings.
- `./build/shapeshifter_tests` → 964 cases / 3369 assertions pass.
- `python3 tools/check_enum_allowlist.py` → 8 enums, all allowlisted.

Comment-only change — no behavior delta.

Refs #1526, #1558 (comment-drift cleanup pattern).