### PR TITLE
#1636 ui_render_system.cpp: inline single-call anon-ns helper popup_font_for_size

### DIFF
--- a/app/systems/ui_render_system.cpp
+++ b/app/systems/ui_render_system.cpp
@@ -31,27 +31,6 @@
 
 namespace {
 
-const Font& popup_font_for_size(const TextContext& ctx, FontSize font_size) {
-    // Fabian Principle 1 / issue #1306: label-to-value lookup by ordinal,
-    // not by `switch`. `Font` carries runtime GPU state so a `constexpr`
-    // array of `Font` is not viable; instead the table is a `std::array`
-    // of pointer-to-data-members, indexed by `static_cast<size_t>(font_size)`.
-    // Row order must match the `FontSize` declaration in
-    // `app/components/text.h`.
-    static constexpr std::array<const Font TextContext::*, 3> kFontByFontSize{{
-        /* Small  */ &TextContext::font_small,
-        /* Medium */ &TextContext::font_medium,
-        /* Large  */ &TextContext::font_large,
-    }};
-    static_assert(kFontByFontSize.size() ==
-                  static_cast<std::size_t>(FontSize::Large) + 1,
-                  "kFontByFontSize must cover every FontSize enumerator");
-
-    const auto idx = static_cast<std::size_t>(font_size);
-    if (idx >= kFontByFontSize.size()) return ctx.font_medium;
-    return ctx.*kFontByFontSize[idx];
-}
-
 // ── Entity-driven UI render (issue #1287) ──────────────────────────────────
 //
 // Iterates the per-kind tag views populated by the rguilayout codegen
@@ -621,7 +600,24 @@ void ui_render_system(entt::registry& reg, float /*alpha*/) {
                 continue;
             }
 
-            const Font& font = popup_font_for_size(*text_ctx, pd.font_size);
+            // Fabian Principle 1 / issue #1306: label-to-value lookup by
+            // ordinal, not by `switch`. `Font` carries runtime GPU state so
+            // a `constexpr` array of `Font` is not viable; instead the table
+            // is a `std::array` of pointer-to-data-members, indexed by
+            // `static_cast<size_t>(font_size)`. Row order must match the
+            // `FontSize` declaration in `app/components/text.h`.
+            static constexpr std::array<const Font TextContext::*, 3> kFontByFontSize{{
+                /* Small  */ &TextContext::font_small,
+                /* Medium */ &TextContext::font_medium,
+                /* Large  */ &TextContext::font_large,
+            }};
+            static_assert(kFontByFontSize.size() ==
+                          static_cast<std::size_t>(FontSize::Large) + 1,
+                          "kFontByFontSize must cover every FontSize enumerator");
+            const auto font_idx = static_cast<std::size_t>(pd.font_size);
+            const Font& font = (font_idx < kFontByFontSize.size())
+                                   ? (*text_ctx).*kFontByFontSize[font_idx]
+                                   : text_ctx->font_medium;
             const float font_size = static_cast<float>(font.baseSize);
             const float spacing = 1.0f;
 


### PR DESCRIPTION
Closes #1636.

## What

Removes the single-call anonymous-namespace helper `popup_font_for_size` from `app/systems/ui_render_system.cpp` and inlines the table + lookup at its lone call site inside the `PopupDisplay` draw loop in `ui_render_system`.

## Diff shape

```diff
 namespace {

-const Font& popup_font_for_size(const TextContext& ctx, FontSize font_size) {
-    static constexpr std::array<const Font TextContext::*, 3> kFontByFontSize{{
-        /* Small  */ &TextContext::font_small,
-        /* Medium */ &TextContext::font_medium,
-        /* Large  */ &TextContext::font_large,
-    }};
-    static_assert(kFontByFontSize.size() ==
-                  static_cast<std::size_t>(FontSize::Large) + 1,
-                  "kFontByFontSize must cover every FontSize enumerator");
-    const auto idx = static_cast<std::size_t>(font_size);
-    if (idx >= kFontByFontSize.size()) return ctx.font_medium;
-    return ctx.*kFontByFontSize[idx];
-}
-
 // ── Entity-driven UI render (issue #1287) ─────────...
```

```diff
             if (pd.text[0] == '\0') {
                 continue;
             }

-            const Font& font = popup_font_for_size(*text_ctx, pd.font_size);
+            static constexpr std::array<const Font TextContext::*, 3> kFontByFontSize{{
+                /* Small  */ &TextContext::font_small,
+                /* Medium */ &TextContext::font_medium,
+                /* Large  */ &TextContext::font_large,
+            }};
+            static_assert(kFontByFontSize.size() ==
+                          static_cast<std::size_t>(FontSize::Large) + 1,
+                          "kFontByFontSize must cover every FontSize enumerator");
+            const auto font_idx = static_cast<std::size_t>(pd.font_size);
+            const Font& font = (font_idx < kFontByFontSize.size())
+                                   ? (*text_ctx).*kFontByFontSize[font_idx]
+                                   : text_ctx->font_medium;
```

Continuation of the single-call anon-ns helper inlining train (#1551 / #1559 / #1564 / #1566 / #1567 / #1568 / #1570 / #1571 / #1572 / #1582 / #1583 / #1584 / #1592 / #1594 / #1595 / #1600 / #1602 / #1604 / #1605 / #1606). Same shape as those siblings: TU-local indirection with no header declaration, no external caller, no test reference; folded into the loop body that already owns the surrounding `PopupTextMeasured` cache / `DrawTextEx` call.

## Fabian Principle 1 preserved

The lookup table from #1306 is the load-bearing part of this helper. The inlined form keeps it intact verbatim:

- Same `std::array<const Font TextContext::*, 3>` shape (no `Font`-by-value, since `Font` carries runtime GPU state).
- Same `static_assert` row-count guard tied to `FontSize::Large`.
- Same out-of-range fallback to `text_ctx->font_medium`.
- No `switch (font_size)` and no `if (size == Small) ... else if ...` ladder reintroduced.

`static constexpr` on the table inside the loop body keeps the array a single TU-static instance (initialized once at first reach), not a per-iteration stack rebuild — identical codegen to the helper's previous `static constexpr` local.

## Behaviour

Bit-for-bit identical:

- The same row table is indexed by `static_cast<std::size_t>(pd.font_size)`.
- Same out-of-range guard (`font_idx < kFontByFontSize.size()`), same fallback (`text_ctx->font_medium`).
- The `(*text_ctx).*kFontByFontSize[font_idx]` expression resolves to the same `const Font&` the helper used to return — the dereference of `text_ctx` is safe under the enclosing `if (text_ctx != nullptr)` guard at the surrounding block, exactly as it was for the helper's `const TextContext&` parameter.

## Verification

- `grep -rn '\bpopup_font_for_size\b' app/ tests/ benchmarks/` → 0 matches.
- Native build (`cmake --build build`): clean, zero warnings (`-Wall -Wextra -Werror`).
- Native tests (`./build/shapeshifter_tests`): **3364 assertions in 965 test cases pass.**

## References

- #1636 — issue.
- #1306 — original Fabian Principle 1 eradication that introduced this helper as a table lookup; the table shape is preserved verbatim here.
- #1602 / #1604 / #1605 / #1606 — recent sibling inlines of single-call anon-ns helpers in the same campaign.
- `.squad/decisions.md` § 9 Principle 1 — control-flow enums become tables, not switch statements (still holds).
