### PR TITLE
#1595 obstacle_render_entity.cpp: inline single-call helper destroy_obstacle_mesh_children

### DIFF
--- a/app/entities/obstacle_render_entity.cpp
+++ b/app/entities/obstacle_render_entity.cpp
@@ -132,7 +132,8 @@ void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical) {
 }
 
 
-void destroy_obstacle_mesh_children(entt::registry& reg, entt::entity parent) {
+void destroy_obstacle_with_children(entt::registry& reg, entt::entity parent) {
+    if (!reg.valid(parent)) return;
     // Collect first then destroy: removing entities mid-iteration would
     // invalidate the MeshChild view's packed-storage iterator.
     entt::entity to_destroy[ObstacleChildren::MAX];
@@ -145,10 +146,5 @@ void destroy_obstacle_mesh_children(entt::registry& reg, entt::entity parent) {
     for (int i = 0; i < destroy_count; ++i) {
         if (reg.valid(to_destroy[i])) reg.destroy(to_destroy[i]);
     }
-}
-
-void destroy_obstacle_with_children(entt::registry& reg, entt::entity parent) {
-    if (!reg.valid(parent)) return;
-    destroy_obstacle_mesh_children(reg, parent);
     reg.destroy(parent);
 }

--- a/app/entities/obstacle_render_entity.h
+++ b/app/entities/obstacle_render_entity.h
@@ -9,5 +9,4 @@ void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical);
 
 
 // Explicit obstacle lifetime helpers. Do not call from EnTT destroy listeners.
-void destroy_obstacle_mesh_children(entt::registry& reg, entt::entity parent);
 void destroy_obstacle_with_children(entt::registry& reg, entt::entity parent);


### PR DESCRIPTION
Resolves #1595.

Inlines the namespace-scoped helper `destroy_obstacle_mesh_children` (formerly lines 135-148 in `obstacle_render_entity.cpp`) into its sole caller `destroy_obstacle_with_children` and drops the public header declaration. Mirrors #1567 (same file's prior `count_mesh_children_of` inlining) and #1587 (helper-body + header-decl removal pattern).

### What

- `app/entities/obstacle_render_entity.h`: remove decl of `destroy_obstacle_mesh_children`.
- `app/entities/obstacle_render_entity.cpp`: drop helper definition; fold its body (collect-then-destroy walk over the `MeshChild` view filtered by parent) into `destroy_obstacle_with_children` between the `reg.valid(parent)` early-out and the final `reg.destroy(parent)`.
- The explanatory comment "Collect first then destroy: removing entities mid-iteration would invalidate the MeshChild view's packed-storage iterator." is preserved at the inlined site — it documents a non-obvious EnTT invariant.

### Behaviour

Bit-for-bit identical:
- Same `ObstacleChildren::MAX` upper bound on collected children.
- Same `reg.valid(...)` guard before each `destroy`.
- Same destruction order (view iteration order).
- Same parent `reg.destroy(parent)` at the tail.

### Verification

- `rg -n destroy_obstacle_mesh_children app/ tests/` → no matches.
- `cmake --build build` succeeds with zero warnings.
- `./build/shapeshifter_tests` → `All tests passed (3369 assertions in 964 test cases)`.