### PR TITLE
#1579 design-docs: fix 9 stale byte-counts across architecture.md / rhythm-spec.md / beatmap-integration.md

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -676,7 +676,7 @@ COMPONENT          BYTES   ACCESS     ITERATED BY
 WorldPosition       8     HOT        motion, render, collision, despawn
 MotionVelocity       8     HOT        motion, particle effects
 ParticleData        12     HOT        particle expiry/render fade
-ScorePopup          16     HOT        popup expiry/render fade
+ScorePopup          12     HOT        popup expiry/render fade
 PlayerTag            0     HOT        collision/filter
 PlayerShape          4     HOT        shape_window, collision, render, player_action
 ShapeWindow          8     HOT        shape_window, input dispatcher, collision
@@ -685,7 +685,7 @@ LaneTransition       8     HOT        present when mid-lane-shift; movement, col
 Jumping              8     HOT        present when mid-jump; collision (y_offset), camera, movement
 Sliding              4     HOT        present when mid-slide; movement, render
 ObstacleTag          0     HOT        scroll, collision, cleanup
-Obstacle             4     WARM       collision, miss_detection, scoring
+Obstacle             2     WARM       collision, miss_detection, scoring
 RequiredShape*Tag    0     WARM       collision, scoring (one of 4 per obstacle; see tags.h)
 int8_t (lane)        1     WARM       collision (semantics selected by ShapeGateTag vs SplitPathTag)
 ShapeGateTag         0     WARM       collision (gate-archetype kind tag)
@@ -713,10 +713,10 @@ GameState            4     per-frame  game_state_system (phase_timer only; phase
 GamePhase*Tag        0     per-frame  active-phase mirror; one present at a time (see `app/tags/tags.h`)
 NextPhase*Tag        0     per-frame  pending-transition mirror; drained by `clear_next_phase_tags`
 BeatMap             var    session    setup_play_session (write), beat_scheduler (read)
-SongState           48     per-frame  song_playback/beat_scheduler
+SongState          160     per-frame  song_playback/beat_scheduler
 EnergyState         12     per-frame  energy_system (write), ui_render (read)
 PendingEnergyEffects var   per-frame  scoring_system (push), energy_system (drain)
-ScoreState          28     per-frame  scoring_system (write), render (read)
+ScoreState          12     per-frame  scoring_system (write), render (read)
 ScorePopupRequestQueue var per-frame  scoring_system (push), popup_feedback_system (drain)
 PlaySfxEvent        var    per-frame  dispatcher events drained by audio_system
 TestPlayerState     var    session    test_player_system (read/write), test_player_session (init), game_loop (reset)

--- a/design-docs/beatmap-integration.md
+++ b/design-docs/beatmap-integration.md
@@ -612,8 +612,8 @@ Ordered by dependency chain. Steps marked ✅ are already on `main`.
   │  Data                      │ Per-elem │ Max count │ Total bytes  │
   ├────────────────────────────┼──────────┼───────────┼──────────────┤
   │  BeatMap.beats vector      │    8B    │   256     │    2,048     │
-  │  SongState singleton       │   64B    │     1     │       64     │
-  │  SongResults singleton     │   32B    │     1     │       32     │
+  │  SongState singleton       │  160B    │     1     │      160     │
+  │  SongResults singleton     │   28B    │     1     │       28     │
   │  MusicContext singleton    │   ~40B   │     1     │       40     │
   │  BeatMap strings + fields  │  ~128B   │     1     │      128     │
   │  Live obstacles (entities) │  ~80B    │    ~10    │      800     │

--- a/design-docs/rhythm-spec.md
+++ b/design-docs/rhythm-spec.md
@@ -164,8 +164,8 @@ constexpr int32_t CHAIN_MULT_BONUS_STEPS_CAP = 20; // caps at 2.0x from chain 21
   │  SINGLETON CONTEXTS (reg.ctx())                              │
   ├──────────────────────────────────────────────────────────────┤
   │  BeatMap         varies ← authored level data               │
-  │  SongState         48B ← runtime playback position          │
-  │  SongResults       32B ← accumulated score / grade          │
+  │  SongState        160B ← runtime playback position          │
+  │  SongResults       28B ← accumulated score / grade          │
   └──────────────────────────────────────────────────────────────┘
 
   ┌──────────────────────────────────────────────────────────────┐
@@ -180,7 +180,7 @@ constexpr int32_t CHAIN_MULT_BONUS_STEPS_CAP = 20; // caps at 2.0x from chain 21
   │  RequiredShape*Tag  0B ← one of 4 per-shape tags            │
   │  int8_t lane        1B ← raw lane index (issue #1198)       │
   │  BeatInfo          12B ← beat_index, arrival_time, spawn    │
-  │  TimingGrade        5B ← scoring (existential)              │
+  │  TimingGrade        4B ← scoring (existential)              │
   │  ScoredTag          0B ← scored marker (prevents re-fire)   │
   └──────────────────────────────────────────────────────────────┘
 ```


### PR DESCRIPTION
Mechanical byte-count refresh, follow-up to #1574 / #1577. All 9 sites verified against actual structs in `app/components/`.

### architecture.md (Component Summary Table)
| Line | Component | Old | New | Source |
|---|---|---:|---:|---|
| 679 | `ScorePopup`  | 16 | 12  | `popup.h`: int32 + 2 floats |
| 688 | `Obstacle`    |  4 |  2  | `obstacle.h`: single `int16_t base_points` |
| 716 | `SongState`   | 48 | 160 | `song_state.h`: post-#1533/#1202/#1204 cursors |
| 719 | `ScoreState`  | 28 | 12  | `scoring.h`: 2 × int32 + 1 float (`displayed_score` / `high_score` migrated to `ScoreDisplay` / `CurrentSongHighScore` singletons) |

### rhythm-spec.md (Section 3 memory-layout box)
| Line | Component | Old | New | Source |
|---|---|---:|---:|---|
| 167 | `SongState`   | 48B | 160B | same as #3 above |
| 168 | `SongResults` | 32B | 28B  | `song_state.h`: 7 × int counters |
| 183 | `TimingGrade` | 5B  | 4B   | `rhythm.h`: single `float precision` (the "5B" was a typo — no combination of members sums to 5) |

### beatmap-integration.md (Section 8 memory budget table)
| Line | Cell | Old | New | Source |
|---|---|---:|---:|---|
| 615 | `SongState` singleton (Per-elem + Total) | 64B / 64  | 160B / 160 | same as #3 above |
| 616 | `SongResults` singleton (Per-elem + Total) | 32B / 32 | 28B / 28 | same as #6 above |

### Alignment
Box-drawing column alignment is preserved by adjusting whitespace between the name column and the number column on rows whose width changed (same approach as #1577). Diff stat: `+9 / −9`.

### TOTAL ADDED row
Unchanged. New sum: 2048 + 160 + 28 + 40 + 128 + 800 + 65536 + 8192 = **76,932 B ≈ 75 KB**, still inside the existing "~77 KB" bucket (old sum was 76,840 B, same bucket).

### Acceptance
- [x] All 9 listed numbers updated to actual sizes; column / box-drawing alignment preserved.
- [x] The issue's acceptance grep `grep -nE 'ScorePopup\\s+16|Obstacle\\s+4 +WARM|SongState\\s+(48|64)B|SongState\\s+48 |ScoreState\\s+28 |SongResults\\s+32B|TimingGrade\\s+5B'` returns no hits.
- [x] Broader grep across all `design-docs/` for the same patterns returns no hits.
- [x] No source code touched; docs-only.
- [x] Build + tests unaffected (no rebuild needed).

### Out of scope (per the issue body)
The three field-shape drift sites the issue flagged as out-of-scope (`architecture.md:391-397` `ScoreState` code block, `architecture.md:1057` `ScorePopup` `tier:` reference, `architecture.md:415-433` self-flagged legacy `SongState` block) are **not** touched. File a separate issue if anyone wants those cleaned up.

Refs #1574, #1577 (recent precedent), #1533, #1202, #1204, #1545 (root-cause refactors).

Closes #1579.