### PR TITLE
#1640 floor_render_system: lane shape outlines via per-lane edge table (Fabian Principle 1)

### DIFF
--- a/app/systems/floor_render_system.cpp
+++ b/app/systems/floor_render_system.cpp
@@ -10,7 +10,9 @@
 #include <rlgl.h>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
+#include <span>
 
 namespace {
 
@@ -24,6 +26,39 @@ Color floor_lane_color(int lane, uint8_t alpha) {
     c.a = alpha;
     return c;
 }
+
+// Per-lane outline edges expressed as unit offsets from the shape centre
+// (multiplied by `floor_params.half` at draw time). Lane 0 (ring) has no
+// outline rows here — the ring is drawn in its own block below.
+struct OutlineEdge {
+    float from_dx;
+    float from_dz;
+    float to_dx;
+    float to_dz;
+};
+
+constexpr OutlineEdge kSquareOutlineEdges[] = {
+    {-1.0f, -1.0f, +1.0f, -1.0f},
+    {+1.0f, -1.0f, +1.0f, +1.0f},
+    {+1.0f, +1.0f, -1.0f, +1.0f},
+    {-1.0f, +1.0f, -1.0f, -1.0f},
+};
+
+constexpr OutlineEdge kTriangleOutlineEdges[] = {
+    { 0.0f, -1.0f, +1.0f, +1.0f},
+    {+1.0f, +1.0f, -1.0f, +1.0f},
+    {-1.0f, +1.0f,  0.0f, -1.0f},
+};
+
+constexpr std::array<std::span<const OutlineEdge>, constants::LANE_COUNT>
+    kLaneOutlineEdges = {
+        std::span<const OutlineEdge>{},
+        std::span<const OutlineEdge>{kSquareOutlineEdges},
+        std::span<const OutlineEdge>{kTriangleOutlineEdges},
+};
+
+static_assert(kLaneOutlineEdges.size() == constants::LANE_COUNT,
+              "Lane outline table must match lane count");
 
 }  // namespace
 
@@ -61,6 +96,7 @@ void floor_render_system(const entt::registry& reg) {
         for (int lane = 0; lane < constants::LANE_COUNT; ++lane) {
             const float cx = constants::LANE_X[lane];
             const Color c = floor_lane_color(lane, floor_params.alpha);
+            const auto edges = kLaneOutlineEdges[static_cast<size_t>(lane)];
 
             for (int j = 0; j < constants::FLOOR_SHAPE_COUNT; ++j) {
                 const float cz = constants::FLOOR_Y_START
@@ -72,27 +108,11 @@ void floor_render_system(const entt::registry& reg) {
                                {cx, y, next_cz - floor_params.half}, c);
                 }
 
-                if (lane == 1) {
-                    const float l = cx - floor_params.half;
-                    const float r = cx + floor_params.half;
-                    const float t = cz - floor_params.half;
-                    const float b = cz + floor_params.half;
-                    DrawLine3D({l, y, t}, {r, y, t}, c);
-                    DrawLine3D({r, y, t}, {r, y, b}, c);
-                    DrawLine3D({r, y, b}, {l, y, b}, c);
-                    DrawLine3D({l, y, b}, {l, y, t}, c);
-                }
-
-                if (lane == 2) {
-                    const float apex_x = cx;
-                    const float apex_z = cz - floor_params.half;
-                    const float bl_x = cx - floor_params.half;
-                    const float bl_z = cz + floor_params.half;
-                    const float br_x = cx + floor_params.half;
-                    const float br_z = cz + floor_params.half;
-                    DrawLine3D({apex_x, y, apex_z}, {br_x, y, br_z}, c);
-                    DrawLine3D({br_x, y, br_z}, {bl_x, y, bl_z}, c);
-                    DrawLine3D({bl_x, y, bl_z}, {apex_x, y, apex_z}, c);
+                for (const auto& edge : edges) {
+                    DrawLine3D({cx + edge.from_dx * floor_params.half, y,
+                                cz + edge.from_dz * floor_params.half},
+                               {cx + edge.to_dx   * floor_params.half, y,
+                                cz + edge.to_dz   * floor_params.half}, c);
                 }
             }
         }


### PR DESCRIPTION
## Summary

Replaces two `if (lane == 1) / if (lane == 2)` arms in `floor_render_system` that dispatched which geometric outline (square vs triangle) to draw based on the `lane` loop index with a `constexpr` per-lane edge table — the same shape #1306 used for `FontSize` switch → `std::array` lookup.

Per Fabian Principle 1 (`.squad/decisions.md` § 9), `lane` here was a 0..`LANE_COUNT-1` integer playing the role of a sparse shape discriminator driving control flow (which `DrawLine3D` sequence to emit). The dispatch now dissolves into uniform iteration over a span; lane 0 (ring, drawn elsewhere) is a natural no-op via an empty span.

## Mechanism (Option A from the issue)

- New `OutlineEdge { from_dx, from_dz, to_dx, to_dz }` row type holds unit-offset endpoints (multiplied by `floor_params.half` at draw time). Y is implicitly 0 — outlines are planar.
- `kSquareOutlineEdges[4]` / `kTriangleOutlineEdges[3]` encode the former hand-written `DrawLine3D` sequences as data, in the same orientation order.
- `kLaneOutlineEdges` is `std::array<std::span<const OutlineEdge>, LANE_COUNT>`; lane 0 is an empty span.
- A `static_assert` pins the table size to `LANE_COUNT` so any future lane addition fails to compile until its outline row is filled in.

## Acceptance criteria (from #1640)

- [x] `grep -nE 'if \(lane == [0-9]+\)' app/systems/floor_render_system.cpp` → 0 matches
- [x] Native build clean under `-Wall -Wextra -Werror`
- [x] `./build/shapeshifter_tests` → `All tests passed (3364 assertions in 965 test cases)`
- [x] Cyclomatic ratchet on the file trends down by 2 (the two `if (lane == N)` arms are gone)
- [x] Visual smoke: each former `DrawLine3D` call has a 1:1 row in the per-shape table in the same orientation, so floor rendering is byte-identical

## Diff stat

```
 app/systems/floor_render_system.cpp | 62 +++++++++++++++++++++++++++++++++++++++++---------------------
 1 file changed, 41 insertions(+), 21 deletions(-)
```

## References

- Closes #1640
- Precedent: #1306 (closed) — `switch (FontSize)` → `std::array<const Font TextContext::*, 3>` lookup
- Precedent: #1279 (closed) — if-ladder on `Direction` enum → per-direction event types
- `.squad/decisions.md` § 9 Principle 1 (control-flow enums become tables, not switch statements)
- #1638 / #1639 — preserved this pattern verbatim during the helper-inline pass; this is the dedicated follow-up.