### PR TITLE
#1619 TextContext: drop loaded=false parallel-bool NULL-column gate, presence of ctx singleton IS "fonts loaded" (Fabian Principle 3)

### DIFF
--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -53,12 +53,13 @@ T& reset_ctx_singleton(entt::registry& reg, Args&&... args) {
     return reg.ctx().emplace<T>(std::forward<Args>(args)...);
 }
 
-bool load_text_fonts(TextContext& ctx, const char* font_path) {
+bool try_load_text_fonts(entt::registry& reg, const char* font_path) {
     if (!FileExists(font_path)) {
         TraceLog(LOG_WARNING, "Font file not found: %s", font_path);
         return false;
     }
 
+    TextContext ctx;
     ctx.font_small  = LoadFontEx(font_path, 16, nullptr, 0);
     ctx.font_medium = LoadFontEx(font_path, 28, nullptr, 0);
     ctx.font_large  = LoadFontEx(font_path, 48, nullptr, 0);
@@ -67,13 +68,8 @@ bool load_text_fonts(TextContext& ctx, const char* font_path) {
         ctx.font_medium.baseSize == 0 ||
         ctx.font_large.baseSize == 0) {
         TraceLog(LOG_WARNING, "Failed to load font: %s", font_path);
-        if (ctx.font_large.baseSize > 0)  UnloadFont(ctx.font_large);
-        if (ctx.font_medium.baseSize > 0) UnloadFont(ctx.font_medium);
-        if (ctx.font_small.baseSize > 0)  UnloadFont(ctx.font_small);
-        ctx.font_large = {};
-        ctx.font_medium = {};
-        ctx.font_small = {};
-        ctx.loaded = false;
+        // ctx destructor unloads any partial-load fonts via TextContext::release()
+        // (IsFontValid()-gated UnloadFont per face).
         return false;
     }
 
@@ -81,7 +77,8 @@ bool load_text_fonts(TextContext& ctx, const char* font_path) {
     SetTextureFilter(ctx.font_medium.texture, TEXTURE_FILTER_BILINEAR);
     SetTextureFilter(ctx.font_large.texture, TEXTURE_FILTER_BILINEAR);
 
-    ctx.loaded = true;
+    reg.ctx().erase<TextContext>();
+    reg.ctx().emplace<TextContext>(std::move(ctx));
     return true;
 }
 
@@ -164,11 +161,12 @@ bool game_loop_init(entt::registry& reg,
     TraceLog(LOG_INFO, "SHAPESHIFTER v%s", SHAPESHIFTER_VERSION);
 
     // Text rendering — fall back through bundled, repo-relative, and OS
-    // system font paths in order; the first one `load_text_fonts` accepts
-    // wins. `load_text_fonts` itself remains the anon-ns helper because
-    // its cleanup-on-partial-load logic warrants the abstraction.
+    // system font paths in order; the first one `try_load_text_fonts` accepts
+    // wins and emplaces the `TextContext` ctx singleton. Presence of the
+    // singleton IS "fonts loaded" (Fabian Principle 3, issue #1619), so all
+    // failure paths simply leave the singleton absent and consumers query
+    // `reg.ctx().find<TextContext>() != nullptr`.
     {
-        auto& text_ctx = reset_ctx_singleton<TextContext>(reg);
         std::string exe_font = util::join_app_dir(
             GetApplicationDirectory(), "content/fonts/LiberationMono-Regular.ttf");
         const char* font_paths[] = {
@@ -177,9 +175,10 @@ bool game_loop_init(entt::registry& reg,
             "/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf",
             "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
         };
+        reg.ctx().erase<TextContext>();
         bool loaded = false;
         for (const char* path : font_paths) {
-            if (load_text_fonts(text_ctx, path)) {
+            if (try_load_text_fonts(reg, path)) {
                 TraceLog(LOG_INFO, "Loaded font: %s", path);
                 loaded = true;
                 break;

--- a/app/systems/text_resources.h
+++ b/app/systems/text_resources.h
@@ -13,11 +13,15 @@
 // (consolidated)". UI/domain enums (FontSize) remain in
 // `app/components/text.h`.
 
+// Presence of the `TextContext` ctx singleton IS "text fonts are loaded"
+// (Fabian Principle 3, issue #1619 — eradicated the parallel-bool `loaded`
+// NULL column gate over the three Font payloads, mirroring #1616 / PR #1617's
+// eradication of `SFXBank::loaded`). The loader emplaces only on success;
+// readers query `reg.ctx().find<TextContext>() != nullptr`.
 struct TextContext {
     Font font_small{};
     Font font_medium{};
     Font font_large{};
-    bool loaded = false;
 
     TextContext() = default;
     TextContext(const TextContext&) = delete;
@@ -42,7 +46,6 @@ inline void TextContext::release() {
     font_large = {};
     font_medium = {};
     font_small = {};
-    loaded = false;
 }
 
 inline TextContext::~TextContext() { release(); }
@@ -50,13 +53,11 @@ inline TextContext::~TextContext() { release(); }
 inline TextContext::TextContext(TextContext&& other) noexcept
     : font_small{other.font_small},
       font_medium{other.font_medium},
-      font_large{other.font_large},
-      loaded{other.loaded}
+      font_large{other.font_large}
 {
     other.font_small = {};
     other.font_medium = {};
     other.font_large = {};
-    other.loaded = false;
 }
 
 inline TextContext& TextContext::operator=(TextContext&& other) noexcept {
@@ -65,11 +66,9 @@ inline TextContext& TextContext::operator=(TextContext&& other) noexcept {
         font_small = other.font_small;
         font_medium = other.font_medium;
         font_large = other.font_large;
-        loaded = other.loaded;
         other.font_small = {};
         other.font_medium = {};
         other.font_large = {};
-        other.loaded = false;
     }
     return *this;
 }

--- a/app/systems/ui_render_system.cpp
+++ b/app/systems/ui_render_system.cpp
@@ -604,22 +604,24 @@ void render_ui_entities(entt::registry& reg) {
 } // namespace
 
 void ui_render_system(entt::registry& reg, float /*alpha*/) {
-    auto& text_ctx = reg.ctx().get<TextContext>();
+    auto* text_ctx = reg.ctx().find<TextContext>();
     const auto& st = reg.ctx().get<ScreenTransform>();
     auto& ui_cam = ui_camera(reg).cam;
 
     ClearBackground(BLANK);
     BeginMode2D(ui_cam);
 
-    // Popups
-    {
+    // Popups (skipped entirely when fonts failed to load — issue #1619 made
+    // presence of the `TextContext` ctx singleton IS the "fonts loaded"
+    // predicate, eradicating the parallel-bool `loaded` NULL column).
+    if (text_ctx != nullptr) {
         auto view = reg.view<PopupDisplay, ScreenPosition, TagHUDPass>();
         for (auto [entity, pd, sp] : view.each()) {
-            if (!text_ctx.loaded || pd.text[0] == '\0') {
+            if (pd.text[0] == '\0') {
                 continue;
             }
 
-            const Font& font = popup_font_for_size(text_ctx, pd.font_size);
+            const Font& font = popup_font_for_size(*text_ctx, pd.font_size);
             const float font_size = static_cast<float>(font.baseSize);
             const float spacing = 1.0f;
 

--- a/tests/test_gpu_resource_lifecycle.cpp
+++ b/tests/test_gpu_resource_lifecycle.cpp
@@ -186,7 +186,6 @@ TEST_CASE("runtime contexts: explicit release is idempotent without live handles
     MusicContext music;
     SessionLog log;
 
-    text.loaded = true;
     music.loaded = true;
     music.started = true;
     music.paused = true;
@@ -198,7 +197,6 @@ TEST_CASE("runtime contexts: explicit release is idempotent without live handles
     log.release();
     log.release();
 
-    CHECK_FALSE(text.loaded);
     CHECK_FALSE(music.loaded);
     CHECK_FALSE(music.started);
     CHECK_FALSE(music.paused);


### PR DESCRIPTION
Closes #1619.

`TextContext::loaded` was a parallel-bool NULL column gating the three `Font` payloads — meaningful only when the fonts were valid, exactly the shape #1616 / PR #1617 eradicated on `SFXBank::loaded`.

### Normalization (Shape A)
Loader emplaces `TextContext` into the registry ctx only on success, so **presence of the singleton IS "fonts loaded"**. The one external reader (`ui_render_system.cpp` popup pass) uses `reg.ctx().find<TextContext>() != nullptr` instead of the boolean flag.

### Changes
- `app/systems/text_resources.h` — remove `loaded` field; drop it from `release()`, move-ctor, move-assign.
- `app/game_loop.cpp` — rename `load_text_fonts(TextContext&, …)` → `try_load_text_fonts(entt::registry&, …)`; on success `reg.ctx().emplace<TextContext>(std::move(ctx))`; on failure the local ctx's dtor (`release()`) handles partial-load cleanup. Init block `erase`s up-front; if all fallback paths fail the ctx stays absent.
- `app/systems/ui_render_system.cpp` — `find<TextContext>()` + null-check IS the "fonts loaded" predicate. The `pd.text[0] == '\\0'` skip is preserved inside.
- `tests/test_gpu_resource_lifecycle.cpp` — drop the `text.loaded` write and `CHECK_FALSE(text.loaded)` assertion in the headless release-idempotence test.

### Acceptance criteria
- [x] `TextContext::loaded` eradicated from the struct.
- [x] Presence of the `TextContext` ctx singleton IS "text fonts are loaded".
- [x] `try_load_text_fonts` failure path does not emplace the singleton.
- [x] `ui_render_system.cpp:618` reads `find<TextContext>() != nullptr`, not `text_ctx.loaded`.
- [x] Internal `release()` / move-ctor / move-assign no longer reference `loaded`.
- [x] Local build + `shapeshifter_tests` green (3373 assertions, 965 test cases); zero-warning build.

### References
- .squad/decisions.md § 9 Principle 3 (no NULL columns)
- #1616 / PR #1617 — `SFXBank.loaded` eradication precedent
- #1610 / #1611 / #1612 — recent NULL-column eradication wave