### PR TITLE
#1602 input_system.cpp: inline single-call anon-ns helper find_touch_slot

### DIFF
--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -88,15 +88,6 @@ GoEnqueueFn raylib_gesture_swipe_direction() {
     return classify_swipe(drag.x, drag.y, GetGestureHoldDuration());
 }
 
-int find_touch_slot(InputState& input, int touch_id) {
-    for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
-        if (input.touch_slots[i].active && input.touch_slots[i].id == touch_id) {
-            return i;
-        }
-    }
-    return -1;
-}
-
 bool touch_id_is_current(int touch_id, int touch_point_count) {
     for (int touch_index = 0; touch_index < touch_point_count; ++touch_index) {
         if (GetTouchPointId(touch_index) == touch_id) {
@@ -293,7 +284,13 @@ void input_system(entt::registry& reg, float raw_dt) {
             const int touch_id = GetTouchPointId(touch_index);
             const Vector2 touch_pos = GetTouchPosition(touch_index);
             const Vector2 tp = screen_to_virtual({touch_pos.x, touch_pos.y}, st);
-            int slot_index = find_touch_slot(input, touch_id);
+            int slot_index = -1;
+            for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
+                if (input.touch_slots[i].active && input.touch_slots[i].id == touch_id) {
+                    slot_index = i;
+                    break;
+                }
+            }
             if (slot_index < 0) {
                 const bool button_zone = tp.y >= zone_y;
                 if (has_active_touch_in_zone(input, button_zone)) {


### PR DESCRIPTION
Closes #1602.

## What

Removes the single-call anonymous-namespace helper `find_touch_slot` from `app/systems/input_system.cpp` and inlines its body at the lone call site inside `input_system`.

## Diff shape

```diff
-int find_touch_slot(InputState& input, int touch_id) {
-    for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
-        if (input.touch_slots[i].active && input.touch_slots[i].id == touch_id) {
-            return i;
-        }
-    }
-    return -1;
-}

-            int slot_index = find_touch_slot(input, touch_id);
+            int slot_index = -1;
+            for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
+                if (input.touch_slots[i].active && input.touch_slots[i].id == touch_id) {
+                    slot_index = i;
+                    break;
+                }
+            }
```

Mirrors #1559 — same file, same shape, same transform applied to the sibling `find_free_touch_slot` a few lines below. Continuation of the single-call anon-ns/static inline cleanup train (#1551 / #1559 / #1564 / #1566 / #1567 / #1568 / #1570 / #1571 / #1572 / #1582 / #1583 / #1584 / #1592 / #1594 / #1595 / #1600).

## Behaviour

Bit-for-bit identical:

- `int slot_index = -1` initialiser preserves the original "no-match returns -1" contract.
- Loop iterates `[0, InputState::MaxTrackedTouches)` and matches on `active && id == touch_id`, exactly as the helper did.
- Downstream `if (slot_index < 0) { ... }` (allocate fresh slot) and `if (slot_index < 0) { continue; }` (skip if still no slot) branches see the same value they used to.

## Verification

- `rg -n '\bfind_touch_slot\b' app/ tests/ benchmarks/` → 0 matches after.
- Native build (`cmake --build build`): clean, zero warnings.
- Native tests (`ctest --test-dir build`): 977/977 pass (`startup_shutdown_smoke` skipped, as on `main`).
