### PR TITLE
Fix stale pipeline docs and beatmap duration metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,10 +133,15 @@ it identifies historical migration plans and the current authoritative runtime d
 
 ```
 compute_screen_transform -> input_system -> ui_update_system ->
-test_player_system -> fixed timestep loop -> game_camera_system ->
-ui_camera_system -> game_render_system -> ui_render_system ->
-audio_system -> haptic_system
+title_start_tap_system -> test_player_system -> fixed timestep loop ->
+screen_lifecycle_system -> per-screen bind systems ->
+approach_ring_envelope_system -> game_camera_system -> ui_camera_system ->
+game_render_system -> ui_render_system -> audio_system -> haptic_system
 ```
+
+`app/game_loop.cpp` and `app/systems/fixed_tick_runner.cpp` are
+authoritative when implementation details change; this summary intentionally
+stays descriptive rather than listing every generated screen binder by name.
 
 Each fixed timestep runs `tick_fixed_systems`:
 

--- a/design-docs/beatmap-editor.md
+++ b/design-docs/beatmap-editor.md
@@ -290,7 +290,7 @@ Each module exports a well-defined API. Sub-agents build to these contracts.
 export const state = {
   // Beatmap data (exported to JSON)
   songId: "", title: "", bpm: 120, offset: 0, leadBeats: 4,
-  duration: 180, songPath: "",
+  duration_sec: 180, songPath: "",
   difficulties: { easy: { beats: [] }, medium: { beats: [] }, hard: { beats: [] } },
   activeDifficulty: "easy",
 

--- a/tests/test_beat_map_parser_unknown_fields.cpp
+++ b/tests/test_beat_map_parser_unknown_fields.cpp
@@ -286,6 +286,21 @@ TEST_CASE("parse: unshipped obstacle kinds are rejected", "[parse][kind][issue87
     CHECK(map.onset_marker_beats.empty());
 }
 
+TEST_CASE("parse: legacy duration metadata is ignored", "[parse][metadata][issue1665]") {
+    BeatMap map;
+    std::vector<BeatMapError> errors;
+    std::string json = R"({
+        "bpm": 120, "offset": 0.0, "lead_beats": 4, "duration": 8.0,
+        "beats": [
+            { "beat": 4, "kind": "shape_gate", "shape": "circle", "lane": 1 }
+        ]
+    })";
+
+    REQUIRE(parse_beat_map(json, map, errors));
+    CHECK(errors.empty());
+    CHECK(map.duration == 180.0f);
+}
+
 TEST_CASE("parse: wrong metadata types report BeatMapError instead of throwing", "[parse][metadata][types][regression]") {
     BeatMap map;
     std::vector<BeatMapError> errors;

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -159,7 +159,7 @@ TEST_CASE("Play session: high score key uses loaded fallback difficulty",
         "bpm": 120,
         "offset": 0,
         "lead_beats": 4,
-        "duration": 8,
+        "duration_sec": 8,
         "difficulties": {
             "medium": {
                 "beats": [


### PR DESCRIPTION
## Summary
- Updates README frame pipeline to match `game_loop_frame` and names the authoritative runtime files.
- Replaces stale high-score fixture metadata with canonical `duration_sec`.
- Documents current parser behavior with a regression test: legacy `duration` is ignored.
- Updates beatmap editor docs to use canonical `duration_sec`.

Fixes #1666
Fixes #1665

## Verification
- `cmake -B build -S . -Wno-dev`
- `cmake --build build`
- `./build/shapeshifter_tests "parse: legacy duration metadata is ignored"`
- `./build/shapeshifter_tests "Play session: high score key uses loaded fallback difficulty"`
- `./build/shapeshifter_tests`
- `ctest --test-dir build --output-on-failure -R "^check_enum_allowlist$"`