### PR TITLE
`SongState::playing + finished + restart_music` encoded a 4-state song-lifecycle (#1624)

### DIFF
--- a/app/components/song_state.h
+++ b/app/components/song_state.h
@@ -35,12 +35,15 @@ struct SongState {
     // `BeatCursor` ctx-singleton row table below (Fabian Principle 3 /
     // issue #1545): membership IS "at least one beat has been crossed",
     // and `last_crossed` is always meaningful while the row exists.
+    //
+    // The former `playing` / `finished` / `restart_music` parallel-bool
+    // gates likewise migrated to per-tag ctx tables (Fabian Principle 3 /
+    // issue #1624):
+    //   - presence of `SongPlayingTag`         IS "song is currently playing"
+    //   - presence of `SongFinishedTag`        IS "song has finished"
+    //   - presence of `RestartMusicRequestTag` IS "music restart pending"
+    // See `app/tags/tags.h` for the doc comments.
     float  song_time     = 0.0f;   // mutated every frame by song_playback_system
-    bool   playing       = false;  // set true by setup_play_session; cleared by
-                                   //   song_playback_system or terminal GameOver entry
-    bool   finished      = false;  // set true by song_playback_system or terminal GameOver entry
-    bool   restart_music = false;  // set true by setup_play_session; consumed/cleared
-                                   //   on the next tick by song_playback_system
 
     // ── Beat-schedule cursors (per-(kind, shape, timing-source), reset at session init) ──
     // Replaces the former `next_spawn_idx` single cursor (issue #1202/#1204).

--- a/app/entities/beat_map.cpp
+++ b/app/entities/beat_map.cpp
@@ -1095,8 +1095,9 @@ void init_song_state(SongState& state, const BeatMap& map) {
     // membership IS "at least one beat has been crossed" (issue #1545 /
     // Fabian Principle 3). `setup_play_session` erases any prior row at
     // session init, so this function intentionally does not touch it.
-    state.playing      = false;
-    state.finished     = false;
+    // The former `playing` / `finished` field resets likewise migrated to
+    // ctx tag erases on the caller side (issue #1624 / Fabian Principle 3
+    // / `SongPlayingTag` + `SongFinishedTag`); see `setup_play_session`.
     state.next_shape_gate_circle_idx         = 0;
     state.next_shape_gate_square_idx         = 0;
     state.next_shape_gate_triangle_idx       = 0;

--- a/app/systems/beat_log_system.cpp
+++ b/app/systems/beat_log_system.cpp
@@ -16,7 +16,8 @@ void beat_log_system(entt::registry& reg, [[maybe_unused]] float dt) {
     if (!log || !log->file) return;
 
     auto* song = ctx.find<SongState>();
-    if (!song || !song->playing || song->finished) return;
+    if (!song) return;
+    if (!ctx.contains<SongPlayingTag>() || ctx.contains<SongFinishedTag>()) return;
 
     const auto* cursor = ctx.find<BeatCursor>();
     if (!cursor) return;  // no beat crossed yet → nothing to log

--- a/app/systems/beat_scheduler_system.cpp
+++ b/app/systems/beat_scheduler_system.cpp
@@ -143,7 +143,7 @@ void schedule_onset_marker_bin(ScheduleContext& ctx,
 void beat_scheduler_system(entt::registry& reg, [[maybe_unused]] float dt) {
     auto* song = reg.ctx().find<SongState>();
     auto* map  = find_beat_map(reg);
-    if (!song || !map || !song->playing) return;
+    if (!song || !map || !reg.ctx().contains<SongPlayingTag>()) return;
     if (!std::isfinite(song->scroll_speed) || song->scroll_speed <= 0.0f) {
         TraceLog(LOG_WARNING, "beat_scheduler_system skipped: invalid scroll_speed %.3f", song->scroll_speed);
         return;

--- a/app/systems/camera_system.cpp
+++ b/app/systems/camera_system.cpp
@@ -326,7 +326,7 @@ void game_camera_system(entt::registry& reg, [[maybe_unused]] float dt) {
         const float audio_offset_sec = settings ? settings::audio_offset_seconds(*settings) : 0.0f;
         const auto* cursor = reg.ctx().find<BeatCursor>();
         float pulse = 0.0f;
-        if (song && song->playing && song->beat_period > 0.0f && cursor) {
+        if (song && reg.ctx().contains<SongPlayingTag>() && song->beat_period > 0.0f && cursor) {
             float beat_time = song->offset + static_cast<float>(cursor->last_crossed) * song->beat_period;
             const auto beat_index = static_cast<size_t>(cursor->last_crossed);
             if (map && beat_index < map->beat_times.size()) {

--- a/app/systems/collision_system.cpp
+++ b/app/systems/collision_system.cpp
@@ -59,7 +59,9 @@ void collision_system(entt::registry& reg, [[maybe_unused]] float dt) {
     (void)p_shape;
 
     auto& song = reg.ctx().get<SongState>();
-    const bool rhythm_mode = song.playing || song.finished;
+    const auto& ctx = reg.ctx();
+    const bool rhythm_mode =
+        ctx.contains<SongPlayingTag>() || ctx.contains<SongFinishedTag>();
 
     // Frame-constant precomputes — both values are invariant across all obstacle
     // loops since player transform and vertical state don't change mid-frame.

--- a/app/systems/energy_bar_system.cpp
+++ b/app/systems/energy_bar_system.cpp
@@ -18,7 +18,7 @@ void energy_bar_system(entt::registry& reg, [[maybe_unused]] float dt) {
     const auto* settings = find_settings_state(reg);
     const bool reduce_motion = settings && settings->reduce_motion;
     const auto* song = reg.ctx().find<SongState>();
-    const bool song_playing = song && song->playing;
+    const bool song_playing = song && reg.ctx().contains<SongPlayingTag>();
 
     float bounce = 0.0f;
     if (song_playing && !reduce_motion && song->beat_period > 0.0f) {

--- a/app/systems/floor_render_system.cpp
+++ b/app/systems/floor_render_system.cpp
@@ -129,8 +129,8 @@ void draw_floor_rings(const FloorParams& fp) {
     rlEnd();
 }
 
-void draw_floor_beat_lines(const SongState* song, const BeatMap* map, float audio_offset_sec) {
-    if (!song || !song->playing || song->scroll_speed <= 0.0f) {
+void draw_floor_beat_lines(const SongState* song, bool song_playing, const BeatMap* map, float audio_offset_sec) {
+    if (!song || !song_playing || song->scroll_speed <= 0.0f) {
         return;
     }
 
@@ -190,8 +190,9 @@ void floor_render_system(const entt::registry& reg) {
     const auto* map = find_beat_map(reg);
     const auto* settings = find_settings_state(reg);
     const float audio_offset_sec = settings ? settings::audio_offset_seconds(*settings) : 0.0f;
+    const bool song_playing = reg.ctx().contains<SongPlayingTag>();
 
     draw_floor_lines(floor_params);
-    draw_floor_beat_lines(song, map, audio_offset_sec);
+    draw_floor_beat_lines(song, song_playing, map, audio_offset_sec);
     draw_floor_rings(floor_params);
 }

--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -179,7 +179,7 @@ void game_state_system(entt::registry& reg, float dt) {
             return;
         }
 
-        if (song && song->finished) {
+        if (song && reg.ctx().contains<SongFinishedTag>()) {
             // Wait until all obstacle entities have been destroyed.
             if (reg.view<ObstacleTag>().empty()) {
                 request_phase_transition<NextPhaseSongCompleteTag>(reg);

--- a/app/systems/game_state_terminal_phase_system.cpp
+++ b/app/systems/game_state_terminal_phase_system.cpp
@@ -64,10 +64,13 @@ void game_state_enter_terminal_phase_game_over(entt::registry& reg) {
 
     enter_phase<GamePhaseGameOverTag>(reg);
 
-    if (auto* song = reg.ctx().find<SongState>()) {
-        song->finished = true;
-        song->playing = false;
-    }
+    // Terminal song stop: flip the song-lifecycle tags (Fabian Principle 3
+    // / issue #1624). `SongFinishedTag` and `SongPlayingTag` are mutex;
+    // emplace one and erase the other regardless of whether a SongState
+    // payload still exists (mirrors the prior `song.finished = true;
+    // song.playing = false;` invariant).
+    reg.ctx().emplace<SongFinishedTag>();
+    reg.ctx().erase<SongPlayingTag>();
 }
 
 void game_state_enter_terminal_phase_song_complete(entt::registry& reg) {

--- a/app/systems/play_session.cpp
+++ b/app/systems/play_session.cpp
@@ -179,6 +179,9 @@ void setup_play_session(entt::registry& reg) {
         erase_ctx_if_exists<CurrentSongHighScore>(reg);
         erase_ctx_if_exists<SongState>(reg);
         erase_ctx_if_exists<BeatCursor>(reg);
+        erase_ctx_if_exists<SongPlayingTag>(reg);
+        erase_ctx_if_exists<SongFinishedTag>(reg);
+        erase_ctx_if_exists<RestartMusicRequestTag>(reg);
         erase_ctx_if_exists<EnergyState>(reg);
         erase_ctx_if_exists<SongResults>(reg);
         erase_ctx_if_exists<EnergyDepletedDeath>(reg);
@@ -223,14 +226,23 @@ void setup_play_session(entt::registry& reg) {
     // membership IS "at least one beat has been crossed", so erase any
     // carry-over from a prior session before the new session begins.
     erase_ctx_if_exists<BeatCursor>(reg);
+    // Reset the song-lifecycle ctx tags (Fabian Principle 3 / issue
+    // #1624): presence of `SongPlayingTag` IS "song is currently
+    // playing"; presence of `SongFinishedTag` IS "song has finished".
+    // Erase both up-front to give the new session a clean slate, then
+    // emplace the playing-state tag below. Mirrors the `MusicContext`
+    // ctx erase pattern (#1623).
+    erase_ctx_if_exists<SongPlayingTag>(reg);
+    erase_ctx_if_exists<SongFinishedTag>(reg);
+    erase_ctx_if_exists<RestartMusicRequestTag>(reg);
     if (!beat_map_empty(beatmap)) {
         init_song_state(song, beatmap);
     } else {
         song.bpm = 120.0f;
         song_state_compute_derived(song);
     }
-    song.playing = true;
-    song.restart_music = true;
+    reg.ctx().emplace<SongPlayingTag>();
+    reg.ctx().emplace<RestartMusicRequestTag>();
 
     // Load music — presence of `MusicContext` ctx singleton IS "stream
     // loaded" (Fabian Principle 3, issue #1618). We erase any prior

--- a/app/systems/player_input_system.cpp
+++ b/app/systems/player_input_system.cpp
@@ -115,7 +115,9 @@ namespace {
 void player_input_handle_shape_press_impl(entt::registry& reg, Shape pressed_shape) {
     if (!gameplay_input_enabled(reg)) return;
     auto* song = reg.ctx().find<SongState>();
-    const bool rhythm_mode = (song != nullptr && (song->playing || song->finished));
+    const auto& ctx = reg.ctx();
+    const bool rhythm_mode = (song != nullptr) &&
+        (ctx.contains<SongPlayingTag>() || ctx.contains<SongFinishedTag>());
 
     const int pressed_shape_index = shape_index(pressed_shape);
     if (pressed_shape_index < 0) return;  // unreachable: callers pass Circle/Square/Triangle

--- a/app/systems/player_movement_system.cpp
+++ b/app/systems/player_movement_system.cpp
@@ -11,7 +11,9 @@
 
 void player_movement_system(entt::registry& reg, float dt) {
     auto* song = reg.ctx().find<SongState>();
-    const bool rhythm_mode = (song != nullptr && (song->playing || song->finished));
+    const auto& ctx = reg.ctx();
+    const bool rhythm_mode = (song != nullptr) &&
+        (ctx.contains<SongPlayingTag>() || ctx.contains<SongFinishedTag>());
 
     auto view = reg.view<PlayerTag, WorldPosition, PlayerShape, Lane>();
     for (auto [entity, transform, pshape, lane] : view.each()) {

--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -234,10 +234,13 @@ void process_ungraded_hit_pass(entt::registry& reg,
 
 void scoring_system(entt::registry& reg, float dt) {
     auto& score   = reg.ctx().get<ScoreState>();
-    auto* song    = reg.ctx().find<SongState>();
 
     // Passive score accrual (PTS_PER_SECOND) only while song playback is active.
-    const bool allow_passive_score = (song == nullptr) || !song->finished;
+    // Per Fabian Principle 3 / issue #1624: absence of `SongFinishedTag`
+    // IS "song has not finished yet" — covers both the "no song / pre-play"
+    // case (which used the former `song == nullptr` proxy) and the
+    // "song actively playing" case in a single tag check.
+    const bool allow_passive_score = !reg.ctx().contains<SongFinishedTag>();
     if (allow_passive_score) {
         const float passive_score = score.passive_score_remainder +
             dt * static_cast<float>(constants::PTS_PER_SECOND);

--- a/app/systems/scroll_system.cpp
+++ b/app/systems/scroll_system.cpp
@@ -9,11 +9,12 @@
 
 void scroll_system(entt::registry& reg, [[maybe_unused]] float dt) {
     auto* song = reg.ctx().find<SongState>();
+    const auto& ctx = reg.ctx();
 
     // Rhythm obstacles: position derived from song_time, not accumulated dt.
     // This prevents floating-point drift from desynchronizing collisions
     // with the beat grid. (See: "never use anything other than song position")
-    if (song && (song->playing || song->finished)) {
+    if (song && (ctx.contains<SongPlayingTag>() || ctx.contains<SongFinishedTag>())) {
         if (!std::isfinite(song->scroll_speed) || song->scroll_speed <= 0.0f) {
             TraceLog(LOG_WARNING, "scroll_system skipped: invalid scroll_speed %.3f", song->scroll_speed);
             return;

--- a/app/systems/song_playback_system.cpp
+++ b/app/systems/song_playback_system.cpp
@@ -17,7 +17,14 @@ void song_playback_system(entt::registry& reg, float dt) {
     // `loaded` NULL-column gate). The `started`/`paused` bools are likewise
     // eradicated — `MusicPlayingTag` / `MusicPausedTag` ctx tags carry the
     // playback machine state.
-    const bool music_loaded = (music != nullptr);
+    // Per Fabian Principle 3 / issue #1624: the former
+    // `SongState::playing` / `finished` / `restart_music` parallel-bool
+    // gates are likewise eradicated — `SongPlayingTag` / `SongFinishedTag`
+    // / `RestartMusicRequestTag` ctx tags carry the song-lifecycle
+    // machine state.
+    const bool music_loaded   = (music != nullptr);
+    const bool song_playing   = ctx.contains<SongPlayingTag>();
+    const bool song_finished  = ctx.contains<SongFinishedTag>();
 
     // Must pump the stream buffer every frame to prevent audio underruns,
     // even when the game is paused.
@@ -26,8 +33,8 @@ void song_playback_system(entt::registry& reg, float dt) {
     }
 
     // ── Music restart request (from enter_playing) ────────────
-    if (song && song->restart_music) {
-        song->restart_music = false;
+    if (ctx.contains<RestartMusicRequestTag>()) {
+        ctx.erase<RestartMusicRequestTag>();
         if (music_loaded) {
             StopMusicStream(music->stream);
             PlayMusicStream(music->stream);
@@ -47,7 +54,7 @@ void song_playback_system(entt::registry& reg, float dt) {
     const bool game_over_phase     = ctx.contains<GamePhaseGameOverTag>();
     const bool song_complete_phase = ctx.contains<GamePhaseSongCompleteTag>();
 
-    if (music_loaded && playing_phase && song && song->playing) {
+    if (music_loaded && playing_phase && song_playing) {
         if (!ctx.contains<MusicPlayingTag>()) {
             PlayMusicStream(music->stream);
             ctx.emplace<MusicPlayingTag>();
@@ -73,13 +80,13 @@ void song_playback_system(entt::registry& reg, float dt) {
     if (!playing_phase) return;
     if (!song) return;
 
-    if (song->finished) {
+    if (song_finished) {
         // Keep song_time advancing after playback ends so remaining spawned
         // obstacles can continue scrolling to resolution/despawn.
         song->song_time += dt;
         return;
     }
-    if (!song->playing) return;
+    if (!song_playing) return;
 
     // Authoritative clock from audio stream; fall back to dt accumulation
     // when running in silent/test mode (no music loaded).
@@ -121,8 +128,8 @@ void song_playback_system(entt::registry& reg, float dt) {
 
     // Song end detection
     if (song->song_time >= song->duration_sec) {
-        song->finished = true;
-        song->playing  = false;
+        ctx.emplace<SongFinishedTag>();
+        ctx.erase<SongPlayingTag>();
         if (music_loaded && ctx.contains<MusicPlayingTag>()) {
             StopMusicStream(music->stream);
             ctx.erase<MusicPlayingTag>();

--- a/app/systems/ui_render_system.cpp
+++ b/app/systems/ui_render_system.cpp
@@ -468,7 +468,7 @@ void render_ui_entities(entt::registry& reg) {
         const auto* settings = find_settings_state(reg);
         const bool reduce_motion = (settings != nullptr) && settings->reduce_motion;
         const auto* song = reg.ctx().find<SongState>();
-        const float pulse_time = (song != nullptr && song->playing)
+        const float pulse_time = (song != nullptr && reg.ctx().contains<SongPlayingTag>())
                                  ? song->song_time
                                  : static_cast<float>(GetTime());
         const float pulse = reduce_motion

--- a/app/tags/tags.h
+++ b/app/tags/tags.h
@@ -131,6 +131,28 @@ struct TestPlayerPlannedTag {};
 struct MusicPlayingTag {};
 struct MusicPausedTag  {};
 
+// ── Song lifecycle (per-tag ctx tables) ──────────────────────
+// Per Fabian's existential processing (issue #1624 / .squad/decisions.md
+// § 9 Principle 3), the former `SongState::playing`,
+// `SongState::finished`, and `SongState::restart_music` parallel-bool
+// NULL-column gates over the song-lifecycle state machine are eradicated.
+// The 4-state machine — *(absent / playing / finished / restart-pending)* —
+// is now expressed as:
+//   - presence of `SongPlayingTag`         IS "song is currently playing"
+//   - presence of `SongFinishedTag`        IS "song has finished"
+//     (mutex with `SongPlayingTag`; emplace one and erase the other at
+//      the two terminal flip sites — natural song end and terminal
+//      GameOver entry)
+//   - presence of `RestartMusicRequestTag` IS "music restart pending"
+//     (one-shot; `song_playback_system` erases on consumption — same
+//      shape as `SettingsDirtyTag` / `MusicPlayingTag`)
+// State transitions are `ctx.emplace<...>` / `ctx.erase<...>`
+// (Principle 4). Mirrors the `MusicPlayingTag` / `MusicPausedTag`
+// precedent set by PR #1623.
+struct SongPlayingTag         {};
+struct SongFinishedTag        {};
+struct RestartMusicRequestTag {};
+
 // ── Render-pass membership; one per entity ───────────────────
 struct TagWorldPass   {};  // drawn in BeginMode3D (3D world geometry)
 struct TagEffectsPass {};  // particles, post-process overlays

--- a/tests/test_audio_offset_calibration.cpp
+++ b/tests/test_audio_offset_calibration.cpp
@@ -368,7 +368,7 @@ TEST_CASE("game camera floor pulse honors audio_offset_ms",
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 1.25f;
     set_beat_cursor(reg, 0);
-    song.playing = true;
+    reg.ctx().emplace<SongPlayingTag>();
 
     auto& map = beat_map(reg);
     map.beat_times = {1.0f};

--- a/tests/test_beat_log_system.cpp
+++ b/tests/test_beat_log_system.cpp
@@ -72,8 +72,7 @@ TEST_CASE("beat_log: no-op when not in Playing phase", "[beat_log]") {
 
 TEST_CASE("beat_log: no-op when song not playing", "[beat_log]") {
     auto reg = make_rhythm_registry();
-    auto& song = reg.ctx().get<SongState>();
-    song.playing = false;
+    reg.ctx().erase<SongPlayingTag>();
     set_beat_cursor(reg, 2);
 
     auto slog = make_open_log();

--- a/tests/test_beat_map_validation.cpp
+++ b/tests/test_beat_map_validation.cpp
@@ -346,8 +346,6 @@ TEST_CASE("init_song_state: resets playback state", "[init_song]") {
 
     SongState state;
     state.song_time = 50.0f;
-    state.playing = true;
-    state.finished = true;
     state.next_shape_gate_circle_idx = 5;
     state.next_split_path_circle_idx = 7;
     state.next_onset_marker_idx = 3;
@@ -358,8 +356,12 @@ TEST_CASE("init_song_state: resets playback state", "[init_song]") {
     // BeatCursor lives in `reg.ctx()` (issue #1545); init_song_state operates
     // on the plain `SongState` value alone and intentionally does not touch
     // the cursor — `setup_play_session` owns the per-session cursor reset.
-    CHECK_FALSE(state.playing);
-    CHECK_FALSE(state.finished);
+    //
+    // The former `playing` / `finished` field resets likewise migrated to
+    // ctx tag erases on the `setup_play_session` side (issue #1624 /
+    // Fabian Principle 3 / `SongPlayingTag` + `SongFinishedTag`); see
+    // `tests/test_setup_play_session.cpp` (if any) for coverage of that
+    // path. `init_song_state` no longer touches playback state.
     CHECK(state.next_shape_gate_circle_idx == 0);
     CHECK(state.next_split_path_circle_idx == 0);
     CHECK(state.next_onset_marker_idx == 0);

--- a/tests/test_beat_scheduler_system.cpp
+++ b/tests/test_beat_scheduler_system.cpp
@@ -37,7 +37,7 @@ TEST_CASE("beat_scheduler: no spawn when SongState absent", "[beat_scheduler]") 
 
 TEST_CASE("beat_scheduler: no spawn when song not playing", "[beat_scheduler]") {
     auto reg = make_rhythm_registry();
-    reg.ctx().get<SongState>().playing = false;
+    reg.ctx().erase<SongPlayingTag>();
 
     auto& map = beat_map(reg);
     map.shape_gate_circle_beats.push_back({0, 1});

--- a/tests/test_collision_extended.cpp
+++ b/tests/test_collision_extended.cpp
@@ -251,10 +251,9 @@ TEST_CASE("collision: finished song still requires active shape window",
           "[collision][rhythm][issue950]") {
     auto idle_reg = make_rhythm_registry();
     auto idle_player = make_rhythm_player(idle_reg);
-    auto& idle_song = idle_reg.ctx().get<SongState>();
 
-    idle_song.playing = false;
-    idle_song.finished = true;
+    idle_reg.ctx().erase<SongPlayingTag>();
+    idle_reg.ctx().emplace<SongFinishedTag>();
     set_player_shape_tag(idle_reg, idle_player, Shape::Circle);
     set_target_shape_tag(idle_reg, idle_player, Shape::Circle);
     set_window_phase_idle(idle_reg, idle_player);
@@ -271,8 +270,8 @@ TEST_CASE("collision: finished song still requires active shape window",
     auto active_player = make_rhythm_player(active_reg);
     auto& active_song = active_reg.ctx().get<SongState>();
 
-    active_song.playing = false;
-    active_song.finished = true;
+    active_reg.ctx().erase<SongPlayingTag>();
+    active_reg.ctx().emplace<SongFinishedTag>();
     active_song.song_time = 5.0f;
     set_player_shape_tag(active_reg, active_player, Shape::Circle);
     set_target_shape_tag(active_reg, active_player, Shape::Circle);

--- a/tests/test_death_model_unified.cpp
+++ b/tests/test_death_model_unified.cpp
@@ -66,7 +66,7 @@ TEST_CASE("death_model: GameOver is requested when energy depletes", "[death_mod
     game_state_system(reg, 0.016f);
 
     CHECK(reg.ctx().contains<GamePhaseGameOverTag>());
-    CHECK_FALSE(reg.ctx().get<SongState>().playing);
+    CHECK_FALSE(reg.ctx().contains<SongPlayingTag>());
 }
 
 TEST_CASE("death_model: timing recovery can preserve survival margin", "[death_model]") {

--- a/tests/test_energy_system.cpp
+++ b/tests/test_energy_system.cpp
@@ -24,7 +24,7 @@ TEST_CASE("energy: no action when energy is positive", "[energy]") {
     energy_system(reg, 0.016f);
 
     CHECK_FALSE(is_phase_transition_pending(reg));
-    CHECK(reg.ctx().get<SongState>().playing);
+    CHECK(reg.ctx().contains<SongPlayingTag>());
 }
 
 TEST_CASE("energy: pending miss drain is applied by energy_system", "[energy]") {
@@ -120,7 +120,7 @@ TEST_CASE("energy: no action when SongState not present", "[energy]") {
 
 TEST_CASE("energy: depleted energy requests game over when song is not playing", "[energy][issue961]") {
     auto reg = make_rhythm_registry();
-    reg.ctx().get<SongState>().playing = false;
+    reg.ctx().erase<SongPlayingTag>();
     auto& energy = reg.ctx().get<EnergyState>();
     energy.energy = 0.0f;
 
@@ -136,7 +136,8 @@ TEST_CASE("energy: no action when EnergyState not present", "[energy]") {
     
     bare_reg.ctx().emplace<GameState>(GameState{ 0.0f });
     auto& song = bare_reg.ctx().emplace<SongState>();
-    song.playing = true;
+    bare_reg.ctx().emplace<SongPlayingTag>();
+    (void)song;
 
     energy_system(bare_reg, 0.016f);
 
@@ -151,7 +152,7 @@ TEST_CASE("energy: small positive energy does not trigger game over", "[energy]"
     game_state_system(reg, 0.016f);
 
     CHECK_FALSE(is_phase_transition_pending(reg));
-    CHECK(reg.ctx().get<SongState>().playing);
+    CHECK(reg.ctx().contains<SongPlayingTag>());
 }
 
 TEST_CASE("energy: display smooths toward energy value", "[energy]") {
@@ -184,9 +185,8 @@ TEST_CASE("energy: enter_game_over owns song stop", "[energy][gamestate]") {
 
     game_state_system(reg, 0.016f);
 
-    auto& song = reg.ctx().get<SongState>();
-    CHECK(song.finished);
-    CHECK_FALSE(song.playing);
+    CHECK(reg.ctx().contains<SongFinishedTag>());
+    CHECK_FALSE(reg.ctx().contains<SongPlayingTag>());
 }
 
 TEST_CASE("energy: flash timer clamps to zero", "[energy]") {

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -11,9 +11,8 @@
 TEST_CASE("game_state: song complete when song finished and no obstacles", "[gamestate]") {
     auto reg = make_rhythm_registry();
     set_test_phase<GamePhasePlayingTag>(reg);
-    auto& song = reg.ctx().get<SongState>();
-    song.finished = true;
-    song.playing = false;
+    reg.ctx().emplace<SongFinishedTag>();
+    reg.ctx().erase<SongPlayingTag>();
     // No obstacle entities → should trigger SongComplete
 
     game_state_system(reg, 0.016f);
@@ -25,9 +24,8 @@ TEST_CASE("game_state: energy depletion beats song complete after playback finis
           "[gamestate][issue755]") {
     auto reg = make_rhythm_registry();
     set_test_phase<GamePhasePlayingTag>(reg);
-    auto& song = reg.ctx().get<SongState>();
-    song.finished = true;
-    song.playing = false;
+    reg.ctx().emplace<SongFinishedTag>();
+    reg.ctx().erase<SongPlayingTag>();
     reg.ctx().get<EnergyState>().energy = 0.0f;
     REQUIRE(reg.ctx().find<EnergyDepletedDeath>() == nullptr);
 
@@ -40,9 +38,8 @@ TEST_CASE("game_state: energy depletion beats song complete after playback finis
 TEST_CASE("game_state: song complete waits for obstacles to clear", "[gamestate]") {
     auto reg = make_rhythm_registry();
     set_test_phase<GamePhasePlayingTag>(reg);
-    auto& song = reg.ctx().get<SongState>();
-    song.finished = true;
-    song.playing = false;
+    reg.ctx().emplace<SongFinishedTag>();
+    reg.ctx().erase<SongPlayingTag>();
 
     // Create an unscored obstacle
     auto obs = reg.create();
@@ -57,9 +54,8 @@ TEST_CASE("game_state: song complete waits for obstacles to clear", "[gamestate]
 TEST_CASE("game_state: song complete proceeds when scored obstacle is destroyed", "[gamestate]") {
     auto reg = make_rhythm_registry();
     set_test_phase<GamePhasePlayingTag>(reg);
-    auto& song = reg.ctx().get<SongState>();
-    song.finished = true;
-    song.playing = false;
+    reg.ctx().emplace<SongFinishedTag>();
+    reg.ctx().erase<SongPlayingTag>();
 
     // Obstacle scored and destroyed (scoring_system + obstacle_despawn_system both ran) → SongComplete
     auto obs = reg.create();
@@ -75,9 +71,8 @@ TEST_CASE("game_state: song complete proceeds when scored obstacle is destroyed"
 TEST_CASE("game_state: song complete waits for scored obstacle to be destroyed", "[gamestate]") {
     auto reg = make_rhythm_registry();
     set_test_phase<GamePhasePlayingTag>(reg);
-    auto& song = reg.ctx().get<SongState>();
-    song.finished = true;
-    song.playing = false;
+    reg.ctx().emplace<SongFinishedTag>();
+    reg.ctx().erase<SongPlayingTag>();
 
     // Obstacle scored but still alive (obstacle_despawn_system has not yet destroyed it)
     auto obs = reg.create();

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -304,7 +304,7 @@ inline entt::registry make_rhythm_registry() {
     song.offset = 0.0f;
     song.lead_beats = 4;
     song.duration_sec = 60.0f;
-    song.playing = true;
+    reg.ctx().emplace<SongPlayingTag>();
     song_state_compute_derived(song);
     reg.ctx().get<EnergyState>() = EnergyState{};
     reg.ctx().get<SongResults>() = SongResults{};

--- a/tests/test_helpers_and_functions.cpp
+++ b/tests/test_helpers_and_functions.cpp
@@ -198,7 +198,7 @@ TEST_CASE("make_rhythm_registry: SongState is configured", "[helpers]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     CHECK(song.bpm == 120.0f);
-    CHECK(song.playing);
+    CHECK(reg.ctx().contains<SongPlayingTag>());
     CHECK(song.beat_period > 0.0f);
     CHECK(song.scroll_speed > 0.0f);
 }

--- a/tests/test_phase_runner.cpp
+++ b/tests/test_phase_runner.cpp
@@ -215,15 +215,15 @@ TEST_CASE("tick_fixed_systems: fatal final drain wins after song finishes",
     auto& pending = reg.ctx().get<PendingEnergyEffects>();
 
     song.song_time = song.duration_sec;
-    song.playing = true;
-    song.finished = false;
+    reg.ctx().emplace<SongPlayingTag>();
+    reg.ctx().erase<SongFinishedTag>();
     energy.energy = constants::ENERGY_DRAIN_MISS;
     pending.events.push_back({-constants::ENERGY_DRAIN_MISS, true});
 
     tick_fixed_systems(reg, 0.016f);
 
-    CHECK(song.finished);
-    CHECK_FALSE(song.playing);
+    CHECK(reg.ctx().contains<SongFinishedTag>());
+    CHECK_FALSE(reg.ctx().contains<SongPlayingTag>());
     REQUIRE(energy.energy == 0.0f);
     REQUIRE(reg.ctx().contains<NextPhaseGameOverTag>());
     CHECK(reg.ctx().find<EnergyDepletedDeath>() != nullptr);

--- a/tests/test_player_action_rhythm.cpp
+++ b/tests/test_player_action_rhythm.cpp
@@ -41,8 +41,8 @@ TEST_CASE("player_action: post-song rhythm context still starts window for trail
     auto& sw = reg.get<ShapeWindow>(player);
     auto& song = reg.ctx().get<SongState>();
     song.song_time = song.duration_sec + 0.25f;
-    song.playing = false;
-    song.finished = true;
+    reg.ctx().erase<SongPlayingTag>();
+    reg.ctx().emplace<SongFinishedTag>();
 
     auto btn = make_shape_button(reg, Shape::Square);
     press_button(reg, btn);
@@ -286,10 +286,9 @@ TEST_CASE("player_movement: post-song rhythm context still leaves morph_t to sha
           "[player][issue866]") {
     auto reg = make_rhythm_registry();
     auto p = make_rhythm_player(reg);
-    auto& song = reg.ctx().get<SongState>();
     auto& ps = reg.get<PlayerShape>(p);
-    song.playing = false;
-    song.finished = true;
+    reg.ctx().erase<SongPlayingTag>();
+    reg.ctx().emplace<SongFinishedTag>();
     ps.morph_t = 0.3f;
 
     player_movement_system(reg, 0.016f);

--- a/tests/test_redfoot_testflight_ui.cpp
+++ b/tests/test_redfoot_testflight_ui.cpp
@@ -141,8 +141,8 @@ TEST_CASE("redfoot/#168: energy depletion falls back to ENERGY DEPLETED",
     sync_game_phase_tags<GamePhasePlayingTag>(reg);
     reg.ctx().emplace<entt::dispatcher>();
     auto& energy = reg.ctx().emplace<EnergyState>();
-    auto& song = reg.ctx().emplace<SongState>();
-    song.playing = true;
+    reg.ctx().emplace<SongState>();
+    reg.ctx().emplace<SongPlayingTag>();
     energy.energy = 0.0f;
 
     game_state_system(reg, 0.016f);
@@ -157,8 +157,8 @@ TEST_CASE("redfoot/#168: energy depletion writes terminal cause",
     sync_game_phase_tags<GamePhasePlayingTag>(reg);
     reg.ctx().emplace<entt::dispatcher>();
     auto& energy = reg.ctx().emplace<EnergyState>();
-    auto& song = reg.ctx().emplace<SongState>();
-    song.playing = true;
+    reg.ctx().emplace<SongState>();
+    reg.ctx().emplace<SongPlayingTag>();
     REQUIRE(reg.ctx().find<EnergyDepletedDeath>() == nullptr);
     energy.energy = 0.0f;
 

--- a/tests/test_reduce_motion.cpp
+++ b/tests/test_reduce_motion.cpp
@@ -27,7 +27,7 @@ TEST_CASE("energy_bar_system: beat bounce expands visible level when motion is e
     auto reg = make_registry();
     create_energy_bar_entity(reg);
     auto& song = reg.ctx().get<SongState>();
-    song.playing = true;
+    reg.ctx().emplace<SongPlayingTag>();
     song.song_time = 0.10f;
     song.beat_period = 0.50f;
     auto& energy = reg.ctx().get<EnergyState>();
@@ -49,7 +49,7 @@ TEST_CASE("energy_bar_system: reduce_motion suppresses decorative bounce and fla
     create_energy_bar_entity(reg);
     settings_state(reg).reduce_motion = true;
     auto& song = reg.ctx().get<SongState>();
-    song.playing = true;
+    reg.ctx().emplace<SongPlayingTag>();
     song.song_time = 0.10f;
     song.beat_period = 0.50f;
     auto& energy = reg.ctx().get<EnergyState>();
@@ -71,7 +71,7 @@ TEST_CASE("energy_bar_system: reduce_motion pins critical pulse to a stable midp
     create_energy_bar_entity(reg);
     settings_state(reg).reduce_motion = true;
     auto& song = reg.ctx().get<SongState>();
-    song.playing = true;
+    reg.ctx().emplace<SongPlayingTag>();
     song.song_time = 99.7f;
     auto& energy = reg.ctx().get<EnergyState>();
     energy.display = 0.0f;
@@ -104,7 +104,7 @@ TEST_CASE("energy_bar_system: invalid segment counts keep visual levels finite",
     auto& layout = reg.get<EnergyBarLayout>(entity);
     auto& energy = reg.ctx().get<EnergyState>();
     auto& song = reg.ctx().get<SongState>();
-    song.playing = true;
+    reg.ctx().emplace<SongPlayingTag>();
     song.song_time = 0.0f;
     song.beat_period = 0.5f;
     energy.display = 0.25f;

--- a/tests/test_rhythm_system.cpp
+++ b/tests/test_rhythm_system.cpp
@@ -204,7 +204,6 @@ TEST_CASE("song_state: init from beat map", "[rhythm][songstate]") {
     init_song_state(state, map);
     CHECK(state.bpm == 140.0f);
     CHECK(state.offset == 0.3f);
-    CHECK_FALSE(state.playing);
     CHECK(state.song_time == 0.0f);
     CHECK_THAT(state.beat_period, WithinAbs(60.0f / 140.0f, 0.001f));
 }
@@ -214,7 +213,7 @@ TEST_CASE("song_state: init from beat map", "[rhythm][songstate]") {
 TEST_CASE("song_playback: advances song_time", "[rhythm][playback]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
-    song.playing = true; song.song_time = 0.0f;
+    reg.ctx().emplace<SongPlayingTag>(); song.song_time = 0.0f;
     song_playback_system(reg, 0.016f);
     CHECK_THAT(song.song_time, WithinAbs(0.016f, 0.001f));
 }
@@ -222,7 +221,7 @@ TEST_CASE("song_playback: advances song_time", "[rhythm][playback]") {
 TEST_CASE("song_playback: increments current_beat", "[rhythm][playback]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
-    song.playing = true; song.offset = 0.0f; song.song_time = 0.0f;
+    reg.ctx().emplace<SongPlayingTag>(); song.offset = 0.0f; song.song_time = 0.0f;
     song_playback_system(reg, 0.5f);
     CHECK(beat_cursor_value(reg) >= 1);
 }
@@ -230,16 +229,16 @@ TEST_CASE("song_playback: increments current_beat", "[rhythm][playback]") {
 TEST_CASE("song_playback: detects song end", "[rhythm][playback]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
-    song.playing = true; song.duration_sec = 1.0f; song.song_time = 0.99f;
+    reg.ctx().emplace<SongPlayingTag>(); song.duration_sec = 1.0f; song.song_time = 0.99f;
     song_playback_system(reg, 0.02f);
-    CHECK(song.finished);
-    CHECK_FALSE(song.playing);
+    CHECK(reg.ctx().contains<SongFinishedTag>());
+    CHECK_FALSE(reg.ctx().contains<SongPlayingTag>());
 }
 
 TEST_CASE("song_playback: does nothing when not playing", "[rhythm][playback]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
-    song.playing = false; song.song_time = 0.0f;
+    reg.ctx().erase<SongPlayingTag>(); song.song_time = 0.0f;
     song_playback_system(reg, 0.016f);
     CHECK(song.song_time == 0.0f);
 }
@@ -251,7 +250,7 @@ TEST_CASE("beat_scheduler: spawns obstacle at spawn_time", "[rhythm][scheduler]"
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
     map.shape_gate_circle_beats.push_back({4, 1});
-    song.playing = true;
+    reg.ctx().emplace<SongPlayingTag>();
     // Advance past spawn_time
     song.song_time = 0.1f;
     beat_scheduler_system(reg, 0.016f);
@@ -263,7 +262,7 @@ TEST_CASE("beat_scheduler: obstacle has correct BeatInfo", "[rhythm][scheduler]"
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
     map.shape_gate_triangle_beats.push_back({8, 1});
-    song.playing = true; song.song_time = 2.5f;
+    reg.ctx().emplace<SongPlayingTag>(); song.song_time = 2.5f;
     beat_scheduler_system(reg, 0.016f);
     auto obs_view = reg.view<ObstacleTag, BeatInfo>();
     int obs_count = 0; for (auto _ : obs_view) { (void)_; obs_count++; }
@@ -279,7 +278,7 @@ TEST_CASE("beat_scheduler: does not spawn before spawn_time", "[rhythm][schedule
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
     map.shape_gate_circle_beats.push_back({20, 1});
-    song.playing = true; song.song_time = 0.5f;
+    reg.ctx().emplace<SongPlayingTag>(); song.song_time = 0.5f;
     beat_scheduler_system(reg, 0.016f);
     CHECK(reg.view<ObstacleTag>().size() == 0);
 }
@@ -290,7 +289,7 @@ TEST_CASE("beat_scheduler: spawns multiple when time catches up", "[rhythm][sche
     auto& map = beat_map(reg);
     map.shape_gate_circle_beats.push_back({4, 1});
     map.shape_gate_circle_beats.push_back({8, 1});
-    song.playing = true; song.song_time = 3.0f;
+    reg.ctx().emplace<SongPlayingTag>(); song.song_time = 3.0f;
     beat_scheduler_system(reg, 0.016f);
     CHECK(reg.view<ObstacleTag>().size() == 2);
 }
@@ -300,7 +299,7 @@ TEST_CASE("beat_scheduler: rhythm obstacles use BeatInfo without Vector2", "[rhy
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
     map.shape_gate_circle_beats.push_back({4, 1});
-    song.playing = true; song.song_time = 0.1f;
+    reg.ctx().emplace<SongPlayingTag>(); song.song_time = 0.1f;
     beat_scheduler_system(reg, 0.016f);
     auto obs_view = reg.view<ObstacleTag, BeatInfo>();
     REQUIRE(std::distance(obs_view.begin(), obs_view.end()) == 1);
@@ -652,9 +651,8 @@ TEST_CASE("game_state: enter_game_over marks song finished on depletion", "[rhyt
     reg.ctx().get<EnergyState>().energy = 0.0f;
     game_state_system(reg, 0.016f);
     game_state_system(reg, 0.016f);
-    auto& song = reg.ctx().get<SongState>();
-    CHECK(song.finished);
-    CHECK_FALSE(song.playing);
+    CHECK(reg.ctx().contains<SongFinishedTag>());
+    CHECK_FALSE(reg.ctx().contains<SongPlayingTag>());
 }
 
 // Scoring with Timing
@@ -862,7 +860,7 @@ TEST_CASE("integration: obstacle arrives on-beat within 1 frame", "[rhythm][inte
     auto& song = reg.ctx().get<SongState>();
     auto& map = beat_map(reg);
     map.shape_gate_circle_beats.push_back({4, 1});
-    song.playing = true; song.song_time = 0.1f;
+    reg.ctx().emplace<SongPlayingTag>(); song.song_time = 0.1f;
     constexpr float dt = 1.0f / 60.0f;
     bool obstacle_at_player = false;
     int frames = 0;

--- a/tests/test_scoring_system.cpp
+++ b/tests/test_scoring_system.cpp
@@ -451,9 +451,8 @@ TEST_CASE("scoring: missed obstacle drains energy without setting terminal death
 
 TEST_CASE("scoring: passive accrual stops once song playback has finished", "[scoring][issue445]") {
     auto reg = make_registry();
-    auto& song = reg.ctx().get<SongState>();
-    song.finished = true;
-    song.playing = false;
+    reg.ctx().emplace<SongFinishedTag>();
+    reg.ctx().erase<SongPlayingTag>();
 
     auto& score = reg.ctx().get<ScoreState>();
     score.score = 500;
@@ -465,9 +464,8 @@ TEST_CASE("scoring: passive accrual stops once song playback has finished", "[sc
 
 TEST_CASE("scoring: obstacle/timing points still apply after playback has finished", "[scoring][issue445]") {
     auto reg = make_registry();
-    auto& song = reg.ctx().get<SongState>();
-    song.finished = true;
-    song.playing = false;
+    reg.ctx().emplace<SongFinishedTag>();
+    reg.ctx().erase<SongPlayingTag>();
 
     auto& score = reg.ctx().get<ScoreState>();
     score.score = 0;

--- a/tests/test_signal_lifecycle_nogated.cpp
+++ b/tests/test_signal_lifecycle_nogated.cpp
@@ -21,8 +21,9 @@ TEST_CASE("game_state: finished song waits for obstacle drain before SongComplet
     clear_next_phase_tags(reg);
 
     auto& song = reg.ctx().get<SongState>();
-    song.playing = true;
-    song.finished = true;
+    reg.ctx().emplace<SongPlayingTag>();
+    reg.ctx().emplace<SongFinishedTag>();
+    (void)song;
 
     auto& energy = reg.ctx().get<EnergyState>();
     energy.energy = 1.0f;

--- a/tests/test_song_playback_extended.cpp
+++ b/tests/test_song_playback_extended.cpp
@@ -39,8 +39,8 @@ TEST_CASE("song_playback: song ends when duration exceeded", "[song_playback]") 
 
     song_playback_system(reg, 0.2f);
 
-    CHECK(song.finished);
-    CHECK_FALSE(song.playing);
+    CHECK(reg.ctx().contains<SongFinishedTag>());
+    CHECK_FALSE(reg.ctx().contains<SongPlayingTag>());
 }
 
 TEST_CASE("song_playback: does nothing when not in Playing phase", "[song_playback]") {
@@ -57,7 +57,7 @@ TEST_CASE("song_playback: does nothing when not in Playing phase", "[song_playba
 TEST_CASE("song_playback: does nothing when song not playing", "[song_playback]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
-    song.playing = false;
+    reg.ctx().erase<SongPlayingTag>();
     float original_time = song.song_time;
 
     song_playback_system(reg, 1.0f);
@@ -68,7 +68,7 @@ TEST_CASE("song_playback: does nothing when song not playing", "[song_playback]"
 TEST_CASE("song_playback: finished song keeps advancing post-finish timeline", "[song_playback]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
-    song.finished = true;
+    reg.ctx().emplace<SongFinishedTag>();
     float original_time = song.song_time;
 
     song_playback_system(reg, 1.0f);

--- a/tests/test_song_playback_system.cpp
+++ b/tests/test_song_playback_system.cpp
@@ -46,7 +46,7 @@ TEST_CASE("song_playback: no advancement when not Playing", "[song_playback]") {
 TEST_CASE("song_playback: no advancement when song not playing", "[song_playback]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
-    song.playing = false;
+    reg.ctx().erase<SongPlayingTag>();
     song.song_time = 1.0f;
 
     song_playback_system(reg, 0.5f);
@@ -57,7 +57,7 @@ TEST_CASE("song_playback: no advancement when song not playing", "[song_playback
 TEST_CASE("song_playback: finished songs keep post-finish timeline advancing", "[song_playback]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
-    song.finished = true;
+    reg.ctx().emplace<SongFinishedTag>();
     song.song_time = 50.0f;
 
     song_playback_system(reg, 0.5f);
@@ -136,8 +136,8 @@ TEST_CASE("song_playback: song finishes at duration", "[song_playback]") {
 
     song_playback_system(reg, 1.0f);  // song_time = 60.5 > duration
 
-    CHECK(song.finished);
-    CHECK_FALSE(song.playing);
+    CHECK(reg.ctx().contains<SongFinishedTag>());
+    CHECK_FALSE(reg.ctx().contains<SongPlayingTag>());
 }
 
 TEST_CASE("song_playback: song does not finish before duration", "[song_playback]") {
@@ -148,8 +148,8 @@ TEST_CASE("song_playback: song does not finish before duration", "[song_playback
 
     song_playback_system(reg, 1.0f);  // song_time = 59.0 < duration
 
-    CHECK_FALSE(song.finished);
-    CHECK(song.playing);
+    CHECK_FALSE(reg.ctx().contains<SongFinishedTag>());
+    CHECK(reg.ctx().contains<SongPlayingTag>());
 }
 
 TEST_CASE("song_playback: song finishes exactly at duration", "[song_playback]") {
@@ -160,8 +160,8 @@ TEST_CASE("song_playback: song finishes exactly at duration", "[song_playback]")
 
     song_playback_system(reg, 1.0f);  // song_time = 60.0 == duration
 
-    CHECK(song.finished);
-    CHECK_FALSE(song.playing);
+    CHECK(reg.ctx().contains<SongFinishedTag>());
+    CHECK_FALSE(reg.ctx().contains<SongPlayingTag>());
 }
 
 TEST_CASE("song_playback: finished song stays latched and does not restart on later ticks",
@@ -172,18 +172,18 @@ TEST_CASE("song_playback: finished song stays latched and does not restart on la
     song.song_time = 1.9f;
 
     song_playback_system(reg, 0.2f);
-    REQUIRE(song.finished);
-    REQUIRE_FALSE(song.playing);
+    REQUIRE(reg.ctx().contains<SongFinishedTag>());
+    REQUIRE_FALSE(reg.ctx().contains<SongPlayingTag>());
     const float finished_time = song.song_time;
     const int finished_beat = beat_cursor_value(reg);
 
     song_playback_system(reg, 1.5f);
 
-    CHECK(song.finished);
-    CHECK_FALSE(song.playing);
+    CHECK(reg.ctx().contains<SongFinishedTag>());
+    CHECK_FALSE(reg.ctx().contains<SongPlayingTag>());
     CHECK(song.song_time > finished_time);
     CHECK(beat_cursor_value(reg) == finished_beat);
-    CHECK_FALSE(song.restart_music);
+    CHECK_FALSE(reg.ctx().contains<RestartMusicRequestTag>());
 }
 
 TEST_CASE("song_playback: obstacles can clear after playback ends without soft-lock",
@@ -194,8 +194,8 @@ TEST_CASE("song_playback: obstacles can clear after playback ends without soft-l
     auto& song = reg.ctx().get<SongState>();
     song.duration_sec = 1.0f;
     song.song_time = 0.95f;
-    song.playing = true;
-    song.finished = false;
+    reg.ctx().emplace<SongPlayingTag>();
+    reg.ctx().erase<SongFinishedTag>();
 
     const float start_y = constants::DESTROY_Y - 5.0f;
     const float spawn_time = song.song_time
@@ -207,8 +207,8 @@ TEST_CASE("song_playback: obstacles can clear after playback ends without soft-l
     reg.emplace<BeatInfo>(obstacle, BeatInfo{0, song.song_time, spawn_time});
 
     tick_fixed_systems(reg, 0.1f);
-    REQUIRE(song.finished);
-    CHECK_FALSE(song.playing);
+    REQUIRE(reg.ctx().contains<SongFinishedTag>());
+    CHECK_FALSE(reg.ctx().contains<SongPlayingTag>());
     CHECK(reg.view<ObstacleTag>().empty());
 
     tick_fixed_systems(reg, 0.016f);
@@ -223,13 +223,13 @@ TEST_CASE("song_playback: end-of-song transitions to SongComplete and remains st
     auto& song = reg.ctx().get<SongState>();
     song.duration_sec = 1.0f;
     song.song_time = 0.95f;
-    song.playing = true;
-    song.finished = false;
-    song.restart_music = false;
+    reg.ctx().emplace<SongPlayingTag>();
+    reg.ctx().erase<SongFinishedTag>();
+    reg.ctx().erase<RestartMusicRequestTag>();
 
     song_playback_system(reg, 0.1f);
-    REQUIRE(song.finished);
-    REQUIRE_FALSE(song.playing);
+    REQUIRE(reg.ctx().contains<SongFinishedTag>());
+    REQUIRE_FALSE(reg.ctx().contains<SongPlayingTag>());
 
     game_state_system(reg, 0.016f);
     REQUIRE(reg.ctx().contains<NextPhaseSongCompleteTag>());
@@ -241,10 +241,10 @@ TEST_CASE("song_playback: end-of-song transitions to SongComplete and remains st
     const float terminal_song_time = song.song_time;
     song_playback_system(reg, 1.0f);
 
-    CHECK(song.finished);
-    CHECK_FALSE(song.playing);
+    CHECK(reg.ctx().contains<SongFinishedTag>());
+    CHECK_FALSE(reg.ctx().contains<SongPlayingTag>());
     CHECK(song.song_time == terminal_song_time);
-    CHECK_FALSE(song.restart_music);
+    CHECK_FALSE(reg.ctx().contains<RestartMusicRequestTag>());
 }
 
 // ── song_playback_system: beat tracking edge cases ───────────
@@ -290,6 +290,7 @@ TEST_CASE("song_playback: pause to playing resume guard is one-shot",
           "[song_playback][regression][issue504]") {
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
+    (void)song;
 
     // Per issue #1618 / Fabian Principle 3, presence of `MusicContext`
     // ctx singleton IS "stream loaded"; `MusicPlayingTag` / `MusicPausedTag`
@@ -301,7 +302,7 @@ TEST_CASE("song_playback: pause to playing resume guard is one-shot",
     reg.ctx().emplace<MusicPausedTag>();
 
     set_test_phase<GamePhasePlayingTag>(reg);
-    song.playing = true;
+    reg.ctx().emplace<SongPlayingTag>();
 
     song_playback_system(reg, 0.016f);
     CHECK_FALSE(reg.ctx().contains<MusicPausedTag>());

--- a/tests/test_test_player_system.cpp
+++ b/tests/test_test_player_system.cpp
@@ -36,7 +36,7 @@ static entt::entity make_split_path_at(entt::registry& reg, Shape shape, int8_t 
 static void tick_systems(entt::registry& reg, int frames, float dt = 1.0f / 60.0f) {
     for (int i = 0; i < frames; ++i) {
         auto* song = reg.ctx().find<SongState>();
-        if (song && song->playing) song->song_time += dt;
+        if (song && reg.ctx().contains<SongPlayingTag>()) song->song_time += dt;
 
         test_player_system(reg, dt);
         game_state_system(reg, dt);

--- a/tests/test_world_systems.cpp
+++ b/tests/test_world_systems.cpp
@@ -324,8 +324,8 @@ TEST_CASE("game_state: paused resume preserves active play session state", "[gam
 
     auto& song = reg.ctx().get<SongState>();
     song.song_time = 12.5f;
-    song.playing = true;
-    song.restart_music = false;
+    reg.ctx().emplace<SongPlayingTag>();
+    reg.ctx().erase<RestartMusicRequestTag>();
 
     auto btn = make_menu_confirm_button(reg);
     press_button(reg, btn);
@@ -340,8 +340,8 @@ TEST_CASE("game_state: paused resume preserves active play session state", "[gam
     CHECK(energy.energy == 0.42f);
     CHECK(energy.display == 0.37f);
     CHECK(song.song_time == 12.5f);
-    CHECK(song.playing);
-    CHECK_FALSE(song.restart_music);
+    CHECK(reg.ctx().contains<SongPlayingTag>());
+    CHECK_FALSE(reg.ctx().contains<RestartMusicRequestTag>());
 
     int player_count = 0;
     for (auto e : reg.view<PlayerTag>()) {


### PR DESCRIPTION
Closes #1624.

## Drift summary

`SongState::playing + finished + restart_music` encoded a 4-state song-lifecycle machine — *(no song / restart pending / playing / finished)* — as three parallel-bool NULL-column gates over the same `SongState` ctx-singleton payload, then read it via if-cascade across ~16 reader sites.

By .squad/decisions.md § 9 Principle 3 ("No NULL columns. A field that is meaningful only when another field has a particular value is a NULL column in disguise"), each bool is a NULL column over the others:

- `restart_music` is meaningful only while `playing == true && finished == false`
- `finished == true` is meaningful only after `playing` has flipped back to `false`

This is the exact shape PR #1623 eradicated on `MusicContext::loaded + started + paused`, PRs #1621 / #1622 eradicated on `TextContext::loaded` / `TestPlayerState::active`, and PR #1617 eradicated on `SFXBank::loaded`.

## Normalization mapping

| former bool field | new ctx tag | semantics |
| --- | --- | --- |
| `playing`       | `SongPlayingTag`         | presence IS "song is currently playing" |
| `finished`      | `SongFinishedTag`        | presence IS "song has finished" (mutex with `SongPlayingTag` — both flip sites swap atomically) |
| `restart_music` | `RestartMusicRequestTag` | presence IS "music restart pending" (one-shot — `song_playback_system` erases on consumption, same shape as the `SettingsDirtyTag` consume pattern) |

State transitions become `ctx.emplace<...>` / `ctx.erase<...>` (Principle 4) — same shape as the `GamePhase*Tag` mutex family and the just-merged `MusicPlayingTag` / `MusicPausedTag` pair from #1623.

## Per-file changes

**Tags / component**
- `app/components/song_state.h` — remove `playing` / `finished` / `restart_music` fields; update doc comment to point at the three new tags + this issue.
- `app/tags/tags.h` — add `SongPlayingTag`, `SongFinishedTag`, `RestartMusicRequestTag` (next to the `MusicPlayingTag` family) with full Fabian Principle 3 doc comment referencing this issue and the #1623 precedent.

**Writer sites (5)**
- `app/systems/play_session.cpp` — at session setup: erase any pre-existing playback tags up-front (clean-slate at session init), then emplace `SongPlayingTag` + `RestartMusicRequestTag` on the successful path. The beatmap-load-failure cleanup path also erases all three tags alongside the existing SongState reset.
- `app/systems/song_playback_system.cpp` — read playback state via `ctx.contains<SongPlayingTag>()` / `ctx.contains<SongFinishedTag>()`; the natural-end flip (former `finished = true; playing = false;`) becomes a tag swap; the one-shot `restart_music` consume becomes a `contains`-then-`erase` on `RestartMusicRequestTag`.
- `app/systems/game_state_terminal_phase_system.cpp` — terminal GameOver entry drops the SongState payload dereference; the mutex tag flip (`emplace<SongFinishedTag>()`, `erase<SongPlayingTag>()`) works whether or not the SongState ctx singleton is present.
- `app/entities/beat_map.cpp` — `init_song_state` no longer touches the three bools (they no longer exist); per-session tag reset moved to `setup_play_session` (mirrors the BeatCursor reset pattern from #1545). Comment updated.

**Reader sites (16)** — all migrate to `ctx.contains<...Tag>()`:
- `app/systems/player_input_system.cpp` (rhythm_mode)
- `app/systems/player_movement_system.cpp` (rhythm_mode)
- `app/systems/scroll_system.cpp` (rhythm_mode)
- `app/systems/collision_system.cpp` (rhythm_mode)
- `app/systems/scoring_system.cpp` — the former `(song == nullptr) || !song->finished` disjunction collapses to a single `!ctx.contains<SongFinishedTag>()` — tag absence covers both "no song" and "song not yet finished" cases in one check.
- `app/systems/beat_scheduler_system.cpp`
- `app/systems/beat_log_system.cpp`
- `app/systems/game_state_system.cpp`
- `app/systems/energy_bar_system.cpp`
- `app/systems/ui_render_system.cpp`
- `app/systems/camera_system.cpp`
- `app/systems/floor_render_system.cpp` — the `draw_floor_beat_lines` helper signature gains a `bool song_playing` param so the ctx query happens once at the caller, keeping ctx-access out of the inner helper.

**Tests**
- `tests/test_helpers.h::make_rhythm_registry` — emplaces `SongPlayingTag` instead of writing `song.playing = true`. Critical because ~50 tests call this helper.
- 19 test files migrated to `ctx.emplace` / `ctx.erase` / `ctx.contains` for the three former bool fields (test_song_playback_system, test_song_playback_extended, test_rhythm_system, test_phase_runner, test_player_action_rhythm, test_game_state_extended, test_collision_extended, test_beat_log_system, test_audio_offset_calibration, test_redfoot_testflight_ui, test_reduce_motion, test_helpers_and_functions, test_energy_system, test_scoring_system, test_death_model_unified, test_beat_map_validation, test_beat_scheduler_system, test_signal_lifecycle_nogated, test_test_player_system, test_world_systems).
- `tests/test_beat_map_validation.cpp` — the `init_song_state: resets playback state` test loses the two `CHECK_FALSE(state.playing/finished)` assertions (function no longer touches those); other init-field resets are preserved.

## Verification

- `cmake --build build` — clean, **zero-warning** (`-Wall -Wextra -Werror`).
- `./build/shapeshifter_tests` — **all green: 3367 assertions in 965 test cases**.
  - `-4` vs prior baseline (3371) = the four eradicated `CHECK_FALSE` bool assertions in the `init_song_state` + `restart_music` lifecycle tests (two from `test_beat_map_validation`, two from `test_song_playback_system`). Expected — same shape as PR #1623's `-3` baseline drop.

## Acceptance criteria (from #1624)

- [x] `SongState::playing`, `SongState::finished`, `SongState::restart_music` eradicated from the struct.
- [x] `SongPlayingTag`, `SongFinishedTag`, `RestartMusicRequestTag` ctx tags added to `app/tags/tags.h` with doc comments referencing this issue.
- [x] All 16 reader sites migrate to `ctx.contains<...Tag>()` (no field reads remain).
- [x] All 5 writer sites migrate to `ctx.emplace<...>` / `ctx.erase<...>` transitions.
- [x] The mutex (`SongPlayingTag` XOR `SongFinishedTag`, never both) is preserved by the two flip sites.
- [x] `RestartMusicRequestTag` is consumed exactly once by `song_playback_system` (erase after handling).
- [x] No new NULL columns or sentinel values introduced during the migration.
- [x] Local build + `shapeshifter_tests` green (zero-warning, all tests pass).
