### PR TITLE
#1605 input_system.cpp: inline single-call anon-ns helper has_active_touch_in_zone

### DIFF
--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -88,16 +88,6 @@ GoEnqueueFn raylib_gesture_swipe_direction() {
     return classify_swipe(drag.x, drag.y, GetGestureHoldDuration());
 }
 
-bool has_active_touch_in_zone(const InputState& input, bool button_zone) {
-    for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
-        const auto& slot = input.touch_slots[i];
-        if (slot.active && slot.started_in_button_zone == button_zone) {
-            return true;
-        }
-    }
-    return false;
-}
-
 void release_touch_slot(TouchSlot& slot,
                         InputState& input,
                         GoEnqueueFn& latest_swipe,
@@ -294,7 +284,15 @@ void input_system(entt::registry& reg, float raw_dt) {
             }
             if (slot_index < 0) {
                 const bool button_zone = tp.y >= zone_y;
-                if (has_active_touch_in_zone(input, button_zone)) {
+                bool zone_taken = false;
+                for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
+                    const auto& slot = input.touch_slots[i];
+                    if (slot.active && slot.started_in_button_zone == button_zone) {
+                        zone_taken = true;
+                        break;
+                    }
+                }
+                if (zone_taken) {
                     continue;
                 }
                 for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {


### PR DESCRIPTION
Closes #1605.

## Change

Removes the file-local `has_active_touch_in_zone(InputState&, bool)` helper in `app/systems/input_system.cpp`. It had exactly one call site (in `input_system`'s new-touch slot-allocation gate) and no header declaration. Inlined the bounded `for`-over-`InputState::MaxTrackedTouches` scan with a local `zone_taken` flag.

## Behaviour

Bit-for-bit identical: a new touch is still skipped via `continue` when a different slot already owns a touch that started in the same `button_zone`. Same iteration order, same early-out on first match.

## Verification

- `rg "\bhas_active_touch_in_zone\b" app/ tests/ benchmarks/` → 0 hits.
- `cmake --build build` clean, zero warnings.
- `ctest --test-dir build --output-on-failure` → 977/977 (1 skipped `startup_shutdown_smoke` requires a display, same as on `main`).

## Context

Continuation of the single-call anon-ns / static helper cleanup train (#1551 / #1559 / #1564 / #1566 / #1567 / #1568 / #1570 / #1571 / #1572 / #1582 / #1583 / #1584 / #1592 / #1594 / #1595 / #1600 / #1602 / #1604). Direct precedent: #1603 (`find_touch_slot`) and #1607 (`touch_id_is_current`) in the same file.