### PR TITLE
#1610 WasmSmokeLaneMarkerState: drop last_lane=-1 sentinel, use WasmSmokeLastLane row presence (Fabian Principle 3)

### DIFF
--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -16,19 +16,6 @@
 #include <string>
 #endif
 
-#if defined(__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)
-namespace {
-
-WasmSmokeLaneMarkerState& wasm_smoke_lane_marker_state(entt::registry& reg) {
-    if (auto* state = reg.ctx().find<WasmSmokeLaneMarkerState>()) {
-        return *state;
-    }
-    return reg.ctx().emplace<WasmSmokeLaneMarkerState>();
-}
-
-}  // namespace
-#endif
-
 void game_state_system(entt::registry& reg, float dt) {
     auto& gs = reg.ctx().get<GameState>();
 
@@ -131,7 +118,7 @@ void game_state_system(entt::registry& reg, float dt) {
         clear_next_phase_tags(reg);
 #if defined(__EMSCRIPTEN__) && defined(SHAPESHIFTER_WASM_SMOKE_MARKERS)
         if (!reg.ctx().contains<GamePhasePlayingTag>()) {
-            wasm_smoke_lane_marker_state(reg).last_lane = -1;
+            reg.ctx().erase<WasmSmokeLastLane>();
         }
 #endif
         return;
@@ -155,19 +142,20 @@ void game_state_system(entt::registry& reg, float dt) {
     // Update browser tab title with current lane when in Playing phase, so
     // WASM smoke tests can observe player state via document.title polling.
     // Title is rewritten only on lane change; absence of player or non-Playing
-    // phase resets the cached lane to -1 so the next entry rewrites the title.
+    // phase erases the `WasmSmokeLastLane` row so the next entry rewrites the
+    // title (row absence == "no lane reported yet", per Fabian Principle 3).
     {
-        auto& marker = wasm_smoke_lane_marker_state(reg);
         auto player_view = reg.view<PlayerTag, Lane>();
         const bool playing = reg.ctx().contains<GamePhasePlayingTag>();
         const bool has_player = player_view.begin() != player_view.end();
         if (!playing || !has_player) {
-            marker.last_lane = -1;
+            reg.ctx().erase<WasmSmokeLastLane>();
         } else {
             const auto player_entity = *player_view.begin();
             const int lane = static_cast<int>(player_view.get<Lane>(player_entity).current);
-            if (lane != marker.last_lane) {
-                marker.last_lane = lane;
+            const auto* prev = reg.ctx().find<WasmSmokeLastLane>();
+            if (prev == nullptr || prev->lane != lane) {
+                reg.ctx().insert_or_assign(WasmSmokeLastLane{lane});
                 const std::string title = std::string("SHAPESHIFTER [Playing][Lane:")
                     + std::to_string(lane) + "]";
                 EM_ASM(

--- a/app/systems/game_state_system.h
+++ b/app/systems/game_state_system.h
@@ -6,8 +6,12 @@
 
 // Tracks the last lane reported by the wasm smoke marker so the system can
 // emit transitions without re-reporting on every frame. Only consumed under
-// SHAPESHIFTER_WASM_SMOKE_MARKERS, but the type is initialized
-// unconditionally so registry-context contracts stay consistent.
-struct WasmSmokeLaneMarkerState {
-    int last_lane = -1;
+// SHAPESHIFTER_WASM_SMOKE_MARKERS.
+//
+// Per Fabian Principle 3 (.squad/decisions.md § 9 — NULL columns), the
+// "no lane reported yet" state is encoded as row ABSENCE in `reg.ctx()`, not
+// a sentinel `last_lane = -1`. Presence of the row IS the precondition for
+// reading `lane`; the row is erased on phase exit / missing player to reset.
+struct WasmSmokeLastLane {
+    int lane;
 };

--- a/app/systems/runtime_system_scratch.cpp
+++ b/app/systems/runtime_system_scratch.cpp
@@ -25,7 +25,11 @@ void runtime_system_scratch_init(entt::registry& reg) {
     reg.ctx().insert_or_assign(PopupDisplayScratch{});
     reg.ctx().insert_or_assign(ParticleSystemScratch{});
     reg.ctx().insert_or_assign(MeshChildCleanupScratch{});
-    reg.ctx().insert_or_assign(WasmSmokeLaneMarkerState{});
+    // WasmSmokeLastLane uses row presence as the "lane reported" predicate
+    // (Fabian Principle 3 — no sentinel NULL columns). Erase any stale row
+    // carried over from a prior session so the next title update rewrites
+    // unconditionally.
+    reg.ctx().erase<WasmSmokeLastLane>();
 
     runtime_system_scratch_reserve(reg, 0);
 }

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -234,16 +234,23 @@ TEST_CASE("wasm smoke lane marker state is registry-owned and reset with runtime
     auto first = make_registry();
     auto second = make_registry();
 
-    auto& first_marker = first.ctx().get<WasmSmokeLaneMarkerState>();
-    auto& second_marker = second.ctx().get<WasmSmokeLaneMarkerState>();
-    first_marker.last_lane = 2;
+    // Row absence is the "no lane reported yet" state (Fabian Principle 3 —
+    // no sentinel NULL column). make_registry() must leave both fresh.
+    CHECK_FALSE(first.ctx().contains<WasmSmokeLastLane>());
+    CHECK_FALSE(second.ctx().contains<WasmSmokeLastLane>());
 
-    CHECK(second_marker.last_lane == -1);
+    first.ctx().insert_or_assign(WasmSmokeLastLane{2});
+
+    // Registries are independent: writing to `first` must not leak into `second`.
+    CHECK(first.ctx().contains<WasmSmokeLastLane>());
+    CHECK(first.ctx().get<WasmSmokeLastLane>().lane == 2);
+    CHECK_FALSE(second.ctx().contains<WasmSmokeLastLane>());
 
     runtime_system_scratch_init(first);
 
-    CHECK(first.ctx().get<WasmSmokeLaneMarkerState>().last_lane == -1);
-    CHECK(second.ctx().get<WasmSmokeLaneMarkerState>().last_lane == -1);
+    // Init erases any stale row so the next title update rewrites unconditionally.
+    CHECK_FALSE(first.ctx().contains<WasmSmokeLastLane>());
+    CHECK_FALSE(second.ctx().contains<WasmSmokeLastLane>());
 }
 
 TEST_CASE("game_state: transition clears in-flight pointer capture", "[gamestate][input]") {


### PR DESCRIPTION
Closes #1610.

## What

`WasmSmokeLaneMarkerState::last_lane = -1` was an `int` sentinel-discriminated NULL column in disguise: `-1` meant "no lane reported yet" and gated the per-frame compare/commit at `game_state_system.cpp:169` (`if (lane != marker.last_lane)`), plus two reset sites at :134 and :165. Per Fabian Principle 3 (`.squad/decisions.md` § 9 — a field whose meaning depends on another field's value is a NULL column in disguise), eradicate by promoting the meaningful state into a ctx-singleton row table whose membership IS the "at-least-one-lane-reported" precondition. Same family as #1545.

## Schema change

- Drop `WasmSmokeLaneMarkerState { int last_lane = -1; }`.
- Add `WasmSmokeLastLane { int lane; }` — ctx-singleton row table in `app/systems/game_state_system.h`; presence == "a lane has been reported".

## Writers / readers

- Phase-exit and missing-player resets use `reg.ctx().erase<WasmSmokeLastLane>()` (safe when absent).
- Lane-change commit uses `reg.ctx().insert_or_assign(WasmSmokeLastLane{lane})`.
- Compare site becomes `prev == nullptr || prev->lane != lane` (where `prev = reg.ctx().find<WasmSmokeLastLane>()`) — the sentinel-equality test collapses into presence-OR-value-mismatch.
- `runtime_system_scratch_init` drops the unconditional `insert_or_assign(WasmSmokeLaneMarkerState{})` (ctx rows do not need pre-registration) and adds `erase<WasmSmokeLastLane>()` to preserve the per-session reset semantic for cross-session test reuse.
- Anonymous-namespace lazy-init helper `wasm_smoke_lane_marker_state` is dropped (no longer needed).

## Tests

- `tests/test_game_state_extended.cpp` "wasm smoke lane marker state is registry-owned and reset with runtime scratch": rewritten to the presence-based shape — default state is row-absent, `insert_or_assign` on `first` does not leak into `second`, and `runtime_system_scratch_init` erases any stale row. Test name and `[issue973]` regression tag preserved.

## Verified

- Native build: zero warnings (clean rebuild on Clang with `-Wall -Wextra -Werror` via `build.sh`).
- Tests: `./build/shapeshifter_tests` 3373 assertions / 964 cases pass. `ctest --test-dir build` 977/977 jobs pass.
- WASM-guarded path: syntactically validated by force-defining `__EMSCRIPTEN__` + `SHAPESHIFTER_WASM_SMOKE_MARKERS` against the native toolchain (stubbed `<emscripten/emscripten.h>`); compiles clean with the same warning flags.

## Stats

```
 app/systems/game_state_system.cpp      | 26 +++++++-------------------
 app/systems/game_state_system.h        | 12 ++++++++----
 app/systems/runtime_system_scratch.cpp |  6 +++++-
 tests/test_game_state_extended.cpp     | 19 +++++++++++++------
 4 files changed, 33 insertions(+), 30 deletions(-)
```
