### PR TITLE
#1589 design-docs/beatmap-integration.md: replace stale § 3.3 song_playback_system cpp code block with prose pointer

### DIFF
--- a/design-docs/beatmap-integration.md
+++ b/design-docs/beatmap-integration.md
@@ -256,40 +256,35 @@ creates the standard runtime obstacle archetypes via the kind-specific
 ## 3.3 song_playback_system — ✅ IMPLEMENTED
 
 ```
-  Uses GetMusicTimePlayed(music) as the authoritative clock when music is
-  loaded and started. Falls back to song_time += dt for silent/test mode.
-```
+  app/systems/song_playback_system.cpp — on main branch.
+  Authoritative clock: GetMusicTimePlayed(music) when the song is
+  loaded and started; falls back to song_time += dt for silent/test mode.
+  UpdateMusicStream(music) is pumped every frame (even while paused) to
+  prevent stream-buffer underruns.
 
-```cpp
-void song_playback_system(entt::registry& reg, float dt) {
-    if (!reg.ctx().contains<GamePhasePlayingTag>()) return;
+  Music lifecycle is driven by GamePhase*Tag presence on reg.ctx():
+    GamePhasePlayingTag       → PlayMusicStream / ResumeMusicStream
+    GamePhasePausedTag        → PauseMusicStream
+    GamePhaseGameOverTag    \
+    GamePhaseSongCompleteTag /→ StopMusicStream + clear started/paused
+  A restart_music handshake from setup_play_session is consumed on the
+  next tick: it stops + replays the stream so each new session starts
+  from t = 0 with a clean buffer.
 
-    auto* song  = reg.ctx().find<SongState>();
-    auto* music = reg.ctx().find<MusicContext>();
-    if (!song || !song->playing || song->finished) return;
+  Beat advancement (Playing phase only). The former `int current_beat = -1`
+  sentinel on SongState was migrated to the BeatCursor ctx-singleton row
+  table (Fabian Principle 3 / issue #1545) — the row is absent until the
+  first beat is crossed; while it exists, `last_crossed` is the highest
+  beat index that has been crossed and is always meaningful.
 
-    // Use audio position as authoritative clock when available
-    if (music && music->loaded && music->started) {
-        UpdateMusicStream(music->stream);
-        song->song_time = GetMusicTimePlayed(music->stream);
-    } else {
-        song->song_time += dt;  // fallback: silent mode
-    }
+  When a BeatMap is loaded, beat crossings advance through
+  `map->beat_times[]` (authored). Otherwise the BPM-derived fallback
+  is used (song_time − offset) / beat_period. Both paths apply the
+  user audio offset from `settings::audio_offset_seconds(*settings)` so
+  the crossing time matches the apparent audio position.
 
-    // Update current beat
-    if (song->beat_period > 0.0f) {
-        int beat = static_cast<int>((song->song_time - song->offset) / song->beat_period);
-        if (beat > song->current_beat && song->song_time >= song->offset) {
-            song->current_beat = beat;
-        }
-    }
-
-    // Detect song end
-    if (song->song_time >= song->duration_sec) {
-        song->finished = true;
-        song->playing  = false;
-    }
-}
+  Song end: when song_time ≥ duration_sec, sets finished + clears playing
+  and stops the music stream so the next session starts cleanly.
 ```
 
 ## 3.4 beat_scheduler_system — ✅ ALREADY IMPLEMENTED


### PR DESCRIPTION
Continues the recent design-docs drift wave
(#1580 / #1578 / #1576 / #1573).

The § 3.3 `cpp` code block in `beatmap-integration.md` predated #1545
(BeatCursor migration) and #1204 (Fabian relational normalization).
On HEAD `main`, `app/systems/song_playback_system.cpp` diverges from
the listed code in six concrete ways:

1. It uses `BeatCursor::last_crossed` from `reg.ctx()` instead of the
   eradicated `SongState::current_beat = -1` sentinel.
2. It handles music start / pause / resume / stop driven by
   `GamePhase{Playing,Paused,GameOver,SongComplete}Tag` presence
   on `reg.ctx()`.
3. It honours a `restart_music` handshake set by `setup_play_session`.
4. It applies `settings::audio_offset_seconds(*settings)` to both the
   `map->beat_times[]` and BPM-derived crossing comparisons.
5. It prefers the authored `map->beat_times[]` path when a BeatMap is
   loaded, falling back to the BPM-derived path otherwise.
6. It pumps `UpdateMusicStream` **unconditionally** every frame to
   prevent stream-buffer underruns during pause.

## Change

`design-docs/beatmap-integration.md` only — docs-only PR.

Replace the stale `cpp` listing in § 3.3 with a prose summary in the
same style as the sibling "✅ IMPLEMENTED" sections (3.2 beat_map,
3.4 beat_scheduler_system, 3.5 runtime source, 3.6 audio_system). The
prose:

- Names `app/systems/song_playback_system.cpp` as the authoritative
  source — same pattern as 3.2 / 3.4 / 3.5 / 3.6 (no inline code).
- Captures all six current behaviours listed above.
- Documents the `current_beat → BeatCursor` migration in past-tense
  "former" form (same convention as `rhythm-spec.md:265`
  and `app/components/song_state.h:33-37,84-97`).

## Verification

- `grep -n 'current_beat' design-docs/beatmap-integration.md` → 1 hit,
  past-tense historical-attribution.
- The other `song_playback_system` references in `design-docs/`
  (`rhythm-spec.md:270-275,374,451,793`, `energy-bar.md:167`,
  `tester-personas-tech-spec.md:114`) were verified as function-name
  references in correct contexts; they are not in scope.
- Docs-only change. Build state unchanged from baseline (964 cases,
  3369 assertions, zero warnings).

Closes #1589.
