### PR TITLE
fix: make Linux startup smoke fail on missing context

### DIFF
--- a/tests/smoke/startup_shutdown_smoke.cpp
+++ b/tests/smoke/startup_shutdown_smoke.cpp
@@ -44,8 +44,9 @@ int main(int argc, char** argv) {
 
     SetTraceLogLevel(LOG_WARNING);
     const char* smoke_mode = std::getenv("SHAPESHIFTER_STARTUP_SHUTDOWN_SMOKE");
-    if (smoke_mode && smoke_mode[0] != '\0' &&
-        !(smoke_mode[0] == '0' && smoke_mode[1] == '\0')) {
+    const bool smoke_mode_enabled = smoke_mode && smoke_mode[0] != '\0' &&
+                                    !(smoke_mode[0] == '0' && smoke_mode[1] == '\0');
+    if (smoke_mode_enabled) {
 #if defined(__APPLE__) || defined(_WIN32)
         std::fprintf(stderr, "SKIPPED: hosted runner has no reliable OpenGL window context\n");
         return 77;
@@ -59,6 +60,12 @@ int main(int argc, char** argv) {
     for (int cycle = 0; cycle < cycles; ++cycle) {
         game_loop_init(reg, false, SKILL_PRO, "medium");
         if (!IsWindowReady()) {
+#if defined(__linux__)
+            if (smoke_mode_enabled) {
+                std::fprintf(stderr, "FAILED: hidden OpenGL window context is unavailable\n");
+                return 1;
+            }
+#endif
             std::fprintf(stderr, "SKIPPED: OpenGL window context is unavailable\n");
             return 77;
         }


### PR DESCRIPTION
## Summary
- require Linux smoke mode to fail when the hidden OpenGL window context is unavailable
- keep macOS/Windows hosted smoke behavior explicitly skipped until they have reliable harnesses

Fixes #1681

## Verification
- cmake --build build --target shapeshifter_startup_shutdown_smoke shapeshifter_tests --parallel
- ctest --test-dir build --output-on-failure -R '^(startup_shutdown_smoke|check_enum_allowlist)$'\n- ctest --test-dir build --output-on-failure