### PR TITLE
#1606 play_session.cpp: inline single-call anon-ns helper load_runtime_beat_map

### DIFF
--- a/app/systems/play_session.cpp
+++ b/app/systems/play_session.cpp
@@ -28,44 +28,6 @@
 
 namespace {
 
-bool load_runtime_beat_map(const char* path,
-                           BeatMap& out,
-                           std::vector<BeatMapError>& errors,
-                           const std::string& difficulty_key) {
-    BeatMap candidate;
-    if (!load_beat_map(path, candidate, errors, difficulty_key)) {
-        return false;
-    }
-
-    std::vector<BeatMapError> validation_errors;
-    if (validate_beat_map(candidate, validation_errors)) {
-        out = std::move(candidate);
-        return true;
-    }
-
-    // Runtime tolerates the "Different-shape gates must be >= 3 beats apart"
-    // validation error and treats it as a warning; any other validation error
-    // fails the load.
-    bool only_allowed_errors = !validation_errors.empty();
-    for (const BeatMapError& error : validation_errors) {
-        if (error.message != "Different-shape gates must be >= 3 beats apart") {
-            only_allowed_errors = false;
-        }
-        errors.push_back(error);
-    }
-
-    if (!only_allowed_errors) {
-        return false;
-    }
-
-    for (const BeatMapError& error : validation_errors) {
-        TraceLog(LOG_WARNING, "Beatmap validation warning at beat %d: %s",
-                 error.beat_index, error.message.c_str());
-    }
-    out = std::move(candidate);
-    return true;
-}
-
 template <typename T>
 T& assign_or_emplace_ctx(entt::registry& reg, T value = T{}) {
     if (auto* existing = reg.ctx().find<T>()) {
@@ -159,7 +121,35 @@ void setup_play_session(entt::registry& reg) {
     bool loaded = false;
     for (const char* path : paths) {
         load_errors.clear();
-        if (load_runtime_beat_map(path, beatmap, load_errors, difficulty_key)) {
+        bool loaded_this_path = false;
+        BeatMap candidate;
+        if (load_beat_map(path, candidate, load_errors, difficulty_key)) {
+            std::vector<BeatMapError> validation_errors;
+            if (validate_beat_map(candidate, validation_errors)) {
+                beatmap = std::move(candidate);
+                loaded_this_path = true;
+            } else {
+                // Runtime tolerates the "Different-shape gates must be >= 3
+                // beats apart" validation error and treats it as a warning;
+                // any other validation error fails the load.
+                bool only_allowed_errors = !validation_errors.empty();
+                for (const BeatMapError& error : validation_errors) {
+                    if (error.message != "Different-shape gates must be >= 3 beats apart") {
+                        only_allowed_errors = false;
+                    }
+                    load_errors.push_back(error);
+                }
+                if (only_allowed_errors) {
+                    for (const BeatMapError& error : validation_errors) {
+                        TraceLog(LOG_WARNING, "Beatmap validation warning at beat %d: %s",
+                                 error.beat_index, error.message.c_str());
+                    }
+                    beatmap = std::move(candidate);
+                    loaded_this_path = true;
+                }
+            }
+        }
+        if (loaded_this_path) {
             const size_t total_beats = beat_map_total_count(beatmap);
             TraceLog(LOG_INFO, "Loaded beatmap: %s (%zu beats, difficulty=%s)",
                      path, total_beats, beatmap.difficulty.c_str());


### PR DESCRIPTION
Closes #1606.

## Change

Removes the file-local `load_runtime_beat_map` helper in `app/systems/play_session.cpp` (the anon-namespace function spanning the former lines 31-67). It had exactly one call site inside the path-fallback `for` loop in `setup_play_session`, and no public header declaration.

The load / validate / warning-classification logic is now inlined at the call site behind a per-iteration `loaded_this_path` flag, so the success postlude (`Loaded beatmap …` info log + `loaded = true` + `break`) lives in exactly one place.

## Behaviour

Bit-for-bit identical:

- Same `load_beat_map` / `validate_beat_map` call sequence.
- Tolerance for the `"Different-shape gates must be >= 3 beats apart"` validation warning is preserved (still classified as a warning, still logged via `TraceLog(LOG_WARNING, …)` at the same severity, still ends in `loaded = true`).
- Any other validation error still drops out of the candidate path, accumulates into `reported_load_errors`, and the loop advances to the next path.
- `out = std::move(candidate)` ordering and `load_errors.push_back` semantics on the caller-provided vector are unchanged.

## Verification

- `rg "\bload_runtime_beat_map\b" app/ tests/ benchmarks/` → 0 hits.
- `cmake --build build` clean, zero warnings.
- `ctest --test-dir build` → 100% (977/977, 1 skipped `startup_shutdown_smoke` requires a display — same as on `main`).

## Context

Continuation of the single-call anon-ns / static helper cleanup train (#1551 / #1559 / #1564 / #1566 / #1567 / #1568 / #1570 / #1571 / #1572 / #1582 / #1583 / #1584 / #1592 / #1594 / #1595 / #1600 / #1602 / #1604).