### PR TITLE
fix: reject truncated high score keys

### DIFF
--- a/app/components/high_score.h
+++ b/app/components/high_score.h
@@ -17,7 +17,7 @@
 // runtime overflow guard in set_score / ensure_entry / high_score_state_from_json.
 struct HighScoreState {
     static constexpr int32_t MAX_ENTRIES = 9;
-    static constexpr int32_t KEY_CAP     = 32; // fits "song_id|difficulty\0"
+    static constexpr int32_t KEY_CAP     = 32; // max stored key bytes including NUL
 };
 
 // Row component: one entity per stored high score. The printable `key` is

--- a/app/systems/high_score_system.cpp
+++ b/app/systems/high_score_system.cpp
@@ -29,15 +29,23 @@ persistence::Result get_high_scores_file_path(
 }
 
 int32_t make_key_str(char* buf, int32_t cap, const char* song_id, const char* difficulty) {
-    if (cap <= 0) {
+    if (buf == nullptr || cap <= 0) {
         return -1;
     }
-    return std::snprintf(buf, static_cast<std::size_t>(cap), "%s|%s", song_id, difficulty);
+    const int32_t written =
+        std::snprintf(buf, static_cast<std::size_t>(cap), "%s|%s", song_id, difficulty);
+    if (written < 0 || written >= cap) {
+        buf[0] = '\0';
+        return -1;
+    }
+    return written;
 }
 
 entt::hashed_string::hash_type make_key_hash(const char* song_id, const char* difficulty) {
     char buf[HighScoreState::KEY_CAP]{};
-    make_key_str(buf, HighScoreState::KEY_CAP, song_id, difficulty);
+    if (make_key_str(buf, HighScoreState::KEY_CAP, song_id, difficulty) < 0) {
+        return 0;
+    }
     // Cast to const char* to select the const_wrapper (runtime) overload of
     // hashed_string::value(), not the consteval array-literal overload.
     return entt::hashed_string::value(static_cast<const char*>(buf));
@@ -49,6 +57,9 @@ namespace {
 // matching row. The table caps at MAX_ENTRIES (9), so O(N) per lookup is
 // the dense-flat-array equivalent of the prior inline `std::array` scan.
 entt::entity find_entry_by_key(const entt::registry& reg, const char* key) {
+    if (key == nullptr || std::strlen(key) >= HighScoreState::KEY_CAP) {
+        return entt::null;
+    }
     auto view = reg.view<HighScoreEntry>();
     for (auto entity : view) {
         const auto& entry = view.get<HighScoreEntry>(entity);
@@ -69,10 +80,13 @@ entt::entity find_entry_by_hash(const entt::registry& reg, entt::hashed_string::
     return entt::null;
 }
 
-void write_key(HighScoreEntry& entry, const char* key) {
-    std::strncpy(entry.key, key, HighScoreState::KEY_CAP - 1);
-    entry.key[HighScoreState::KEY_CAP - 1] = '\0';
+bool write_key(HighScoreEntry& entry, const char* key) {
+    if (key == nullptr || std::strlen(key) >= HighScoreState::KEY_CAP) {
+        return false;
+    }
+    std::strncpy(entry.key, key, HighScoreState::KEY_CAP);
     entry.key_hash = entt::hashed_string::value(static_cast<const char*>(entry.key));
+    return true;
 }
 
 }  // namespace
@@ -94,6 +108,11 @@ int32_t get_score_by_hash(const entt::registry& reg, entt::hashed_string::hash_t
 }
 
 bool set_score(entt::registry& reg, const char* key, int32_t score) {
+    if (key == nullptr || std::strlen(key) >= HighScoreState::KEY_CAP) {
+        TraceLog(LOG_WARNING, "High score key too long; dropping score for key '%s'",
+                 key == nullptr ? "<null>" : key);
+        return false;
+    }
     if (const auto existing = find_entry_by_key(reg, key); existing != entt::null) {
         reg.get<HighScoreEntry>(existing).score = score;
         return true;
@@ -110,6 +129,11 @@ bool set_score(entt::registry& reg, const char* key, int32_t score) {
 }
 
 bool ensure_entry(entt::registry& reg, const char* key) {
+    if (key == nullptr || std::strlen(key) >= HighScoreState::KEY_CAP) {
+        TraceLog(LOG_WARNING, "High score key too long; cannot create entry for key '%s'",
+                 key == nullptr ? "<null>" : key);
+        return false;
+    }
     if (find_entry_by_key(reg, key) != entt::null) return true;
     if (entry_count(reg) < HighScoreState::MAX_ENTRIES) {
         const auto entity = reg.create();
@@ -189,7 +213,9 @@ bool high_score_state_from_json(const nlohmann::json& obj, entt::registry& reg) 
             }
 
             HighScoreEntry entry{};
-            write_key(entry, key.c_str());
+            if (!write_key(entry, key.c_str())) {
+                return false;
+            }
             entry.score = static_cast<std::int32_t>(raw);
             staged.push_back(entry);
         }

--- a/app/systems/high_score_system.h
+++ b/app/systems/high_score_system.h
@@ -26,7 +26,8 @@ persistence::Result get_high_scores_file_path(
 bool update_if_higher(entt::registry& reg, const HighScoreSession& session, int32_t new_score);
 
 // Build "song_id|difficulty" into caller-supplied buf (no heap allocation).
-// Returns snprintf-style char count (excluding NUL), or -1 if cap is invalid.
+// Returns snprintf-style char count (excluding NUL), or -1 if cap is invalid
+// or the key would not fit in the supplied buffer.
 // cap should be HighScoreState::KEY_CAP.
 int32_t make_key_str(char* buf, int32_t cap, const char* song_id, const char* difficulty);
 

--- a/app/systems/play_session.cpp
+++ b/app/systems/play_session.cpp
@@ -212,12 +212,20 @@ void setup_play_session(entt::registry& reg) {
             stem.erase(stem.size() - BEATMAP_SUFFIX.size());
         }
         char key_buf[HighScoreState::KEY_CAP]{};
-        high_score::make_key_str(key_buf, HighScoreState::KEY_CAP,
-                                 stem.c_str(), beatmap.difficulty.c_str());
+        const int32_t key_len = high_score::make_key_str(
+            key_buf, HighScoreState::KEY_CAP, stem.c_str(), beatmap.difficulty.c_str());
         if (auto* session = reg.ctx().find<HighScoreSession>()) {
-            session->key_hash = entt::hashed_string::value(static_cast<const char*>(key_buf));
+            session->key_hash = key_len >= 0
+                ? entt::hashed_string::value(static_cast<const char*>(key_buf))
+                : 0;
         }
-        high_score::ensure_entry(reg, key_buf);
+        if (key_len >= 0) {
+            high_score::ensure_entry(reg, key_buf);
+        } else {
+            TraceLog(LOG_WARNING,
+                     "High score key too long for song '%s' difficulty '%s'; high score disabled for session",
+                     stem.c_str(), beatmap.difficulty.c_str());
+        }
     }
 
     // Init song state

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -183,6 +183,36 @@ TEST_CASE("Play session: high score key uses loaded fallback difficulty",
     CHECK(reg.ctx().get<CurrentSongHighScore>().value == 4321);
 }
 
+TEST_CASE("Play session: overlong high-score key disables session score entry",
+          "[play_session][high_score][issue1694]") {
+    const TempBeatMapFile beatmap("song_identifier_that_exceeds_key_capacity_beatmap.json", R"json({
+        "song_id": "long_key",
+        "title": "Long Key",
+        "bpm": 120,
+        "offset": 0,
+        "lead_beats": 4,
+        "duration_sec": 8,
+        "difficulties": {
+           "medium": {
+               "beats": [
+                   {"beat": 4, "kind": "shape_gate", "shape": "circle", "lane": 1}
+               ]
+           }
+        }
+    })json");
+
+    ScopedTraceLogSilencer silence_warning;
+    auto reg = make_registry();
+    reg.ctx().emplace<PlaySessionContentOverride>(
+        PlaySessionContentOverride{beatmap.path.string(), "medium"});
+
+    setup_play_session(reg);
+
+    CHECK(reg.ctx().get<HighScoreSession>().key_hash == 0);
+    CHECK(reg.ctx().get<CurrentSongHighScore>().value == 0);
+    CHECK(high_score::entry_count(reg) == 0);
+}
+
 TEST_CASE("Play session: SongResults total_notes excludes onset marker metadata",
           "[play_session][song_results][issue-773]") {
     bool saw_onset_marker = false;

--- a/tests/test_high_score_persistence.cpp
+++ b/tests/test_high_score_persistence.cpp
@@ -44,11 +44,22 @@ TEST_CASE("High score: make_key_str rejects invalid capacity", "[high_score]") {
     char buf[HighScoreState::KEY_CAP]{};
     buf[0] = 'x';
 
+    CHECK(high_score::make_key_str(nullptr, HighScoreState::KEY_CAP, "song_001", "easy") == -1);
     CHECK(high_score::make_key_str(buf, 0, "song_001", "easy") == -1);
     CHECK(buf[0] == 'x');
 
     CHECK(high_score::make_key_str(buf, -1, "song_001", "easy") == -1);
     CHECK(buf[0] == 'x');
+}
+
+TEST_CASE("High score: make_key_str rejects truncated keys", "[high_score][issue1694]") {
+    char buf[HighScoreState::KEY_CAP]{};
+    buf[0] = 'x';
+
+    CHECK(high_score::make_key_str(buf, HighScoreState::KEY_CAP,
+                                   "song_id_that_is_far_too_long", "hard") == -1);
+    CHECK(buf[0] == '\0');
+    CHECK(high_score::make_key_hash("song_id_that_is_far_too_long", "hard") == 0);
 }
 
 TEST_CASE("High score: no hash collisions across all 9 shipped song+difficulty keys", "[high_score]") {
@@ -153,6 +164,14 @@ TEST_CASE("High score persistence: round-trips score map", "[high_score]") {
     remove_path(dir);
 }
 
+TEST_CASE("High score persistence: rejects overlong keys without truncating", "[high_score][issue1694]") {
+    entt::registry reg;
+    CHECK_FALSE(high_score::set_score(reg, "song_id_that_is_far_too_long|hard", 1000));
+    CHECK_FALSE(high_score::ensure_entry(reg, "song_id_that_is_far_too_long|hard"));
+    CHECK(high_score::entry_count(reg) == 0);
+    CHECK(high_score::get_score(reg, "song_id_that_is_far_too_long|hard") == 0);
+}
+
 TEST_CASE("High score persistence: supports current-directory files", "[high_score]") {
     const auto file = std::filesystem::path("high_scores_current_dir_tmp.json");
     remove_path(file);
@@ -226,6 +245,27 @@ TEST_CASE("High score persistence: invalid schema preserves state", "[high_score
 
     CHECK(high_score::load_high_scores(reg, file).status == persistence::Status::CorruptData);
     CHECK(high_score::get_score(reg, "song_001|easy") == 500);
+
+    remove_path(dir);
+}
+
+TEST_CASE("High score persistence: overlong JSON key is corrupt", "[high_score][issue1694]") {
+    const auto dir = temp_high_score_path("shapeshifter_high_score_overlong_key");
+    const auto file = dir / "overlong_key.json";
+    remove_path(dir);
+    std::filesystem::create_directories(dir);
+
+    {
+        std::ofstream out(file);
+        out << R"({"scores":{"song_id_that_is_far_too_long|hard":1234}})";
+    }
+
+    entt::registry reg;
+    REQUIRE(high_score::set_score(reg, "song_001|easy", 500));
+
+    CHECK(high_score::load_high_scores(reg, file).status == persistence::Status::CorruptData);
+    CHECK(high_score::get_score(reg, "song_001|easy") == 500);
+    CHECK(high_score::entry_count(reg) == 1);
 
     remove_path(dir);
 }


### PR DESCRIPTION
## Summary
- Make high-score key building fail when `song_id|difficulty` would exceed the fixed key buffer instead of silently truncating.
- Reject overlong runtime and JSON high-score keys without mutating existing score rows.
- Skip session high-score setup with a warning when the active beatmap key is too long.

Fixes #1694

## Verification
- `git diff --check`
- `cmake --build build -- -j2`
- `./build/shapeshifter_tests "~[bench]"`
- `./build/shapeshifter_tests "[high_score]" "~[bench]"`