### PR TITLE
#1618 MusicContext: drop loaded/started/paused triple NULL-column gate; ctx singleton + MusicPlayingTag/MusicPausedTag carry playback state (Fabian Principle 3)

### DIFF
--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -251,10 +251,14 @@ bool game_loop_init(entt::registry& reg,
     // Cameras + render targets + GPU meshes
     camera::init(reg);
 
-    // UI + beatmap + music
+    // UI + beatmap + music — `MusicContext` is no longer pre-emplaced.
+    // Per issue #1618 / Fabian Principle 3, presence of the `MusicContext`
+    // ctx singleton IS "stream loaded"; `play_session.cpp` emplaces it
+    // lazily after a successful `LoadMusicStream`. Audio-device availability
+    // is gated by `IsAudioDeviceReady()` instead of the former "is the
+    // singleton emplaced?" proxy.
     create_beat_map_entity(reg);
     reset_ctx_singleton<SongState>(reg);
-    reset_ctx_singleton<MusicContext>(reg);
 
     // Test player (optional)
     if (test_player_mode) {
@@ -391,6 +395,9 @@ void game_loop_shutdown(entt::registry& reg) {
         if (music) {
             music->release();
         }
+        reg.ctx().erase<MusicContext>();
+        reg.ctx().erase<MusicPlayingTag>();
+        reg.ctx().erase<MusicPausedTag>();
     }
     camera::shutdown(reg);
     if (auto* text_ctx = reg.ctx().find<TextContext>()) {

--- a/app/systems/audio_resources.h
+++ b/app/systems/audio_resources.h
@@ -2,14 +2,23 @@
 
 #include <raylib.h>
 
-// Audio runtime resource owner: holds the raylib Music handle and playback
-// state for the active song. Lives in registry context (not on an entity)
+// Audio runtime resource owner: holds the raylib Music handle for the
+// currently-loaded song. Lives in registry context (not on an entity)
 // and is read/written 1–2× per frame by song_playback_system only.
 //
 // Lives beside its owning system (not under `app/components/`) because this
 // is a ctx-singleton RAII wrapper, not entity-owned plain data —
 // `app/components/` stays reserved for atomic, queryable entity-owned tables
 // per .squad/decisions.md §"app/components parallel audit verdict (consolidated)".
+//
+// Per Fabian Principle 3 (.squad/decisions.md § 9 — no NULL columns) the
+// former `loaded` / `started` / `paused` parallel-bool NULL-column gates
+// over `stream` were eradicated in issue #1618:
+//   - `loaded`  → presence of `MusicContext` ctx singleton IS "stream loaded"
+//   - `started` → presence of `MusicPlayingTag` ctx tag IS "PlayMusicStream() in flight"
+//   - `paused`  → presence of `MusicPausedTag`  ctx tag IS "PauseMusicStream() in flight"
+// This mirrors the precedent set by PR #1617 (`SFXBank::loaded`) and
+// PRs in this cycle (#1621 `TextContext`, #1622 `TestPlayerState::active`).
 
 inline bool music_stream_is_playable(const Music& music) {
     return IsMusicValid(music) && music.stream.buffer != nullptr;
@@ -17,9 +26,6 @@ inline bool music_stream_is_playable(const Music& music) {
 
 struct MusicContext {
     Music stream{};        // raylib Music handle (zero-initialized)
-    bool  loaded  = false; // LoadMusicStream succeeded
-    bool  started = false; // PlayMusicStream has been called
-    bool  paused  = false; // PauseMusicStream called; consumed by one-shot resume
     float volume  = 0.8f;  // master volume [0.0, 1.0]
 
     MusicContext() = default;
@@ -48,38 +54,23 @@ inline void unload_music_stream_resources(Music& stream) {
 
 inline void MusicContext::release() {
     unload_music_stream_resources(stream);
-    loaded = false;
-    started = false;
-    paused = false;
 }
 
 inline MusicContext::~MusicContext() { release(); }
 
 inline MusicContext::MusicContext(MusicContext&& other) noexcept
     : stream{other.stream},
-      loaded{other.loaded},
-      started{other.started},
-      paused{other.paused},
       volume{other.volume}
 {
     other.stream = {};
-    other.loaded = false;
-    other.started = false;
-    other.paused = false;
 }
 
 inline MusicContext& MusicContext::operator=(MusicContext&& other) noexcept {
     if (this != &other) {
         release();
         stream = other.stream;
-        loaded = other.loaded;
-        started = other.started;
-        paused = other.paused;
         volume = other.volume;
         other.stream = {};
-        other.loaded = false;
-        other.started = false;
-        other.paused = false;
     }
     return *this;
 }

--- a/app/systems/play_session.cpp
+++ b/app/systems/play_session.cpp
@@ -165,9 +165,12 @@ void setup_play_session(entt::registry& reg) {
                      error.beat_index, error.message.c_str());
         }
         runtime_system_scratch_init(reg);
-        if (auto* music = reg.ctx().find<MusicContext>()) {
-            music->release();
-        }
+        // Per issue #1618: presence of `MusicContext` ctx singleton IS
+        // "stream loaded" (Fabian Principle 3). On beatmap load failure we
+        // drop the entire singleton plus its playback-state tags.
+        reg.ctx().erase<MusicContext>();
+        reg.ctx().erase<MusicPlayingTag>();
+        reg.ctx().erase<MusicPausedTag>();
         if (auto* session = reg.ctx().find<HighScoreSession>()) {
             session->key_hash = 0;
         }
@@ -229,23 +232,25 @@ void setup_play_session(entt::registry& reg) {
     song.playing = true;
     song.restart_music = true;
 
-    // Load music (only if MusicContext exists — not in test mode)
-    auto* music = reg.ctx().find<MusicContext>();
-    if (music) {
-        music->release();
-    }
-    if (music && !beatmap.song_path.empty()) {
+    // Load music — presence of `MusicContext` ctx singleton IS "stream
+    // loaded" (Fabian Principle 3, issue #1618). We erase any prior
+    // singleton + playback tags up-front, then emplace on a successful
+    // `LoadMusicStream`. `IsAudioDeviceReady()` is the proper "audio
+    // available" gate (replaces the former `if (music)` proxy which
+    // depended on game_loop_init pre-emplacing an empty MusicContext).
+    reg.ctx().erase<MusicContext>();
+    reg.ctx().erase<MusicPlayingTag>();
+    reg.ctx().erase<MusicPausedTag>();
+    if (IsAudioDeviceReady() && !beatmap.song_path.empty()) {
         std::string exe_audio = util::join_app_dir(GetApplicationDirectory(), beatmap.song_path);
         const char* audio_paths[] = { exe_audio.c_str(), beatmap.song_path.c_str() };
         for (const char* path : audio_paths) {
             Music stream = LoadMusicStream(path);
             stream.looping = false;
             if (music_stream_is_playable(stream)) {
-                music->stream  = stream;
-                music->loaded  = true;
-                music->started = false;
-                music->paused = false;
-                SetMusicVolume(music->stream, music->volume);
+                auto& music = reg.ctx().emplace<MusicContext>();
+                music.stream = stream;
+                SetMusicVolume(music.stream, music.volume);
                 TraceLog(LOG_INFO, "Loaded music: %s", path);
                 break;
             }

--- a/app/systems/song_playback_system.cpp
+++ b/app/systems/song_playback_system.cpp
@@ -12,11 +12,16 @@ void song_playback_system(entt::registry& reg, float dt) {
     auto* song  = ctx.find<SongState>();
     auto* map   = find_beat_map(reg);
     auto* music = ctx.find<MusicContext>();
-    const bool music_loaded = music && music->loaded;
+    // Per Fabian Principle 3 / issue #1618: presence of the `MusicContext`
+    // ctx singleton IS "stream loaded" (eradicated the parallel-bool
+    // `loaded` NULL-column gate). The `started`/`paused` bools are likewise
+    // eradicated — `MusicPlayingTag` / `MusicPausedTag` ctx tags carry the
+    // playback machine state.
+    const bool music_loaded = (music != nullptr);
 
     // Must pump the stream buffer every frame to prevent audio underruns,
     // even when the game is paused.
-    if (music_loaded && music->started) {
+    if (music_loaded && ctx.contains<MusicPlayingTag>()) {
         UpdateMusicStream(music->stream);
     }
 
@@ -26,8 +31,8 @@ void song_playback_system(entt::registry& reg, float dt) {
         if (music_loaded) {
             StopMusicStream(music->stream);
             PlayMusicStream(music->stream);
-            music->started = true;
-            music->paused = false;
+            if (!ctx.contains<MusicPlayingTag>()) ctx.emplace<MusicPlayingTag>();
+            ctx.erase<MusicPausedTag>();
         }
     }
 
@@ -43,25 +48,25 @@ void song_playback_system(entt::registry& reg, float dt) {
     const bool song_complete_phase = ctx.contains<GamePhaseSongCompleteTag>();
 
     if (music_loaded && playing_phase && song && song->playing) {
-        if (!music->started) {
+        if (!ctx.contains<MusicPlayingTag>()) {
             PlayMusicStream(music->stream);
-            music->started = true;
-            music->paused = false;
-        } else if (music->paused) {
+            ctx.emplace<MusicPlayingTag>();
+            ctx.erase<MusicPausedTag>();
+        } else if (ctx.contains<MusicPausedTag>()) {
             ResumeMusicStream(music->stream);
-            music->paused = false;
+            ctx.erase<MusicPausedTag>();
         }
-    } else if (music_loaded && paused_phase && music->started) {
-        if (!music->paused) {
+    } else if (music_loaded && paused_phase && ctx.contains<MusicPlayingTag>()) {
+        if (!ctx.contains<MusicPausedTag>()) {
             PauseMusicStream(music->stream);
-            music->paused = true;
+            ctx.emplace<MusicPausedTag>();
         }
     } else if (music_loaded &&
                (game_over_phase || song_complete_phase) &&
-               music->started) {
+               ctx.contains<MusicPlayingTag>()) {
         StopMusicStream(music->stream);
-        music->started = false;
-        music->paused = false;
+        ctx.erase<MusicPlayingTag>();
+        ctx.erase<MusicPausedTag>();
     }
 
     // ── Song time / beat advancement (Playing phase only) ─────
@@ -78,7 +83,7 @@ void song_playback_system(entt::registry& reg, float dt) {
 
     // Authoritative clock from audio stream; fall back to dt accumulation
     // when running in silent/test mode (no music loaded).
-    if (music_loaded && music->started) {
+    if (music_loaded && ctx.contains<MusicPlayingTag>()) {
         song->song_time = GetMusicTimePlayed(music->stream);
     } else {
         song->song_time += dt;
@@ -118,10 +123,10 @@ void song_playback_system(entt::registry& reg, float dt) {
     if (song->song_time >= song->duration_sec) {
         song->finished = true;
         song->playing  = false;
-        if (music_loaded && music->started) {
+        if (music_loaded && ctx.contains<MusicPlayingTag>()) {
             StopMusicStream(music->stream);
-            music->started = false;
-            music->paused = false;
+            ctx.erase<MusicPlayingTag>();
+            ctx.erase<MusicPausedTag>();
         }
     }
 }

--- a/app/tags/tags.h
+++ b/app/tags/tags.h
@@ -115,6 +115,22 @@ struct EnergyBarTag {};
 // ── Test player (deterministic AI) ───────────────────────────
 struct TestPlayerPlannedTag {};
 
+// ── Music playback (per-tag ctx tables) ──────────────────────
+// Per Fabian's existential processing (issue #1618 / .squad/decisions.md
+// § 9 Principle 3), the former `MusicContext::started` and `paused`
+// parallel-bool NULL-column gates over the `Music stream` payload are
+// eradicated. The four-state playback machine — *(absent / loaded-stopped
+// / loaded-playing / loaded-paused)* — is now expressed as:
+//   - presence of the `MusicContext` ctx singleton IS "stream loaded"
+//   - presence of `MusicPlayingTag` IS "PlayMusicStream() in flight"
+//   - presence of `MusicPausedTag` IS "PauseMusicStream() in flight"
+//     (only meaningful while `MusicPlayingTag` is also present)
+// `song_playback_system` reads tag presence; transitions are
+// `emplace<...>` / `erase<...>` on the ctx. Mirrors the precedent set
+// by the `GamePhase*Tag` family and PR #1617's `SFXBank` eradication.
+struct MusicPlayingTag {};
+struct MusicPausedTag  {};
+
 // ── Render-pass membership; one per entity ───────────────────
 struct TagWorldPass   {};  // drawn in BeginMode3D (3D world geometry)
 struct TagEffectsPass {};  // particles, post-process overlays

--- a/tests/test_gpu_resource_lifecycle.cpp
+++ b/tests/test_gpu_resource_lifecycle.cpp
@@ -186,10 +186,6 @@ TEST_CASE("runtime contexts: explicit release is idempotent without live handles
     MusicContext music;
     SessionLog log;
 
-    music.loaded = true;
-    music.started = true;
-    music.paused = true;
-
     text.release();
     text.release();
     music.release();
@@ -197,9 +193,6 @@ TEST_CASE("runtime contexts: explicit release is idempotent without live handles
     log.release();
     log.release();
 
-    CHECK_FALSE(music.loaded);
-    CHECK_FALSE(music.started);
-    CHECK_FALSE(music.paused);
     CHECK(log.file == nullptr);
 }
 

--- a/tests/test_song_playback_system.cpp
+++ b/tests/test_song_playback_system.cpp
@@ -291,20 +291,24 @@ TEST_CASE("song_playback: pause to playing resume guard is one-shot",
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
 
-    auto& music = reg.ctx().emplace<MusicContext>();
-    music.loaded = true;
-    music.started = true;
-    music.paused = true;
+    // Per issue #1618 / Fabian Principle 3, presence of `MusicContext`
+    // ctx singleton IS "stream loaded"; `MusicPlayingTag` / `MusicPausedTag`
+    // ctx tags carry the started/paused state machine. raylib's stream
+    // entry points are no-ops on a zero-initialized `Music`, so the
+    // lifecycle dispatch is exercised without an actual loaded stream.
+    reg.ctx().emplace<MusicContext>();
+    reg.ctx().emplace<MusicPlayingTag>();
+    reg.ctx().emplace<MusicPausedTag>();
 
     set_test_phase<GamePhasePlayingTag>(reg);
     song.playing = true;
 
     song_playback_system(reg, 0.016f);
-    CHECK_FALSE(music.paused);
+    CHECK_FALSE(reg.ctx().contains<MusicPausedTag>());
 
     song_playback_system(reg, 0.016f);
-    CHECK_FALSE(music.paused);
+    CHECK_FALSE(reg.ctx().contains<MusicPausedTag>());
 
     song_playback_system(reg, 0.016f);
-    CHECK_FALSE(music.paused);
+    CHECK_FALSE(reg.ctx().contains<MusicPausedTag>());
 }


### PR DESCRIPTION
Closes #1618.

`MusicContext::loaded + started + paused` encoded a 4-state playback machine — *(none / loaded-stopped / loaded-playing / loaded-paused)* — as three parallel-bool NULL-column gates over the raylib `Music` payload, then read via `if`-cascade in `song_playback_system`. By .squad/decisions.md § 9 Principle 3 ("No NULL columns. A field that is meaningful only when another field has a particular value is a NULL column in disguise"), each bool is a NULL column over `stream`. Same shape as `SFXBank::loaded` (#1616 / PR #1617) and the two sibling PRs this cycle: `TextContext::loaded` (#1619 / PR #1621), `TestPlayerState::active` (#1620 / PR #1622).

### Normalization
- `loaded`  → presence of the `MusicContext` ctx singleton IS "stream loaded"
- `started` → presence of `MusicPlayingTag` ctx tag IS "PlayMusicStream() in flight"
- `paused`  → presence of `MusicPausedTag`  ctx tag IS "PauseMusicStream() in flight" (only meaningful while `MusicPlayingTag` is also present)

State transitions are `ctx.emplace<...>` / `ctx.erase<...>` (Principle 4) — same shape as the `GamePhase*Tag` family already used in this system.

### Changes
- `app/systems/audio_resources.h` — remove `loaded` / `started` / `paused` fields; collapse `release()` / move-ctor / move-assign to the single `stream` payload (+ `volume`).
- `app/tags/tags.h` — add `MusicPlayingTag` + `MusicPausedTag` with doc comments referencing this issue.
- `app/systems/song_playback_system.cpp` — read playback state via `ctx.contains<MusicPlayingTag>()` / `ctx.contains<MusicPausedTag>()`; write transitions via `emplace<...>` / `erase<...>`. `music_loaded` collapses to `(music != nullptr)`. Lifecycle dispatch shape preserved (mutual-exclusion via the `GamePhase*Tag` mirror).
- `app/systems/play_session.cpp` — gate music load on `IsAudioDeviceReady()` (replaces the former `if (music)` proxy that depended on `game_loop_init` pre-emplacing an empty singleton); erase prior `MusicContext` + tags up-front; on a successful `LoadMusicStream` emplace a fresh `MusicContext` with the loaded stream. The beatmap-load-failure path also erases the singleton + tags.
- `app/game_loop.cpp` — drop the unconditional `reset_ctx_singleton<MusicContext>(reg)` at startup; singleton is now emplaced lazily on successful music load. Shutdown also erases the `MusicPlayingTag` / `MusicPausedTag` ctx tags alongside the existing `MusicContext::release()`.
- `tests/test_song_playback_system.cpp` — the "pause→playing resume guard is one-shot" regression switches to `emplace<MusicPlayingTag>() + emplace<MusicPausedTag>()` for the fixture and `contains<MusicPausedTag>()` for the assertion; raylib's stream entry points are no-ops on zero-init `Music`, so the lifecycle dispatch is exercised without an actual loaded stream.
- `tests/test_gpu_resource_lifecycle.cpp` — drop the `music.loaded/started/paused` writes and matching `CHECK_FALSE` assertions in the headless release-idempotence test.

### Acceptance criteria
- [x] `MusicContext::loaded` / `started` / `paused` eradicated from the struct.
- [x] Presence of `MusicContext` ctx singleton IS "stream loaded".
- [x] `MusicPlayingTag` / `MusicPausedTag` ctx tags carry the started/paused state machine.
- [x] All transitions use `emplace<...>` / `erase<...>` on ctx (Principle 4).
- [x] `song_playback_system` no longer reads `music->loaded` / `music->started` / `music->paused` anywhere.
- [x] `play_session.cpp` gate uses `IsAudioDeviceReady()` instead of "singleton emplaced as proxy".
- [x] Tests in `test_song_playback_system.cpp` + `test_gpu_resource_lifecycle.cpp` updated.
- [x] Local build + `shapeshifter_tests` green (3371 assertions in 965 test cases); zero-warning build.

### References
- .squad/decisions.md § 9 Principle 3 (no NULL columns) and Principle 4 (per-case tables)
- #1616 / PR #1617 — `SFXBank.loaded` eradication precedent
- #1619 / PR #1621 (this cycle) — `TextContext.loaded` eradication
- #1620 / PR #1622 (this cycle) — `TestPlayerState.active` eradication
- #1610 / #1611 / #1612 — recent NULL-column eradication wave
