### PR TITLE
#1577 design-docs: fix ShapeWindow byte-count drift (24B/16B → 8B)

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -164,9 +164,11 @@ struct PlayerShape {
     float    morph_t = 1.0f;           // 0.0 = morph just started, 1.0 = settled
 };
 
-/// Rhythm-mode timing window state for the player. 16 bytes
-/// (1 bool + 3 floats; the former `target_shape` and `WindowPhase phase`
-/// fields are now per-tag rows — see migration notes below).
+/// Rhythm-mode timing window state for the player. 8 bytes (2 floats).
+/// The former `bool graded` and `float press_time` migrated to the
+/// `WindowGraded` tag and `Pressed` row table (issue #1533); the former
+/// `target_shape` and `WindowPhase phase` fields are now per-tag rows
+/// (issues #1202/#1204; see migration notes below).
 /// Hot: read/written by shape_window_system and input dispatcher callbacks;
 /// read by collision_system. Lives on the player entity alongside PlayerShape.
 ///
@@ -677,7 +679,7 @@ ParticleData        12     HOT        particle expiry/render fade
 ScorePopup          16     HOT        popup expiry/render fade
 PlayerTag            0     HOT        collision/filter
 PlayerShape          4     HOT        shape_window, collision, render, player_action
-ShapeWindow         24     HOT        shape_window, input dispatcher, collision
+ShapeWindow          8     HOT        shape_window, input dispatcher, collision
 Lane                 1     HOT        collision, render, player_action
 LaneTransition       8     HOT        present when mid-lane-shift; movement, collision, player_action
 Jumping              8     HOT        present when mid-jump; collision (y_offset), camera, movement

--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -172,7 +172,7 @@ constexpr int32_t CHAIN_MULT_BONUS_STEPS_CAP = 20; // caps at 2.0x from chain 21
   │  PER-ENTITY COMPONENTS                                       │
   ├──────────────────────────────────────────────────────────────┤
   │  PlayerShape       4B  ← morph animation progress           │
-  │  ShapeWindow      24B  ← rhythm window timing state         │
+  │  ShapeWindow       8B  ← rhythm window timing state         │
   │  WorldPosition     8B ← world position (single Vector2)     │
   │  MotionVelocity     8B ← dx, dy                             │
   │  ObstacleTag        0B ← marker                             │


### PR DESCRIPTION
Fixes #1577.

## Root cause

`ShapeWindow` (`app/components/player.h:61-64`) is currently:

```cpp
struct ShapeWindow {
    float       window_timer  = 0.0f;
    float       window_start  = 0.0f;
};
```

Two floats = **8 bytes**. The pre-#1533 / pre-#1202 / pre-#1204 struct had `bool graded + float press_time + 3 floats` (~16B/24B with padding). After those refactors:

- `bool graded` → `WindowGraded` zero-column tag (#1533)
- `float press_time` → `Pressed` row table (#1533)
- `target_shape` + `WindowPhase phase` → per-tag rows (#1202/#1204)

…three doc sites still reported the old size.

## Fixes

1. **`design-docs/architecture.md:167`** — `16 bytes (1 bool + 3 floats; ...)` → `8 bytes (2 floats)`. Parenthetical rewritten to cite all three migrations (#1533 for graded/press_time, #1202/#1204 for target_shape/WindowPhase) instead of only the latter.
2. **`design-docs/architecture.md:680`** (component byte-count table) — `ShapeWindow 24` → `ShapeWindow 8`; spacing widened by one to keep numeric column right-aligned with `PlayerShape 4` above.
3. **`design-docs/rhythm-spec.md:175`** (per-entity components box) — `ShapeWindow 24B` → `ShapeWindow 8B`; one space added between name and number so the `B` stays at the same column and the trailing `│` alignment is preserved.

## Acceptance

- [x] `grep -nE 'ShapeWindow\s+24|16 bytes' design-docs/architecture.md design-docs/rhythm-spec.md` returns no hits.
- [x] No source code touched; docs-only.
- [x] Build + tests unaffected (no rebuild needed).

Refs #1533, #1202, #1204. Spotted while fixing #1574.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
