### PR TITLE
#1604 input_system.cpp: inline single-call anon-ns helper touch_id_is_current

### DIFF
--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -88,15 +88,6 @@ GoEnqueueFn raylib_gesture_swipe_direction() {
     return classify_swipe(drag.x, drag.y, GetGestureHoldDuration());
 }
 
-bool touch_id_is_current(int touch_id, int touch_point_count) {
-    for (int touch_index = 0; touch_index < touch_point_count; ++touch_index) {
-        if (GetTouchPointId(touch_index) == touch_id) {
-            return true;
-        }
-    }
-    return false;
-}
-
 bool has_active_touch_in_zone(const InputState& input, bool button_zone) {
     for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
         const auto& slot = input.touch_slots[i];
@@ -271,7 +262,17 @@ void input_system(entt::registry& reg, float raw_dt) {
 
         for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
             auto& slot = input.touch_slots[i];
-            if (slot.active && !touch_id_is_current(slot.id, touch_point_count)) {
+            if (!slot.active) {
+                continue;
+            }
+            bool current = false;
+            for (int touch_index = 0; touch_index < touch_point_count; ++touch_index) {
+                if (GetTouchPointId(touch_index) == slot.id) {
+                    current = true;
+                    break;
+                }
+            }
+            if (!current) {
                 release_touch_slot(slot,
                                    input,
                                    latest_swipe,


### PR DESCRIPTION
Closes #1604.

## What

Removes the single-call anonymous-namespace helper `touch_id_is_current` from `app/systems/input_system.cpp` and inlines its body at the lone call site inside `input_system`'s per-slot stale-touch cleanup loop.

## Diff shape

```diff
-bool touch_id_is_current(int touch_id, int touch_point_count) {
-    for (int touch_index = 0; touch_index < touch_point_count; ++touch_index) {
-        if (GetTouchPointId(touch_index) == touch_id) {
-            return true;
-        }
-    }
-    return false;
-}

         for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
             auto& slot = input.touch_slots[i];
-            if (slot.active && !touch_id_is_current(slot.id, touch_point_count)) {
+            if (!slot.active) {
+                continue;
+            }
+            bool current = false;
+            for (int touch_index = 0; touch_index < touch_point_count; ++touch_index) {
+                if (GetTouchPointId(touch_index) == slot.id) {
+                    current = true;
+                    break;
+                }
+            }
+            if (!current) {
                 release_touch_slot(slot, input, latest_swipe, had_swipe_zone_release);
             }
         }
```

Mirrors #1602 / #1559 — same file, same bounded-`for`-or-`return false` shape, same caller-local-init + break-on-match transform applied to the sibling helpers `find_touch_slot` and `find_free_touch_slot`. Continuation of the single-call anon-ns/static inline cleanup train (#1551 / #1559 / #1564 / #1566 / #1567 / #1568 / #1570 / #1571 / #1572 / #1582 / #1583 / #1584 / #1592 / #1594 / #1595 / #1600 / #1602).

## Behaviour

Bit-for-bit identical:

- The original guard was `slot.active && !touch_id_is_current(slot.id, touch_point_count)`. Inlining splits this into an early-`continue` on `!slot.active` followed by the membership scan and a `!current` guard. Short-circuit semantics are preserved: the membership scan only runs when `slot.active` is true, exactly as before.
- The scan iterates `[0, touch_point_count)` and matches `GetTouchPointId(touch_index) == slot.id`, identical to the helper's loop.
- `release_touch_slot(slot, input, latest_swipe, had_swipe_zone_release)` fires in exactly the same set of cases it used to.

## Verification

- `rg -n '\btouch_id_is_current\b' app/ tests/ benchmarks/` → 0 matches after.
- Native build (`cmake --build build`): clean, zero warnings.
- Native tests (`ctest --test-dir build`): 977/977 pass (`startup_shutdown_smoke` skipped, as on `main`).
