### PR TITLE
#1583 test_player_system.cpp: inline single-call anon-ns helper shape_press_for

### DIFF
--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -59,19 +59,13 @@ inline constexpr ShapePressSpec kShapePressTriangle{&enqueue_press_triangle, "ke
 // Index-aligned with `shape_index(Shape)`. Hexagon's slot is `nullptr`
 // because Hexagon is never a required-shape value — `current_required_shape`
 // only returns Hexagon as the no-tag sentinel, which `determine_action`
-// gates out via `has_required_shape_tag` before calling `shape_press_for`.
+// gates out via `has_required_shape_tag` before indexing this table.
 inline constexpr std::array<const ShapePressSpec*, kShapeCount> kShapePressByIndex{
     &kShapePressCircle,
     &kShapePressSquare,
     &kShapePressTriangle,
     nullptr,
 };
-
-inline const ShapePressSpec* shape_press_for(Shape s) noexcept {
-    const int idx = shape_index(s);
-    if (idx < 0 || idx >= kShapeCount) return nullptr;
-    return kShapePressByIndex[static_cast<size_t>(idx)];
-}
 }  // namespace
 
 static bool test_player_shape_done(const TestPlayerAction& action) {
@@ -114,7 +108,10 @@ static TestPlayerAction determine_action(
 
     // Shape requirement
     if (has_required_shape_tag(reg, entity)) {
-        action.shape_press = shape_press_for(current_required_shape(reg, entity));
+        const int shape_idx = shape_index(current_required_shape(reg, entity));
+        action.shape_press = (shape_idx >= 0 && shape_idx < kShapeCount)
+            ? kShapePressByIndex[static_cast<size_t>(shape_idx)]
+            : nullptr;
 
         // ShapeGate: player must also be in the lane where the shape hole is.
         // The hole is at obs_pos.x — find which lane that corresponds to.


### PR DESCRIPTION
Continuation of the single-call anon-ns/static inline cleanup train
(#1551 / #1559 / #1564 / #1566 / #1567 / #1568 / #1570 / #1571 / #1572 / #1582).

The `shape_press_for` anon-ns helper at lines 70-74 had exactly one
caller in this translation unit (`determine_action:117`) and no
references anywhere else in `app/`, `tests/`, or `benchmarks/`.

## Change

- Remove `inline const ShapePressSpec* shape_press_for(Shape s) noexcept`
  at the previous lines 70-74.
- Update the `kShapePressByIndex` doc comment (lines 59-62) to refer
  to the inlined index lookup instead of the deleted helper name.
- Inline the bounds-checked index lookup directly at the call site in
  `determine_action`: a local `const int shape_idx` followed by the
  ternary `(shape_idx >= 0 && shape_idx < kShapeCount) ? kShapePressByIndex[static_cast<size_t>(shape_idx)] : nullptr`.

## Behaviour

Bit-for-bit identical:

- Same `shape_index(Shape)` call to produce the lookup index.
- Same out-of-range `[0, kShapeCount)` guard returning `nullptr`.
- Same in-range index into `kShapePressByIndex` (Hexagon's `nullptr`
  slot still propagates exactly as before — though `has_required_shape_tag`
  upstream still gates that path out, the defensive `nullptr` mapping
  is preserved as documented).

## Verification

- `grep -r "\bshape_press_for\b" app/ tests/ benchmarks/` → zero hits.
- Native build: zero warnings.
- Tests: 964 cases / 3369 assertions pass.

Closes #1583.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
