### PR TITLE
#1648 design-docs/beatmap-integration.md: eradicate 3 stale BeatMap.beats refs (replaced by 14 per-(kind, shape, timing-source) row tables per #1204/#1533)

### DIFF
--- a/design-docs/beatmap-integration.md
+++ b/design-docs/beatmap-integration.md
@@ -290,7 +290,8 @@ creates the standard runtime obstacle archetypes via the kind-specific
 ## 3.4 beat_scheduler_system — ✅ ALREADY IMPLEMENTED
 
 ```
-  Spawns obstacle entities from BeatMap.beats[] when song_time
+  Spawns obstacle entities from BeatMap's per-(kind, shape, timing-source)
+  row tables (see rhythm-spec.md / app/components/beat_map.h) when song_time
   crosses spawn_time thresholds. It calls the kind-specific
   spawn_<kind>_rhythm() helpers (spawn_shape_gate_rhythm,
   spawn_split_path_rhythm, spawn_onset_marker_rhythm) in
@@ -526,7 +527,7 @@ Ordered by dependency chain. Steps marked ✅ are already on `main`.
   STEP 4 — Song Playback + Beat Scheduler          ✅ DONE
   ──────────────────────────────
   • song_playback_system: advances song_time, detects song end
-  • beat_scheduler_system: spawns obstacles from BeatMap.beats[]
+  • beat_scheduler_system: spawns obstacles from BeatMap's per-(kind, shape, timing-source) row tables
   • no separate random obstacle spawner is part of the current runtime path
 
   STEP 5 — Content Asset Copying                    ✅ DONE
@@ -606,7 +607,7 @@ Ordered by dependency chain. Steps marked ✅ are already on `main`.
   ┌────────────────────────────┬──────────┬───────────┬──────────────┐
   │  Data                      │ Per-elem │ Max count │ Total bytes  │
   ├────────────────────────────┼──────────┼───────────┼──────────────┤
-  │  BeatMap.beats vector      │    8B    │   256     │    2,048     │
+  │  BeatMap row tables (14)   │   ~8B    │   ~256    │   ~2,048     │
   │  SongState singleton       │  160B    │     1     │      160     │
   │  SongResults singleton     │   28B    │     1     │       28     │
   │  MusicContext singleton    │   ~40B   │     1     │       40     │
@@ -619,7 +620,7 @@ Ordered by dependency chain. Steps marked ✅ are already on `main`.
   └────────────────────────────┴──────────┴───────────┴──────────────┘
 
   nlohmann::json temporary is freed after load_beat_map returns.
-  Steady-state overhead: ~3 KB (singletons + beats vector).
+  Steady-state overhead: ~3 KB (singletons + BeatMap row tables).
   raylib music stream buffer is internal to raylib, managed automatically.
 ```
 


### PR DESCRIPTION
Closes #1648.

## What

`design-docs/beatmap-integration.md` had three references to `BeatMap.beats[]` / `beats vector` — that field was eradicated in #1204 / #1533 when `BeatMap` was normalized into 14 per-(kind, shape, timing-source) vectors + a `beat_times` index. The canonical shape lives in `app/components/beat_map.h:69-101` and is already correctly documented in `design-docs/rhythm-spec.md` § "BeatMap (singleton)".

## Sites updated

| Line | Section | Before | After |
|------|---------|--------|-------|
| 293 | § 3.4 beat_scheduler_system | "Spawns obstacle entities from BeatMap.beats[] …" | "Spawns obstacle entities from BeatMap's per-(kind, shape, timing-source) row tables (see rhythm-spec.md / app/components/beat_map.h) …" |
| 529 | § STEP 4 checklist | "spawns obstacles from BeatMap.beats[]" | "spawns obstacles from BeatMap's per-(kind, shape, timing-source) row tables" |
| 609 | § Memory Budget table row | "BeatMap.beats vector \| 8B \| 256 \| 2,048" | "BeatMap row tables (14) \| ~8B \| ~256 \| ~2,048" |
| 622 | § Memory Budget prose | "singletons + beats vector" | "singletons + BeatMap row tables" |

The memory-budget total is preserved (~2 KB across the 14 row tables ≈ same order of magnitude as the former aggregate vector) and the row is marked approximate (~) since the actual per-frame footprint depends on the per-vector split, which is authoritatively documented in `app/components/beat_map.h`. The 2-line trailing prose was reconciled to match.

## Verification

```
$ grep -nE "BeatMap\.beats|\.beats\[\]|beats vector" design-docs/beatmap-integration.md
(no matches)
```

The remaining `beats`-substring matches in this file are:
- `lead_beats` / `"beats"` JSON key in the authoring sidecar schema (correct — that *is* still the JSON shape on disk)
- `*_beats` in `int beat_index` comment (canonical struct field name)
- "All beats spawned" prose in the song-end state-machine diagram (generic noun, not a field reference)

All other beatmap docs already use the per-(kind, shape, timing-source) language.

## Scope

`design-docs/beatmap-integration.md` only. No code, no tests, no other docs touched.

## Precedent

This file already received a similar focused fix in #1591 (§ 3.3 `song_playback_system` stale code block → prose pointer). Same shape.
