### PR TITLE
#1574 design-docs: drop eradicated PlayerShape.current + fix wrong byte counts + replace VertState

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -155,10 +155,12 @@ enum class Shape : uint8_t {
 /// Empty tag — marks the single player entity. 0 bytes.
 struct PlayerTag {};
 
-/// Current shape and morph progress. 8 bytes.
+/// Morph animation progress. 4 bytes.
 /// Hot: read by shape_window_system, collision_system, game_camera_system.
+/// The current shape lives as one of `ShapeCircleTag` / `ShapeSquareTag` /
+/// `ShapeTriangleTag` / `ShapeHexagonTag` on the player entity, not a field
+/// on this struct (issue #1202/#1204; see `app/util/shape_tag.h`).
 struct PlayerShape {
-    Shape    current = Shape::Circle;  // active gameplay shape
     float    morph_t = 1.0f;           // 0.0 = morph just started, 1.0 = settled
 };
 
@@ -674,7 +676,7 @@ MotionVelocity       8     HOT        motion, particle effects
 ParticleData        12     HOT        particle expiry/render fade
 ScorePopup          16     HOT        popup expiry/render fade
 PlayerTag            0     HOT        collision/filter
-PlayerShape          8     HOT        shape_window, collision, render, player_action
+PlayerShape          4     HOT        shape_window, collision, render, player_action
 ShapeWindow         24     HOT        shape_window, input dispatcher, collision
 Lane                 1     HOT        collision, render, player_action
 LaneTransition       8     HOT        present when mid-lane-shift; movement, collision, player_action
@@ -1215,7 +1217,7 @@ int main(int argc, char* argv[]) {
     ┌──────────────┐                                             ┌─────────────┐
     │ BeatMap      │                                             │ PlayerShape │
     │ SongState    │                                             │ Lane        │
-    └──────┬───────┘                                             │ VertState   │
+    └──────┬───────┘                                             │ Jump/Slide? │
            │ beat_scheduler_system                               │ WorldPosition │
            │ creates note when spawn_time arrives                └──────┬──────┘
            ▼                                                            │

--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -171,7 +171,7 @@ constexpr int32_t CHAIN_MULT_BONUS_STEPS_CAP = 20; // caps at 2.0x from chain 21
   ┌──────────────────────────────────────────────────────────────┐
   │  PER-ENTITY COMPONENTS                                       │
   ├──────────────────────────────────────────────────────────────┤
-  │  PlayerShape       8B  ← current shape + morph progress     │
+  │  PlayerShape       4B  ← morph animation progress           │
   │  ShapeWindow      24B  ← rhythm window timing state         │
   │  WorldPosition     8B ← world position (single Vector2)     │
   │  MotionVelocity     8B ← dx, dy                             │


### PR DESCRIPTION
Closes #1574.

Four drift sites carried over from before #1202/#1204 (Fabian existential processing) and #1526 (architecture.md drift fix):

1. `architecture.md` L158-163 — canonical struct definition still showed `Shape current = Shape::Circle` and claimed 8 bytes. The current shape lives as a `Shape*Tag` row per #1202/#1204; the struct is now just `{ float morph_t }` = 4 bytes.

2. `architecture.md` L677 — component byte-count table claimed `PlayerShape          8     HOT`. Fixed 8 → 4.

3. `architecture.md` L1218 — § 7.1 'Critical Path' data-flow diagram still listed `VertState` as a current player row. `VerticalState` / `VMode` were eradicated per #1202/#1204 (see same file L242-244). Replaced with `Jump/Slide?` (the optional `Jumping`/`Sliding` rows).

4. `rhythm-spec.md` L174 — per-entity component summary table claimed `PlayerShape       8B  ← current shape + morph progress`. Fixed to `4B  ← morph animation progress`. The adjacent canonical struct at L299-314 was already correct.

## Verification

- `grep -nE 'VertState|Shape\s+current\s*=|PlayerShape\s+8\s+HOT|PlayerShape\s+8B' design-docs/` → no hits.
- `cmake --build build` → zero warnings.
- `./build/shapeshifter_tests` → 964 cases / 3369 assertions pass.

Docs-only change. No source code touched.

Refs #1087, #1526 (prior architecture.md / rhythm-spec.md drift fixes), #1202/#1204 (canonical PlayerShape / VMode eradication).