### PR TITLE
#1638 floor_render_system.cpp: inline 3 single-call anon-ns helpers (draw_floor_lines / draw_floor_beat_lines / draw_floor_rings)

### DIFF
--- a/app/systems/floor_render_system.cpp
+++ b/app/systems/floor_render_system.cpp
@@ -25,163 +25,6 @@ Color floor_lane_color(int lane, uint8_t alpha) {
     return c;
 }
 
-void draw_floor_lines(const FloorParams& fp) {
-    constexpr float y = 0.0f;
-
-    {
-        constexpr float sw = static_cast<float>(constants::SCREEN_W);
-        constexpr float sh = static_cast<float>(constants::SCREEN_H);
-        const Color edge_color{40, 40, 60, 120};
-        DrawLine3D({0.0f, y, 0.0f}, {0.0f, y, sh}, edge_color);
-        DrawLine3D({sw, y, 0.0f}, {sw, y, sh}, edge_color);
-    }
-
-    {
-        constexpr float sh = static_cast<float>(constants::SCREEN_H);
-        constexpr float lane_half = 120.0f;
-        for (int lane = 0; lane < constants::LANE_COUNT; ++lane) {
-            const float cx = constants::LANE_X[lane];
-            const Color c = floor_lane_color(lane, 50);
-            DrawLine3D({cx - lane_half, y, 0.0f}, {cx - lane_half, y, sh}, c);
-            DrawLine3D({cx + lane_half, y, 0.0f}, {cx + lane_half, y, sh}, c);
-        }
-    }
-
-    for (int lane = 0; lane < constants::LANE_COUNT; ++lane) {
-        const float cx = constants::LANE_X[lane];
-        const Color c = floor_lane_color(lane, fp.alpha);
-
-        for (int j = 0; j < constants::FLOOR_SHAPE_COUNT; ++j) {
-            const float cz = constants::FLOOR_Y_START
-                + static_cast<float>(j) * constants::FLOOR_SHAPE_SPACING;
-
-            if (j < constants::FLOOR_SHAPE_COUNT - 1) {
-                const float next_cz = cz + constants::FLOOR_SHAPE_SPACING;
-                DrawLine3D({cx, y, cz + fp.half}, {cx, y, next_cz - fp.half}, c);
-            }
-
-            if (lane == 1) {
-                const float l = cx - fp.half;
-                const float r = cx + fp.half;
-                const float t = cz - fp.half;
-                const float b = cz + fp.half;
-                DrawLine3D({l, y, t}, {r, y, t}, c);
-                DrawLine3D({r, y, t}, {r, y, b}, c);
-                DrawLine3D({r, y, b}, {l, y, b}, c);
-                DrawLine3D({l, y, b}, {l, y, t}, c);
-            }
-
-            if (lane == 2) {
-                const float apex_x = cx;
-                const float apex_z = cz - fp.half;
-                const float bl_x = cx - fp.half;
-                const float bl_z = cz + fp.half;
-                const float br_x = cx + fp.half;
-                const float br_z = cz + fp.half;
-                DrawLine3D({apex_x, y, apex_z}, {br_x, y, br_z}, c);
-                DrawLine3D({br_x, y, br_z}, {bl_x, y, bl_z}, c);
-                DrawLine3D({bl_x, y, bl_z}, {apex_x, y, apex_z}, c);
-            }
-        }
-    }
-}
-
-void draw_floor_rings(const FloorParams& fp) {
-    constexpr int ring_segments = 24;
-    constexpr float tau = 6.28318530717958647692f;
-    const Color c = floor_lane_color(0, fp.alpha);
-
-    rlBegin(RL_TRIANGLES);
-    for (int j = 0; j < constants::FLOOR_SHAPE_COUNT; ++j) {
-        const float cz = constants::FLOOR_Y_START
-            + static_cast<float>(j) * constants::FLOOR_SHAPE_SPACING;
-        const float cx = constants::LANE_X[0];
-        const float inner_r = fp.half - fp.thick;
-        const float outer_r = fp.half;
-
-        for (int i = 0; i < ring_segments; ++i) {
-            const int next = (i + 1) % ring_segments;
-            const float angle1 = (static_cast<float>(i) / static_cast<float>(ring_segments)) * tau;
-            const float angle2 = (static_cast<float>(next) / static_cast<float>(ring_segments)) * tau;
-            const float dir_x1 = std::cos(angle1);
-            const float dir_z1 = std::sin(angle1);
-            const float dir_x2 = std::cos(angle2);
-            const float dir_z2 = std::sin(angle2);
-
-            const float ox1 = cx + dir_x1 * outer_r;
-            const float oz1 = cz + dir_z1 * outer_r;
-            const float ox2 = cx + dir_x2 * outer_r;
-            const float oz2 = cz + dir_z2 * outer_r;
-            const float ix1 = cx + dir_x1 * inner_r;
-            const float iz1 = cz + dir_z1 * inner_r;
-            const float ix2 = cx + dir_x2 * inner_r;
-            const float iz2 = cz + dir_z2 * inner_r;
-
-            rlColor4ub(c.r, c.g, c.b, c.a);
-            rlVertex3f(ox1, 0.0f, oz1);
-            rlVertex3f(ix1, 0.0f, iz1);
-            rlVertex3f(ox2, 0.0f, oz2);
-            rlVertex3f(ix1, 0.0f, iz1);
-            rlVertex3f(ix2, 0.0f, iz2);
-            rlVertex3f(ox2, 0.0f, oz2);
-        }
-    }
-    rlEnd();
-}
-
-void draw_floor_beat_lines(const SongState* song, bool song_playing, const BeatMap* map, float audio_offset_sec) {
-    if (!song || !song_playing || song->scroll_speed <= 0.0f) {
-        return;
-    }
-
-    constexpr float z_min = 0.0f;
-    constexpr float z_max = static_cast<float>(constants::SCREEN_H);
-    constexpr float x_min = 0.0f;
-    constexpr float x_max = static_cast<float>(constants::SCREEN_W);
-
-    const float visible_time_min = song->song_time
-        - (z_max - constants::PLAYER_Y) / song->scroll_speed;
-    const float visible_time_max = song->song_time
-        + (constants::PLAYER_Y - z_min) / song->scroll_speed;
-
-    const auto draw_line_at_time = [&](float beat_time) {
-        const float z = floor_visuals::beat_line_z(
-            song->song_time, beat_time, song->scroll_speed, audio_offset_sec);
-        if (z < z_min || z > z_max) {
-            return;
-        }
-
-        const float dist_to_player = constants::PLAYER_Y - z;
-        const bool on_beat_line = dist_to_player >= 0.0f && dist_to_player <= 4.0f;
-        const uint8_t alpha = on_beat_line ? 220 : 120;
-        const uint8_t red = on_beat_line ? 220 : 120;
-        const uint8_t green = on_beat_line ? 245 : 170;
-        const uint8_t blue = on_beat_line ? 255 : 210;
-        DrawLine3D({x_min, 0.0f, z}, {x_max, 0.0f, z}, {red, green, blue, alpha});
-    };
-
-    if (map && !map->beat_times.empty()) {
-        const auto& beats = map->beat_times;
-        auto it = std::lower_bound(beats.begin(), beats.end(), visible_time_min - audio_offset_sec);
-        for (; it != beats.end() && *it <= visible_time_max - audio_offset_sec; ++it) {
-            draw_line_at_time(*it);
-        }
-    } else if (song->beat_period > 0.0f) {
-        int beat_index = static_cast<int>(
-            std::ceil((visible_time_min - audio_offset_sec - song->offset) / song->beat_period));
-        if (beat_index < 0) {
-            beat_index = 0;
-        }
-        for (;; ++beat_index) {
-            const float beat_time = song->offset + beat_index * song->beat_period;
-            if (beat_time > visible_time_max) {
-                break;
-            }
-            draw_line_at_time(beat_time);
-        }
-    }
-}
-
 }  // namespace
 
 void floor_render_system(const entt::registry& reg) {
@@ -192,7 +35,160 @@ void floor_render_system(const entt::registry& reg) {
     const float audio_offset_sec = settings ? settings::audio_offset_seconds(*settings) : 0.0f;
     const bool song_playing = reg.ctx().contains<SongPlayingTag>();
 
-    draw_floor_lines(floor_params);
-    draw_floor_beat_lines(song, song_playing, map, audio_offset_sec);
-    draw_floor_rings(floor_params);
+    // ── draw lane lines ─────────────────────────────────────────────────
+    {
+        constexpr float y = 0.0f;
+
+        {
+            constexpr float sw = static_cast<float>(constants::SCREEN_W);
+            constexpr float sh = static_cast<float>(constants::SCREEN_H);
+            const Color edge_color{40, 40, 60, 120};
+            DrawLine3D({0.0f, y, 0.0f}, {0.0f, y, sh}, edge_color);
+            DrawLine3D({sw, y, 0.0f}, {sw, y, sh}, edge_color);
+        }
+
+        {
+            constexpr float sh = static_cast<float>(constants::SCREEN_H);
+            constexpr float lane_half = 120.0f;
+            for (int lane = 0; lane < constants::LANE_COUNT; ++lane) {
+                const float cx = constants::LANE_X[lane];
+                const Color c = floor_lane_color(lane, 50);
+                DrawLine3D({cx - lane_half, y, 0.0f}, {cx - lane_half, y, sh}, c);
+                DrawLine3D({cx + lane_half, y, 0.0f}, {cx + lane_half, y, sh}, c);
+            }
+        }
+
+        for (int lane = 0; lane < constants::LANE_COUNT; ++lane) {
+            const float cx = constants::LANE_X[lane];
+            const Color c = floor_lane_color(lane, floor_params.alpha);
+
+            for (int j = 0; j < constants::FLOOR_SHAPE_COUNT; ++j) {
+                const float cz = constants::FLOOR_Y_START
+                    + static_cast<float>(j) * constants::FLOOR_SHAPE_SPACING;
+
+                if (j < constants::FLOOR_SHAPE_COUNT - 1) {
+                    const float next_cz = cz + constants::FLOOR_SHAPE_SPACING;
+                    DrawLine3D({cx, y, cz + floor_params.half},
+                               {cx, y, next_cz - floor_params.half}, c);
+                }
+
+                if (lane == 1) {
+                    const float l = cx - floor_params.half;
+                    const float r = cx + floor_params.half;
+                    const float t = cz - floor_params.half;
+                    const float b = cz + floor_params.half;
+                    DrawLine3D({l, y, t}, {r, y, t}, c);
+                    DrawLine3D({r, y, t}, {r, y, b}, c);
+                    DrawLine3D({r, y, b}, {l, y, b}, c);
+                    DrawLine3D({l, y, b}, {l, y, t}, c);
+                }
+
+                if (lane == 2) {
+                    const float apex_x = cx;
+                    const float apex_z = cz - floor_params.half;
+                    const float bl_x = cx - floor_params.half;
+                    const float bl_z = cz + floor_params.half;
+                    const float br_x = cx + floor_params.half;
+                    const float br_z = cz + floor_params.half;
+                    DrawLine3D({apex_x, y, apex_z}, {br_x, y, br_z}, c);
+                    DrawLine3D({br_x, y, br_z}, {bl_x, y, bl_z}, c);
+                    DrawLine3D({bl_x, y, bl_z}, {apex_x, y, apex_z}, c);
+                }
+            }
+        }
+    }
+
+    // ── draw beat lines ─────────────────────────────────────────────────
+    if (song && song_playing && song->scroll_speed > 0.0f) {
+        constexpr float z_min = 0.0f;
+        constexpr float z_max = static_cast<float>(constants::SCREEN_H);
+        constexpr float x_min = 0.0f;
+        constexpr float x_max = static_cast<float>(constants::SCREEN_W);
+
+        const float visible_time_min = song->song_time
+            - (z_max - constants::PLAYER_Y) / song->scroll_speed;
+        const float visible_time_max = song->song_time
+            + (constants::PLAYER_Y - z_min) / song->scroll_speed;
+
+        const auto draw_line_at_time = [&](float beat_time) {
+            const float z = floor_visuals::beat_line_z(
+                song->song_time, beat_time, song->scroll_speed, audio_offset_sec);
+            if (z < z_min || z > z_max) {
+                return;
+            }
+
+            const float dist_to_player = constants::PLAYER_Y - z;
+            const bool on_beat_line = dist_to_player >= 0.0f && dist_to_player <= 4.0f;
+            const uint8_t alpha = on_beat_line ? 220 : 120;
+            const uint8_t red = on_beat_line ? 220 : 120;
+            const uint8_t green = on_beat_line ? 245 : 170;
+            const uint8_t blue = on_beat_line ? 255 : 210;
+            DrawLine3D({x_min, 0.0f, z}, {x_max, 0.0f, z}, {red, green, blue, alpha});
+        };
+
+        if (map && !map->beat_times.empty()) {
+            const auto& beats = map->beat_times;
+            auto it = std::lower_bound(beats.begin(), beats.end(), visible_time_min - audio_offset_sec);
+            for (; it != beats.end() && *it <= visible_time_max - audio_offset_sec; ++it) {
+                draw_line_at_time(*it);
+            }
+        } else if (song->beat_period > 0.0f) {
+            int beat_index = static_cast<int>(
+                std::ceil((visible_time_min - audio_offset_sec - song->offset) / song->beat_period));
+            if (beat_index < 0) {
+                beat_index = 0;
+            }
+            for (;; ++beat_index) {
+                const float beat_time = song->offset + beat_index * song->beat_period;
+                if (beat_time > visible_time_max) {
+                    break;
+                }
+                draw_line_at_time(beat_time);
+            }
+        }
+    }
+
+    // ── draw rings ──────────────────────────────────────────────────────
+    {
+        constexpr int ring_segments = 24;
+        constexpr float tau = 6.28318530717958647692f;
+        const Color c = floor_lane_color(0, floor_params.alpha);
+
+        rlBegin(RL_TRIANGLES);
+        for (int j = 0; j < constants::FLOOR_SHAPE_COUNT; ++j) {
+            const float cz = constants::FLOOR_Y_START
+                + static_cast<float>(j) * constants::FLOOR_SHAPE_SPACING;
+            const float cx = constants::LANE_X[0];
+            const float inner_r = floor_params.half - floor_params.thick;
+            const float outer_r = floor_params.half;
+
+            for (int i = 0; i < ring_segments; ++i) {
+                const int next = (i + 1) % ring_segments;
+                const float angle1 = (static_cast<float>(i) / static_cast<float>(ring_segments)) * tau;
+                const float angle2 = (static_cast<float>(next) / static_cast<float>(ring_segments)) * tau;
+                const float dir_x1 = std::cos(angle1);
+                const float dir_z1 = std::sin(angle1);
+                const float dir_x2 = std::cos(angle2);
+                const float dir_z2 = std::sin(angle2);
+
+                const float ox1 = cx + dir_x1 * outer_r;
+                const float oz1 = cz + dir_z1 * outer_r;
+                const float ox2 = cx + dir_x2 * outer_r;
+                const float oz2 = cz + dir_z2 * outer_r;
+                const float ix1 = cx + dir_x1 * inner_r;
+                const float iz1 = cz + dir_z1 * inner_r;
+                const float ix2 = cx + dir_x2 * inner_r;
+                const float iz2 = cz + dir_z2 * inner_r;
+
+                rlColor4ub(c.r, c.g, c.b, c.a);
+                rlVertex3f(ox1, 0.0f, oz1);
+                rlVertex3f(ix1, 0.0f, iz1);
+                rlVertex3f(ox2, 0.0f, oz2);
+                rlVertex3f(ix1, 0.0f, iz1);
+                rlVertex3f(ix2, 0.0f, iz2);
+                rlVertex3f(ox2, 0.0f, oz2);
+            }
+        }
+        rlEnd();
+    }
 }


### PR DESCRIPTION
Closes #1638.

## What

Removes the three single-call anonymous-namespace helpers from `app/systems/floor_render_system.cpp` and inlines each at its lone call site inside `floor_render_system`. Takes **option 1** from the issue (inline all three, mirroring the sweep verbatim).

## Why option 1

The issue flagged this as a judgement call because the three helpers are ~40–60 lines each, at the upper edge of the sweep precedent's typical 5–25 line targets. Going option 1 anyway because:

- Each helper is called exactly once, has no header declaration, and has no test/benchmark reference (verified by the issue's grep).
- The three calls are already a tight visual triplet at the bottom of `floor_render_system` (the former lines 195/196/197). The intent that `draw_floor_*` names communicated is preserved by three `// ── draw … ──` banner comments inside the inlined body.
- The lane-shape selection (`if (lane == 1) ...` / `if (lane == 2) ...`) is unchanged — no `switch` or if-ladder reintroduced, so Fabian Principle 1 still holds.
- The `beat_times` lower-bound walk and indexed-onset stepping branches are preserved verbatim — Principle 3 still holds.

## Diff shape

- Remove `draw_floor_lines(const FloorParams&)` (was ~60 lines), inline at the former call site under a `// ── draw lane lines ──` banner.
- Remove `draw_floor_beat_lines(const SongState*, bool, const BeatMap*, float)` (was ~52 lines), inline under a `// ── draw beat lines ──` banner. The helper's early-out `if (!song || !song_playing || song->scroll_speed <= 0.0f) { return; }` is rewritten as a wrapping `if (song && song_playing && song->scroll_speed > 0.0f) { ... }` so the subsequent rings draw still runs when this block is skipped (the helper's `return` only skipped its own body).
- Remove `draw_floor_rings(const FloorParams&)` (was ~42 lines), inline under a `// ── draw rings ──` banner.
- The `fp.*` shorthand parameter aliases unfold to `floor_params.*` at every use — `fp.alpha`, `fp.half`, `fp.thick` become `floor_params.alpha`, `floor_params.half`, `floor_params.thick`. No `FloorParams` field is read anywhere else, so this is a 1:1 substitution.
- The `draw_line_at_time` lambda inside the former `draw_floor_beat_lines` survives verbatim — it captures `song` and `audio_offset_sec` by reference, both already locals of `floor_render_system` (lines 32 / 35 of the new body).

## What stays in the anonymous namespace

- `SHAPE_COLOR_COUNT` + its `static_assert(constants::LANE_COUNT <= SHAPE_COLOR_COUNT, ...)` — load-bearing TU-local row-count guard tied to `constants::SHAPE_COLORS`.
- `floor_lane_color(int lane, uint8_t alpha)` — still has **three** call sites in the inlined body (two inside the lane-lines block at the former lines 44/52, one inside the rings block at the former line 92), so it remains a real multi-call helper, not single-call. Not subject to this sweep.

## Behaviour

Bit-for-bit identical:

- Lane edge lines / lane-half guides / per-lane shape outlines (line, square, triangle) draw in the same order with the same colors and the same `y = 0` base plane.
- Beat lines walk the same authored/indexed source, gated by the same `visible_time_min`/`visible_time_max` window, and produce identical on-beat-line color shifts (`on_beat_line` test, `220/120/220/245/255` color ramp).
- Rings emit the same vertex pattern in the same `rlBegin(RL_TRIANGLES) / rlEnd()` pairing, in the same `j` × `i` traversal order.

The outer-scope draw order inside `floor_render_system` is unchanged: lines → beat lines → rings (matching the former lines 195/196/197).

## Verification

- `grep -rn '\bdraw_floor_lines\b\|\bdraw_floor_rings\b\|\bdraw_floor_beat_lines\b' app/ tests/ benchmarks/` → **0 matches.**
- Native build (`cmake --build build`): clean, zero warnings (`-Wall -Wextra -Werror`).
- Native tests (`./build/shapeshifter_tests`): **3364 assertions in 965 test cases pass.**

## References

- #1638 — issue.
- #1551 / #1559 / #1564 / #1566 / #1567 / #1568 / #1570 / #1571 / #1572 / #1582 / #1583 / #1584 / #1592 / #1594 / #1595 / #1600 / #1602 / #1604 / #1605 / #1606 / #1636 — sibling sweep precedents.
- `.squad/decisions.md` § 9 Principle 1 / Principle 3 — both still satisfied (no switch/ladder reintroduced; table-style `SHAPE_COLORS[lane]` lookup preserved).
