### PR TITLE
Split obstacle mesh spawners by archetype

### DIFF
--- a/app/components/obstacle.h
+++ b/app/components/obstacle.h
@@ -42,7 +42,7 @@ struct Obstacle {
 // normalized away: each child entity carries its own `MeshChild { parent }`
 // row, and "the children of obstacle X" is now `view<MeshChild>` filtered by
 // `parent == X`. The `MAX` cap survives as a hard limit enforced by the
-// obstacle mesh factory (`require_child_capacity` in
+// obstacle mesh helpers (`require_child_capacity` in
 // app/entities/obstacle_render_entity.cpp).
 struct ObstacleChildren {
     static constexpr int MAX = 8;

--- a/app/entities/obstacle_entity.cpp
+++ b/app/entities/obstacle_entity.cpp
@@ -11,8 +11,9 @@
 
 namespace {
 
-void finish_obstacle(entt::registry& reg, entt::entity e) {
-    spawn_obstacle_meshes(reg, e);
+template <typename MeshSpawner>
+void finish_obstacle(entt::registry& reg, entt::entity e, MeshSpawner spawn_meshes) {
+    spawn_meshes(reg, e);
     reg.emplace<ObstacleTag>(e);
 }
 
@@ -25,20 +26,21 @@ void finish_obstacle(entt::registry& reg, entt::entity e) {
 // per-kind symbols remain (call sites in `app/systems/beat_scheduler_system.cpp`
 // and several `tests/*.cpp` files reference them by name) and thin-call
 // into one of these two finalizers parameterized on the builder.
-template <typename Builder, typename Params>
-entt::entity spawn_with_velocity(entt::registry& reg, Builder build, const Params& params) {
+template <typename Builder, typename Params, typename MeshSpawner>
+entt::entity spawn_with_velocity(entt::registry& reg, Builder build, const Params& params,
+                                 MeshSpawner spawn_meshes) {
     auto e = build(reg, params);
     reg.emplace<Vector2>(e, Vector2{0.0f, params.speed});
-    finish_obstacle(reg, e);
+    finish_obstacle(reg, e, spawn_meshes);
     return e;
 }
 
-template <typename Builder, typename Params>
+template <typename Builder, typename Params, typename MeshSpawner>
 entt::entity spawn_with_beat(entt::registry& reg, Builder build, const Params& params,
-                             const BeatInfo& beat_info) {
+                             const BeatInfo& beat_info, MeshSpawner spawn_meshes) {
     auto e = build(reg, params);
     reg.emplace<BeatInfo>(e, beat_info);
-    finish_obstacle(reg, e);
+    finish_obstacle(reg, e, spawn_meshes);
     return e;
 }
 
@@ -93,28 +95,28 @@ entt::entity create_onset_marker(entt::registry& reg, const OnsetMarkerSpawn& pa
 } // namespace
 
 entt::entity spawn_shape_gate_obstacle(entt::registry& reg, const ShapeGateSpawn& params) {
-    return spawn_with_velocity(reg, create_shape_gate, params);
+    return spawn_with_velocity(reg, create_shape_gate, params, spawn_shape_gate_meshes);
 }
 
 entt::entity spawn_split_path_obstacle(entt::registry& reg, const SplitPathSpawn& params) {
-    return spawn_with_velocity(reg, create_split_path, params);
+    return spawn_with_velocity(reg, create_split_path, params, spawn_split_path_meshes);
 }
 
 entt::entity spawn_onset_marker_obstacle(entt::registry& reg, const OnsetMarkerSpawn& params) {
-    return spawn_with_velocity(reg, create_onset_marker, params);
+    return spawn_with_velocity(reg, create_onset_marker, params, spawn_onset_marker_meshes);
 }
 
 entt::entity spawn_shape_gate_rhythm(entt::registry& reg, const ShapeGateSpawn& params,
                                      const BeatInfo& beat_info) {
-    return spawn_with_beat(reg, create_shape_gate, params, beat_info);
+    return spawn_with_beat(reg, create_shape_gate, params, beat_info, spawn_shape_gate_meshes);
 }
 
 entt::entity spawn_split_path_rhythm(entt::registry& reg, const SplitPathSpawn& params,
                                      const BeatInfo& beat_info) {
-    return spawn_with_beat(reg, create_split_path, params, beat_info);
+    return spawn_with_beat(reg, create_split_path, params, beat_info, spawn_split_path_meshes);
 }
 
 entt::entity spawn_onset_marker_rhythm(entt::registry& reg, const OnsetMarkerSpawn& params,
                                        const BeatInfo& beat_info) {
-    return spawn_with_beat(reg, create_onset_marker, params, beat_info);
+    return spawn_with_beat(reg, create_onset_marker, params, beat_info, spawn_onset_marker_meshes);
 }

--- a/app/entities/obstacle_render_entity.cpp
+++ b/app/entities/obstacle_render_entity.cpp
@@ -77,58 +77,55 @@ static entt::entity add_shape_child(entt::registry& reg, entt::entity parent,
     return e;
 }
 
-void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical) {
+void spawn_shape_gate_meshes(entt::registry& reg, entt::entity logical) {
     const auto* wt_ptr = reg.try_get<WorldPosition>(logical);
     auto& col = reg.get<Color>(logical);
-    auto& dsz = reg.get<DrawSize>(logical);
 
-    // Per-kind transforms (issue #1202/#1204). Each obstacle entity
-    // carries exactly one kind tag (ShapeGateTag/SplitPathTag/OnsetMarkerTag);
-    // each branch below operates on that tag's filtered view of one row.
-    if (reg.all_of<ShapeGateTag>(logical)) {
-        if (!wt_ptr) return;
-        const auto& wt = *wt_ptr;
-        const bool has_req = has_required_shape_tag(reg, logical);
-        uint8_t mesh_index = 0;
-        if (has_req) {
-            mesh_index = checked_shape_mesh_index(current_required_shape(reg, logical));
-        }
-        // Shape gates now render as shape-only prompts (no side walls/slabs).
-        if (has_req)
-            add_shape_child(reg, logical, mesh_index, wt.position.x, 0.0f,
-                            40, col);
-        return;
+    if (!wt_ptr) return;
+    const auto& wt = *wt_ptr;
+    const bool has_req = has_required_shape_tag(reg, logical);
+    uint8_t mesh_index = 0;
+    if (has_req) {
+        mesh_index = checked_shape_mesh_index(current_required_shape(reg, logical));
     }
-    if (reg.all_of<SplitPathTag>(logical)) {
-        auto* rlane = reg.try_get<int8_t>(logical);
-        int lane_index = 0;
-        if (rlane) {
-            const int candidate = static_cast<int>(*rlane);
-            if (candidate < 0 || candidate >= constants::LANE_COUNT) {
-                throw std::logic_error("Invalid required lane index");
-            }
-            lane_index = candidate;
+    // Shape gates render as shape-only prompts (no side walls/slabs).
+    if (has_req)
+        add_shape_child(reg, logical, mesh_index, wt.position.x, 0.0f,
+                        40, col);
+}
+
+void spawn_split_path_meshes(entt::registry& reg, entt::entity logical) {
+    auto& col = reg.get<Color>(logical);
+    auto& dsz = reg.get<DrawSize>(logical);
+    auto* rlane = reg.try_get<int8_t>(logical);
+    int lane_index = 0;
+    if (rlane) {
+        const int candidate = static_cast<int>(*rlane);
+        if (candidate < 0 || candidate >= constants::LANE_COUNT) {
+            throw std::logic_error("Invalid required lane index");
         }
-        const bool has_req = has_required_shape_tag(reg, logical);
-        uint8_t mesh_index = 0;
-        if (has_req) {
-            mesh_index = checked_shape_mesh_index(current_required_shape(reg, logical));
-        }
-        for (int i = 0; i < constants::LANE_COUNT; ++i)
-            if (!rlane || i != lane_index)
-                add_slab_child(reg, logical, constants::LANE_X[i]-120,
-                               240.0f, dsz.h, constants::OBSTACLE_3D_HEIGHT, col);
-        if (has_req && rlane)
-            add_shape_child(reg, logical, mesh_index,
-                            constants::LANE_X[lane_index],
-                            0.0f, 30, {255, 255, 255, 180});
-        return;
+        lane_index = candidate;
     }
-    if (reg.all_of<OnsetMarkerTag>(logical)) {
-        add_slab_child(reg, logical, 0.0f, dsz.w, dsz.h,
-                       constants::OBSTACLE_3D_HEIGHT, col);
-        return;
+    const bool has_req = has_required_shape_tag(reg, logical);
+    uint8_t mesh_index = 0;
+    if (has_req) {
+        mesh_index = checked_shape_mesh_index(current_required_shape(reg, logical));
     }
+    for (int i = 0; i < constants::LANE_COUNT; ++i)
+        if (!rlane || i != lane_index)
+            add_slab_child(reg, logical, constants::LANE_X[i]-120,
+                           240.0f, dsz.h, constants::OBSTACLE_3D_HEIGHT, col);
+    if (has_req && rlane)
+        add_shape_child(reg, logical, mesh_index,
+                        constants::LANE_X[lane_index],
+                        0.0f, 30, {255, 255, 255, 180});
+}
+
+void spawn_onset_marker_meshes(entt::registry& reg, entt::entity logical) {
+    auto& col = reg.get<Color>(logical);
+    auto& dsz = reg.get<DrawSize>(logical);
+    add_slab_child(reg, logical, 0.0f, dsz.w, dsz.h,
+                   constants::OBSTACLE_3D_HEIGHT, col);
 }
 
 

--- a/app/entities/obstacle_render_entity.h
+++ b/app/entities/obstacle_render_entity.h
@@ -3,9 +3,11 @@
 #include "../components/rendering.h"
 #include <entt/entt.hpp>
 
-// Spawn render child entities for multi-slab obstacle types.
-// Call after creating the logical obstacle entity.
-void spawn_obstacle_meshes(entt::registry& reg, entt::entity logical);
+// Spawn render child entities for each obstacle archetype.
+// Call after creating the logical obstacle entity's per-kind rows.
+void spawn_shape_gate_meshes(entt::registry& reg, entt::entity logical);
+void spawn_split_path_meshes(entt::registry& reg, entt::entity logical);
+void spawn_onset_marker_meshes(entt::registry& reg, entt::entity logical);
 
 
 // Explicit obstacle lifetime helpers. Do not call from EnTT destroy listeners.

--- a/tests/test_obstacle_archetypes.cpp
+++ b/tests/test_obstacle_archetypes.cpp
@@ -114,7 +114,7 @@ TEST_CASE("entity: obstacle mesh overflow does not create orphan MeshChild", "[a
     reg.emplace<ShapeGateTag>(parent);
 
     CHECK(count_mesh_children(reg) == ObstacleChildren::MAX);
-    CHECK_THROWS_AS(spawn_obstacle_meshes(reg, parent), std::logic_error);
+    CHECK_THROWS_AS(spawn_shape_gate_meshes(reg, parent), std::logic_error);
     CHECK(count_mesh_children(reg) == ObstacleChildren::MAX);
 
     destroy_obstacle_with_children(reg, parent);
@@ -133,14 +133,14 @@ TEST_CASE("entity: obstacle mesh lifetime helper cleans factory children", "[arc
     CHECK(count_mesh_children(reg) == 0);
 }
 
-TEST_CASE("entity: direct mesh factory cleanup does not depend on ObstacleTag order", "[archetype][render][cleanup]") {
+TEST_CASE("entity: direct shape-gate mesh cleanup does not depend on ObstacleTag order", "[archetype][render][cleanup]") {
     entt::registry reg;
     auto parent = make_mesh_factory_obstacle(reg);
     set_required_shape_tag(reg, parent, Shape::Circle);
     reg.emplace<ObstacleTag>(parent);
     reg.emplace<ShapeGateTag>(parent);
 
-    spawn_obstacle_meshes(reg, parent);
+    spawn_shape_gate_meshes(reg, parent);
     REQUIRE(count_mesh_children(reg) > 0);
 
     destroy_obstacle_with_children(reg, parent);
@@ -156,7 +156,7 @@ TEST_CASE("entity: mesh factory rejects invalid required lane before children", 
         reg.emplace<int8_t>(parent, int8_t{-1});
         reg.emplace<SplitPathTag>(parent);
 
-        CHECK_THROWS_AS(spawn_obstacle_meshes(reg, parent), std::logic_error);
+        CHECK_THROWS_AS(spawn_split_path_meshes(reg, parent), std::logic_error);
         check_no_mesh_children(reg, parent);
     }
 
@@ -167,7 +167,7 @@ TEST_CASE("entity: mesh factory rejects invalid required lane before children", 
         reg.emplace<int8_t>(parent, int8_t{3});
         reg.emplace<SplitPathTag>(parent);
 
-        CHECK_THROWS_AS(spawn_obstacle_meshes(reg, parent), std::logic_error);
+        CHECK_THROWS_AS(spawn_split_path_meshes(reg, parent), std::logic_error);
         check_no_mesh_children(reg, parent);
     }
 }

--- a/tests/test_pr43_regression.cpp
+++ b/tests/test_pr43_regression.cpp
@@ -76,7 +76,7 @@ TEST_CASE("screen_transform ordering: stale identity ST mismaps letterbox-offset
 
 // ═══════════════════════════════════════════════════════════════════════
 // Theme 2 – game_camera_system slab_matrix dimension order: MeshChild field
-//           contract.  spawn_obstacle_meshes stores depth = DrawSize.h
+//           contract.  obstacle mesh spawners store depth = DrawSize.h
 //           (scroll-axis) and height = 3D height constant (Y-axis).
 //           game_camera_system must pass mc.height as h (Y) and mc.depth as
 //           d (Z) to slab_matrix, not the other way around.
@@ -122,7 +122,7 @@ TEST_CASE("MeshChild: ShapeGate renders shape-only (no side slabs)",
            "[camera][slab][pr43]") {
     auto reg = make_registry();
     auto obs = make_shape_gate(reg, Shape::Circle, 500.0f);
-    spawn_obstacle_meshes(reg, obs);
+    spawn_shape_gate_meshes(reg, obs);
 
     int slab_count = 0;
     int shape_count = 0;


### PR DESCRIPTION
## Summary
- Fixes #1653 by replacing the central `spawn_obstacle_meshes()` tag-dispatch ladder with per-archetype mesh spawners.
- Wires shape gate, split path, and onset marker spawn paths directly to their matching mesh creation helper.
- Updates render/archetype tests to exercise the explicit mesh spawners.

## Root cause
`spawn_obstacle_meshes()` centralized render-child creation behind `ShapeGateTag` / `SplitPathTag` / `OnsetMarkerTag` checks, reintroducing a discriminator ladder instead of letting obstacle archetype creation paths attach their own render rows.

## Verification
- `cmake -B build -S . -Wno-dev`
- `cmake --build build`
- `./build/shapeshifter_tests`

All tests passed locally: 3364 assertions in 965 test cases.