### PR TITLE
#1649 loop.md:30: replace stale 'make check-enum-allowlist' + 'Drift baselines' refs with actual entry points

### DIFF
--- a/loop.md
+++ b/loop.md
@@ -27,7 +27,7 @@ description: "My squad work loop"
 
 3) **Fabian drift check** (file `ecs_refactor` issues with file:line + principle #; do NOT fix this cycle)
 - Canon: `.squad/decisions.md` § "DoD source-text grounding (Fabian)" Principles 0–4; cross-refs in #1203 / #1204.
-- Checks: folder layout (only `components/ entities/ systems/ tags/ util/` under `app/`), existential processing (no `switch` on discriminator, no `virtual`/`override`/`dynamic_cast` — P0), components-as-data vs entities-as-factories, no inheritance (`: public ` outside raylib/EnTT wrappers), tags single-header (`app/tags/tags.h` only — P2), enum allowlist (`make check-enum-allowlist` from #1204 — P1), cyclomatic ratchet (`switch`/`if` branches in `app/` trend down only vs `.squad/decisions.md` § "Drift baselines").
+- Checks: folder layout (only `components/ entities/ systems/ tags/ util/` under `app/`), existential processing (no `switch` on discriminator, no `virtual`/`override`/`dynamic_cast` — P0), components-as-data vs entities-as-factories, no inheritance (`: public ` outside raylib/EnTT wrappers), tags single-header (`app/tags/tags.h` only — P2), enum allowlist (`ctest --test-dir build -R check_enum_allowlist` or `python3 tools/check_enum_allowlist.py` from #1204 — P1), cyclomatic ratchet (`switch`/`if` branches in `app/` trend down only; mechanism captured in #1204, no checked-in baseline numbers — see `.squad/decisions.md:3355`).
 - Cluster file-level hits into one issue. Comment on existing issue instead of duplicating.
 
 4) **Parallel pass (only if no actionable issues)**


### PR DESCRIPTION
Closes #1649.

## What

`loop.md:30` had two stale references in the Fabian-drift-check bullet:

1. `make check-enum-allowlist` — there is no `Makefile` in this repo. The drift guard from #1204 is a Python script registered as a CTest test.
2. `.squad/decisions.md § "Drift baselines"` — no such section exists. The cyclomatic-ratchet mechanism is captured in #1204 with a one-line pointer at `.squad/decisions.md:3355`.

Replaced both with the actual entry points so a loop runner executing step 3 verbatim can run the enum guard and find the ratchet definition.

## Verification

```
$ ls Makefile
ls: Makefile: No such file or directory

$ ctest --test-dir build -R check_enum_allowlist
... 1/1 Test #N: check_enum_allowlist ........ Passed

$ python3 tools/check_enum_allowlist.py
ok: 8 enum(s) in app/, all allowlisted

$ grep -nE "^#+ .*Drift baselines" .squad/decisions.md
(no matches)

$ sed -n '3355p' .squad/decisions.md
The cyclomatic-complexity ratchet (1 + branches + switch cases, downward only) and the grep-based enum allowlist (`app/.allowed-enums.txt`, `tools/check_enum_allowlist.py`) are mechanism-level decisions captured in #1204. ...
```

## Scope

`loop.md` only, single bullet edit. No code, no tests, no other docs touched.
