### PR TITLE
#1600 collision_system.cpp: inline single-call anon-ns helper player_matches_required_shape

### DIFF
--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -42,27 +42,6 @@ bool shape_row_match(entt::registry& reg,
     return window_open && reg.all_of<TargetTag>(player_entity);
 }
 
-bool player_matches_required_shape(entt::registry& reg,
-                                    entt::entity player_entity,
-                                    entt::entity obstacle_entity,
-                                    bool rhythm_mode) {
-    if (reg.all_of<RequiredShapeHexagonTag>(obstacle_entity)) {
-        // No Hexagon-required obstacles are spawned in production; preserve
-        // the legacy "Hexagon-required → unclearable" contract by short-
-        // circuiting here regardless of player state.
-        return false;
-    }
-
-    // Per-shape match check: each row of the shape table is its own
-    // per-shape table-join (issue #1202/#1204), so we probe the three
-    // playable rows by tag-presence. No `switch`, no `if (x == Shape::Bar)`
-    // — each `shape_row_match` instantiation IS the per-row transform.
-    if (shape_row_match<RequiredShapeCircleTag,   ShapeCircleTag,   TargetShapeCircleTag>  (reg, player_entity, obstacle_entity, rhythm_mode)) return true;
-    if (shape_row_match<RequiredShapeSquareTag,   ShapeSquareTag,   TargetShapeSquareTag>  (reg, player_entity, obstacle_entity, rhythm_mode)) return true;
-    if (shape_row_match<RequiredShapeTriangleTag, ShapeTriangleTag, TargetShapeTriangleTag>(reg, player_entity, obstacle_entity, rhythm_mode)) return true;
-    return false;
-}
-
 bool shape_gate_lane_match(int8_t obstacle_lane, int player_lane) {
     return static_cast<int>(obstacle_lane) == player_lane;
 }
@@ -147,8 +126,17 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
             return;
         }
 
+        // Per-shape match: each row of the shape table is its own per-shape
+        // table-join (issue #1202/#1204). The Hexagon row is required but
+        // never spawned in production — preserved as an "unclearable" short-
+        // circuit. The other three rows are probed by tag-presence; no
+        // `switch`, no `if (x == Shape::Bar)` — each `shape_row_match`
+        // instantiation IS the per-row transform.
         const bool shape_ok =
-            player_matches_required_shape(reg, player_entity, entity, rhythm_mode);
+            !reg.all_of<RequiredShapeHexagonTag>(entity)
+            && (shape_row_match<RequiredShapeCircleTag,   ShapeCircleTag,   TargetShapeCircleTag>  (reg, player_entity, entity, rhythm_mode)
+             || shape_row_match<RequiredShapeSquareTag,   ShapeSquareTag,   TargetShapeSquareTag>  (reg, player_entity, entity, rhythm_mode)
+             || shape_row_match<RequiredShapeTriangleTag, ShapeTriangleTag, TargetShapeTriangleTag>(reg, player_entity, entity, rhythm_mode));
         if (shape_ok && timing_info && can_grade_shape) {
             grade_shape_timing(entity, timing_info->arrival_time);
         }
@@ -158,8 +146,9 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
     // Per-kind structural views — each loop touches only entities that actually
     // carry the required components, eliminating per-entity try_get branches.
     // The required-shape data lives as a per-shape tag (issue #1202/#1204),
-    // so the views below filter on `ShapeGateTag` / `SplitPathTag` and the
-    // resolver dispatches per-shape via `player_matches_required_shape`.
+    // so the views below filter on `ShapeGateTag` / `SplitPathTag` and
+    // `resolve_shape_obstacle` dispatches per-shape inline via the three
+    // `shape_row_match` template instantiations.
 
     // ShapeGate: ShapeGateTag (carries RequiredShape*Tag + raw int8_t lane).
     // The raw int8_t component is the ShapeGate positional lane per the slot


### PR DESCRIPTION
Resolves #1600.

Inlines the anonymous-namespace helper `player_matches_required_shape` (formerly lines 45-64 in `collision_system.cpp`) into the `resolve_shape_obstacle` lambda's `shape_ok` expression. Mirrors #1586 (`#1583 test_player_system.cpp: inline single-call anon-ns helper shape_press_for`) and #1593 (`#1592 beat_map.cpp: inline single-call helper kind_string_is_supported`).

### What

- `app/systems/collision_system.cpp`: drop the 20-line helper at lines 45-64; fold its body into `resolve_shape_obstacle`'s `shape_ok` expression as `!RequiredShapeHexagonTag && (shape_row_match<Circle> || <Square> || <Triangle>)`.
- The "per-shape table-join (issue #1202/#1204)" comment and the Hexagon "never-spawned → unclearable short-circuit" contract are preserved as one block above the inlined `shape_ok` expression — both document the Fabian existential-processing dispatch pattern and the legacy contract respectively.
- The top-of-`collision_system` comment is updated to point readers at the inline dispatch in `resolve_shape_obstacle` instead of the removed helper.

No public header declaration to drop — the helper was anon-namespace internal.

### Behaviour

Bit-for-bit identical:
- `shape_row_match<...>` is pure (read-only `reg.all_of` / `reg.any_of` probes, no mutation), so the `||` short-circuit chain evaluates exactly the same predicates in the same order as the original `if (...) return true;` ladder.
- `!reg.all_of<RequiredShapeHexagonTag>(entity) && (...)` preserves the early-return semantics of the original `if (...) return false;` guard.

### Verification

- `rg -n 'player_matches_required_shape' app/ tests/` → no matches.
- `cmake --build build` succeeds with zero warnings.
- `./build/shapeshifter_tests` → `All tests passed (3369 assertions in 964 test cases)`.
