### PR TITLE
#1592 beat_map.cpp: inline single-call helper kind_string_is_supported

### DIFF
--- a/app/entities/beat_map.cpp
+++ b/app/entities/beat_map.cpp
@@ -310,12 +310,6 @@ bool kind_string_requires_payload(std::string_view kind_str) {
     return kind_str == "shape_gate" || kind_str == "split_path";
 }
 
-bool kind_string_is_supported(std::string_view kind_str) {
-    return kind_str == "shape_gate" ||
-           kind_str == "split_path" ||
-           kind_str == "onset_marker";
-}
-
 bool parse_beat_map(const std::string& json_str, BeatMap& out,
                     std::vector<BeatMapError>& errors,
                     const std::string& difficulty) {
@@ -499,7 +493,9 @@ bool parse_beat_map(const std::string& json_str, BeatMap& out,
             parse_ok = false;
             continue;
         }
-        if (!kind_string_is_supported(kind_str)) {
+        if (kind_str != "shape_gate" &&
+            kind_str != "split_path" &&
+            kind_str != "onset_marker") {
             errors.push_back({entry.beat_index,
                 "Unknown obstacle kind '" + kind_str + "' at beat " + std::to_string(entry.beat_index)});
             parse_ok = false;


### PR DESCRIPTION
Closes #1592.

Continuation of the single-call static/anon-ns inline cleanup train
(#1559 / #1564 / #1566 / #1567 / #1568 / #1570 / #1571 / #1572 / #1582 / #1586 / #1587).

The `kind_string_is_supported` file-scope helper (previously lines 313-317) had exactly one caller in this translation unit (`beat_map.cpp:502`) and is not declared in `beat_map.h`. Inlining mirrors #1581/#1582, which similarly inlined `parse_shape` in the same `parse_beat_map` body.

## Change

- Remove `bool kind_string_is_supported(std::string_view)` at the previous lines 313-317.
- Inline the three-string `==` ladder directly at the call site as a negated `kind_str != "shape_gate" && kind_str != "split_path" && kind_str != "onset_marker"` form, preserving the same error message + `parse_ok = false; continue;` control flow.

## Behaviour

Bit-for-bit identical:

- Same three recognised kind strings (`shape_gate`, `split_path`, `onset_marker`).
- Same error text on failure (`Unknown obstacle kind <kind> at beat <n>`).
- Same `parse_ok = false; continue;` failure path.

## Verification

- `rg -n kind_string_is_supported app/ tests/` is empty.
- `cmake --build build` is clean (zero warnings, `-Wall -Wextra -Werror`).
- `./build/shapeshifter_tests` reports `All tests passed (3369 assertions in 964 test cases)`.