### PR TITLE
#1620 TestPlayerState: drop active=false parallel-bool NULL-column gate, presence of ctx singleton IS "test player enabled" (Fabian Principle 3)

### DIFF
--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -204,7 +204,10 @@ bool game_loop_init(entt::registry& reg,
     reset_ctx_singleton<LevelSelectState>(reg);
     reset_ctx_singleton<EnergyState>(reg);
     reset_ctx_singleton<SongResults>(reg);
-    reset_ctx_singleton<TestPlayerState>(reg);
+    // `TestPlayerState` is no longer pre-emplaced at startup — its presence
+    // IS "test player enabled" (Fabian Principle 3, issue #1620). The sole
+    // emplace site is `test_player_init`; default play sessions leave it
+    // absent and `test_player_system` early-outs on `find<>() == nullptr`.
     reset_ctx_singleton<TestPlayerSessionState>(reg);
     reset_ctx_singleton<SessionLog>(reg);
     runtime_system_scratch_init(reg);

--- a/app/systems/test_player.h
+++ b/app/systems/test_player.h
@@ -66,18 +66,23 @@ struct TestPlayerAction {
 };
 
 // ── Test player state (context singleton) ────────────────────
-// Hot state (accessed every frame): active, swipe_cooldown_timer.
+// Hot state (accessed every frame): swipe_cooldown_timer.
 // Warm state (accessed during perception): skill, rng.
 //
-// Per Fabian Principle 3 (.squad/decisions.md § 9 — no array columns), the
-// former `actions[MAX_ACTIONS] + action_count` inline array column is
-// eradicated. Each queued action now lives as a `TestPlayerAction` component
-// attached to the obstacle entity it tracks (the `obstacle` field IS the
-// foreign key — identity-driven membership). MAX_ACTIONS survives as a
-// runtime cap asserted at enqueue time, not a static array bound.
+// Per Fabian Principle 3 (.squad/decisions.md § 9 — no NULL columns / no
+// array columns), the former `actions[MAX_ACTIONS] + action_count` inline
+// array column is eradicated (issue #1611); each queued action now lives
+// as a `TestPlayerAction` component attached to the obstacle entity it
+// tracks. The former `bool active` parallel-bool NULL-column gate over
+// the singleton is also eradicated (issue #1620) — presence of the
+// `TestPlayerState` ctx singleton IS "test player enabled", so
+// `test_player_init` is the sole emplace site and `test_player_system`
+// reads `find<TestPlayerState>() != nullptr` instead of a flag.
+//
+// MAX_ACTIONS survives as a runtime cap asserted at enqueue time, not a
+// static array bound.
 struct TestPlayerState {
     SkillConfig skill   = SKILL_PRO;
-    bool        active  = false;
 
     // Delay between consecutive lane swipes (simulates human re-swipe time)
     static constexpr float SWIPE_COOLDOWN = 0.125f;  // 125ms (midpoint of 100-150ms)

--- a/app/systems/test_player_session.cpp
+++ b/app/systems/test_player_session.cpp
@@ -39,10 +39,13 @@ void test_player_init(entt::registry& reg, SkillConfig skill,
         session_state = &reg.ctx().emplace<TestPlayerSessionState>();
     }
 
-    auto& tp_state = reg.ctx().get<TestPlayerState>();
-    tp_state = TestPlayerState{};
+    // `TestPlayerState` ctx singleton presence IS "test player enabled"
+    // (Fabian Principle 3, issue #1620). `test_player_init` is the sole
+    // emplace site; erase-then-emplace is idempotent and resets all hot
+    // state in one move (replaces the old `tp_state = TestPlayerState{}`).
+    reg.ctx().erase<TestPlayerState>();
+    auto& tp_state = reg.ctx().emplace<TestPlayerState>();
     tp_state.skill  = skill;
-    tp_state.active = true;
 
     unsigned seed = session_state->rng_seed;
     if (session_state->use_runtime_seed) {

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -144,8 +144,12 @@ static TestPlayerAction determine_action(
 // ── System ───────────────────────────────────────────────────
 
 void test_player_system(entt::registry& reg, float dt) {
+    // Presence of the `TestPlayerState` ctx singleton IS "test player
+    // enabled" (Fabian Principle 3, issue #1620 — eradicated the parallel-
+    // bool `active` NULL-column gate). `test_player_init` is the sole
+    // emplace site; default game-loop startup leaves the singleton absent.
     auto* state = reg.ctx().find<TestPlayerState>();
-    if (!state || !state->active) return;
+    if (!state) return;
 
     auto& gs    = reg.ctx().get<GameState>();
     auto& ctx   = reg.ctx();

--- a/tests/test_game_loop_raw_dt_hitch_clamp.cpp
+++ b/tests/test_game_loop_raw_dt_hitch_clamp.cpp
@@ -44,7 +44,6 @@ TEST_CASE("test_player_system: action timers advance by at most kMaxFrameDt unde
     auto reg = make_rhythm_registry();
     auto& tp = reg.ctx().emplace<TestPlayerState>();
     tp.skill  = SKILL_PRO;
-    tp.active = true;
     tp.rng.seed(42);
 
     // Per Fabian Principle 3 / #1611, queued actions live as components on

--- a/tests/test_test_player_system.cpp
+++ b/tests/test_test_player_system.cpp
@@ -10,7 +10,6 @@ static entt::registry make_test_player_registry(SkillConfig skill = SKILL_PRO) {
     entt::registry reg = make_rhythm_registry();
     auto& tp = reg.ctx().emplace<TestPlayerState>();
     tp.skill = skill;
-    tp.active = true;
     tp.rng.seed(42);
     return reg;
 }


### PR DESCRIPTION
Closes #1620.

`TestPlayerState::active` was a parallel-bool NULL column gating the entire singleton — meaningful only when the test-player session was started, the same shape PR #1617 / #1616 eradicated on `SFXBank::loaded` and PR #1621 (this cycle) eradicates on `TextContext::loaded`.

### Normalization (Shape A)
`test_player_init` becomes the sole emplace site; default game-loop startup no longer pre-emplaces an inactive singleton. **Presence of `TestPlayerState` in the ctx IS "test player enabled"** — `test_player_system` reads `reg.ctx().find<TestPlayerState>() != nullptr` instead of a boolean flag.

### Changes
- `app/systems/test_player.h` — remove `active` field; update hot-state header comment.
- `app/systems/test_player_system.cpp` —
- `app/systems/test_player_session.cpp` — replace `get<TestPlayerState>() + tp_state = TestPlayerState{} + active=true` with `erase<TestPlayerState>() + emplace<TestPlayerState>()` (idempotent emplace-or-replace; both ensures presence and resets hot state).
- `app/game_loop.cpp` — remove the unconditional `reset_ctx_singleton<TestPlayerState>(reg)` at startup; singleton is now emplaced lazily on session start.
- `tests/test_test_player_system.cpp` + `tests/test_game_loop_raw_dt_hitch_clamp.cpp` — drop `tp.active = true;` lines from the two direct-emplace fixtures.

### Acceptance criteria
- [x] `TestPlayerState::active` eradicated from the struct.
- [x] Presence of `TestPlayerState` ctx singleton IS "test player enabled".
- [x] `test_player_init` is the only emplace site; default-startup does not emplace.
- [x] `test_player_system` reads `find<TestPlayerState>() != nullptr`, not `state->active`.
- [x] Tests in `tests/test_test_player_system.cpp` and `tests/test_game_loop_raw_dt_hitch_clamp.cpp` updated.
- [x] Local build + `shapeshifter_tests` green (3374 assertions, 965 test cases); zero-warning build.

### References
- .squad/decisions.md § 9 Principle 3 (no NULL columns) and Principle 0 (existential processing)
- #1616 / PR #1617 — `SFXBank.loaded` eradication precedent
- #1619 / PR #1621 (this cycle) — `TextContext.loaded` eradication
- #1610 / #1611 / #1612 — recent NULL-column eradication wave