### PR TITLE
#1627 PendingEnergyEffects.events: drop std::vector<Event> array column, walk PendingEnergyEffectTag row table (Fabian Principle 3)

### DIFF
--- a/app/systems/energy_system.cpp
+++ b/app/systems/energy_system.cpp
@@ -18,16 +18,24 @@ void energy_system(entt::registry& reg, float dt) {
     };
 
     // Apply deferred gameplay energy effects (single writer boundary).
+    // Per-frame row table (issue #1627): one entity per enqueued delta,
+    // tagged `PendingEnergyEffectTag` (+ optional `EnergyFlashTag`).
+    // EnTT's default forward iteration on `sparse_set` walks the packed
+    // array back-to-front (last-emplaced first); the original
+    // `vector<Event>` forward-iterated insertion order. Use `rbegin/rend`
+    // to traverse the row table in insertion order, preserving the
+    // "misses first, then per-tier hits" clamp semantics scoring_system
+    // writes the rows in.
     {
-        auto& pending = reg.ctx().get<PendingEnergyEffects>();
-        // Preserve per-event clamp semantics (misses first, then hits).
-        for (const auto& effect : pending.events) {
-            apply_clamped_delta(effect.delta);
-            if (effect.flash) {
+        auto pending = reg.view<PendingEnergyEffectTag>();
+        for (auto it = pending.rbegin(), last = pending.rend(); it != last; ++it) {
+            const auto e = *it;
+            apply_clamped_delta(reg.get<EnergyDelta>(e).value);
+            if (reg.all_of<EnergyFlashTag>(e)) {
                 energy->flash_timer = constants::ENERGY_FLASH_DURATION;
             }
         }
-        pending.events.clear();
+        reg.destroy(pending.begin(), pending.end());
     }
 
     if (song && energy->energy <= 0.0f && !is_phase_transition_pending(reg)) {

--- a/app/systems/gameplay_intents.h
+++ b/app/systems/gameplay_intents.h
@@ -5,14 +5,14 @@
 
 #include "../components/rhythm.h"
 
-struct PendingEnergyEffects {
-    struct Event {
-        float delta = 0.0f;
-        bool  flash = false;
-    };
-
-    std::vector<Event> events;
-    uint32_t capacity_exceeded_count = 0;
+// Per-row value for one pending energy delta (issue #1627). Attached to
+// an entity carrying `PendingEnergyEffectTag` (+ optional `EnergyFlashTag`)
+// by `scoring_system` during the miss/hit passes; drained and destroyed by
+// `energy_system` at the start of the same frame. Replaces the former
+// `PendingEnergyEffects::events` `std::vector<Event>` array column
+// (Fabian Principle 3 — no array columns).
+struct EnergyDelta {
+    float value = 0.0f;
 };
 
 // Per-tier popup request (no tier discriminator field — the queue it lives

--- a/app/systems/runtime_system_scratch.cpp
+++ b/app/systems/runtime_system_scratch.cpp
@@ -19,7 +19,6 @@ constexpr std::size_t kMinimumGameplayScratchCapacity = 8;
 
 void runtime_system_scratch_init(entt::registry& reg) {
     reg.ctx().insert_or_assign(ScoringSystemScratch{});
-    reg.ctx().insert_or_assign(PendingEnergyEffects{});
     reg.ctx().insert_or_assign(ScorePopupRequestQueue{});
     reg.ctx().insert_or_assign(ObstacleDespawnScratch{});
     reg.ctx().insert_or_assign(PopupDisplayScratch{});
@@ -40,7 +39,9 @@ void runtime_system_scratch_reserve(entt::registry& reg, std::size_t beat_capaci
     scoring.miss_buf.reserve(capacity);
     scoring.hit_buf.reserve(capacity);
 
-    reg.ctx().get<PendingEnergyEffects>().events.reserve(capacity);
+    // PendingEnergyEffects events were a `std::vector<Event>` array column —
+    // eradicated by issue #1627 into a per-frame row table. No reserve
+    // needed; entt's storage grows as `scoring_system` emplaces rows.
     // Each per-tier popup queue is reserved independently — the total capacity
     // budget is sized so any single tier can absorb a full-frame burst without
     // reallocating. (Per #1202/#1204, ScorePopupRequestQueue is now 5 per-tier

--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -19,11 +19,14 @@
 namespace {
 
 void enqueue_energy_effect(entt::registry& reg, float delta, bool flash = false) {
-    auto& pending = reg.ctx().get<PendingEnergyEffects>();
-    if (pending.events.size() >= pending.events.capacity()) {
-        ++pending.capacity_exceeded_count;
-    }
-    pending.events.push_back(PendingEnergyEffects::Event{delta, flash});
+    // Per-frame row table (issue #1627): each enqueued effect is its own
+    // entity. `energy_system` walks the row table in insertion order and
+    // destroys the rows. Replaces the former `PendingEnergyEffects::events`
+    // `std::vector<Event>` array column (Fabian Principle 3).
+    auto e = reg.create();
+    reg.emplace<PendingEnergyEffectTag>(e);
+    reg.emplace<EnergyDelta>(e, EnergyDelta{delta});
+    if (flash) reg.emplace<EnergyFlashTag>(e);
 }
 
 // Per-tier traits — Fabian per-value table: each specialization carries the

--- a/app/tags/tags.h
+++ b/app/tags/tags.h
@@ -112,6 +112,22 @@ struct ParticleTag {};
 // ── HUD / Energy bar ─────────────────────────────────────────
 struct EnergyBarTag {};
 
+// ── Pending energy effect (per-frame row table) ──────────────
+// Per Fabian's existential processing (issue #1627 / .squad/decisions.md
+// § 9 Principle 3 — "No array columns"), each enqueued energy delta is
+// its own entity in a per-frame row table. `scoring_system` creates one
+// entity per gameplay event (miss drain, tier recovery); `energy_system`
+// walks `view<PendingEnergyEffectTag>` in storage order (= insertion
+// order = miss-pass-first, then per-tier hit-pass), applies the deltas,
+// and `reg.destroy()`s the rows. Replaces the former
+// `PendingEnergyEffects::events` `std::vector<Event>` array column.
+//
+// Presence of `EnergyFlashTag` alongside the tag signals "trigger
+// the energy-bar flash for this delta" — what the former
+// `Event::flash` bool encoded.
+struct PendingEnergyEffectTag {};
+struct EnergyFlashTag         {};
+
 // ── Test player (deterministic AI) ───────────────────────────
 struct TestPlayerPlannedTag {};
 

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -719,7 +719,7 @@ NextPhase*Tag        0     per-frame  pending-transition mirror; drained by `cle
 BeatMap             var    session    setup_play_session (write), beat_scheduler (read)
 SongState          160     per-frame  song_playback/beat_scheduler
 EnergyState         12     per-frame  energy_system (write), ui_render (read)
-PendingEnergyEffects var   per-frame  scoring_system (push), energy_system (drain)
+PendingEnergyEffectTag var per-frame  scoring_system (emplace rows), energy_system (drain rows)
 ScoreState          12     per-frame  scoring_system (write), render (read)
 ScorePopupRequestQueue var per-frame  scoring_system (push), popup_feedback_system (drain)
 PlaySfxEvent        var    per-frame  dispatcher events drained by audio_system

--- a/design-docs/beatmap-integration.md
+++ b/design-docs/beatmap-integration.md
@@ -224,7 +224,7 @@ creates the standard runtime obstacle archetypes via the kind-specific
   │  ✅ obstacle_despawn_system    (destroy off-camera obstacles)   │
   │  ✅ popup_feedback_system      (drain ScorePopupRequestQueue)   │
   │  ✅ popup_display_system       (ScorePopup timer → fade/cull)   │
-  │  ✅ energy_system              (drain PendingEnergyEffects)     │
+  │  ✅ energy_system              (drain PendingEnergyEffectTag rows)│
   │  ✅ energy_bar_system          (HUD bar visual update)          │
   │  ✅ particle_system            (ParticleData timer → cull)      │
   │                                                                  │

--- a/design-docs/energy-bar.md
+++ b/design-docs/energy-bar.md
@@ -114,8 +114,10 @@ constexpr float ENERGY_CRITICAL_THRESH  = 0.25f;   // below this → bar pulses 
 ## Energy Modification Points
 
 Energy deltas are enqueued by gameplay systems and applied by
-`energy_system` through `PendingEnergyEffects`.  Gameplay systems should not
-mutate `EnergyState::energy` directly.
+`energy_system` through the `PendingEnergyEffectTag` row table (issue
+#1627: each enqueued effect is its own per-frame entity tagged
+`PendingEnergyEffectTag` + `EnergyDelta` + optional `EnergyFlashTag`).
+Gameplay systems should not mutate `EnergyState::energy` directly.
 
 ### 1. collision_system.cpp — on MISS
 

--- a/tests/test_energy_system.cpp
+++ b/tests/test_energy_system.cpp
@@ -31,58 +31,54 @@ TEST_CASE("energy: pending miss drain is applied by energy_system", "[energy]") 
     auto reg = make_rhythm_registry();
     auto& energy = reg.ctx().get<EnergyState>();
     energy.energy = 0.8f;
-    auto& pending = reg.ctx().emplace<PendingEnergyEffects>();
-    pending.events.push_back({-constants::ENERGY_DRAIN_MISS, true});
+    enqueue_pending_energy_effect(reg, -constants::ENERGY_DRAIN_MISS, true);
 
     energy_system(reg, 0.016f);
 
     CHECK_THAT(energy.energy, Catch::Matchers::WithinAbs(0.8f - constants::ENERGY_DRAIN_MISS, 0.0001f));
     CHECK(energy.flash_timer > 0.0f);
     CHECK(energy.flash_timer < constants::ENERGY_FLASH_DURATION);
-    CHECK(pending.events.empty());
+    CHECK(pending_energy_effects_empty(reg));
 }
 
 TEST_CASE("energy: pending perfect recovery is applied by energy_system", "[energy]") {
     auto reg = make_rhythm_registry();
     auto& energy = reg.ctx().get<EnergyState>();
     energy.energy = 0.2f;
-    auto& pending = reg.ctx().emplace<PendingEnergyEffects>();
-    pending.events.push_back({constants::ENERGY_RECOVER_PERFECT, false});
+    enqueue_pending_energy_effect(reg, constants::ENERGY_RECOVER_PERFECT, false);
 
     energy_system(reg, 0.016f);
 
     CHECK_THAT(energy.energy,
                Catch::Matchers::WithinAbs(0.2f + constants::ENERGY_RECOVER_PERFECT, 0.0001f));
-    CHECK(pending.events.empty());
+    CHECK(pending_energy_effects_empty(reg));
 }
 
 TEST_CASE("energy: pending events clamp each step in order", "[energy]") {
     auto reg = make_rhythm_registry();
     auto& energy = reg.ctx().get<EnergyState>();
     energy.energy = 0.0f;
-    auto& pending = reg.ctx().emplace<PendingEnergyEffects>();
-    pending.events.push_back({-constants::ENERGY_DRAIN_MISS, true});
-    pending.events.push_back({constants::ENERGY_RECOVER_PERFECT, false});
+    enqueue_pending_energy_effect(reg, -constants::ENERGY_DRAIN_MISS, true);
+    enqueue_pending_energy_effect(reg, constants::ENERGY_RECOVER_PERFECT, false);
 
     energy_system(reg, 0.016f);
 
     CHECK_THAT(energy.energy, Catch::Matchers::WithinAbs(constants::ENERGY_RECOVER_PERFECT, 0.0001f));
     CHECK(energy.flash_timer > 0.0f);
-    CHECK(pending.events.empty());
+    CHECK(pending_energy_effects_empty(reg));
 }
 
 TEST_CASE("energy: sloppy early-player pattern remains net-positive", "[energy][tuning][issue395]") {
     auto reg = make_rhythm_registry();
     auto& energy = reg.ctx().get<EnergyState>();
     energy.energy = 0.5f;
-    auto& pending = reg.ctx().emplace<PendingEnergyEffects>();
 
-    pending.events.push_back({constants::ENERGY_RECOVER_OK, false});
-    pending.events.push_back({constants::ENERGY_RECOVER_OK, false});
-    pending.events.push_back({constants::ENERGY_RECOVER_OK, false});
-    pending.events.push_back({constants::ENERGY_RECOVER_OK, false});
-    pending.events.push_back({constants::ENERGY_RECOVER_OK, false});
-    pending.events.push_back({-constants::ENERGY_DRAIN_BAD, true});
+    enqueue_pending_energy_effect(reg, constants::ENERGY_RECOVER_OK, false);
+    enqueue_pending_energy_effect(reg, constants::ENERGY_RECOVER_OK, false);
+    enqueue_pending_energy_effect(reg, constants::ENERGY_RECOVER_OK, false);
+    enqueue_pending_energy_effect(reg, constants::ENERGY_RECOVER_OK, false);
+    enqueue_pending_energy_effect(reg, constants::ENERGY_RECOVER_OK, false);
+    enqueue_pending_energy_effect(reg, -constants::ENERGY_DRAIN_BAD, true);
 
     energy_system(reg, 0.016f);
 

--- a/tests/test_entt_dispatcher_contract.cpp
+++ b/tests/test_entt_dispatcher_contract.cpp
@@ -195,7 +195,9 @@ TEST_CASE("runtime scratch queues are explicit registry context state",
     auto reg = make_registry();
 
     CHECK(reg.ctx().contains<ScoringSystemScratch>());
-    CHECK(reg.ctx().contains<PendingEnergyEffects>());
+    // PendingEnergyEffects ctx singleton was eradicated by issue #1627 — its
+    // contents now live as per-frame row entities tagged
+    // `PendingEnergyEffectTag` (no ctx residency to assert).
     CHECK(reg.ctx().contains<ScorePopupRequestQueue>());
     CHECK(reg.ctx().contains<ObstacleDespawnScratch>());
     CHECK(reg.ctx().contains<PopupDisplayScratch>());

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -296,6 +296,28 @@ inline void run_semantic_input_tick(entt::registry& reg, float dt = 0.016f) {
     game_state_system(reg, dt);
 }
 
+// ── PendingEnergyEffect row-table helpers (issue #1627) ───────────────────
+// `PendingEnergyEffects::events` was a `std::vector<Event>` array column on
+// a ctx singleton — eradicated by issue #1627 into a per-frame row table.
+// Each enqueued effect is its own entity carrying `PendingEnergyEffectTag` +
+// `EnergyDelta` (+ optional `EnergyFlashTag`). Mirrors scoring_system's
+// `enqueue_energy_effect`. Tests use these to seed gameplay-energy effects
+// without re-coding the per-row emplace pattern at every test site.
+
+inline entt::entity enqueue_pending_energy_effect(entt::registry& reg,
+                                                  float delta,
+                                                  bool flash = false) {
+    auto e = reg.create();
+    reg.emplace<PendingEnergyEffectTag>(e);
+    reg.emplace<EnergyDelta>(e, EnergyDelta{delta});
+    if (flash) reg.emplace<EnergyFlashTag>(e);
+    return e;
+}
+
+inline bool pending_energy_effects_empty(const entt::registry& reg) {
+    return reg.view<PendingEnergyEffectTag>().empty();
+}
+
 // Sets up a registry with rhythm singletons included
 inline entt::registry make_rhythm_registry() {
     entt::registry reg = make_registry();

--- a/tests/test_phase_runner.cpp
+++ b/tests/test_phase_runner.cpp
@@ -141,9 +141,9 @@ TEST_CASE("tick_fixed_systems: popup_feedback and energy run in score-feedback c
     auto& queue = reg.ctx().emplace<ScorePopupRequestQueue>();
     queue.untimed.push_back({100.0f, 200.0f, 10});
 
-    // Pre-seed a pending energy effect to verify energy_system is wired.
-    auto& pending = reg.ctx().emplace<PendingEnergyEffects>();
-    pending.events.push_back({20.0f, false});
+    // Pre-seed a pending energy effect to verify energy_system is wired
+    // (per-frame row table — issue #1627).
+    enqueue_pending_energy_effect(reg, 20.0f, false);
 
     // Set energy to 0 so the +20 effect is visible after clamping.
     reg.ctx().get<EnergyState>().energy = 0.0f;
@@ -163,25 +163,24 @@ TEST_CASE("tick_fixed_systems: popup_feedback and energy run in score-feedback c
     CHECK(reg.ctx().get<EnergyState>().energy > 0.0f);
 
     // Pending events must be cleared.
-    CHECK(pending.events.empty());
+    CHECK(pending_energy_effects_empty(reg));
 }
 
 TEST_CASE("tick_fixed_systems: energy depletion requests GameOver before next Playing pass",
           "[phase_guard][energy][regression][issue781]") {
     auto reg = make_rhythm_registry();
     auto& energy = reg.ctx().get<EnergyState>();
-    auto& pending = reg.ctx().get<PendingEnergyEffects>();
     auto& results = reg.ctx().get<SongResults>();
 
     energy.energy = constants::ENERGY_DRAIN_MISS;
-    pending.events.push_back({-constants::ENERGY_DRAIN_MISS, true});
+    enqueue_pending_energy_effect(reg, -constants::ENERGY_DRAIN_MISS, true);
 
     tick_fixed_systems(reg, 0.016f);
 
     REQUIRE(energy.energy == 0.0f);
     REQUIRE(reg.ctx().contains<NextPhaseGameOverTag>());
     CHECK(reg.ctx().find<EnergyDepletedDeath>() != nullptr);
-    CHECK(pending.events.empty());
+    CHECK(pending_energy_effects_empty(reg));
 
     auto late_miss = reg.create();
     reg.emplace<ObstacleTag>(late_miss);
@@ -212,13 +211,12 @@ TEST_CASE("tick_fixed_systems: fatal final drain wins after song finishes",
     auto reg = make_rhythm_registry();
     auto& song = reg.ctx().get<SongState>();
     auto& energy = reg.ctx().get<EnergyState>();
-    auto& pending = reg.ctx().get<PendingEnergyEffects>();
 
     song.song_time = song.duration_sec;
     reg.ctx().emplace<SongPlayingTag>();
     reg.ctx().erase<SongFinishedTag>();
     energy.energy = constants::ENERGY_DRAIN_MISS;
-    pending.events.push_back({-constants::ENERGY_DRAIN_MISS, true});
+    enqueue_pending_energy_effect(reg, -constants::ENERGY_DRAIN_MISS, true);
 
     tick_fixed_systems(reg, 0.016f);
 

--- a/tests/test_scoring_system.cpp
+++ b/tests/test_scoring_system.cpp
@@ -485,10 +485,8 @@ TEST_CASE("runtime scratch: dense scoring burst stays within reserved capacity",
     runtime_system_scratch_reserve(reg, dense_count);
 
     auto& scratch = reg.ctx().get<ScoringSystemScratch>();
-    auto& energy = reg.ctx().get<PendingEnergyEffects>();
     auto& popup_queue = reg.ctx().get<ScorePopupRequestQueue>();
     const auto hit_capacity = scratch.hit_buf.capacity();
-    const auto energy_capacity = energy.events.capacity();
     // Per-tier queues (post-#1202/#1204): the dense burst below all goes
     // into queue.good, so guard the Good queue's capacity for this test.
     const auto popup_capacity = popup_queue.good.capacity();
@@ -502,12 +500,14 @@ TEST_CASE("runtime scratch: dense scoring burst stays within reserved capacity",
     scoring_system(reg, 0.0f);
 
     CHECK(scratch.hit_buf.capacity() == hit_capacity);
-    CHECK(energy.events.capacity() == energy_capacity);
     CHECK(popup_queue.good.capacity() == popup_capacity);
     CHECK(scratch.hit_capacity_exceeded_count == 0);
-    CHECK(energy.capacity_exceeded_count == 0);
     CHECK(popup_queue.capacity_exceeded_count == 0);
-    CHECK(energy.events.size() == static_cast<std::size_t>(dense_count));
+    // PendingEnergyEffects → row table (issue #1627): each enqueued effect is
+    // now a `PendingEnergyEffectTag` row entity, not a vector slot. There is
+    // no per-frame reserved capacity to guard — the storage grows naturally
+    // and `energy_system` destroys all rows at the start of its tick.
+    CHECK(reg.view<PendingEnergyEffectTag>().size() == static_cast<std::size_t>(dense_count));
     CHECK(popup_queue.good.size() == static_cast<std::size_t>(dense_count));
 }
 


### PR DESCRIPTION
Closes #1627.

## Summary

`PendingEnergyEffects` was a ctx singleton holding a `std::vector<Event>` array column (per-event `{delta, flash}` records) plus a parallel `capacity_exceeded_count` overflow counter. Per Fabian Principle 3 (`.squad/decisions.md` § 9 — _"a `std::vector<X>` field is a 1NF violation; each element becomes a row in its own table, with the parent's entity ID as the foreign key"_), this commit eradicates the singleton: each enqueued energy effect is now its own per-frame entity tagged `PendingEnergyEffectTag` + `EnergyDelta` (+ optional `EnergyFlashTag`).

Mirrors the precedent shape from #1554 (ObstacleChildren), #1611/#1614 (TestPlayerState.actions), #1612/#1615 (ActiveTouchSlot), and #1616/#1617 (LoadedSfx).

## Schema change

- `PendingEnergyEffects` struct erased (`app/systems/gameplay_intents.h`).
- New per-row value `EnergyDelta { float value; }` in the same header.
- New tags `PendingEnergyEffectTag` + `EnergyFlashTag` in `app/tags/tags.h` (presence of `EnergyFlashTag` alongside the row tag encodes the former `Event::flash` bool).

## Writers (`app/systems/scoring_system.cpp`)

- `enqueue_energy_effect(reg, delta, flash)` was `pending.events.push_back` + parallel overflow counter; now `reg.create()` + `emplace` of the row tag, `EnergyDelta`, and optional `EnergyFlashTag`. The overflow counter disappears — entt storage grows naturally.

## Drain (`app/systems/energy_system.cpp`)

- Was a `for (effect : pending.events) { apply; if (flash) … } clear()` loop. Now a `view<PendingEnergyEffectTag>` walk + `destroy(begin, end)` at the end of the pass.
- EnTT's `sparse_set` forward iteration is back-to-front of the packed array (last-emplaced first). The `vector` path forward-iterated insertion order, so the drain pass now traverses `rbegin/rend` to preserve the "misses-first, then per-tier hits" clamp semantics scoring_system writes the rows in. Destroy uses `begin/end` since order doesn't matter for destruction.

## Scratch init/reserve (`app/systems/runtime_system_scratch.cpp`)

- Removed `insert_or_assign(PendingEnergyEffects{})` and the `events.reserve(capacity)` call. No `capacity_exceeded_count` to track.

## Tests

- New helpers `enqueue_pending_energy_effect(reg, delta, flash)` and `pending_energy_effects_empty(reg)` in `tests/test_helpers.h` keep per-test setup ergonomic.
- `test_energy_system.cpp` (4 cases), `test_phase_runner.cpp` (3 cases): replace `pending.events.push_back({...})` with the helper; replace `pending.events.empty()` with `pending_energy_effects_empty(reg)`.
- `test_entt_dispatcher_contract.cpp`: drop the `reg.ctx().contains<PendingEnergyEffects>()` assertion (singleton no longer exists).
- `test_scoring_system.cpp` ("dense scoring burst stays within reserved capacity"): replace the `energy.events.capacity/size/count` triple with a `reg.view<PendingEnergyEffectTag>().size()` check. The reserved-capacity contract no longer applies to the row table.

## Docs

- `design-docs/architecture.md`: ctx-singleton table row renamed to `PendingEnergyEffectTag` row table.
- `design-docs/energy-bar.md`: § "Energy Modification Points" intro prose refreshed to describe the row-table mechanic.
- `design-docs/beatmap-integration.md`: tick diagram entry refreshed.

## Verified

- Native build: zero warnings (clean rebuild on Clang with `-Wall -Wextra -Werror`).
- Tests: `./build/shapeshifter_tests` 3364 assertions / 965 cases pass.
- `ctest --test-dir build`: 978/978 jobs pass.
