### PR TITLE
Fix terminal ctx tag idempotency

### DIFF
--- a/app/systems/game_state_terminal_phase_system.cpp
+++ b/app/systems/game_state_terminal_phase_system.cpp
@@ -27,7 +27,7 @@ bool update_and_persist_high_score(entt::registry& reg) {
     }
     if (auto* hp = reg.ctx().find<HighScorePersistence>()) {
         if (score_exceeds_high_score && recorded_new_high_score && has_active_high_score_key) {
-            reg.ctx().emplace<HighScoreDirtyTag>();
+            reg.ctx().insert_or_assign(HighScoreDirtyTag{});
         }
         if (reg.ctx().contains<HighScoreDirtyTag>()) {
             if (hp->path.empty()) {
@@ -69,7 +69,7 @@ void game_state_enter_terminal_phase_game_over(entt::registry& reg) {
     // emplace one and erase the other regardless of whether a SongState
     // payload still exists (mirrors the prior `song.finished = true;
     // song.playing = false;` invariant).
-    reg.ctx().emplace<SongFinishedTag>();
+    reg.ctx().insert_or_assign(SongFinishedTag{});
     reg.ctx().erase<SongPlayingTag>();
 }
 

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -35,6 +35,25 @@ TEST_CASE("game_state: energy depletion beats song complete after playback finis
     CHECK(reg.ctx().find<EnergyDepletedDeath>() != nullptr);
 }
 
+TEST_CASE("game_state: game over entry is idempotent after song already finished",
+          "[gamestate][issue1676]") {
+    auto reg = make_rhythm_registry();
+    set_test_phase<GamePhasePlayingTag>(reg);
+    reg.ctx().emplace<SongFinishedTag>();
+    reg.ctx().erase<SongPlayingTag>();
+    reg.ctx().get<EnergyState>().energy = 0.0f;
+
+    game_state_system(reg, 0.016f);
+    REQUIRE(reg.ctx().contains<NextPhaseGameOverTag>());
+
+    game_state_system(reg, 0.016f);
+
+    CHECK(reg.ctx().contains<GamePhaseGameOverTag>());
+    CHECK(reg.ctx().contains<SongFinishedTag>());
+    CHECK_FALSE(reg.ctx().contains<SongPlayingTag>());
+    CHECK_FALSE(is_phase_transition_pending(reg));
+}
+
 TEST_CASE("game_state: song complete waits for obstacles to clear", "[gamestate]") {
     auto reg = make_rhythm_registry();
     set_test_phase<GamePhasePlayingTag>(reg);

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -326,6 +326,17 @@ TEST_CASE("High score integration: failed save keeps dirty state for retry",
     CHECK(reg.ctx().contains<HighScoreDirtyTag>());
     CHECK(persistence_state.last_save.status == persistence::Status::DirectoryCreateFailed);
 
+    score.score = 3000;
+    request_phase_transition<NextPhaseGameOverTag>(reg);
+
+    game_state_system(reg, 0.016f);
+
+    CHECK(current.value == 3000);
+    CHECK(high_score::get_score(reg, "song_001|easy") == 3000);
+    CHECK(reg.ctx().contains<HighScoreDirtyTag>());
+    CHECK(reg.ctx().get<HighScorePersistence>().last_save.status
+          == persistence::Status::DirectoryCreateFailed);
+
     remove_path(root);
     const auto retry_file = root / "high_scores.json";
     reg.ctx().get<HighScorePersistence>().path = retry_file.string();
@@ -340,7 +351,7 @@ TEST_CASE("High score integration: failed save keeps dirty state for retry",
 
     entt::registry loaded;
     REQUIRE(high_score::load_high_scores(loaded, retry_file).ok());
-    CHECK(high_score::get_score(loaded, "song_001|easy") == 2500);
+    CHECK(high_score::get_score(loaded, "song_001|easy") == 3000);
 
     remove_path(root);
 }


### PR DESCRIPTION
## Summary
- Fixes #1676
- Make terminal ctx tag writes idempotent for `SongFinishedTag` and `HighScoreDirtyTag`
- Add regressions for GameOver after natural song finish and failed high-score save retry

## Tests
- `cmake -B build -S . -Wno-dev && cmake --build build --parallel && ./build/shapeshifter_tests "[gamestate],[high_score]"`
- `./build/shapeshifter_tests`