### PR TITLE
#1598 design-docs/tester-personas-tech-spec.md: drop phantom TestPlayerConfig row + fix session_logger path/name drift

### DIFF
--- a/design-docs/tester-personas-tech-spec.md
+++ b/design-docs/tester-personas-tech-spec.md
@@ -53,8 +53,12 @@
   ├──────────────────────┼──────┼────────────┼────────────────────────┤
   │ TestPlayerState      │~2.6KB│ 1 singleton│ COLD: once per frame   │
   │ SessionLog           │ 16B  │ 1 singleton│ COLD: on events only   │
-  │ TestPlayerConfig     │ 20B  │ 1 singleton│ COLD: read-only        │
   └──────────────────────┴──────┴────────────┴────────────────────────┘
+
+  Skill config is not a separate singleton: `SkillConfig` is a value
+  type embedded in `TestPlayerState.skill` (see § 3) and surfaced as
+  the compile-time named constants `SKILL_PRO` / `SKILL_GOOD` /
+  `SKILL_BAD` in `app/systems/test_player.h`.
 
   Max ~10 obstacles on screen at 120 BPM, 4 lead beats.
   All obstacle data fits in < 1 cache line per entity.
@@ -642,8 +646,8 @@ inside `tick_playing_systems`.
       │                           Platform-portable: enqueues events
       │                           directly on the EnTT dispatcher
       all_systems.h            ← System declarations
-    session_logger.h           ← SessionLog struct, session_log_write() and friends
-    session_logger.cpp         ← File I/O, EnTT signal handlers, formatting
+      session_logger_system.h  ← SessionLog struct, session_log_write() and friends
+      session_logger_system.cpp ← File I/O, EnTT signal handlers, formatting
     main.cpp                   ← CLI arg parsing, setup, system insertion
 ```
 


### PR DESCRIPTION
Fixes #1598.

## What

Two stale references in `design-docs/tester-personas-tech-spec.md`:

1. **DATA INVENTORY (line 56)** — dropped the phantom `TestPlayerConfig` row. No such symbol exists anywhere in `app/`. The real per-skill config is `SkillConfig` (`app/systems/test_player.h:22-28`), a value type embedded in `TestPlayerState.skill` and exposed as three `inline constexpr` named constants `SKILL_PRO` / `SKILL_GOOD` / `SKILL_BAD` — not a runtime singleton. Added a short clarifying note below the table so the row doesn't get re-added.

2. **FILE LAYOUT (lines 645-646)** — renamed `session_logger.h` / `.cpp` (listed directly under `app/`) to the real path `app/systems/session_logger_system.h` / `.cpp`, consistent with the `CMakeLists.txt` snippet two lines below (line 655) which already pointed at the correct path. Prior closed issue #1147 fixed an earlier `app/session_logger` drift; the file has since moved again per the systems-in-costume cleanup in #1197.

## Verification

```
$ grep -n 'TestPlayerConfig' design-docs/tester-personas-tech-spec.md
(no matches)

$ grep -n 'app/session_logger' design-docs/tester-personas-tech-spec.md
(no matches)
```

## Acceptance criteria

- [x] `grep -n 'TestPlayerConfig' design-docs/tester-personas-tech-spec.md` returns no matches.
- [x] `grep -n 'app/session_logger' design-docs/tester-personas-tech-spec.md` returns no matches.
- [x] DATA INVENTORY table renders cleanly (no broken borders).
- [x] FILE LAYOUT block renders cleanly (no broken borders).
- [x] No code changes; docs-only fix.
