### PR TITLE
#1581 beat_map.cpp: inline single-call static helper parse_shape

### DIFF
--- a/app/entities/beat_map.cpp
+++ b/app/entities/beat_map.cpp
@@ -246,14 +246,6 @@ ValidationConstants load_validation_constants(const std::string& app_dir) {
     return vc;
 }
 
-static std::optional<Shape> parse_shape(const std::string& s) {
-    if (s == "circle")   return Shape::Circle;
-    if (s == "square")   return Shape::Square;
-    if (s == "triangle") return Shape::Triangle;
-    if (s == "hexagon")  return Shape::Hexagon;
-    return std::nullopt;
-}
-
 // ── Per-(kind, shape, timing-source) beat-entry sinks (#1202/#1204/#1533) ──
 // The former `BeatEntry::shape` discriminator is encoded by which per-shape
 // vector receives the entry; the former `BeatEntry::has_time_sec` optionality
@@ -520,14 +512,18 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
                 parse_ok = false;
                 continue;
             }
-            auto shape_opt = parse_shape(shape_str);
-            if (!shape_opt) {
+            bool shape_recognised = true;
+            if      (shape_str == "circle")   parsed_shape = Shape::Circle;
+            else if (shape_str == "square")   parsed_shape = Shape::Square;
+            else if (shape_str == "triangle") parsed_shape = Shape::Triangle;
+            else if (shape_str == "hexagon")  parsed_shape = Shape::Hexagon;
+            else                              shape_recognised = false;
+            if (!shape_recognised) {
                 errors.push_back({entry.beat_index,
                     "Unknown shape '" + shape_str + "' at beat " + std::to_string(entry.beat_index)});
                 parse_ok = false;
                 continue;
             }
-            parsed_shape = *shape_opt;
             has_parsed_shape = true;
         } else if (kind_string_requires_payload(kind_str)) {
             errors.push_back({entry.beat_index,


### PR DESCRIPTION
Continuation of the single-call static/anon-ns inline cleanup train
(#1559 / #1564 / #1566 / #1567 / #1568 / #1570 / #1571 / #1572).

The `parse_shape` static helper (lines 249-255) had exactly one caller
in this translation unit (`beat_map.cpp:523`). The only other mention
of the symbol is in `docs/audio-pipeline-spec.md:247`, which is
explicitly flagged at the top of the file as a "Historical
implementation log" snapshot and already references other long-
eradicated symbols (`entry.shape`, `entry.blocked_mask`, `out.beats`).

## Change

- Remove `static std::optional<Shape> parse_shape(const std::string&)`
  at the previous lines 249-255.
- Inline the four-string-compare ladder + error-fallthrough directly at
  the call site. Replace the `std::optional<Shape>` round-trip with a
  local `bool shape_recognised` flag that drives the same error message
  + `parse_ok = false; continue;` path.

## Behaviour

Bit-for-bit identical:

- Same four recognised strings (`"circle"`, `"square"`, `"triangle"`,
  `"hexagon"`).
- Same `parsed_shape` values on success.
- Same `has_parsed_shape = true` on success.
- Same error-message text and same `parse_ok / continue` control flow
  on failure (any other input string).

`<optional>` include stays — still used by
`max_derived_beat_for_metadata` (line 128), the local `max_beat` in
`apply_synthetic_onsets` (line 826), and the `step_merge` lambda's
return type (line 1016).

## Verification

- `rg "\bparse_shape\b" app/ tests/ benchmarks/` → zero hits.
- Native build: zero warnings.
- Tests: 964 cases / 3369 assertions pass.

Closes #1581.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
