### PR TITLE
#1612 InputState.touch_slots: drop array column + TouchSlot.id=-1 NULL column, walk ActiveTouchSlot row table (Fabian Principle 3)

### DIFF
--- a/app/systems/input.h
+++ b/app/systems/input.h
@@ -24,18 +24,27 @@
 struct InputSourceMouse {};
 struct InputSourceTouch {};
 
-struct TouchSlot {
-    static constexpr int InvalidId = -1;
-
-    int id = InvalidId;
-    bool active = false;
-    bool started_in_button_zone = false;
-    float start_x = 0.0f, start_y = 0.0f;
-    float curr_x = 0.0f, curr_y = 0.0f;
-    float duration = 0.0f;
+// One row per currently-tracked finger (issue #1612 / Fabian Principle 3).
+// Presence in `reg.view<ActiveTouchSlot>()` IS membership in "currently
+// tracked"; the parent `InputState` no longer carries a fixed-size
+// `TouchSlot touch_slots[MaxTrackedTouches]` array column nor the
+// `id == InvalidId = -1` NULL column that gated it. The
+// `InputState::MaxTrackedTouches` policy cap survives as a runtime
+// allocation guard at the create site in input_system. The `id` field
+// is the raylib touch id used to match this row against the live
+// `GetTouchPointId(i)` table each frame — it is a real attribute of an
+// active touch, not a sentinel.
+struct ActiveTouchSlot {
+    int   id;
+    bool  started_in_button_zone;
+    float start_x, start_y;
+    float curr_x,  curr_y;
+    float duration;
 };
 
 struct InputState {
+    // Runtime cap on concurrent `ActiveTouchSlot` rows. Enforced at the
+    // create site in input_system; no longer the dim of an inline array.
     static constexpr int MaxTrackedTouches = 2;
 
     float start_x  = 0.0f, start_y = 0.0f;
@@ -50,7 +59,6 @@ struct InputState {
     bool  quit_requested = false;
     bool button_touch_up = false;
     float button_end_x = 0.0f, button_end_y = 0.0f;
-    TouchSlot touch_slots[MaxTrackedTouches] = {};
 };
 
 // Note: directional intent is identity-encoded in per-direction event types

--- a/app/systems/input_system.cpp
+++ b/app/systems/input_system.cpp
@@ -88,7 +88,13 @@ GoEnqueueFn raylib_gesture_swipe_direction() {
     return classify_swipe(drag.x, drag.y, GetGestureHoldDuration());
 }
 
-void release_touch_slot(TouchSlot& slot,
+// Drains a single `ActiveTouchSlot` row's lift-up state onto `InputState`
+// (touch_up flags + end_* / button_end_* coordinates) and feeds any
+// distance/duration-classified swipe through `latest_swipe`. Callers
+// own the entity's destruction — this helper only does the side effects
+// on InputState, mirroring #1612 / Fabian Principle 3 where the row's
+// presence IS its active status (no `slot = TouchSlot{}` reset).
+void release_touch_slot(const ActiveTouchSlot& slot,
                         InputState& input,
                         GoEnqueueFn& latest_swipe,
                         bool& had_swipe_zone_release) {
@@ -107,7 +113,6 @@ void release_touch_slot(TouchSlot& slot,
             latest_swipe = fn;
         }
     }
-    slot = TouchSlot{};
 }
 
 // ── Input-source ctx-tag mutex helper (issues #1202 / #1204) ──────────────
@@ -159,8 +164,20 @@ void input_system_clear_pointer_state(entt::registry& reg) {
         input->button_touch_up = false;
         input->touching = false;
         input->duration = 0.0f;
-        for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
-            input->touch_slots[i] = TouchSlot{};
+    }
+    // Drop every currently-tracked touch row (#1612 / Fabian Principle 3 —
+    // presence in `view<ActiveTouchSlot>()` IS slot activity, so clearing
+    // it replaces the former `touch_slots[i] = TouchSlot{}` reset).
+    {
+        entt::entity to_destroy[InputState::MaxTrackedTouches];
+        std::size_t destroy_count = 0;
+        for (auto [entity, slot] : reg.view<ActiveTouchSlot>().each()) {
+            (void)slot;
+            if (destroy_count >= InputState::MaxTrackedTouches) break;
+            to_destroy[destroy_count++] = entity;
+        }
+        for (std::size_t i = 0; i < destroy_count; ++i) {
+            if (reg.valid(to_destroy[i])) reg.destroy(to_destroy[i]);
         }
     }
     clear_input_source(reg);
@@ -250,23 +267,26 @@ void input_system(entt::registry& reg, float raw_dt) {
         GoEnqueueFn latest_swipe = nullptr;
         bool had_swipe_zone_release = false;
 
-        for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
-            auto& slot = input.touch_slots[i];
-            if (!slot.active) {
-                continue;
-            }
-            bool current = false;
-            for (int touch_index = 0; touch_index < touch_point_count; ++touch_index) {
-                if (GetTouchPointId(touch_index) == slot.id) {
-                    current = true;
-                    break;
+        {
+            entt::entity to_destroy[InputState::MaxTrackedTouches];
+            std::size_t destroy_count = 0;
+            for (auto [entity, slot] : reg.view<ActiveTouchSlot>().each()) {
+                bool current = false;
+                for (int touch_index = 0; touch_index < touch_point_count; ++touch_index) {
+                    if (GetTouchPointId(touch_index) == slot.id) {
+                        current = true;
+                        break;
+                    }
+                }
+                if (!current) {
+                    release_touch_slot(slot, input, latest_swipe, had_swipe_zone_release);
+                    if (destroy_count < InputState::MaxTrackedTouches) {
+                        to_destroy[destroy_count++] = entity;
+                    }
                 }
             }
-            if (!current) {
-                release_touch_slot(slot,
-                                   input,
-                                   latest_swipe,
-                                   had_swipe_zone_release);
+            for (std::size_t i = 0; i < destroy_count; ++i) {
+                if (reg.valid(to_destroy[i])) reg.destroy(to_destroy[i]);
             }
         }
 
@@ -275,19 +295,21 @@ void input_system(entt::registry& reg, float raw_dt) {
             const int touch_id = GetTouchPointId(touch_index);
             const Vector2 touch_pos = GetTouchPosition(touch_index);
             const Vector2 tp = screen_to_virtual({touch_pos.x, touch_pos.y}, st);
-            int slot_index = -1;
-            for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
-                if (input.touch_slots[i].active && input.touch_slots[i].id == touch_id) {
-                    slot_index = i;
+
+            entt::entity slot_entity = entt::null;
+            for (auto [entity, slot] : reg.view<ActiveTouchSlot>().each()) {
+                if (slot.id == touch_id) {
+                    slot_entity = entity;
                     break;
                 }
             }
-            if (slot_index < 0) {
+
+            if (slot_entity == entt::null) {
                 const bool button_zone = tp.y >= zone_y;
                 bool zone_taken = false;
-                for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
-                    const auto& slot = input.touch_slots[i];
-                    if (slot.active && slot.started_in_button_zone == button_zone) {
+                for (auto [entity, slot] : reg.view<ActiveTouchSlot>().each()) {
+                    (void)entity;
+                    if (slot.started_in_button_zone == button_zone) {
                         zone_taken = true;
                         break;
                     }
@@ -295,30 +317,25 @@ void input_system(entt::registry& reg, float raw_dt) {
                 if (zone_taken) {
                     continue;
                 }
-                for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
-                    if (!input.touch_slots[i].active) {
-                        slot_index = i;
-                        break;
-                    }
+                if (reg.view<ActiveTouchSlot>().size() >=
+                    static_cast<std::size_t>(InputState::MaxTrackedTouches)) {
+                    continue;
                 }
-            }
-            if (slot_index < 0) {
-                continue;
-            }
-
-            auto& slot = input.touch_slots[slot_index];
-            if (!slot.active) {
+                slot_entity = reg.create();
+                auto& slot = reg.emplace<ActiveTouchSlot>(slot_entity);
                 slot.id = touch_id;
-                slot.active = true;
-                slot.started_in_button_zone = tp.y >= zone_y;
+                slot.started_in_button_zone = button_zone;
                 slot.start_x = slot.curr_x = tp.x;
                 slot.start_y = slot.curr_y = tp.y;
                 slot.duration = 0.0f;
                 input.touch_down = true;
             } else {
+                auto& slot = reg.get<ActiveTouchSlot>(slot_entity);
                 slot.curr_x = tp.x;
                 slot.curr_y = tp.y;
             }
+
+            const auto& slot = reg.get<ActiveTouchSlot>(slot_entity);
             input.start_x = slot.start_x;
             input.start_y = slot.start_y;
             input.curr_x = tp.x;
@@ -335,11 +352,10 @@ void input_system(entt::registry& reg, float raw_dt) {
         }
 
         input.touching = false;
-        for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
-            if (input.touch_slots[i].active) {
-                input.touching = true;
-                input.touch_slots[i].duration += raw_dt;
-            }
+        for (auto [entity, slot] : reg.view<ActiveTouchSlot>().each()) {
+            (void)entity;
+            input.touching = true;
+            slot.duration += raw_dt;
         }
         if (input.touching) {
             reg.ctx().insert_or_assign(InputSourceTouch{});
@@ -348,9 +364,10 @@ void input_system(entt::registry& reg, float raw_dt) {
             }
         }
         input.duration = 0.0f;
-        for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
-            if (input.touch_slots[i].active && input.touch_slots[i].duration > input.duration) {
-                input.duration = input.touch_slots[i].duration;
+        for (auto [entity, slot] : reg.view<ActiveTouchSlot>().each()) {
+            (void)entity;
+            if (slot.duration > input.duration) {
+                input.duration = slot.duration;
             }
         }
     } else if (allow_touch_input &&
@@ -362,15 +379,18 @@ void input_system(entt::registry& reg, float raw_dt) {
         input.touching  = false;
         priv.suppress_mouse_release = true;
         clear_input_source(reg);
-        for (int i = 0; i < InputState::MaxTrackedTouches; ++i) {
-            auto& slot = input.touch_slots[i];
-            if (!slot.active) {
-                continue;
+        {
+            entt::entity to_destroy[InputState::MaxTrackedTouches];
+            std::size_t destroy_count = 0;
+            for (auto [entity, slot] : reg.view<ActiveTouchSlot>().each()) {
+                release_touch_slot(slot, input, latest_swipe, had_swipe_zone_release);
+                if (destroy_count < InputState::MaxTrackedTouches) {
+                    to_destroy[destroy_count++] = entity;
+                }
             }
-            release_touch_slot(slot,
-                               input,
-                               latest_swipe,
-                               had_swipe_zone_release);
+            for (std::size_t i = 0; i < destroy_count; ++i) {
+                if (reg.valid(to_destroy[i])) reg.destroy(to_destroy[i]);
+            }
         }
         if (!latest_swipe && had_swipe_zone_release) {
             if (auto fn = raylib_gesture_swipe_direction()) {

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -468,14 +468,19 @@ struct EnergyState {
 struct InputSourceMouse {};
 struct InputSourceTouch {};
 
-struct TouchSlot {
-    static constexpr int InvalidId = -1;
-    int   id      = InvalidId;
-    bool  active  = false;
-    bool  started_in_button_zone = false;
-    float start_x = 0.0f, start_y = 0.0f;
-    float curr_x  = 0.0f, curr_y  = 0.0f;
-    float duration = 0.0f;
+/// Active touch slot — one row per currently-tracked finger (#1612 /
+/// Fabian Principle 3). Presence in `view<ActiveTouchSlot>()` IS slot
+/// activity; the parent `InputState` no longer carries a fixed-size
+/// `TouchSlot touch_slots[]` array column nor the `id == InvalidId`
+/// NULL column that gated it. The `MaxTrackedTouches = 2` policy cap
+/// survives as a runtime allocation guard at the create site in
+/// `input_system`.
+struct ActiveTouchSlot {
+    int   id;
+    bool  started_in_button_zone;
+    float start_x, start_y;
+    float curr_x,  curr_y;
+    float duration;
 };
 
 struct InputState {
@@ -497,7 +502,6 @@ struct InputState {
     bool  suppress_mouse_release = false;
     bool  button_touch_up       = false;  // released inside a HUD button zone
     float button_end_x = 0.0f, button_end_y = 0.0f;
-    TouchSlot touch_slots[MaxTrackedTouches] = {};
 };
 ```
 
@@ -1744,7 +1748,7 @@ app/
 │   └── song_state.h             ← SongState, BeatCursor (row table, issue #1545)
 │
 ├── systems/                     ← all system free functions
-│   ├── input.h                  ← InputState, TouchSlot, InputSourceMouse, InputSourceTouch (singleton hardware-capture state)
+│   ├── input.h                  ← InputState, ActiveTouchSlot, InputSourceMouse, InputSourceTouch (singleton hardware-capture state + per-finger touch row)
 │   ├── all_systems.h            ← convenience #include for all systems
 │   ├── input_system.cpp         ← raylib polling → semantic dispatcher events
 │   ├── game_state_system.cpp    ← phase transitions

--- a/design-docs/feature-specs.md
+++ b/design-docs/feature-specs.md
@@ -109,16 +109,19 @@ The Input System translates raw touch / mouse / keyboard events into game action
 struct InputSourceMouse {};
 struct InputSourceTouch {};
 
-// ── Per-touch tracking slot (multi-touch support) ──
-struct TouchSlot {
-    static constexpr int InvalidId = -1;
-
-    int   id = InvalidId;
-    bool  active = false;
-    bool  started_in_button_zone = false;
-    float start_x = 0.0f, start_y = 0.0f;
-    float curr_x  = 0.0f, curr_y  = 0.0f;
-    float duration = 0.0f;
+// ── Active touch slot — one row per currently-tracked finger (#1612) ──
+// Per Fabian Principle 3, the former fixed-size `TouchSlot
+// touch_slots[MaxTrackedTouches]` array column on `InputState` + its
+// `id == InvalidId = -1` NULL column was normalized into a row table:
+// presence in `view<ActiveTouchSlot>()` IS slot activity, and the
+// `MaxTrackedTouches = 2` policy cap survives as a runtime allocation
+// guard at the create site in `input_system`.
+struct ActiveTouchSlot {
+    int   id;
+    bool  started_in_button_zone;
+    float start_x, start_y;
+    float curr_x,  curr_y;
+    float duration;
 };
 
 // ── Per-frame input state, singleton component ──
@@ -143,7 +146,6 @@ struct InputState {
     bool  suppress_mouse_release = false;
     bool  button_touch_up        = false;
     float button_end_x = 0.0f, button_end_y = 0.0f;
-    TouchSlot touch_slots[MaxTrackedTouches] = {};
 };
 
 // ── Event types: semantic player intentions ──

--- a/tests/test_game_loop_raw_dt_hitch_clamp.cpp
+++ b/tests/test_game_loop_raw_dt_hitch_clamp.cpp
@@ -6,8 +6,10 @@
 // debugger break, or web tab-inactive interval, GetFrameTime() reports the
 // full hitch duration (seconds), which:
 //
-//   • input_system: accumulated touch_slots[i].duration += raw_dt, spuriously
-//     crossing long-press / gesture-duration thresholds.
+//   • input_system: accumulated ActiveTouchSlot::duration += raw_dt
+//     (formerly `touch_slots[i].duration` before #1612 normalized the
+//     fixed-size array column into a row table), spuriously crossing
+//     long-press / gesture-duration thresholds.
 //   • test_player_system: ticked every queued action timer by the full hitch,
 //     fast-forwarding the entire AI plan in a single frame (relevant to the
 //     WASM smoke flake history — see #1341).
@@ -72,19 +74,23 @@ TEST_CASE("test_player_system: action timers advance by at most kMaxFrameDt unde
 TEST_CASE("InputState: touch-slot duration advances by at most kMaxFrameDt under a hitch",
           "[input][game_loop][issue-1352]") {
     auto reg = make_rhythm_registry();
-    auto& input = reg.ctx().get<InputState>();
 
-    // Simulate an active touch carried over a hitch frame.
-    input.touch_slots[0].active   = true;
-    input.touch_slots[0].duration = 0.0f;
+    // Simulate an active touch carried over a hitch frame. Per Fabian
+    // Principle 3 / #1612, the former `InputState::touch_slots[N]`
+    // fixed-size array column was normalized into an `ActiveTouchSlot`
+    // row table — presence in the registry IS slot activity.
+    auto slot_entity = reg.create();
+    auto& slot       = reg.emplace<ActiveTouchSlot>(slot_entity);
+    slot.id          = 0;
+    slot.duration    = 0.0f;
 
     // game_loop_frame clamps GetFrameTime() through clamp_frame_dt before
     // calling input_system. Reproduce the same accumulation expression
-    // input_system uses (app/systems/input_system.cpp:357) to assert the
-    // bounded-advance contract.
+    // input_system uses (the touching/duration loop in input_system.cpp)
+    // to assert the bounded-advance contract.
     constexpr float k5sHitch = 5.0f;
     const float raw_dt = clamp_frame_dt(k5sHitch);
-    input.touch_slots[0].duration += raw_dt;
+    slot.duration += raw_dt;
 
-    CHECK(input.touch_slots[0].duration <= kMaxFrameDt);
+    CHECK(slot.duration <= kMaxFrameDt);
 }


### PR DESCRIPTION
## What
Normalizes `InputState::TouchSlot touch_slots[MaxTrackedTouches] = {}` (an inline fixed-size array column + parallel `id == InvalidId = -1` NULL gate) into an `ActiveTouchSlot` row table — one entity per currently-tracked finger — matching the precedent shape from #1561 (`ObstacleChildren { entt::entity children[MAX]; int count; }`) and #1562 (`HighScoreState { Entry entries[N]; int entry_count; }`).

## Why
Per `.squad/decisions.md` § 9 / Principle 3:

> **No array columns.** A `std::vector<X>` field is a 1NF violation. Each element becomes a row in its own table, with the parent's entity ID as the foreign key.

Fixed-size `T arr[N]` columns are the static-cap equivalent and fail 1NF for the same reason. `TouchSlot.id = InvalidId = -1` was the parallel NULL-column sentinel that gated which array indices were "live" — eradicated by construction in the row form (presence in the storage IS slot activity, mirroring the #1535–#1538 NULL-column wave).

## How

- **`app/systems/input.h`**: drop `TouchSlot` struct (incl. `InvalidId` sentinel and `active` gate); add `ActiveTouchSlot { id; started_in_button_zone; start_*; curr_*; duration; }` row component; drop `touch_slots[]` field from `InputState`; retain `InputState::MaxTrackedTouches = 2` as the policy cap referenced from the runtime allocate guard.

- **`app/systems/input_system.cpp`** (6 sites):
  - `release_touch_slot` takes `const ActiveTouchSlot&`; callers own entity destruction (no `slot = TouchSlot{}` reset).
  - `input_system_clear_pointer_state` collects + destroys all `ActiveTouchSlot` rows (collect-then-destroy pattern from #1597 to avoid mid-iteration view invalidation).
  - Touch outer block:
    1. Orphan-release scan iterates the view and destroys rows whose `id` is no longer in raylib's `GetTouchPointId(...)` table.
    2. Per-touch-point allocate-or-update: find existing row by `id`; else zone-taken probe via view scan; else `view<ActiveTouchSlot>().size() < MaxTrackedTouches` cap guard; else `reg.create() + emplace<ActiveTouchSlot>`.
    3. Touching / duration-max passes iterate the view.
  - Mass-release else-if (focus-loss path) collects + destroys all rows after draining each one's lift-up state.

- **`tests/test_game_loop_raw_dt_hitch_clamp.cpp`**: the "touch-slot duration advances by at most `kMaxFrameDt` under a hitch" test now spawns a fresh entity with `ActiveTouchSlot { id=0, duration=0 }` and accumulates `slot.duration += raw_dt` against the same `clamp_frame_dt`-clamped raw_dt the production input_system loop uses — the bounded-advance contract is unchanged.

- **`design-docs/architecture.md` + `design-docs/feature-specs.md`**: updated `TouchSlot` / `InputState` excerpts and the `app/systems/` layout legend to reflect the new `ActiveTouchSlot` row table shape.

## Acceptance criteria (from #1612)
- [x] `InputState::touch_slots[MaxTrackedTouches]` is eradicated.
- [x] Each tracked finger exists as its own row in `reg.view<ActiveTouchSlot>()`.
- [x] `TouchSlot::id = InvalidId = -1` NULL column is gone (replaced by presence in the storage).
- [x] All read sites use a view iteration instead of `touch_slots[]` indexing.
- [x] All write sites use `emplace` / mutate / `destroy` instead of in-place slot allocation arithmetic.
- [x] `MaxTrackedTouches = 2` survives as a runtime cap assertion at the allocate site.
- [x] All input tests pass; zero-warning build.

## Verification
- Clean rebuild from scratch: zero warnings.
- `./build/shapeshifter_tests` → `All tests passed (3374 assertions in 964 test cases)`.
- `./build/shapeshifter_startup_shutdown_smoke` → exit 0.
- `rg -n 'TouchSlot\b|touch_slots|InvalidId' app/ tests/` → remaining hits are explanatory comments documenting the migration.

Refs: `.squad/decisions.md` § 9 Principle 3 · #1203 (god-class epic) · #1561 / #1562 (precedent shape) · #1535–#1538 (NULL-column wave) · #1603 / #1607 / #1608 / #1609 (recent input_system helper-inline train, its three helpers were the prior surface area).

Closes #1612
