### PR TITLE
#1584 settings_system.cpp: inline single-call helper settings::clamp_ftue_run_count + drop public header decl

### DIFF
--- a/app/components/settings.h
+++ b/app/components/settings.h
@@ -7,9 +7,11 @@
 
 // Settings entity component data — read by gameplay/UI systems each frame.
 //
-// Field bounds enforced by settings::clamp_audio_offset / clamp_ftue_run_count
-// (see systems/settings_system.h). Values outside the constants below get
-// pulled back into range on load.
+// Field bounds enforced by settings::clamp_audio_offset (audio offset on load
+// and per user adjustment) and by settings::mark_ftue_complete (FTUE run
+// count, clamped inline when marking the FTUE complete). See
+// systems/settings_system.h. Values outside the constants below get pulled
+// back into range on load.
 struct SettingsState {
     static constexpr int16_t MIN_AUDIO_OFFSET_MS = -250;
     static constexpr int16_t MAX_AUDIO_OFFSET_MS = 250;

--- a/app/systems/settings_system.cpp
+++ b/app/systems/settings_system.cpp
@@ -259,18 +259,14 @@ void clamp_audio_offset(SettingsState& state) {
         SettingsState::MAX_AUDIO_OFFSET_MS);
 }
 
-void clamp_ftue_run_count(SettingsState& state) {
-    state.ftue_run_count = static_cast<uint8_t>(std::clamp(
-        static_cast<int>(state.ftue_run_count),
-        static_cast<int>(SettingsState::MIN_FTUE_RUN_COUNT),
-        static_cast<int>(SettingsState::MAX_FTUE_RUN_COUNT)));
-}
-
 void mark_ftue_complete(SettingsState& state) {
     if (state.ftue_run_count == 0) {
         state.ftue_run_count = 1;
     }
-    clamp_ftue_run_count(state);
+    state.ftue_run_count = static_cast<uint8_t>(std::clamp(
+        static_cast<int>(state.ftue_run_count),
+        static_cast<int>(SettingsState::MIN_FTUE_RUN_COUNT),
+        static_cast<int>(SettingsState::MAX_FTUE_RUN_COUNT)));
 }
 
 float audio_offset_seconds(const SettingsState& state) {

--- a/app/systems/settings_system.h
+++ b/app/systems/settings_system.h
@@ -33,7 +33,6 @@ persistence::Result get_settings_file_path(
 nlohmann::json settings_to_json(const SettingsState& state);
 bool settings_from_json(const nlohmann::json& obj, SettingsState& state);
 void clamp_audio_offset(SettingsState& state);
-void clamp_ftue_run_count(SettingsState& state);
 void mark_ftue_complete(SettingsState& state);
 float audio_offset_seconds(const SettingsState& state);
 bool ftue_complete(const SettingsState& state);


### PR DESCRIPTION
Continuation of the single-call anon-ns/static inline cleanup train
(#1551 / #1559 / #1564 / #1566 / #1567 / #1568 / #1570 / #1571 / #1572 / #1582 / #1583).

`settings::clamp_ftue_run_count` (`settings_system.cpp:262-267`,
declared in `settings_system.h:36`) had exactly one caller:
`settings::mark_ftue_complete` at `settings_system.cpp:273` in the
same TU. No external callers in `app/`, `tests/`, or `benchmarks/`.

## Change

- `app/systems/settings_system.cpp`: remove the `clamp_ftue_run_count`
  definition and inline its `static_cast<uint8_t>(std::clamp(...))`
  expression directly into `mark_ftue_complete`, where it was the
  single user.
- `app/systems/settings_system.h`: remove the
  `void clamp_ftue_run_count(SettingsState&);` declaration.
- `app/components/settings.h`: update the field-bounds doc comment
  (lines 8-12) to refer to `clamp_audio_offset` and to note that the
  `ftue_run_count` clamp lives inside `mark_ftue_complete`.

`clamp_audio_offset` immediately above is kept as-is: it has a real
external caller (`load_settings_from_path`).

## Behaviour

Bit-for-bit identical:

- `mark_ftue_complete` still bumps `ftue_run_count` from `0` to `1`
  when zero.
- It still clamps the final value to
  `[MIN_FTUE_RUN_COUNT, MAX_FTUE_RUN_COUNT]` using the exact same
  `int`-widening / `std::clamp` / `static_cast<uint8_t>` sequence.
- No other public `settings::` API has changed; only the now-empty
  one-call helper went away.

## Verification

- `grep -r "\bclamp_ftue_run_count\b" app/ tests/ benchmarks/` → zero hits.
- Native build: zero warnings.
- Tests: 964 cases / 3369 assertions pass.

Closes #1584.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
