### PR TITLE
#1594 high_score_system.cpp: inline single-call helper set_score_by_hash

### DIFF
--- a/app/systems/high_score_system.cpp
+++ b/app/systems/high_score_system.cpp
@@ -109,17 +109,6 @@ bool set_score(entt::registry& reg, const char* key, int32_t score) {
     return false;
 }
 
-bool set_score_by_hash(entt::registry& reg, entt::hashed_string::hash_type hash, int32_t score) {
-    const auto entity = find_entry_by_hash(reg, hash);
-    if (entity == entt::null) {
-        TraceLog(LOG_WARNING, "High score entry hash %u not found; score update skipped",
-                 static_cast<unsigned int>(hash));
-        return false;
-    }
-    reg.get<HighScoreEntry>(entity).score = score;
-    return true;
-}
-
 bool ensure_entry(entt::registry& reg, const char* key) {
     if (find_entry_by_key(reg, key) != entt::null) return true;
     if (entry_count(reg) < HighScoreState::MAX_ENTRIES) {
@@ -282,7 +271,13 @@ bool update_if_higher(entt::registry& reg, const HighScoreSession& session, int3
     if (new_score < 0) new_score = 0;
     int32_t stored = get_score_by_hash(reg, session.key_hash);
     if (new_score > stored) {
-        return set_score_by_hash(reg, session.key_hash, new_score);
+        const auto entity = find_entry_by_hash(reg, session.key_hash);
+        if (entity == entt::null) {
+            TraceLog(LOG_WARNING, "High score entry hash %u not found; score update skipped",
+                     static_cast<unsigned int>(session.key_hash));
+            return false;
+        }
+        reg.get<HighScoreEntry>(entity).score = new_score;
     }
     return true;
 }

--- a/app/systems/high_score_system.h
+++ b/app/systems/high_score_system.h
@@ -42,9 +42,6 @@ int32_t get_score_by_hash(const entt::registry& reg, entt::hashed_string::hash_t
 // Insert or update entry by string key. Returns false if the table is full.
 bool set_score(entt::registry& reg, const char* key, int32_t score);
 
-// Update an existing entry's score by hash. Returns false if hash is not found.
-bool set_score_by_hash(entt::registry& reg, entt::hashed_string::hash_type hash, int32_t score);
-
 // Ensure an entry exists for key with score 0 if not already present.
 // Returns false if the table is full.
 bool ensure_entry(entt::registry& reg, const char* key);


### PR DESCRIPTION
Resolves #1594.

Inlines the namespace-scoped helper `set_score_by_hash` (formerly lines 112-121 in `high_score_system.cpp`) into its sole caller `update_if_higher` and drops the public header declaration. Mirrors #1587.

### What

- `app/systems/high_score_system.h`: remove decl of `set_score_by_hash`.
- `app/systems/high_score_system.cpp`: drop helper definition; fold the find-then-log-or-write body into `update_if_higher` between the existing `new_score > stored` check and the trailing `return true`.

### Behaviour

Bit-for-bit identical:
- Same `TraceLog(LOG_WARNING, ...)` text on hash miss.
- Same `return false` on hash miss when `new_score > stored`.
- Same write to `HighScoreEntry::score` on the hit path.
- Same `return true` for the no-improvement path (`new_score <= stored`).

### Verification

- `rg -n set_score_by_hash app/ tests/` → no matches.
- `cmake --build build` succeeds with zero warnings.
- `./build/shapeshifter_tests` → `All tests passed (3369 assertions in 964 test cases)`.