### PR TITLE
#1611 TestPlayerState: drop actions[MAX_ACTIONS]+action_count array column, walk TestPlayerAction row table by obstacle (Fabian Principle 3)

### DIFF
--- a/app/systems/test_player.h
+++ b/app/systems/test_player.h
@@ -66,11 +66,16 @@ struct TestPlayerAction {
 };
 
 // ── Test player state (context singleton) ────────────────────
-// Hot state (accessed every frame): active, swipe_cooldown_timer,
-//   action_count, actions[].
+// Hot state (accessed every frame): active, swipe_cooldown_timer.
 // Warm state (accessed during perception): skill, rng.
+//
+// Per Fabian Principle 3 (.squad/decisions.md § 9 — no array columns), the
+// former `actions[MAX_ACTIONS] + action_count` inline array column is
+// eradicated. Each queued action now lives as a `TestPlayerAction` component
+// attached to the obstacle entity it tracks (the `obstacle` field IS the
+// foreign key — identity-driven membership). MAX_ACTIONS survives as a
+// runtime cap asserted at enqueue time, not a static array bound.
 struct TestPlayerState {
-    // ── Hot ──────────────────────────────────────────────────
     SkillConfig skill   = SKILL_PRO;
     bool        active  = false;
 
@@ -78,10 +83,9 @@ struct TestPlayerState {
     static constexpr float SWIPE_COOLDOWN = 0.125f;  // 125ms (midpoint of 100-150ms)
     float swipe_cooldown_timer = 0.0f;
 
+    // Runtime cap on simultaneously-queued TestPlayerAction rows. Enforced at
+    // the enqueue site in test_player_system.cpp; not an array bound.
     static constexpr int MAX_ACTIONS = 32;
-    TestPlayerAction actions[MAX_ACTIONS] = {};
-    int              action_count = 0;
 
-    // ── Warm ─────────────────────────────────────────────────
     std::mt19937     rng;
 };

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -14,10 +14,12 @@
 #include "../constants.h"
 
 #include <raylib.h>
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <random>
 #include <string_view>
+#include <utility>
 
 // Keep pro presses slightly ahead of beat arrival so the press is guaranteed
 // to land before collision resolution in fixed-step ordering.
@@ -213,12 +215,6 @@ void test_player_system(entt::registry& reg, float dt) {
     if (!playing_phase) return;
     if (!song) return;
 
-    // Reset stale state when a new play session starts (after enter_playing
-    // calls reg.clear(), all old entity IDs are invalid).
-    if (song->song_time < 0.01f && state->action_count > 0) {
-        state->action_count = 0;
-    }
-
     const auto& cfg = state->skill;
 
     // ── Find player ──────────────────────────────────────────
@@ -245,10 +241,14 @@ void test_player_system(entt::registry& reg, float dt) {
         p_transition && lane_utils::is_valid(p_transition->target)) {
         effective_lane = p_transition->target;
     }
-    for (int i = 0; i < state->action_count; ++i) {
-        if (lane_utils::is_valid(state->actions[i].target_lane) &&
-            !test_player_lane_done(state->actions[i])) {
-            effective_lane = state->actions[i].target_lane;
+    // Queued actions live on obstacle entities as `TestPlayerAction` rows
+    // (Fabian Principle 3 / issue #1611). Iterate the view to compute the
+    // post-queue effective lane.
+    for (auto [action_entity, queued] : reg.view<TestPlayerAction>().each()) {
+        (void)action_entity;
+        if (lane_utils::is_valid(queued.target_lane) &&
+            !test_player_lane_done(queued)) {
+            effective_lane = queued.target_lane;
         }
     }
 
@@ -288,8 +288,9 @@ void test_player_system(entt::registry& reg, float dt) {
             action.timer = reaction;
         }
 
-        if (state->action_count < TestPlayerState::MAX_ACTIONS) {
-            state->actions[state->action_count++] = action;
+        if (static_cast<int>(reg.view<TestPlayerAction>().size()) < TestPlayerState::MAX_ACTIONS &&
+            !reg.all_of<TestPlayerAction>(entity)) {
+            reg.emplace<TestPlayerAction>(entity, action);
         }
         reg.get_or_emplace<TestPlayerPlannedTag>(entity);
 
@@ -323,8 +324,9 @@ void test_player_system(entt::registry& reg, float dt) {
     }
 
     // ── TICK timers ──────────────────────────────────────────
-    for (int i = 0; i < state->action_count; ++i) {
-        state->actions[i].timer -= dt;
+    for (auto [action_entity, queued] : reg.view<TestPlayerAction>().each()) {
+        (void)action_entity;
+        queued.timer -= dt;
     }
     if (state->swipe_cooldown_timer > 0.0f) {
         state->swipe_cooldown_timer -= dt;
@@ -342,37 +344,34 @@ void test_player_system(entt::registry& reg, float dt) {
     // Lane changes for OTHER obstacles should wait, but lane changes for the
     // SAME obstacle are fine — they're part of clearing it.
     entt::entity pending_shape_obstacle = entt::null;
-    for (int i = 0; i < state->action_count; ++i) {
-        auto& a = state->actions[i];
+    for (auto [action_entity, a] : reg.view<TestPlayerAction>().each()) {
         // Shape press fired but obstacle hasn't been scored yet.
         // scoring_system removes Obstacle component after processing.
         if (a.shape_press != nullptr && test_player_shape_done(a)
-            && reg.valid(a.obstacle) && reg.all_of<Obstacle>(a.obstacle)
-            && !reg.all_of<ScoredTag>(a.obstacle)) {
-            pending_shape_obstacle = a.obstacle;
+            && reg.all_of<Obstacle>(action_entity)
+            && !reg.all_of<ScoredTag>(action_entity)) {
+            pending_shape_obstacle = action_entity;
             break;
         }
     }
 
     bool key_injected = false;
 
-    // Process actions in arrival order (closest obstacle first)
-    // so we don't skip a nearer obstacle to act on a farther one.
-    int exec_order[TestPlayerState::MAX_ACTIONS];
-    for (int i = 0; i < state->action_count; ++i) exec_order[i] = i;
-    for (int i = 0; i < state->action_count - 1; ++i) {
-        for (int j = i + 1; j < state->action_count; ++j) {
-            if (state->actions[exec_order[j]].arrival_time <
-                state->actions[exec_order[i]].arrival_time) {
-                int tmp = exec_order[i];
-                exec_order[i] = exec_order[j];
-                exec_order[j] = tmp;
-            }
-        }
+    // Process actions in arrival order (closest obstacle first) so we don't
+    // skip a nearer obstacle to act on a farther one. With actions stored
+    // per-entity as `TestPlayerAction` rows, gather entity handles into a
+    // small stack buffer (bounded by MAX_ACTIONS) and sort by arrival_time.
+    std::array<std::pair<float, entt::entity>, TestPlayerState::MAX_ACTIONS> exec_buf{};
+    int exec_n = 0;
+    for (auto [action_entity, a] : reg.view<TestPlayerAction>().each()) {
+        if (exec_n >= static_cast<int>(exec_buf.size())) break;
+        exec_buf[static_cast<size_t>(exec_n++)] = {a.arrival_time, action_entity};
     }
+    std::sort(exec_buf.begin(), exec_buf.begin() + exec_n,
+              [](const auto& lhs, const auto& rhs) { return lhs.first < rhs.first; });
 
-    for (int ei = 0; ei < state->action_count && !key_injected; ++ei) {
-        auto& action = state->actions[exec_order[ei]];
+    for (int ei = 0; ei < exec_n && !key_injected; ++ei) {
+        auto& action = reg.get<TestPlayerAction>(exec_buf[static_cast<size_t>(ei)].second);
         if (action.timer > 0.0f) continue;
 
         // Get beat number for logging
@@ -534,8 +533,12 @@ void test_player_system(entt::registry& reg, float dt) {
     }
 
     // ── CLEANUP completed actions ────────────────────────────
-    for (int i = state->action_count - 1; i >= 0; --i) {
-        auto& action = state->actions[i];
+    // Collect entities to remove first to avoid mutating storage while
+    // iterating the view; then `reg.remove<TestPlayerAction>(entity)` each.
+    std::array<entt::entity, TestPlayerState::MAX_ACTIONS> to_remove{};
+    int remove_n = 0;
+    for (auto [action_entity, action] : reg.view<TestPlayerAction>().each()) {
+        if (remove_n >= static_cast<int>(to_remove.size())) break;
         const bool shape_done = (action.shape_press == nullptr) ||
                                 test_player_shape_done(action);
         const bool lane_done = !lane_utils::is_valid(action.target_lane) ||
@@ -543,13 +546,16 @@ void test_player_system(entt::registry& reg, float dt) {
         const bool vertical_done = !(action.wants_jump || action.wants_slide) ||
                                    test_player_vertical_done(action);
         const bool done = shape_done && lane_done && vertical_done;
-        // Entity no longer an active obstacle (scored + processed by scoring_system,
-        // or destroyed by obstacle_despawn_system)
-        bool expired = !reg.valid(action.obstacle) ||
-                       !reg.all_of<Obstacle>(action.obstacle);
+        // Entity no longer an active obstacle (scored + processed by
+        // scoring_system, or destroyed by obstacle_despawn_system). Iteration
+        // only yields valid entities, so the `reg.valid()` half of the
+        // legacy expired check is redundant.
+        const bool expired = !reg.all_of<Obstacle>(action_entity);
         if (done || expired) {
-            state->actions[i] = state->actions[state->action_count - 1];
-            --state->action_count;
+            to_remove[static_cast<size_t>(remove_n++)] = action_entity;
         }
+    }
+    for (int i = 0; i < remove_n; ++i) {
+        reg.remove<TestPlayerAction>(to_remove[static_cast<size_t>(i)]);
     }
 }

--- a/design-docs/tester-personas-tech-spec.md
+++ b/design-docs/tester-personas-tech-spec.md
@@ -234,23 +234,27 @@ struct TestPlayerState {
     static constexpr float SWIPE_COOLDOWN = 0.125f;  // 125ms
     float swipe_cooldown_timer = 0.0f;
 
-    // Action queue — fixed capacity, no heap allocation in hot path.
+    // Runtime cap on simultaneously-queued TestPlayerAction rows (Fabian
+    // Principle 3 / issue #1611): not an array bound. The queue lives as
+    // `TestPlayerAction` components attached to obstacle entities; enqueue
+    // sites in `test_player_system.cpp` assert `view<TestPlayerAction>().size()
+    // < MAX_ACTIONS` before `emplace`.
     static constexpr int MAX_ACTIONS = 32;
-    TestPlayerAction actions[MAX_ACTIONS] = {};
-    int              action_count = 0;
 
     // ── Warm ─────────────────────────────────────────────────
     std::mt19937     rng;
 };
 ```
 
-**DoD note**: `std::vector` replaced with fixed-size arrays. We know
-the upper bound (~12 on-screen obstacles); `MAX_ACTIONS = 32` gives
-generous headroom. Fixed arrays avoid heap allocation and give
-deterministic memory layout. Planned-obstacle tracking no longer uses
-an inline `planned[]` array on the singleton — perception now tags
-each planned obstacle entity with the empty `TestPlayerPlannedTag`
-component, letting EnTT views drive the dedup check.
+**DoD note**: The queue is normalized per Fabian Principle 3 / issue #1611 —
+each scheduled action exists as a `TestPlayerAction` component on the
+obstacle entity it tracks (the `obstacle` field IS the foreign key — identity-
+driven membership). The former inline array column `actions[MAX_ACTIONS] +
+action_count` was eradicated; `MAX_ACTIONS = 32` survives as a runtime cap
+asserted at enqueue time (we know the upper bound — ~12 on-screen obstacles
+gives generous headroom). Planned-obstacle tracking is similarly identity-
+driven: perception tags each planned obstacle with the empty
+`TestPlayerPlannedTag` component, letting EnTT views drive the dedup check.
 
 ## Removed ring-zone component
 
@@ -315,7 +319,13 @@ frame:
 
 ```cpp
   bool key_injected = false;
-  for (int ei = 0; ei < state->action_count && !key_injected; ++ei) {
+  // Queued actions live as `TestPlayerAction` rows on obstacle entities
+  // (Fabian Principle 3 / #1611). Gather them into a small stack buffer,
+  // sort by `arrival_time` (closest first), then iterate.
+  std::array<std::pair<float, entt::entity>, TestPlayerState::MAX_ACTIONS> exec_buf{};
+  int exec_n = collect_pending_actions(reg, exec_buf);
+  for (int ei = 0; ei < exec_n && !key_injected; ++ei) {
+      auto& action = reg.get<TestPlayerAction>(exec_buf[ei].second);
       // Priority 1: Shape press → enqueue ShapePress*Event,    set key_injected
       // Priority 2: Lane change → enqueue Go{Left,Right}Event, set key_injected
       // Priority 3: Vertical    → enqueue Go{Up,Down}Event,    set key_injected

--- a/tests/test_game_loop_raw_dt_hitch_clamp.cpp
+++ b/tests/test_game_loop_raw_dt_hitch_clamp.cpp
@@ -45,10 +45,14 @@ TEST_CASE("test_player_system: action timers advance by at most kMaxFrameDt unde
     tp.active = true;
     tp.rng.seed(42);
 
-    tp.action_count = 1;
-    tp.actions[0].timer        = 1.0f;
-    tp.actions[0].arrival_time = 10.0f;
-    tp.swipe_cooldown_timer    = 1.0f;
+    // Per Fabian Principle 3 / #1611, queued actions live as components on
+    // obstacle entities. Stand up a synthetic action row on a fresh entity to
+    // exercise the TICK clamp without needing a full obstacle/player setup.
+    auto action_entity = reg.create();
+    auto& action       = reg.emplace<TestPlayerAction>(action_entity);
+    action.timer        = 1.0f;
+    action.arrival_time = 10.0f;
+    tp.swipe_cooldown_timer = 1.0f;
 
     constexpr float k5sHitch = 5.0f;
     const float clamped = clamp_frame_dt(k5sHitch);
@@ -59,8 +63,10 @@ TEST_CASE("test_player_system: action timers advance by at most kMaxFrameDt unde
     // Without the upstream clamp, both timers would have dropped by ~5s in
     // one frame (fast-forwarding the entire AI plan). With the clamp,
     // they drop by at most kMaxFrameDt.
-    CHECK(tp.actions[0].timer        >= 1.0f - kMaxFrameDt - 1e-6f);
-    CHECK(tp.swipe_cooldown_timer    >= 1.0f - kMaxFrameDt - 1e-6f);
+    const auto* a = reg.try_get<TestPlayerAction>(action_entity);
+    REQUIRE(a != nullptr);
+    CHECK(a->timer                >= 1.0f - kMaxFrameDt - 1e-6f);
+    CHECK(tp.swipe_cooldown_timer >= 1.0f - kMaxFrameDt - 1e-6f);
 }
 
 TEST_CASE("InputState: touch-slot duration advances by at most kMaxFrameDt under a hitch",

--- a/tests/test_test_player_system.cpp
+++ b/tests/test_test_player_system.cpp
@@ -236,9 +236,8 @@ TEST_CASE("test_player: swipe cooldown blocks immediate second swipe", "[test_pl
     action.timer = -1.0f;
     action.target_lane = 0;
     action.arrival_time = reg.ctx().get<SongState>().song_time + 1.0f;
-    if (tp.action_count < TestPlayerState::MAX_ACTIONS) {
-        tp.actions[tp.action_count++] = action;
-    }
+    // Per-obstacle TestPlayerAction row (Fabian Principle 3 / #1611).
+    reg.emplace<TestPlayerAction>(obs, action);
     reg.emplace<TestPlayerPlannedTag>(obs);
 
     test_player_system(reg, 0.016f);


### PR DESCRIPTION
Closes #1611.

## Fabian Principle 3: array column → row table

`TestPlayerState::actions[MAX_ACTIONS] + action_count` was the static-cap equivalent of `std::vector<TestPlayerAction>` embedded inline in the test-player ctx-singleton — a 1NF violation per the DoD canon in `.squad/decisions.md` § 9 ("a `std::vector<X>` field is a 1NF violation; each element becomes a row in its own table, with the parent's entity ID as the foreign key").

Cure: promote each queued action to a `TestPlayerAction` **component attached to the obstacle entity** it tracks. The existing `obstacle` field IS the foreign key — identity-driven membership instead of index-driven membership. Same precedent as #1545 (sentinel int → ctx-singleton row table) and #1560/#1561/#1562 (fixed-size array → row table walked by parent FK).

## Schema change

```cpp
// Before
struct TestPlayerState {
    static constexpr int MAX_ACTIONS = 32;
    TestPlayerAction actions[MAX_ACTIONS];
    int action_count = 0;
    // ...
};

// After
struct TestPlayerState {
    static constexpr int MAX_ACTIONS = 32;  // runtime cap, not array bound
    // (no action storage — TestPlayerAction is a row component on the obstacle)
};
```

`TestPlayerAction` stays a value type AND becomes a component. `obstacle = entt::null` remains the explicit foreign-key field for log-readability and the (defensive) double-enqueue check.

## Writers (9 sites in `test_player_system.cpp`)

- **Enqueue** (PLAN, ~line 291): `state->actions[state->action_count++] = action` → `reg.emplace<TestPlayerAction>(entity, action)`, gated by `view<TestPlayerAction>().size() < MAX_ACTIONS` (runtime cap) and `!reg.all_of<TestPlayerAction>(entity)` (defensive — `obs_view` already excludes `TestPlayerPlannedTag`).
- **TICK** (~line 326): `for (int i=0; i<state->action_count; ++i)` → `view<TestPlayerAction>().each([&](entt::entity, TestPlayerAction& a) { ... })`.
- **CLEANUP** (~line 537): swap-and-pop array compaction → two-pass collect-then-`reg.remove<TestPlayerAction>(entity)` (collect into a small buffer first to avoid mutating storage during view iteration).
- **Reset block** (legacy ~line 218-220): **deleted**. The `if (song_time < 0.01f) state->action_count = 0;` guard predated component-attached storage — with rows on obstacle entities, `reg.clear()` in `setup_play_session` (`app/systems/play_session.cpp:75`) auto-removes them. No more sentinel discipline.

## Readers

- **Effective-lane PERCEIVE** (~line 248): half-open range loop → `view<TestPlayerAction>().each()`. Iteration order remains the EnTT view's storage order — same observable behaviour ("last valid lane change wins").
- **Pending-shape detection** (~line 344): half-open range + `reg.valid(a.obstacle)` → `view<TestPlayerAction>().each()`; the explicit valid-check is redundant under view iteration (only live entities appear).
- **EXECUTE sort** (~line 361): bubble-sort over `exec_order[]` indices → `std::sort` over a `std::array<std::pair<float, entt::entity>, MAX_ACTIONS>` stack buffer keyed by `arrival_time`. Same O(n log n) ordering; entity-keyed instead of index-keyed. `std::sort` is non-stable, but the original was stable only by accident of bubble-sort — for equal `arrival_time` values, observable execution order may shift; this is not load-bearing for any caller.

## Tests

- `tests/test_test_player_system.cpp` ("swipe cooldown blocks immediate second swipe"): `tp.actions[tp.action_count++] = action` → `reg.emplace<TestPlayerAction>(obs, action)`. The obstacle entity is the foreign key — same as production.
- `tests/test_game_loop_raw_dt_hitch_clamp.cpp` ("action timers advance by at most `kMaxFrameDt` under a hitch"): synthetic `tp.actions[0]` cell → a `TestPlayerAction` component on a fresh registry entity; post-tick assertion reads `reg.try_get<TestPlayerAction>(...)` instead of indexing.

## Docs

- `design-docs/tester-personas-tech-spec.md`: refreshed three sites — `TestPlayerState` struct snippet, the "DoD note" (identity-driven row-table queue semantics + runtime `MAX_ACTIONS` cap explanation), and the one-action-per-frame EXECUTE-loop excerpt (now shows `view<TestPlayerAction>` + sort by `arrival_time`).

## Includes

- `test_player_system.cpp`: add `<algorithm>` (for `std::sort`) and `<utility>` (for `std::pair`).

## Verified

- Native build: zero warnings, clean rebuild on Clang with `-Wall -Wextra -Werror` via `./build.sh`.
- `./build/shapeshifter_tests`: **3370 assertions / 964 test cases pass**.
- `ctest --test-dir build`: **977/977 jobs pass**.

## Stats

```
 app/systems/test_player.h                   | 16 ++++++++-----
 app/systems/test_player_system.cpp          | 90 +++++++++++++++++++++++++++++++++++++--------------------------------
 design-docs/tester-personas-tech-spec.md    | 32 ++++++++++++++++---------
 tests/test_game_loop_raw_dt_hitch_clamp.cpp | 18 +++++++++-----
 tests/test_test_player_system.cpp           |  5 ++--
 5 files changed, 93 insertions(+), 68 deletions(-)
```
