### PR TITLE
test: isolate parallel test artifacts

### DIFF
--- a/tests/ctrf_reporter.h
+++ b/tests/ctrf_reporter.h
@@ -48,6 +48,13 @@ static std::string ctrf_report_path() {
 #endif
 }
 
+static bool ctrf_report_path_from_environment() {
+    if (const char* path = std::getenv("SHAPESHIFTER_CTRF_REPORT_PATH")) {
+        return path[0] != '\0';
+    }
+    return false;
+}
+
 struct CtrfTestResult {
     std::string name;
     std::string status;
@@ -118,6 +125,10 @@ public:
     }
 
     void testRunEnded(Catch::TestRunStats const&) override {
+        if (results_.size() <= 1U && !ctrf_report_path_from_environment()) {
+            return;
+        }
+
         int64_t run_stop = ctrf_now_ms();
 
         int passed = 0, failed = 0, skipped = 0, other = 0;

--- a/tests/temp_paths.h
+++ b/tests/temp_paths.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <utility>
+
+namespace test_paths {
+
+inline std::string unique_suffix() {
+    static std::atomic<std::uint64_t> counter{0};
+    const auto ticks = std::chrono::high_resolution_clock::now()
+        .time_since_epoch()
+        .count();
+    const auto thread_hash = std::hash<std::thread::id>{}(std::this_thread::get_id());
+    return std::to_string(ticks) + "_" + std::to_string(thread_hash) + "_" +
+           std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
+}
+
+inline std::filesystem::path unique_temp_path(std::string_view prefix) {
+    return std::filesystem::temp_directory_path() /
+           (std::string(prefix) + "_" + unique_suffix());
+}
+
+inline std::filesystem::path unique_relative_path(std::string_view prefix) {
+    return std::filesystem::path{std::string(prefix) + "_" + unique_suffix()};
+}
+
+struct ScopedPath {
+    explicit ScopedPath(std::filesystem::path p) : path(std::move(p)) {}
+    ScopedPath(const ScopedPath&) = delete;
+    ScopedPath& operator=(const ScopedPath&) = delete;
+    ScopedPath(ScopedPath&&) = delete;
+    ScopedPath& operator=(ScopedPath&&) = delete;
+
+    ~ScopedPath() {
+        std::error_code ec;
+        std::filesystem::remove_all(path, ec);
+    }
+
+    std::filesystem::path path;
+};
+
+}  // namespace test_paths

--- a/tests/test_beat_map_validation.cpp
+++ b/tests/test_beat_map_validation.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <limits>
 #include "test_helpers.h"
+#include "temp_paths.h"
 #include "entities/beat_map.h"
 #include "util/rhythm_math.h"
 
@@ -11,17 +12,15 @@ namespace {
 
 struct TempBeatMapFile {
     explicit TempBeatMapFile(const char* name, const std::string& json)
-        : path(std::filesystem::temp_directory_path() / name) {
+        : scoped_path(test_paths::unique_temp_path(name)),
+          path(scoped_path.path) {
         std::filesystem::remove(path);
         std::ofstream out(path);
         REQUIRE(out.good());
         out << json;
     }
 
-    ~TempBeatMapFile() {
-        std::filesystem::remove(path);
-    }
-
+    test_paths::ScopedPath scoped_path;
     std::filesystem::path path;
 };
 
@@ -490,7 +489,9 @@ TEST_CASE("load_validation_constants: default paths load shipped defaults", "[va
 }
 
 TEST_CASE("load_validation_constants: explicit app_dir takes precedence over CWD fallback", "[validate][constants]") {
-    const std::filesystem::path root = "test_validation_constants_app_dir";
+    test_paths::ScopedPath scoped_root{
+        test_paths::unique_relative_path("test_validation_constants_app_dir")};
+    const std::filesystem::path& root = scoped_root.path;
     std::filesystem::remove_all(root);
     std::filesystem::create_directories(root / "content");
     {
@@ -508,7 +509,6 @@ TEST_CASE("load_validation_constants: explicit app_dir takes precedence over CWD
     CHECK(vc.lead_beats_max == 8);
     CHECK(vc.min_shape_change_gap == 4);
 
-    std::filesystem::remove_all(root);
 }
 
 TEST_CASE("load_validation_constants: bad app_dir falls back to CWD path", "[validate][constants]") {

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -12,11 +12,12 @@
 #include "systems/play_session.h"
 #include "test_helpers.h"
 #include "systems/high_score_system.h"
+#include "temp_paths.h"
 
 namespace {
 
 std::filesystem::path temp_high_score_path(const char* name) {
-    return std::filesystem::temp_directory_path() / name;
+    return test_paths::unique_temp_path(name);
 }
 
 void remove_path(const std::filesystem::path& path) {
@@ -26,17 +27,15 @@ void remove_path(const std::filesystem::path& path) {
 
 struct TempBeatMapFile {
     explicit TempBeatMapFile(const char* name, const std::string& json)
-        : path(std::filesystem::temp_directory_path() / name) {
+        : scoped_path(test_paths::unique_temp_path(name)),
+          path(scoped_path.path) {
         std::filesystem::remove(path);
         std::ofstream out(path);
         REQUIRE(out.good());
         out << json;
     }
 
-    ~TempBeatMapFile() {
-        std::filesystem::remove(path);
-    }
-
+    test_paths::ScopedPath scoped_path;
     std::filesystem::path path;
 };
 
@@ -296,7 +295,9 @@ TEST_CASE("High score integration: missing active entry does not report new best
 
 TEST_CASE("High score integration: failed save keeps dirty state for retry",
           "[high_score][gamestate]") {
-    const auto root = std::filesystem::path("test_high_score_retry_state");
+    test_paths::ScopedPath scoped_root{
+        test_paths::unique_relative_path("test_high_score_retry_state")};
+    const auto& root = scoped_root.path;
     const auto blocked_parent = root / "blocked_parent";
     const auto blocked_file = blocked_parent / "high_scores.json";
     remove_path(root);

--- a/tests/test_high_score_persistence.cpp
+++ b/tests/test_high_score_persistence.cpp
@@ -9,11 +9,12 @@
 #include "components/high_score.h"
 #include "util/level_content_config.h"
 #include "systems/high_score_system.h"
+#include "temp_paths.h"
 
 namespace {
 
 std::filesystem::path temp_high_score_path(const char* name) {
-    return std::filesystem::temp_directory_path() / name;
+    return test_paths::unique_temp_path(name);
 }
 
 void remove_path(const std::filesystem::path& path) {
@@ -154,7 +155,9 @@ TEST_CASE("High score persistence: round-trips score map", "[high_score]") {
 }
 
 TEST_CASE("High score persistence: supports current-directory files", "[high_score]") {
-    const auto file = std::filesystem::path("high_scores_current_dir_tmp.json");
+    test_paths::ScopedPath scoped_file{
+        test_paths::unique_relative_path("high_scores_current_dir_tmp.json")};
+    const auto& file = scoped_file.path;
     remove_path(file);
 
     entt::registry original;
@@ -166,7 +169,6 @@ TEST_CASE("High score persistence: supports current-directory files", "[high_sco
     REQUIRE(high_score::load_high_scores(loaded, file).ok());
     CHECK(high_score::get_score(loaded, "song_001|easy") == 2000);
 
-    remove_path(file);
 }
 
 TEST_CASE("High score persistence: missing file returns false and preserves state", "[high_score]") {
@@ -302,7 +304,9 @@ TEST_CASE("High score persistence: load does not touch session key", "[high_scor
 }
 
 TEST_CASE("High score persistence: save reports unwritable parent path", "[high_score]") {
-    const auto root = std::filesystem::path("test_high_score_unwritable_parent");
+    test_paths::ScopedPath scoped_root{
+        test_paths::unique_relative_path("test_high_score_unwritable_parent")};
+    const auto& root = scoped_root.path;
     const auto not_a_dir = root / "not_a_directory";
     const auto file = not_a_dir / "high_scores.json";
 
@@ -319,12 +323,13 @@ TEST_CASE("High score persistence: save reports unwritable parent path", "[high_
     const auto result = high_score::save_high_scores(reg, file);
     CHECK(result.status == persistence::Status::DirectoryCreateFailed);
 
-    remove_path(root);
 }
 
 TEST_CASE("High score persistence: save creates nested parent directories",
           "[high_score][persistence][issue-1025]") {
-    const auto root = std::filesystem::path("test_high_score_nested_parent");
+    test_paths::ScopedPath scoped_root{
+        test_paths::unique_relative_path("test_high_score_nested_parent")};
+    const auto& root = scoped_root.path;
     const auto file = root / "missing" / "parent" / "high_scores.json";
     remove_path(root);
 
@@ -337,11 +342,12 @@ TEST_CASE("High score persistence: save creates nested parent directories",
     REQUIRE(high_score::load_high_scores(loaded, file).ok());
     CHECK(high_score::get_score(loaded, "song_001|easy") == 1000);
 
-    remove_path(root);
 }
 
 TEST_CASE("High score helper: file path resolution reports failure without CWD fallback", "[high_score]") {
-    const auto root = std::filesystem::path("test_high_score_path_resolution_failure");
+    test_paths::ScopedPath scoped_root{
+        test_paths::unique_relative_path("test_high_score_path_resolution_failure")};
+    const auto& root = scoped_root.path;
     const auto blocked_root = root / "blocked_root";
     remove_path(root);
     std::filesystem::create_directories(root);
@@ -351,10 +357,10 @@ TEST_CASE("High score helper: file path resolution reports failure without CWD f
         out << "file blocks directory creation";
     }
 
-    std::filesystem::path file_path = "seed_should_clear.json";
+    std::filesystem::path file_path =
+        test_paths::unique_relative_path("seed_should_clear.json");
     const auto result = high_score::get_high_scores_file_path(file_path, blocked_root);
     CHECK(result.status == persistence::Status::DirectoryCreateFailed);
     CHECK(file_path.empty());
 
-    remove_path(root);
 }

--- a/tests/test_settings_persistence.cpp
+++ b/tests/test_settings_persistence.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include "temp_paths.h"
 
 using Catch::Matchers::WithinAbs;
 
@@ -177,7 +178,9 @@ TEST_CASE("Settings persistence: settings_from_json rejects malformed field type
 }
 
 TEST_CASE("Settings persistence: round-trip save and load", "[settings]") {
-    std::filesystem::path test_dir = "test_settings_tmp";
+    test_paths::ScopedPath scoped_dir{
+        test_paths::unique_relative_path("test_settings_tmp")};
+    const std::filesystem::path& test_dir = scoped_dir.path;
     std::filesystem::path test_file = test_dir / "settings.json";
 
     std::filesystem::create_directories(test_dir);
@@ -202,12 +205,12 @@ TEST_CASE("Settings persistence: round-trip save and load", "[settings]") {
     CHECK(loaded.reduce_motion == true);
     CHECK(loaded.ftue_run_count == 1);
 
-    // Cleanup
-    std::filesystem::remove_all(test_dir);
 }
 
 TEST_CASE("Settings persistence: save_settings supports current-directory files", "[settings]") {
-    std::filesystem::path test_file = "settings_current_dir_tmp.json";
+    test_paths::ScopedPath scoped_file{
+        test_paths::unique_relative_path("settings_current_dir_tmp.json")};
+    const std::filesystem::path& test_file = scoped_file.path;
     std::filesystem::remove(test_file);
 
     SettingsState state;
@@ -220,11 +223,11 @@ TEST_CASE("Settings persistence: save_settings supports current-directory files"
     CHECK(settings::load_settings(loaded, test_file).ok());
     CHECK(loaded.audio_offset_ms == 20);
 
-    std::filesystem::remove(test_file);
 }
 
 TEST_CASE("Settings persistence: load_settings returns false for missing file", "[settings]") {
-    std::filesystem::path nonexistent = "nonexistent_file_xyz.json";
+    const std::filesystem::path nonexistent =
+        test_paths::unique_relative_path("nonexistent_file_xyz.json");
     SettingsState state;
 
     const auto result = settings::load_settings(state, nonexistent);
@@ -232,7 +235,9 @@ TEST_CASE("Settings persistence: load_settings returns false for missing file", 
 }
 
 TEST_CASE("Settings persistence: load_settings handles malformed JSON", "[settings]") {
-    std::filesystem::path test_dir = "test_settings_tmp";
+    test_paths::ScopedPath scoped_dir{
+        test_paths::unique_relative_path("test_settings_tmp")};
+    const std::filesystem::path& test_dir = scoped_dir.path;
     std::filesystem::path test_file = test_dir / "bad_settings.json";
 
     std::filesystem::create_directories(test_dir);
@@ -246,12 +251,12 @@ TEST_CASE("Settings persistence: load_settings handles malformed JSON", "[settin
     const auto result = settings::load_settings(state, test_file);
     CHECK(result.status == persistence::Status::CorruptData);
 
-    // Cleanup
-    std::filesystem::remove_all(test_dir);
 }
 
 TEST_CASE("Settings persistence: save_settings reports unwritable parent path", "[settings]") {
-    std::filesystem::path root = "test_settings_unwritable_parent";
+    test_paths::ScopedPath scoped_root{
+        test_paths::unique_relative_path("test_settings_unwritable_parent")};
+    const std::filesystem::path& root = scoped_root.path;
     std::filesystem::path not_a_dir = root / "not_a_directory";
     std::filesystem::path target = not_a_dir / "settings.json";
 
@@ -267,11 +272,12 @@ TEST_CASE("Settings persistence: save_settings reports unwritable parent path", 
     const auto result = settings::save_settings(state, target);
     CHECK(result.status == persistence::Status::DirectoryCreateFailed);
 
-    std::filesystem::remove_all(root);
 }
 
 TEST_CASE("Settings persistence runtime: mark_dirty_and_save persists and clears dirty", "[settings][issue-303]") {
-    const std::filesystem::path root = "test_settings_runtime_save";
+    test_paths::ScopedPath scoped_root{
+        test_paths::unique_relative_path("test_settings_runtime_save")};
+    const std::filesystem::path& root = scoped_root.path;
     const std::filesystem::path file = root / "settings.json";
     std::filesystem::remove_all(root);
 
@@ -298,7 +304,6 @@ TEST_CASE("Settings persistence runtime: mark_dirty_and_save persists and clears
     CHECK(loaded.reduce_motion == state.reduce_motion);
     CHECK(loaded.ftue_run_count == state.ftue_run_count);
 
-    std::filesystem::remove_all(root);
 }
 
 TEST_CASE("Settings persistence runtime: mark_dirty_and_save keeps dirty when path unavailable",
@@ -315,16 +320,19 @@ TEST_CASE("Settings persistence runtime: mark_dirty_and_save keeps dirty when pa
 
 TEST_CASE("Persistence paths: one shared policy resolves both settings and high-score files", "[settings]") {
     persistence::Paths paths;
-    const auto result = persistence::resolve_paths(paths, "test_persistence_policy_root");
+    test_paths::ScopedPath scoped_root{
+        test_paths::unique_relative_path("test_persistence_policy_root")};
+    const auto result = persistence::resolve_paths(paths, scoped_root.path);
     REQUIRE(result.ok());
     CHECK(paths.settings_file == paths.root_dir / "settings.json");
     CHECK(paths.high_scores_file == paths.root_dir / "high_scores.json");
-    std::filesystem::remove_all(paths.root_dir);
 }
 
 TEST_CASE("Persistence paths: nested root override creates parent directories recursively",
           "[settings][persistence][issue-1025]") {
-    const auto root = std::filesystem::path("test_persistence_policy_nested_root");
+    test_paths::ScopedPath scoped_root{
+        test_paths::unique_relative_path("test_persistence_policy_nested_root")};
+    const std::filesystem::path& root = scoped_root.path;
     const auto nested_root = root / "missing" / "parent" / "shapeshifter";
     std::filesystem::remove_all(root);
 
@@ -335,11 +343,11 @@ TEST_CASE("Persistence paths: nested root override creates parent directories re
     CHECK(paths.settings_file == nested_root / "settings.json");
     CHECK(paths.high_scores_file == nested_root / "high_scores.json");
 
-    std::filesystem::remove_all(root);
 }
 
 TEST_CASE("Persistence sync seams skip paths outside the web persistence root", "[settings]") {
-    const std::filesystem::path current_dir_file = "settings_current_dir_tmp.json";
+    const std::filesystem::path current_dir_file =
+        test_paths::unique_relative_path("settings_current_dir_tmp.json");
     CHECK(persistence::prepare_for_persistence_read(current_dir_file).ok());
     CHECK(persistence::flush_persistence_writes(current_dir_file).ok());
 }
@@ -377,7 +385,9 @@ TEST_CASE("Web persistence initialization failures remain retryable",
 }
 
 TEST_CASE("Settings persistence helper: file path resolution reports failure without CWD fallback", "[settings]") {
-    const auto root = std::filesystem::path("test_settings_path_resolution_failure");
+    test_paths::ScopedPath scoped_root{
+        test_paths::unique_relative_path("test_settings_path_resolution_failure")};
+    const auto& root = scoped_root.path;
     const auto blocked_root = root / "blocked_root";
     std::filesystem::remove_all(root);
     std::filesystem::create_directories(root);
@@ -387,16 +397,18 @@ TEST_CASE("Settings persistence helper: file path resolution reports failure wit
         out << "file blocks directory creation";
     }
 
-    std::filesystem::path file_path = "seed_should_clear.json";
+    std::filesystem::path file_path =
+        test_paths::unique_relative_path("seed_should_clear.json");
     const auto result = settings::get_settings_file_path(file_path, blocked_root);
     CHECK(result.status == persistence::Status::DirectoryCreateFailed);
     CHECK(file_path.empty());
 
-    std::filesystem::remove_all(root);
 }
 
 TEST_CASE("Persistence paths: directory creation failure is observable", "[settings]") {
-    const auto root = std::filesystem::path("test_persistence_policy_failure");
+    test_paths::ScopedPath scoped_root{
+        test_paths::unique_relative_path("test_persistence_policy_failure")};
+    const auto& root = scoped_root.path;
     const auto blocked_root = root / "blocked_root";
     std::filesystem::remove_all(root);
     std::filesystem::create_directories(root);
@@ -410,12 +422,13 @@ TEST_CASE("Persistence paths: directory creation failure is observable", "[setti
     const auto result = persistence::resolve_paths(paths, blocked_root);
     CHECK(result.status == persistence::Status::DirectoryCreateFailed);
 
-    std::filesystem::remove_all(root);
 }
 
 TEST_CASE("Settings persistence: save_settings creates nested parent directories",
           "[settings][persistence][issue-1025]") {
-    const auto root = std::filesystem::path("test_settings_nested_parent");
+    test_paths::ScopedPath scoped_root{
+        test_paths::unique_relative_path("test_settings_nested_parent")};
+    const auto& root = scoped_root.path;
     const auto file = root / "missing" / "parent" / "settings.json";
     std::filesystem::remove_all(root);
 
@@ -428,5 +441,4 @@ TEST_CASE("Settings persistence: save_settings creates nested parent directories
     REQUIRE(settings::load_settings(loaded, file).ok());
     CHECK(loaded.audio_offset_ms == state.audio_offset_ms);
 
-    std::filesystem::remove_all(root);
 }


### PR DESCRIPTION
## Summary
- Add a small test path helper for unique per-process temp and relative paths.
- Move settings, beatmap, and high-score test artifacts off fixed shared filenames.
- Prevent default CTRF output from single-test discovered CTest runs unless an explicit report env path is set, while preserving the full-suite report path.

Fixes #1695

## Verification
- `git diff --check`
- `cmake --build build --target shapeshifter_tests -- -j2`
- `ctest --test-dir build --output-on-failure -j8 -R "Settings|High score|load_and_validate|load_validation_constants"`
- `./build/shapeshifter_tests "~[bench]"`