### PR TITLE
#1588 design-docs/architecture.md: drop 4 stale 'gameplay_hud(_process_button_input)' refs (mirrors #1539)

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -700,9 +700,9 @@ DrawSize             8     COLD       render
 PopupDisplay        24     COLD       popup_display (fade), ui_render
 PopupTextMeasured   12     COLD       ui_render (per-entity text-width cache; presence + key-match IS valid)
 ParticleTag          0     COLD       render (filter)
-EnergyBarTag         0     COLD       energy_bar_system (filter), gameplay_hud (filter)
-EnergyBarLayout     24     COLD       energy_bar_system (read), gameplay_hud (read)
-EnergyBarVisual     24     COLD       energy_bar_system (write), gameplay_hud (read)
+EnergyBarTag         0     COLD       energy_bar_system (filter), ui_render_system (filter)
+EnergyBarLayout     24     COLD       energy_bar_system (read), ui_render_system (read)
+EnergyBarVisual     24     COLD       energy_bar_system (write), ui_render_system (read)
 ─────────────────────────────────────────────────────────────
 SINGLETONS (ctx)
 ─────────────────────────────────────────────────────────────
@@ -747,10 +747,9 @@ system in the same frame (unidirectional data flow).
  │  │                           Go*Event / ShapePress*Event /│
  │  │                           Menu*Event.                  │
  │  │                                                        │
- │  │  3. other producers       gameplay_hud_process_button_ │
- │  │                           input and test_player_system │
- │  │                           enqueue the same semantic    │
- │  │                           events.                      │
+ │  │  3. other producers       ui_update_system and         │
+ │  │                           test_player_system enqueue   │
+ │  │                           the same semantic events.    │
  │  └────────────────────────────────────────────────────────┘
  │
  │  ┌─ PHASE 2: GAME STATE GATE ────────────────────────────┐


### PR DESCRIPTION
Mirrors the #1539 README fix and the recent design-docs drift wave
(#1580 / #1578 / #1576 / #1573).

`gameplay_hud_process_button_input` and the bare-`gameplay_hud` system
name no longer exist in `app/`. They were eradicated by the
ui_update_system migration; #1539 already fixed the matching drift in
README.md, but architecture.md missed that pass.

## Changes

`design-docs/architecture.md` only — docs-only PR.

- **Lines 703-705 (component-traffic table)**: replace
  `gameplay_hud (filter)` / `gameplay_hud (read)` on EnergyBarTag /
  EnergyBarLayout / EnergyBarVisual with the actual current reader,
  `ui_render_system`. Verified by
  `grep -rn 'EnergyBarLayout\|EnergyBarVisual\|EnergyBarTag' app/systems/`:
    - `app/systems/energy_bar_system.cpp:50` → view over
      `EnergyBarTag, EnergyBarLayout, EnergyBarVisual`
    - `app/systems/ui_render_system.cpp:496-503` → reads
      `EnergyBarLayout` + `EnergyBarVisual` for the HUD bar
- **Lines 750-753 (PHASE 1 main-loop diagram)**: replace
  `gameplay_hud_process_button_input` with `ui_update_system` as the
  current button-input producer. Mirrors the #1539 rename. Box-art
  column widths preserved (68 chars per row).

## Verification

- `grep -n 'gameplay_hud' design-docs/architecture.md` → zero hits.
- Legitimate `app/util/gameplay_hud_ring.{h,cpp}` refs elsewhere in the
  docs are unaffected (the file still exists and is the correct pointer
  for approach-ring math).
- Docs-only change. Build state unchanged from baseline (964 cases,
  3369 assertions, zero warnings).

Closes #1588.
