### PR TITLE
Fix drive-relative app dir paths

### DIFF
--- a/app/util/app_dir_path.h
+++ b/app/util/app_dir_path.h
@@ -8,11 +8,11 @@ namespace util {
 // True if `p` is an absolute path. Recognizes:
 //   - POSIX-rooted: leading '/'
 //   - Windows UNC / drive-rooted: leading '\'
-//   - Windows drive-letter: ASCII letter followed by ':' (e.g. "C:\foo", "C:/foo")
+//   - Windows drive-rooted: ASCII drive + ':' + slash (e.g. "C:\foo", "C:/foo")
 inline bool is_absolute_path(std::string_view p) noexcept {
     if (p.empty()) return false;
     if (p.front() == '/' || p.front() == '\\') return true;
-    if (p.size() >= 2 && p[1] == ':') {
+    if (p.size() >= 3 && p[1] == ':' && (p[2] == '/' || p[2] == '\\')) {
         const char c = p.front();
         return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
     }

--- a/tests/test_app_dir_path.cpp
+++ b/tests/test_app_dir_path.cpp
@@ -47,6 +47,11 @@ TEST_CASE("join_app_dir: absolute Windows drive-letter rel passes through unchan
     CHECK(util::join_app_dir("C:\\path\\to\\app\\", "c:/temp/beatmap.json") == "c:/temp/beatmap.json");
 }
 
+TEST_CASE("join_app_dir: Windows drive-relative rel is joined under app_dir", "[util][app_dir_path][issue1684]") {
+    CHECK(util::join_app_dir("C:\\path\\to\\app\\", "D:temp\\beatmap.json") == "C:\\path\\to\\app\\D:temp\\beatmap.json");
+    CHECK(util::join_app_dir("C:\\path\\to\\app", "c:temp/beatmap.json") == "C:\\path\\to\\app/c:temp/beatmap.json");
+}
+
 TEST_CASE("join_app_dir: absolute Windows UNC rel passes through unchanged", "[util][app_dir_path][issue1361]") {
     CHECK(util::join_app_dir("C:\\path\\to\\app\\", "\\\\server\\share\\file.json") == "\\\\server\\share\\file.json");
 }
@@ -58,6 +63,8 @@ TEST_CASE("is_absolute_path: recognizes POSIX, Windows UNC, and drive-letter pat
     CHECK(util::is_absolute_path("c:/foo"));
     CHECK_FALSE(util::is_absolute_path(""));
     CHECK_FALSE(util::is_absolute_path("content/x.ttf"));
+    CHECK_FALSE(util::is_absolute_path("C:foo"));
+    CHECK_FALSE(util::is_absolute_path("C:"));
     CHECK_FALSE(util::is_absolute_path("9:not-a-drive"));
     CHECK_FALSE(util::is_absolute_path("AB:not-a-drive")); // two letters then colon is not a drive
 }


### PR DESCRIPTION
## Summary\n- Treat Windows drive-relative paths such as C:foo as relative in util::is_absolute_path\n- Preserve drive-root absolute paths like C:\foo and C:/foo\n- Add regression coverage for join_app_dir and is_absolute_path\n\nFixes #1684\n\n## Verification\n- cmake -B build -S . -Wno-dev\n- cmake --build build\n- ./build/shapeshifter_tests