### PR TITLE
Fix ECS drift in session signals and toggles

### DIFF
--- a/app/components/ui.h
+++ b/app/components/ui.h
@@ -97,16 +97,6 @@ struct DifficultyIndex {
     int value = 0;
 };
 
-// Two-state toggle data for buttons carrying `UiToggleTag` (Settings
-// screen, issue #1295). The bind system (e.g.
-// `settings_screen_bind_system`) writes the current ON/OFF state each
-// frame from the underlying domain data (`SettingsState::haptics_enabled`,
-// `!SettingsState::reduce_motion`, …). `ui_render_system` reads it to
-// pick the two-cue colour + icon-prefix row.
-struct UiToggleState {
-    bool on = false;
-};
-
 // Per-entity font-size override for `UiLabel` rendering (issue #1297).
 // When absent the renderer falls back to the bounds-height heuristic
 // (height ≥ 80 ⇒ 56, else 24). Written by per-screen bind systems for

--- a/app/systems/generated/settings_screen.cpp
+++ b/app/systems/generated/settings_screen.cpp
@@ -70,6 +70,7 @@ void spawn_settings_screen(entt::registry& reg) {
         reg.emplace<SettingsScreenTag>(e);
         reg.emplace<UiButtonTag>(e);
         reg.emplace<UiToggleTag>(e);
+        reg.emplace<UiToggleOnTag>(e);
         reg.emplace<UiPosition>(e, 152.0f, 720.0f);
         reg.emplace<UiBounds>(e, 416.0f, 100.0f);
         auto& label = reg.emplace<UiLabel>(e);
@@ -92,6 +93,7 @@ void spawn_settings_screen(entt::registry& reg) {
         reg.emplace<SettingsScreenTag>(e);
         reg.emplace<UiButtonTag>(e);
         reg.emplace<UiToggleTag>(e);
+        reg.emplace<UiToggleOnTag>(e);
         reg.emplace<UiPosition>(e, 152.0f, 880.0f);
         reg.emplace<UiBounds>(e, 416.0f, 100.0f);
         auto& label = reg.emplace<UiLabel>(e);

--- a/app/systems/settings_screen_bind_system.cpp
+++ b/app/systems/settings_screen_bind_system.cpp
@@ -24,7 +24,7 @@ constexpr float kReduceMotionToggleY = 880.0f;
 
 // Bind context — owns the per-frame singleton reads so the per-slot
 // `bind_*` functions are pure transforms over their slot's `UiLabel` +
-// `UiToggleState`. Mirrors the `*BindContext` shape used by the sibling
+// toggle state tags. Mirrors the `*BindContext` shape used by the sibling
 // `game_over_scoreboard_bind_system` / `song_complete_scoreboard_bind_system` /
 // `gameplay_hud_bind_system` binders.
 //
@@ -61,7 +61,12 @@ void bind_toggle_impl(entt::registry& reg, entt::entity e, UiLabel& label,
     std::snprintf(buf, sizeof(buf), "[%s] %s: %s",
                   on ? "X" : " ", name, on ? "ON" : "OFF");
     ui_label_set(label, buf);
-    reg.emplace_or_replace<UiToggleState>(e, UiToggleState{on});
+    reg.remove<UiToggleOnTag, UiToggleOffTag>(e);
+    if (on) {
+        reg.emplace_or_replace<UiToggleOnTag>(e);
+    } else {
+        reg.emplace_or_replace<UiToggleOffTag>(e);
+    }
 }
 
 void bind_haptics_toggle(const SettingsBindContext& ctx, entt::registry& reg,

--- a/app/systems/settings_screen_bind_system.h
+++ b/app/systems/settings_screen_bind_system.h
@@ -2,7 +2,7 @@
 
 #include <entt/entt.hpp>
 
-// Settings screen dynamic-text + toggle-state binder
+// Settings screen dynamic-text + toggle tag-state binder
 // (issue #1295, refs #1287, #1193 OoS-A).
 //
 // Writes per-frame Settings UI data into the entities spawned by
@@ -11,11 +11,11 @@
 //
 //   * AudioOffsetDisplay label  → "%+d ms" from `SettingsState::audio_offset_ms`
 //   * HapticsToggle      label  → "[X] HAPTICS: ON" / "[ ] HAPTICS: OFF"
-//   * HapticsToggle      toggle → `UiToggleState{haptics_enabled}`
+//   * HapticsToggle      toggle → `UiToggleOnTag` / `UiToggleOffTag`
 //   * ReduceMotionToggle label  → "[X] MOTION: ON" / "[ ] MOTION: OFF"
 //                                 (display is inverted — MOTION ON when
 //                                  `reduce_motion` is false)
-//   * ReduceMotionToggle toggle → `UiToggleState{!reduce_motion}`
+//   * ReduceMotionToggle toggle → `UiToggleOnTag` / `UiToggleOffTag`
 //
 // Slot entities are identified by their canonical (x, y) position baked
 // from `content/ui/screens/settings.rgl`; the bind table is per-slot

--- a/app/systems/test_player_session.cpp
+++ b/app/systems/test_player_session.cpp
@@ -15,7 +15,8 @@
 
 namespace {
 struct TestPlayerSessionSignals {
-    bool wired = false;
+    entt::connection obstacle_spawn;
+    entt::connection scored;
 };
 }
 
@@ -93,9 +94,12 @@ void test_player_init(entt::registry& reg, SkillConfig skill,
     if (!signals) {
         signals = &reg.ctx().emplace<TestPlayerSessionSignals>();
     }
-    if (!signals->wired) {
-        reg.on_construct<ObstacleTag>().connect<&session_log_on_obstacle_spawn>();
-        reg.on_construct<ScoredTag>().connect<&session_log_on_scored>();
-        signals->wired = true;
+    if (!signals->obstacle_spawn || !signals->scored) {
+        signals->obstacle_spawn.release();
+        signals->scored.release();
+        signals->obstacle_spawn =
+            reg.on_construct<ObstacleTag>().connect<&session_log_on_obstacle_spawn>();
+        signals->scored =
+            reg.on_construct<ScoredTag>().connect<&session_log_on_scored>();
     }
 }

--- a/app/systems/ui_render_system.cpp
+++ b/app/systems/ui_render_system.cpp
@@ -84,6 +84,30 @@ constexpr Color kLevelCardBorderUnsel  {  60,  60,  80, 255 };
 constexpr Color kDiffActiveBorderColor { 120, 180, 255, 255 };
 constexpr Color kDiffActiveBarColor    {  80, 120, 200, 255 };
 
+template<typename ToggleStateTag>
+void render_toggle_buttons(entt::registry& reg, Color border, Color base,
+                           Color text) {
+    GuiSetStyle(BUTTON, BORDER_COLOR_NORMAL,  ColorToInt(border));
+    GuiSetStyle(BUTTON, BORDER_COLOR_FOCUSED, ColorToInt(border));
+    GuiSetStyle(BUTTON, BASE_COLOR_NORMAL,    ColorToInt(base));
+    GuiSetStyle(BUTTON, BASE_COLOR_FOCUSED,   ColorToInt(base));
+    GuiSetStyle(BUTTON, TEXT_COLOR_NORMAL,    ColorToInt(text));
+    GuiSetStyle(BUTTON, TEXT_COLOR_FOCUSED,   ColorToInt(text));
+
+    auto view = reg.view<UiPosition, UiBounds, UiLabel, UiButtonTag,
+                         UiToggleTag, ToggleStateTag>(
+#ifdef PLATFORM_WEB
+        entt::exclude<UiHiddenOnWebTag>
+#endif
+    );
+    for (auto entity : view) {
+        const auto& pos = view.template get<UiPosition>(entity);
+        const auto& sz  = view.template get<UiBounds>(entity);
+        const auto& lbl = view.template get<UiLabel>(entity);
+        (void)GuiButton(Rectangle{pos.x, pos.y, sz.w, sz.h}, lbl.text.data());
+    }
+}
+
 void render_ui_entities(entt::registry& reg) {
     const int saved_text_size       = GuiGetStyle(DEFAULT, TEXT_SIZE);
     const int saved_label_alignment = GuiGetStyle(LABEL, TEXT_ALIGNMENT);
@@ -213,32 +237,10 @@ void render_ui_entities(entt::registry& reg) {
         constexpr Color kToggleOffBase   {  36,  36,  36, 255 };
         constexpr Color kToggleTextColor { 230, 230, 230, 255 };
 
-        auto toggle_view = reg.view<UiPosition, UiBounds, UiLabel,
-                                    UiButtonTag, UiToggleTag>(
-#ifdef PLATFORM_WEB
-            entt::exclude<UiHiddenOnWebTag>
-#endif
-        );
-        for (auto entity : toggle_view) {
-            const auto& pos = toggle_view.template get<UiPosition>(entity);
-            const auto& sz  = toggle_view.template get<UiBounds>(entity);
-            const auto& lbl = toggle_view.template get<UiLabel>(entity);
-            // `UiToggleState` is written each frame by the per-screen bind
-            // system; if missing (frame 0 race before the bind runs) treat
-            // as OFF — safe default, harmless visual flicker.
-            const auto* state = reg.try_get<UiToggleState>(entity);
-            const bool on = (state != nullptr) && state->on;
-
-            const Color border = on ? kToggleOnBorder : kToggleOffBorder;
-            const Color base   = on ? kToggleOnBase   : kToggleOffBase;
-            GuiSetStyle(BUTTON, BORDER_COLOR_NORMAL,  ColorToInt(border));
-            GuiSetStyle(BUTTON, BORDER_COLOR_FOCUSED, ColorToInt(border));
-            GuiSetStyle(BUTTON, BASE_COLOR_NORMAL,    ColorToInt(base));
-            GuiSetStyle(BUTTON, BASE_COLOR_FOCUSED,   ColorToInt(base));
-            GuiSetStyle(BUTTON, TEXT_COLOR_NORMAL,    ColorToInt(kToggleTextColor));
-            GuiSetStyle(BUTTON, TEXT_COLOR_FOCUSED,   ColorToInt(kToggleTextColor));
-            (void)GuiButton(Rectangle{pos.x, pos.y, sz.w, sz.h}, lbl.text.data());
-        }
+        render_toggle_buttons<UiToggleOnTag>(
+            reg, kToggleOnBorder, kToggleOnBase, kToggleTextColor);
+        render_toggle_buttons<UiToggleOffTag>(
+            reg, kToggleOffBorder, kToggleOffBase, kToggleTextColor);
 
         for (std::size_t i = 0; i < kToggleStylePropCount; ++i) {
             GuiSetStyle(BUTTON, kToggleStyleProps[i], saved_button_style[i]);

--- a/app/tags/tags.h
+++ b/app/tags/tags.h
@@ -409,10 +409,13 @@ struct UiHiddenOnWebTag {};
 // toggle?" is presence of this tag rather than a `UiButtonKind` enum
 // field. Toggle buttons (#1295) render with green ON / grey OFF colors
 // + an `[X] / [ ]` icon prefix per the two-cue A11Y requirement (#390);
-// `ui_render_system` reads the sibling `UiToggleState` component to pick
-// the row. Codegen attaches this tag to `.rgl` button controls whose
-// name is in the NAME_EXTRA_TAGS toggle list (`tools/rguilayout/codegen.py`).
+// `settings_screen_bind_system` moves each toggle between `UiToggleOnTag`
+// and `UiToggleOffTag`, and `ui_render_system` draws one filtered view per
+// state. Codegen attaches this tag to `.rgl` button controls whose name is
+// in the NAME_EXTRA_TAGS toggle list (`tools/rguilayout/codegen.py`).
 struct UiToggleTag {};
+struct UiToggleOnTag {};
+struct UiToggleOffTag {};
 
 // ── Level Select dynamic UI archetypes (issue #1296) ─────────────────
 // Per Fabian's existential processing, the level-select cards and the

--- a/tests/test_ui_update_system.cpp
+++ b/tests/test_ui_update_system.cpp
@@ -1128,7 +1128,7 @@ TEST_CASE("settings_screen_bind_system: writes formatted audio offset text",
     }
 }
 
-TEST_CASE("settings_screen_bind_system: writes toggle labels and UiToggleState",
+TEST_CASE("settings_screen_bind_system: writes toggle labels and state tags",
           "[ui][settings_screen_bind_system][issue1295]") {
     entt::registry reg = make_registry();
     prime_settings_entry(reg);
@@ -1137,22 +1137,22 @@ TEST_CASE("settings_screen_bind_system: writes toggle labels and UiToggleState",
     settings_state(reg).reduce_motion = false;
     settings_screen_bind_system(reg);
 
-    auto view = reg.view<SettingsScreenTag, UiToggleTag, UiPosition, UiLabel,
-                         UiToggleState>();
+    auto view = reg.view<SettingsScreenTag, UiToggleTag, UiPosition, UiLabel>();
     int haptics_match = 0;
     int motion_match = 0;
     for (auto entity : view) {
         const auto& pos = view.get<UiPosition>(entity);
         const auto& label = view.get<UiLabel>(entity);
-        const auto& state = view.get<UiToggleState>(entity);
         if (pos.x == 152.0f && pos.y == 720.0f) {
             CHECK(std::string(label.text.data()) == "[X] HAPTICS: ON");
-            CHECK(state.on);
+            CHECK(reg.all_of<UiToggleOnTag>(entity));
+            CHECK_FALSE(reg.all_of<UiToggleOffTag>(entity));
             ++haptics_match;
         } else if (pos.x == 152.0f && pos.y == 880.0f) {
             // motion_on = !reduce_motion → true → label shows MOTION: ON
             CHECK(std::string(label.text.data()) == "[X] MOTION: ON");
-            CHECK(state.on);
+            CHECK(reg.all_of<UiToggleOnTag>(entity));
+            CHECK_FALSE(reg.all_of<UiToggleOffTag>(entity));
             ++motion_match;
         }
     }
@@ -1166,13 +1166,14 @@ TEST_CASE("settings_screen_bind_system: writes toggle labels and UiToggleState",
     for (auto entity : view) {
         const auto& pos = view.get<UiPosition>(entity);
         const auto& label = view.get<UiLabel>(entity);
-        const auto& state = view.get<UiToggleState>(entity);
         if (pos.x == 152.0f && pos.y == 720.0f) {
             CHECK(std::string(label.text.data()) == "[ ] HAPTICS: OFF");
-            CHECK_FALSE(state.on);
+            CHECK(reg.all_of<UiToggleOffTag>(entity));
+            CHECK_FALSE(reg.all_of<UiToggleOnTag>(entity));
         } else if (pos.x == 152.0f && pos.y == 880.0f) {
             CHECK(std::string(label.text.data()) == "[ ] MOTION: OFF");
-            CHECK_FALSE(state.on);
+            CHECK(reg.all_of<UiToggleOffTag>(entity));
+            CHECK_FALSE(reg.all_of<UiToggleOnTag>(entity));
         }
     }
 }

--- a/tools/rguilayout/codegen.py
+++ b/tools/rguilayout/codegen.py
@@ -76,12 +76,13 @@ NAME_EXTRA_TAGS: Dict[str, Tuple[str, ...]] = {
     # PLATFORM_WEB; `title_start_tap_system` keeps treating their bounds
     # as a dead-zone (defense-in-depth).
     "ExitButton":    ("UiHiddenOnWebTag",),
-    # Settings screen toggle buttons (#1295). `UiToggleTag` selects the
-    # two-cue ON/OFF render row in `ui_render_system`; the sibling
-    # `UiToggleState` is written each frame by `settings_screen_bind_system`
-    # from `SettingsState`.
-    "HapticsToggle":      ("UiToggleTag",),
-    "ReduceMotionToggle": ("UiToggleTag",),
+    # Settings screen toggle buttons (#1295). `UiToggleTag` selects toggle
+    # controls; the state itself is existential (`UiToggleOnTag` /
+    # `UiToggleOffTag`) and is updated each frame by
+    # `settings_screen_bind_system` from `SettingsState`. Both defaults are
+    # ON to match `SettingsState{haptics_enabled=true, reduce_motion=false}`.
+    "HapticsToggle":      ("UiToggleTag", "UiToggleOnTag"),
+    "ReduceMotionToggle": ("UiToggleTag", "UiToggleOnTag"),
     # Gameplay HUD lane buttons (#1297). Each shape button carries the
     # per-shape icon tag (drives the flat 2D icon row inside the lane
     # button render pass) plus `LaneButtonTag` which distinguishes them


### PR DESCRIPTION
## Root cause
- #1664: `TestPlayerSessionSignals` used a parallel `bool wired` lifecycle flag instead of owning the EnTT signal connections.
- #1663: settings toggles stored ON/OFF as `UiToggleState::on`, forcing render-time boolean dispatch.

## Fix
- Replace the session `wired` flag with owned `entt::connection` handles while keeping repeated `test_player_init` idempotent.
- Replace `UiToggleState` with `UiToggleOnTag` / `UiToggleOffTag`, update settings binding/codegen defaults, and render toggles through separate state-tag views.

## Verification
- `python3 tools/rguilayout/codegen.py --output-dir app/systems/generated --actions-header app/components/actions.h content/ui/screens/*.rgl`
- `cmake -Wno-dev -B build -S . && cmake --build build && ./build/shapeshifter_tests`
- `python3 tools/check_enum_allowlist.py`

Closes #1664
Closes #1663
