### PR TITLE
#1645 input.h/tags.h: relocate InputSourceMouse + InputSourceTouch ctx tags into app/tags/tags.h

### DIFF
--- a/app/systems/input.h
+++ b/app/systems/input.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "../tags/tags.h"
+
 // ── Raw input state (internal to input_system) ──────────────────────────────
 // Tracks touch/mouse hardware state. Downstream systems should read
 // semantic events, not this struct — except for quit_requested.
@@ -12,17 +14,10 @@
 // (issue #1194) — this is per-frame ctx-singleton hardware-capture state,
 // not entity-owned component data.
 
-// Per-source ctx tags replacing the former `InputSource` enum
-// (issues #1202 / #1204). The former 3-state mutex
-// (`None`/`Mouse`/`Touch`) on `InputState::active_source` becomes:
-//   • presence of `InputSourceMouse` ctx table  ⇔ Mouse owns the gesture
-//   • presence of `InputSourceTouch` ctx table  ⇔ Touch owns the gesture
-//   • absence of both                            ⇔ None
-// The mutex (at most one tag present) is enforced inline at the two set
-// sites in input_system (insert one tag + erase the sibling) and via the
-// shared `clear_input_source` helper which drops both tags.
-struct InputSourceMouse {};
-struct InputSourceTouch {};
+// The per-source `InputSourceMouse` / `InputSourceTouch` ctx tags that
+// replace the former `InputSource` enum (issues #1202 / #1204) live in
+// `app/tags/tags.h` (canonical tags single-header per Principle 2 /
+// issue #1645). See the "Input source mutex" section there.
 
 // One row per currently-tracked finger (issue #1612 / Fabian Principle 3).
 // Presence in `reg.view<ActiveTouchSlot>()` IS membership in "currently

--- a/app/tags/tags.h
+++ b/app/tags/tags.h
@@ -469,3 +469,16 @@ struct ChainBgPulseTag {};
 // the per-frame check is a view filter, not a `try_get` + bool branch —
 // the per-frame existence is the visibility data (Principle 4).
 struct ApproachRingVisibleTag {};
+
+// ── Input source mutex (ctx tags; issues #1202 / #1204 / #1645) ──
+// Per-source ctx tags replacing the former `InputSource` enum. The
+// former 3-state mutex (`None`/`Mouse`/`Touch`) on
+// `InputState::active_source` becomes:
+//   • presence of `InputSourceMouse` ctx table  ⇔ Mouse owns the gesture
+//   • presence of `InputSourceTouch` ctx table  ⇔ Touch owns the gesture
+//   • absence of both                            ⇔ None
+// The mutex (at most one tag present) is enforced inline at the two set
+// sites in input_system (insert one tag + erase the sibling) and via
+// the shared `clear_input_source` helper which drops both tags.
+struct InputSourceMouse {};
+struct InputSourceTouch {};

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -463,7 +463,8 @@ struct EnergyState {
 /// became per-source ctx tables. Presence of `InputSourceMouse` ⇔ Mouse
 /// owns the current gesture; presence of `InputSourceTouch` ⇔ Touch owns
 /// it; absence of both ⇔ None. The mutex (at most one tag present) is
-/// maintained by input_system helpers.
+/// maintained by input_system helpers. Declared in `app/tags/tags.h`
+/// (canonical tags single-header per issue #1645).
 struct InputSourceMouse {};
 struct InputSourceTouch {};
 
@@ -1748,7 +1749,7 @@ app/
 │   └── song_state.h             ← SongState, BeatCursor (row table, issue #1545)
 │
 ├── systems/                     ← all system free functions
-│   ├── input.h                  ← InputState, ActiveTouchSlot, InputSourceMouse, InputSourceTouch (singleton hardware-capture state + per-finger touch row)
+│   ├── input.h                  ← InputState, ActiveTouchSlot (singleton hardware-capture state + per-finger touch row); InputSourceMouse / InputSourceTouch tags live in app/tags/tags.h (#1645)
 │   ├── all_systems.h            ← convenience #include for all systems
 │   ├── input_system.cpp         ← raylib polling → semantic dispatcher events
 │   ├── game_state_system.cpp    ← phase transitions

--- a/design-docs/feature-specs.md
+++ b/design-docs/feature-specs.md
@@ -106,6 +106,8 @@ The Input System translates raw touch / mouse / keyboard events into game action
 // The mutex is maintained inline at the two set sites in input_system
 // (insert one tag + erase the sibling) and via the shared
 // `clear_input_source` helper which drops both tags.
+// Declared in `app/tags/tags.h` (canonical tags single-header per
+// issue #1645).
 struct InputSourceMouse {};
 struct InputSourceTouch {};
 


### PR DESCRIPTION
Fixes #1645.

## What this changes

Move `InputSourceMouse` + `InputSourceTouch` (the two zero-column ctx-tag structs introduced by the #1202 / #1204 discriminator-eradication wave) from `app/systems/input.h:24-25` into the canonical single-header tag file at `app/tags/tags.h`.

These are tags in EnTT semantics — empty structs used as registry-attached markers, attached via `reg.ctx().insert_or_assign(T{})`, presence-checked via `reg.ctx().find<T>()`, erased via `reg.ctx().erase<T>()` (see `app/systems/input_system.cpp:129-134, 229-243, 361-364`). Per Fabian Principle 2 / `.squad/decisions.md` § Keyser strict `app/` layout, every empty marker struct used as a registry tag belongs in `app/tags/tags.h`.

They were missed by the #1201 single-tags-file migration only because the migration regex was keyed on the `Tag` suffix; these names don't carry it (they precede the post-#1201 naming convention).

## Files touched

- `app/tags/tags.h` — add new `// ── Input source mutex (ctx tags) ──` section at end of file with the two struct declarations + the mutex-semantics comment block (moved verbatim from `input.h`).
- `app/systems/input.h` — drop the two declarations, replace the comment block with a one-line pointer to `tags.h`, and `#include "../tags/tags.h"` so existing consumers (`input_system.cpp`, tests) keep finding the tags via the same include path.
- `design-docs/feature-specs.md`, `design-docs/architecture.md` — refresh the doc-quoted struct comments to note the new home and update the `app/` folder map.

## Verification

Acceptance criteria from the issue:

- ✅ `InputSourceMouse` and `InputSourceTouch` declared in `app/tags/tags.h` only (one match each, line 483-484).
- ✅ No `struct InputSource(Mouse|Touch)\s*\{\s*\}\s*;` declaration outside `app/tags/tags.h`.
- ✅ Sweep `find app -name '*.h' -not -path '*/tags/*' | xargs grep -lE '^struct\s+\w+\s*\{\s*\}\s*;\s*$'` now reports only `app/systems/input_events.h` (dispatcher event identity; explicitly out of scope per the issue).
- ✅ All call sites in `app/systems/input_system.cpp` continue to find the tag types via the `tags.h` include path (transitive via `input.h`).
- ✅ `cmake --build build` is warning-free.
- ✅ `./build/shapeshifter_tests` passes — 3364 assertions in 965 test cases.

## Scope notes

Pure relocation; no semantic change. Same EnTT type identity (struct name unchanged), so the in-flight `reg.ctx().find<InputSourceMouse>()` / `.insert_or_assign(InputSourceMouse{})` / `.erase<InputSourceMouse>()` sites all keep working unchanged.

Out of scope (and remains in `input_events.h`): the dispatcher event types (`ShapePress*Event`, `Menu*Event`, `Go{Up,Down,Left,Right}Event`) — these are zero-column tag-events carrying dispatcher event identity, not registry-attached tags, and the precedent for dispatcher event types is to keep them next to the event wiring.