### PR TITLE
#1626 ScorePopupRequestQueue → per-tier PopupRequest row tables (Fabian Principle 3)

### DIFF
--- a/.squad/skills/entt-ctx-singleton-init/SKILL.md
+++ b/.squad/skills/entt-ctx-singleton-init/SKILL.md
@@ -56,13 +56,15 @@ Declare in `all_systems.h`, call once from `game_loop_init`.
 
 ## Exemptions
 
-Scratch-pad ctx accumulator queues (e.g., `ScorePopupRequestQueue`) used as
-per-frame intent buffers are intentionally optional — they legitimately use
-find/emplace and are not "always-present singletons." Most former scratch-pad
-ctx accumulators have since migrated to per-frame row tables via Fabian
-Principle 3 (see #1627 `PendingEnergyEffectTag`, #1628 `*ExpiredTag` /
-`PendingObstacleDespawnTag`, #1629 `Pending{Miss,Hit,NonScorableCleanup}ResolveTag`);
-new scratch should default to row tables, not new ctx singletons.
+Scratch-pad ctx accumulator queues used as per-frame intent buffers used to
+be intentionally optional — they legitimately used find/emplace and were not
+"always-present singletons." All known scratch-pad ctx accumulators have now
+migrated to per-frame row tables via Fabian Principle 3 (#1627 →
+`PendingEnergyEffectTag`, #1628 → `*ExpiredTag` /
+`PendingObstacleDespawnTag`, #1629 →
+`Pending{Miss,Hit,NonScorableCleanup}ResolveTag`, #1626 →
+`PopupRequestTier{Perfect,Good,Ok,Bad,Untimed}Tag` + `PopupRequest`); new
+scratch must default to row tables, not new ctx singletons.
 
 ## Measured Impact
 

--- a/app/systems/fixed_tick_runner.cpp
+++ b/app/systems/fixed_tick_runner.cpp
@@ -9,7 +9,8 @@ void tick_fixed_systems(entt::registry& reg, float dt) {
     tick_playing_systems(reg, dt);
     // Keep obstacle lifecycle systems contiguous while pools are warm.
     obstacle_despawn_system(reg, dt);
-    // Score feedback runs after scoring populates ScorePopupRequestQueue.
+    // Score feedback runs after scoring emplaces PopupRequest row entities
+    // (issue #1626 — per-tier row tables replaced the old ScorePopupRequestQueue).
     popup_feedback_system(reg, dt);
     popup_display_system(reg, dt);
     energy_system(reg, dt);

--- a/app/systems/gameplay_intents.h
+++ b/app/systems/gameplay_intents.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <cstdint>
-#include <vector>
+#include <entt/entt.hpp>
 
 #include "../components/rhythm.h"
+#include "../tags/tags.h"
 
 // Per-row value for one pending energy delta (issue #1627). Attached to
 // an entity carrying `PendingEnergyEffectTag` (+ optional `EnergyFlashTag`)
@@ -15,28 +15,31 @@ struct EnergyDelta {
     float value = 0.0f;
 };
 
-// Per-tier popup request (no tier discriminator field — the queue it lives
-// in IS the discriminator, per #1202/#1204 per-case-table mechanic).
-struct TimedPopupRequest {
+// Per-row value for one score popup request (issue #1626). Attached to
+// an entity carrying exactly one of the `PopupRequestTier*Tag`s in
+// `app/tags/tags.h` by `scoring_system` during the hit-pass drain;
+// drained and destroyed by `popup_feedback_system` at end of frame.
+// Replaces the former `ScorePopupRequestQueue`'s 5 inline
+// `std::vector<TimedPopupRequest|UntimedPopupRequest>` per-tier columns
+// (Fabian Principle 3 — no array columns).
+//
+// The former `TimedPopupRequest` / `UntimedPopupRequest` split was
+// purely cosmetic — identical schema, named per destination queue. Now
+// that the destination is a tag, the two row types collapse into one.
+struct PopupRequest {
     float x      = 0.0f;
     float y      = 0.0f;
     int   points = 0;
 };
 
-struct UntimedPopupRequest {
-    float x      = 0.0f;
-    float y      = 0.0f;
-    int   points = 0;
-};
-
-// One queue per former TimingTier value (Perfect/Good/Ok/Bad) plus one
-// "untimed" queue for hits without a timing grade. popup_feedback_system
-// runs one transform per queue — no switch on a discriminator.
-struct ScorePopupRequestQueue {
-    std::vector<TimedPopupRequest>   perfect;
-    std::vector<TimedPopupRequest>   good;
-    std::vector<TimedPopupRequest>   ok;
-    std::vector<TimedPopupRequest>   bad;
-    std::vector<UntimedPopupRequest> untimed;
-    uint32_t capacity_exceeded_count = 0;
-};
+// Spawn one popup-request row. `PopupRequestTierTag` is one of the per-tier
+// tags in `app/tags/tags.h` (`PopupRequestTier{Perfect,Good,Ok,Bad,Untimed}Tag`);
+// it selects which `popup_feedback_system` drain transform consumes the row.
+template <typename PopupRequestTierTag>
+inline entt::entity enqueue_popup_request(entt::registry& reg,
+                                          float x, float y, int points) {
+    auto e = reg.create();
+    reg.emplace<PopupRequestTierTag>(e);
+    reg.emplace<PopupRequest>(e, PopupRequest{x, y, points});
+    return e;
+}

--- a/app/systems/popup_feedback_system.cpp
+++ b/app/systems/popup_feedback_system.cpp
@@ -4,41 +4,41 @@
 #include "../components/game_state.h"
 #include "gameplay_intents.h"
 #include "../entities/popup_entity.h"
+#include "../tags/tags.h"
 
 namespace {
 
-// Common per-tier dispatch: drain one tier's queue via the matching spawner.
+// Per-tier drain transform. Walks one popup-request row-table view
+// (#1626 / Fabian Principle 3): each request entity carries
+// `PopupRequest` (x, y, points) + one `PopupRequestTier*Tag`. After
+// spawning the popup and emitting SFX, the request entity is destroyed.
 // SFX is emitted for any positive-points popup regardless of tier — the
 // scoring SFX is a one-shot side-effect tied to "a popup spawned with points,"
 // not to a particular tier, so it lives in the shared epilogue.
-template <typename Request, typename Spawn>
-void drain_timed_queue(entt::registry& reg,
-                       std::vector<Request>& queue,
-                       Spawn spawn,
-                       entt::dispatcher* disp) {
-    for (const auto& req : queue) {
+template <typename TierTag, typename Spawn>
+void drain_popup_requests(entt::registry& reg,
+                          Spawn spawn,
+                          entt::dispatcher* disp) {
+    auto v = reg.view<PopupRequest, TierTag>();
+    if (v.size_hint() == 0u) return;
+    for (auto [e, req] : v.each()) {
         spawn(reg, req.x, req.y, req.points);
         if (disp && req.points > 0) disp->enqueue<PlaySfxEvent>({SFX::ScorePopup});
     }
-    queue.clear();
+    reg.destroy(v.begin(), v.end());
 }
 
 }  // namespace
 
 void popup_feedback_system(entt::registry& reg, [[maybe_unused]] float dt) {
     if (!reg.ctx().contains<GamePhasePlayingTag>()) return;
-    auto& queue = reg.ctx().get<ScorePopupRequestQueue>();
-    if (queue.perfect.empty() && queue.good.empty() && queue.ok.empty() &&
-        queue.bad.empty() && queue.untimed.empty()) {
-        return;
-    }
 
     auto* disp = reg.ctx().find<entt::dispatcher>();
 
     // Per-tier transforms — one per former TimingTier value (#1202/#1204).
-    drain_timed_queue(reg, queue.perfect, spawn_score_popup_perfect, disp);
-    drain_timed_queue(reg, queue.good,    spawn_score_popup_good,    disp);
-    drain_timed_queue(reg, queue.ok,      spawn_score_popup_ok,      disp);
-    drain_timed_queue(reg, queue.bad,     spawn_score_popup_bad,     disp);
-    drain_timed_queue(reg, queue.untimed, spawn_score_popup_untimed, disp);
+    drain_popup_requests<PopupRequestTierPerfectTag>(reg, spawn_score_popup_perfect, disp);
+    drain_popup_requests<PopupRequestTierGoodTag>   (reg, spawn_score_popup_good,    disp);
+    drain_popup_requests<PopupRequestTierOkTag>     (reg, spawn_score_popup_ok,      disp);
+    drain_popup_requests<PopupRequestTierBadTag>    (reg, spawn_score_popup_bad,     disp);
+    drain_popup_requests<PopupRequestTierUntimedTag>(reg, spawn_score_popup_untimed, disp);
 }

--- a/app/systems/runtime_system_scratch.cpp
+++ b/app/systems/runtime_system_scratch.cpp
@@ -2,45 +2,37 @@
 #include "camera_system.h"
 #include "game_state_system.h"
 #include "gameplay_intents.h"
+#include "../tags/tags.h"
 #include "../components/rendering.h"
 
-#include <algorithm>
 #include <cstddef>
 
-namespace {
-
-constexpr std::size_t kMinimumGameplayScratchCapacity = 8;
-
-}  // namespace
-
 void runtime_system_scratch_init(entt::registry& reg) {
-    reg.ctx().insert_or_assign(ScorePopupRequestQueue{});
     // WasmSmokeLastLane uses row presence as the "lane reported" predicate
     // (Fabian Principle 3 — no sentinel NULL columns). Erase any stale row
     // carried over from a prior session so the next title update rewrites
     // unconditionally.
     reg.ctx().erase<WasmSmokeLastLane>();
 
+    // Destroy any stale popup request rows carried over from a prior
+    // session (issue #1626 row-table migration). The former
+    // `ScorePopupRequestQueue` ctx-vector clear was implicit here via
+    // `insert_or_assign(ScorePopupRequestQueue{})`.
+    auto stale = reg.view<PopupRequest>();
+    reg.destroy(stale.begin(), stale.end());
+
     runtime_system_scratch_reserve(reg, 0);
 }
 
-void runtime_system_scratch_reserve(entt::registry& reg, std::size_t beat_capacity) {
-    const std::size_t capacity = std::max(kMinimumGameplayScratchCapacity, beat_capacity);
-
-    // PendingEnergyEffects events were a `std::vector<Event>` array column —
-    // eradicated by issue #1627 into a per-frame row table. ScoringSystemScratch
-    // (miss_buf / hit_buf) was eradicated similarly by issue #1629. No reserve
-    // is needed for either; entt's storage grows as `scoring_system` emplaces
-    // PendingMissResolveTag / PendingHitResolveTag / PendingEnergyEffectTag rows.
+void runtime_system_scratch_reserve(entt::registry& /*reg*/, std::size_t /*beat_capacity*/) {
+    // PendingEnergyEffects (#1627), ScoringSystemScratch (#1629), and
+    // ScorePopupRequestQueue (#1626) were all eradicated into per-frame
+    // row tables. entt's storage grows naturally as `scoring_system`
+    // emplaces `PendingMissResolveTag` / `PendingHitResolveTag` /
+    // `PendingNonScorableCleanupTag` / `PendingEnergyEffectTag` /
+    // `PopupRequestTier*Tag` rows; no caller-driven reserve is needed.
     //
-    // Each per-tier popup queue is reserved independently — the total capacity
-    // budget is sized so any single tier can absorb a full-frame burst without
-    // reallocating. (Per #1202/#1204, ScorePopupRequestQueue is now 5 per-tier
-    // vectors instead of one tagged-union vector.)
-    auto& popup_queue = reg.ctx().get<ScorePopupRequestQueue>();
-    popup_queue.perfect.reserve(capacity);
-    popup_queue.good.reserve(capacity);
-    popup_queue.ok.reserve(capacity);
-    popup_queue.bad.reserve(capacity);
-    popup_queue.untimed.reserve(capacity);
+    // The reserve symbol is retained as a no-op so session-init callers
+    // (`game_loop_init`, `play_session`) and tests still compile against
+    // their existing signatures.
 }

--- a/app/systems/scoring_system.cpp
+++ b/app/systems/scoring_system.cpp
@@ -30,7 +30,7 @@ void enqueue_energy_effect(entt::registry& reg, float delta, bool flash = false)
 
 // Per-tier traits — Fabian per-value table: each specialization carries the
 // row of constants the scoring transform reads for that tier (energy delta,
-// results counter member-pointer, particle color, popup-queue member-pointer).
+// results counter member-pointer, particle color, popup-request tier tag).
 // One specialization per former TimingTier value; the prior 4-way switches
 // are replaced by template selection over the tier tag.
 template <typename TierTag>
@@ -43,8 +43,7 @@ struct tier_score_traits<TimingPerfectTag> {
     static constexpr bool  energy_flash        = false;
     static constexpr Color particle_color{255, 230, 90, 240};
     static constexpr int   SongResults::* results_counter = &SongResults::perfect_count;
-    static constexpr std::vector<TimedPopupRequest> ScorePopupRequestQueue::* queue =
-        &ScorePopupRequestQueue::perfect;
+    using PopupRequestTag = PopupRequestTierPerfectTag;
 };
 
 template <>
@@ -54,8 +53,7 @@ struct tier_score_traits<TimingGoodTag> {
     static constexpr bool  energy_flash        = false;
     static constexpr Color particle_color{120, 255, 160, 230};
     static constexpr int   SongResults::* results_counter = &SongResults::good_count;
-    static constexpr std::vector<TimedPopupRequest> ScorePopupRequestQueue::* queue =
-        &ScorePopupRequestQueue::good;
+    using PopupRequestTag = PopupRequestTierGoodTag;
 };
 
 template <>
@@ -65,8 +63,7 @@ struct tier_score_traits<TimingOkTag> {
     static constexpr bool  energy_flash        = false;
     static constexpr Color particle_color{100, 180, 255, 220};
     static constexpr int   SongResults::* results_counter = &SongResults::ok_count;
-    static constexpr std::vector<TimedPopupRequest> ScorePopupRequestQueue::* queue =
-        &ScorePopupRequestQueue::ok;
+    using PopupRequestTag = PopupRequestTierOkTag;
 };
 
 template <>
@@ -76,8 +73,7 @@ struct tier_score_traits<TimingBadTag> {
     static constexpr bool  energy_flash        = true;
     static constexpr Color particle_color{255, 100, 100, 220};
     static constexpr int   SongResults::* results_counter = &SongResults::bad_count;
-    static constexpr std::vector<TimedPopupRequest> ScorePopupRequestQueue::* queue =
-        &ScorePopupRequestQueue::bad;
+    using PopupRequestTag = PopupRequestTierBadTag;
 };
 
 constexpr Color kUntimedParticleColor{220, 220, 255, 220};
@@ -129,8 +125,7 @@ float chain_multiplier_for_count(int32_t chain_count) {
 template <typename TierTag>
 void process_tier_hit_pass(entt::registry& reg,
                            ScoreState& score,
-                           SongResults* results,
-                           ScorePopupRequestQueue& popup_queue) {
+                           SongResults* results) {
     {
         auto gather = reg.view<ObstacleTag, ScoredTag, Obstacle, WorldPosition, TimingGrade, TierTag>(
             entt::exclude<MissTag, NonScorableTag>);
@@ -167,8 +162,7 @@ void process_tier_hit_pass(entt::registry& reg,
 
         score.score += points;
 
-        auto& queue = popup_queue.*Traits::queue;
-        queue.push_back({wp.position.x, wp.position.y, points});
+        enqueue_popup_request<typename Traits::PopupRequestTag>(reg, wp.position.x, wp.position.y, points);
         spawn_score_particles(reg, wp.position, Traits::particle_color);
 
         reg.get_or_emplace<ResolvedObstacleTag>(e);
@@ -182,8 +176,7 @@ void process_tier_hit_pass(entt::registry& reg,
 
 void process_ungraded_hit_pass(entt::registry& reg,
                                ScoreState& score,
-                               SongResults* results,
-                               ScorePopupRequestQueue& popup_queue) {
+                               SongResults* results) {
     {
         auto gather = reg.view<ObstacleTag, ScoredTag, Obstacle, WorldPosition>(
             entt::exclude<MissTag, NonScorableTag, TimingGrade>);
@@ -215,7 +208,7 @@ void process_ungraded_hit_pass(entt::registry& reg,
 
         score.score += points;
 
-        popup_queue.untimed.push_back({wp.position.x, wp.position.y, points});
+        enqueue_popup_request<PopupRequestTierUntimedTag>(reg, wp.position.x, wp.position.y, points);
         spawn_score_particles(reg, wp.position, kUntimedParticleColor);
 
         reg.get_or_emplace<ResolvedObstacleTag>(e);
@@ -246,7 +239,6 @@ void scoring_system(entt::registry& reg, float dt) {
     }
 
     auto* results = reg.ctx().find<SongResults>();   // #309: hoisted above loop
-    auto& popup_queue = reg.ctx().get<ScorePopupRequestQueue>();
 
     // Miss pass: single owner of ENERGY_DRAIN_MISS and miss_count.
     // Gather → drain via `PendingMissResolveTag` row table (issue #1629):
@@ -289,11 +281,11 @@ void scoring_system(entt::registry& reg, float dt) {
     // Hit pass: one transform per former TimingTier value plus one ungraded
     // transform (#1202/#1204). Per-tier constants live in tier_score_traits;
     // no `switch` on a discriminator anywhere in the hit pipeline.
-    process_tier_hit_pass<TimingPerfectTag>(reg, score, results, popup_queue);
-    process_tier_hit_pass<TimingGoodTag>   (reg, score, results, popup_queue);
-    process_tier_hit_pass<TimingOkTag>     (reg, score, results, popup_queue);
-    process_tier_hit_pass<TimingBadTag>    (reg, score, results, popup_queue);
-    process_ungraded_hit_pass              (reg, score, results, popup_queue);
+    process_tier_hit_pass<TimingPerfectTag>(reg, score, results);
+    process_tier_hit_pass<TimingGoodTag>   (reg, score, results);
+    process_tier_hit_pass<TimingOkTag>     (reg, score, results);
+    process_tier_hit_pass<TimingBadTag>    (reg, score, results);
+    process_ungraded_hit_pass              (reg, score, results);
 
     // ── NonScorable cleanup ───────────────────────────────────────────────────
     // Entities excluded from the hit pass via NonScorableTag still need their

--- a/app/tags/tags.h
+++ b/app/tags/tags.h
@@ -170,6 +170,29 @@ struct PendingMissResolveTag        {};
 struct PendingHitResolveTag         {};
 struct PendingNonScorableCleanupTag {};
 
+// ── Pending score-popup request (per-frame row table) ────────
+// Per Fabian's existential processing (issue #1626 / .squad/decisions.md
+// § 9 Principle 3 — "No array columns"), the former `ScorePopupRequestQueue`
+// `std::vector<TimedPopupRequest>` per-tier columns + `untimed` column +
+// `capacity_exceeded_count` parallel counter are eradicated. Each popup
+// request is its own entity carrying one of the per-tier tags below plus
+// a `PopupRequest` row component (x, y, points).
+//
+// `scoring_system` creates one request entity per scored obstacle during
+// the hit-pass drain (4 graded tiers + 1 ungraded). `popup_feedback_system`
+// walks one view per tier — `view<PopupRequest, PopupRequestTier*Tag>()` —
+// invokes the matching `spawn_score_popup_*` per row, and `reg.destroy()`s
+// the request rows at end-of-pass. The per-tier identity is the tag, not
+// a discriminator field — one transform per former enum value, no `switch`.
+//
+// Mirrors the per-tag row-table mechanic the squad already applies to
+// timing tiers, render passes, screen tags, etc. (#1202 / #1204).
+struct PopupRequestTierPerfectTag {};
+struct PopupRequestTierGoodTag    {};
+struct PopupRequestTierOkTag      {};
+struct PopupRequestTierBadTag     {};
+struct PopupRequestTierUntimedTag {};
+
 // ── Test player (deterministic AI) ───────────────────────────
 struct TestPlayerPlannedTag {};
 

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -720,7 +720,8 @@ SongState          160     per-frame  song_playback/beat_scheduler
 EnergyState         12     per-frame  energy_system (write), ui_render (read)
 PendingEnergyEffectTag var per-frame  scoring_system (emplace rows), energy_system (drain rows)
 ScoreState          12     per-frame  scoring_system (write), render (read)
-ScorePopupRequestQueue var per-frame  scoring_system (push), popup_feedback_system (drain)
+ScorePopupRequestQueue: REMOVED — replaced by `PopupRequest` + `PopupRequestTier*Tag` row tables (issue #1626, Fabian Principle 3).
+PopupRequestTier*Tag    var   per-frame  scoring_system (emplace rows via `enqueue_popup_request<>`), popup_feedback_system (drain rows)
 PlaySfxEvent        var    per-frame  dispatcher events drained by audio_system
 TestPlayerState     var    session    test_player_system (read/write), test_player_session (init), game_loop (reset)
 ─────────────────────────────────────────────────────────────

--- a/design-docs/beatmap-integration.md
+++ b/design-docs/beatmap-integration.md
@@ -222,7 +222,7 @@ creates the standard runtime obstacle archetypes via the kind-specific
   │  ✅ song_playback_system       (advances SongState.song_time)   │
   │  ✅ tick_playing_systems       (gated on GamePhasePlayingTag) │
   │  ✅ obstacle_despawn_system    (destroy off-camera obstacles)   │
-  │  ✅ popup_feedback_system      (drain ScorePopupRequestQueue)   │
+  │  ✅ popup_feedback_system      (drain PopupRequestTier*Tag rows)│
   │  ✅ popup_display_system       (ScorePopup timer → fade/cull)   │
   │  ✅ energy_system              (drain PendingEnergyEffectTag rows)│
   │  ✅ energy_bar_system          (HUD bar visual update)          │

--- a/tests/test_entt_dispatcher_contract.cpp
+++ b/tests/test_entt_dispatcher_contract.cpp
@@ -186,18 +186,25 @@ TEST_CASE("wire_input_dispatcher prewarms semantic event queues without pending 
     CHECK(dispatcher.size<MenuSelectDiffEvent>()     == 0);
 }
 
-TEST_CASE("runtime scratch queues are explicit registry context state",
+TEST_CASE("runtime scratch row tables are empty after init (no ctx residency)",
           "[ecs][scratch]") {
     auto reg = make_registry();
 
-    // ScoringSystemScratch (miss_buf / hit_buf) ctx singleton was eradicated
-    // by issue #1629 — its contents now live as per-frame row entities
-    // tagged `PendingMissResolveTag` / `PendingHitResolveTag` /
-    // `PendingNonScorableCleanupTag` (no ctx residency to assert).
-    // PendingEnergyEffects ctx singleton was eradicated by issue #1627 — its
-    // contents now live as per-frame row entities tagged
-    // `PendingEnergyEffectTag` (no ctx residency to assert).
-    CHECK(reg.ctx().contains<ScorePopupRequestQueue>());
+    // All former scratch-pad ctx singletons have been migrated to per-frame
+    // row tables (Fabian Principle 3 / .squad/decisions.md § 9):
+    //   - ScoringSystemScratch (miss_buf / hit_buf) → PendingMissResolveTag /
+    //     PendingHitResolveTag / PendingNonScorableCleanupTag (issue #1629)
+    //   - PendingEnergyEffects.events → PendingEnergyEffectTag (issue #1627)
+    //   - ScorePopupRequestQueue.{perfect,good,ok,bad,untimed} →
+    //     PopupRequestTier*Tag + PopupRequest row component (issue #1626)
+    // None of these have ctx residency anymore — they are entity-table rows.
+    // The dispatcher remains the canonical synchronous event surface.
+    CHECK(reg.ctx().contains<entt::dispatcher>());
+    CHECK(reg.view<PendingMissResolveTag>().size()       == 0u);
+    CHECK(reg.view<PendingHitResolveTag>().size()        == 0u);
+    CHECK(reg.view<PendingNonScorableCleanupTag>().size()== 0u);
+    CHECK(reg.view<PendingEnergyEffectTag>().size()      == 0u);
+    CHECK(reg.view<PopupRequest>().size()                == 0u);
 }
 
 TEST_CASE("R7: Go*Event delivered in GameOver phase — player_input handler no-ops due to phase guard",

--- a/tests/test_phase_runner.cpp
+++ b/tests/test_phase_runner.cpp
@@ -114,16 +114,17 @@ TEST_CASE("tick_playing_systems: shape window activates before collision", "[pha
 // Verifies that popup_feedback_system and energy_system are wired in
 // tick_fixed_systems (NOT inside tick_playing_systems / the runner).
 //
-// Why placement matters: scoring_system (inside tick_playing_systems) populates
-// ScorePopupRequestQueue; popup_feedback_system must run AFTER tick_playing_systems
-// so the queue is already filled when popup_feedback consumes it.  Moving them
-// INTO tick_playing_systems would run them before scoring_system, silently
-// dropping all popups.
+// Why placement matters: scoring_system (inside tick_playing_systems) emplaces
+// `PopupRequest` row entities tagged with `PopupRequestTier*Tag` (issue #1626);
+// popup_feedback_system must run AFTER tick_playing_systems so the per-tier row
+// tables are populated before popup_feedback drains them. Moving them INTO
+// tick_playing_systems would run them before scoring_system, silently dropping
+// all popups.
 //
 // Why relative ordering between obstacle_despawn and popup_feedback does NOT
 // matter (Keaton-r14 finding): these two systems are commutative.
 //   obstacle_despawn reads ObstacleTag+WorldPosition → destroys entities
-//   popup_feedback  reads ScorePopupRequestQueue (ctx) → creates popup entities
+//   popup_feedback  reads PopupRequest + PopupRequestTier*Tag → creates popup entities
 // Their data surfaces are disjoint; no observable state diff results from
 // swapping them.  The relative call order in fixed_tick_runner.cpp is a
 // cache-locality preference, not a semantic invariant.
@@ -137,9 +138,10 @@ TEST_CASE("tick_fixed_systems: popup_feedback and energy run in score-feedback c
     set_test_phase<GamePhasePlayingTag>(reg);
 
     // Pre-seed a popup request directly (bypasses scoring_system path; tests
-    // that popup_feedback_system is wired and consumes the queue).
-    auto& queue = reg.ctx().emplace<ScorePopupRequestQueue>();
-    queue.untimed.push_back({100.0f, 200.0f, 10});
+    // that popup_feedback_system is wired and consumes the row table).
+    // Per-frame row table (issue #1626): each request is its own entity
+    // tagged with one of the `PopupRequestTier*Tag`s + a `PopupRequest` row.
+    enqueue_popup_request<PopupRequestTierUntimedTag>(reg, 100.0f, 200.0f, 10);
 
     // Pre-seed a pending energy effect to verify energy_system is wired
     // (per-frame row table — issue #1627).
@@ -151,11 +153,12 @@ TEST_CASE("tick_fixed_systems: popup_feedback and energy run in score-feedback c
     tick_fixed_systems(reg, 0.016f);
 
     // popup_feedback_system must have consumed the queue and spawned an entity.
-    CHECK(queue.untimed.empty());
-    CHECK(queue.perfect.empty());
-    CHECK(queue.good.empty());
-    CHECK(queue.ok.empty());
-    CHECK(queue.bad.empty());
+    // Each per-tier row table is empty after drain.
+    CHECK(reg.view<PopupRequest, PopupRequestTierPerfectTag>().size_hint() == 0u);
+    CHECK(reg.view<PopupRequest, PopupRequestTierGoodTag>().size_hint()    == 0u);
+    CHECK(reg.view<PopupRequest, PopupRequestTierOkTag>().size_hint()      == 0u);
+    CHECK(reg.view<PopupRequest, PopupRequestTierBadTag>().size_hint()     == 0u);
+    CHECK(reg.view<PopupRequest, PopupRequestTierUntimedTag>().size_hint() == 0u);
     const auto popup_view = reg.view<ScorePopup>();
     CHECK_FALSE(popup_view.empty());
 

--- a/tests/test_popup_display_system.cpp
+++ b/tests/test_popup_display_system.cpp
@@ -33,7 +33,6 @@
 #include "components/transform.h" // WorldPosition, Vector2
 #include "entities/settings.h"    // SettingsState (reduce_motion)
 #include "systems/all_systems.h"  // popup_display_system declaration
-#include "systems/gameplay_intents.h" // ScorePopupRequestQueue (init sentinel)
 #include "entities/popup_entity.h"
 #include "constants.h"
 
@@ -49,9 +48,10 @@ void seed_popup_common(entt::registry& reg,
                        int32_t        value,
                        float          remaining,
                        float          max_time) {
-    if (!reg.ctx().contains<ScorePopupRequestQueue>()) {
-        runtime_system_scratch_init(reg);
-    }
+    // Idempotent / lightweight after issue #1626 (ScorePopupRequestQueue
+    // eradicated into per-tier row tables); always call so popup_display
+    // tests don't depend on a now-defunct ctx sentinel.
+    runtime_system_scratch_init(reg);
     ScorePopup sp{};
     sp.value     = value;
     sp.remaining = remaining;

--- a/tests/test_scoring_system.cpp
+++ b/tests/test_scoring_system.cpp
@@ -478,12 +478,10 @@ TEST_CASE("scoring: obstacle/timing points still apply after playback has finish
     CHECK(score.score >= constants::PTS_SHAPE_GATE);
 }
 
-TEST_CASE("runtime scratch: dense scoring burst processes all hits correctly", "[scoring][issue557][issue1629]") {
+TEST_CASE("runtime scratch: dense scoring burst processes all hits correctly", "[scoring][issue557][issue1629][issue1626]") {
     auto reg = make_registry();
     constexpr int dense_count = 6;
     runtime_system_scratch_reserve(reg, dense_count);
-
-    auto& popup_queue = reg.ctx().get<ScorePopupRequestQueue>();
 
     for (int i = 0; i < dense_count; ++i) {
         auto obs = make_shape_gate(reg, Shape::Circle, constants::PLAYER_Y + static_cast<float>(i));
@@ -499,7 +497,11 @@ TEST_CASE("runtime scratch: dense scoring burst processes all hits correctly", "
     CHECK(reg.view<PendingHitResolveTag>().size() == 0u);
     CHECK(reg.view<PendingMissResolveTag>().size() == 0u);
     CHECK(reg.view<PendingNonScorableCleanupTag>().size() == 0u);
-    CHECK(popup_queue.good.size() == static_cast<std::size_t>(dense_count));
+    // ScorePopupRequestQueue → per-tier row table (issue #1626): each scored
+    // hit is its own `PopupRequest` row entity tagged with the matching
+    // `PopupRequestTier*Tag` instead of a slot in `queue.<tier>`. All Good-
+    // tier hits in this burst end up in `view<PopupRequest, PopupRequestTierGoodTag>`.
+    CHECK(reg.view<PopupRequest, PopupRequestTierGoodTag>().size_hint() == static_cast<std::size_t>(dense_count));
     // PendingEnergyEffects → row table (issue #1627): each enqueued effect is
     // now a `PendingEnergyEffectTag` row entity, not a vector slot. There is
     // no per-frame reserved capacity to guard — the storage grows naturally


### PR DESCRIPTION
## #1626 — `ScorePopupRequestQueue` → per-tier popup-request row tables (Fabian Principle 3)

Closes #1626.

### Problem

`ScorePopupRequestQueue` is a ctx singleton with **five inline `std::vector` array columns** (`perfect`, `good`, `ok`, `bad`, `untimed`) plus a parallel `capacity_exceeded_count`. This is the canonical Fabian Principle 3 anti-pattern: "no array columns / no inline `std::vector<T>` slots; rows belong on entities."

The queue also encoded a needless `TimedPopupRequest` / `UntimedPopupRequest` split — identical schema, named per destination column.

### Solution

Replace the queue + parallel counter + 2 request structs with:

- **1 `PopupRequest` row component** (`{ x, y, points }`) in `app/systems/gameplay_intents.h`.
- **5 per-tier marker tags** in `app/tags/tags.h`: `PopupRequestTier{Perfect,Good,Ok,Bad,Untimed}Tag`. Tier identity is *existential* — the presence of one of the 5 tags discriminates routing; no enum, no `switch`.
- **1 template helper** `enqueue_popup_request<TierTag>(reg, x, y, pts)` that creates an entity, emplaces the tier tag, emplaces the `PopupRequest` row, returns the entity.

`scoring_system.cpp` now drops the `popup_queue` parameter from `process_tier_hit_pass<TierTraits>` and `process_ungraded_hit_pass` and uses `enqueue_popup_request<TierTraits::PopupRequestTag>(...)` instead of `(queue.*TierTraits::queue).push_back(...)`. The `tier_score_traits` member-pointer `queue` is replaced with a `using PopupRequestTag = ...` alias.

`popup_feedback_system.cpp` drains via 5 per-tier `view<PopupRequest, PopupRequestTier*Tag>()`, then `reg.destroy(view.begin(), view.end())` per pass. No queue-clear at the end; the entity destruction is the clear.

### Eradications

- `ScorePopupRequestQueue` struct + its 5 `std::vector` columns + `capacity_exceeded_count`
- `TimedPopupRequest` / `UntimedPopupRequest` structs (collapsed into single `PopupRequest`)
- `popup_queue` parameter threading through 4 graded + 1 ungraded scoring passes
- `runtime_system_scratch_init`'s `ScorePopupRequestQueue` emplace; `_reserve`'s 5 per-tier `reserve()` calls

### Behavior preserved

- 5-way tier routing is now driven by per-tier tag identity rather than 5 named columns.
- The `popup_feedback_system` continues to consume requests in tier order and spawn `ScorePopup` entities + push `SFX::ScorePopup` per pass.
- `tick_fixed_systems` ordering is unchanged — `popup_feedback_system` runs after `tick_playing_systems`'s `scoring_system`, so per-tier row tables are fully populated before the drain.

### Tests updated

- `test_scoring_system.cpp` — burst test now asserts `view<PopupRequest, PopupRequestTierGoodTag>().size_hint() == dense_count` instead of `popup_queue.good.size()`.
- `test_phase_runner.cpp` — score-feedback chain test now pre-seeds via `enqueue_popup_request<PopupRequestTierUntimedTag>(...)` and asserts each per-tier view is empty after drain.
- `test_entt_dispatcher_contract.cpp` — "scratch ctx" test repurposed to assert all 4 migrated row tables (#1626/#1627/#1628/#1629) are empty after `make_registry()`.
- `test_popup_display_system.cpp` — sentinel guarded on `ScorePopupRequestQueue` ctx residency replaced with unconditional (idempotent) `runtime_system_scratch_init` call.

### Build / test

- `cmake --build build -j` — zero warnings on native clang.
- `./build/shapeshifter_tests` — **3364 assertions in 965 test cases pass.**
- `./build/shapeshifter_startup_shutdown_smoke` — clean exit.

### Lineage

Fourth in the Principle 3 sweep: #1627 (`PendingEnergyEffects`) → #1628 (4 expired-entity scratches) → #1629 (`ScoringSystemScratch`) → **#1626 (this PR — `ScorePopupRequestQueue`).**

After this lands, no `std::vector<T>` column survives inside a singleton ctx struct in `app/` for the scoring/feedback subsystem. The remaining Principle 3 work tracked in #1585 is the BeatMap 14-vector epic.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
