### PR TITLE
Fix pause and FTUE docs drift

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -909,8 +909,9 @@ the request via `is_phase_transition_pending(reg)`, clears stale pointer
 state, and then enters the requested phase. `enter_phase<PhaseTag>(reg)`
 swaps the active `GamePhase*Tag` and resets `GameState::phase_timer`.
 
-`Tutorial` is a defined phase tag with a screen, but current shipped screens do
-not route into it. Its continue action transitions to `Playing`.
+`Tutorial` is a defined phase tag with a screen. Level Select routes into it
+when FTUE is incomplete; its continue action marks FTUE complete, persists
+settings, and transitions to `Playing`.
 
 ### Transition Summary
 
@@ -918,16 +919,17 @@ not route into it. Its continue action transitions to `Playing`.
 |------|----|-----------------|-------|
 | Title | LevelSelect | Title screen body/start action | Defers through `request_phase_transition<NextPhaseLevelSelectTag>`. |
 | Title | Settings | Title screen gear action | Settings exits back to Title. |
-| LevelSelect | Playing | `LevelSelectState::confirmed` | `setup_play_session` loads the selected level/difficulty. |
+| LevelSelect | Tutorial | `LevelSelectConfirmedTag` when FTUE is incomplete | First-time route before gameplay. |
+| LevelSelect | Playing | `LevelSelectConfirmedTag` when FTUE is complete | `setup_play_session` loads the selected level/difficulty. |
 | Playing | Paused | HUD pause, keyboard pause, or app background | Gameplay entities remain intact. |
 | Paused | Playing | Resume action | Resumes without rebuilding the play session. |
-| Paused | Title | Quit action | Leaves the run and returns to menu UI. |
+| Paused | Title | Main-menu action | Leaves the run and returns to menu UI. |
 | Playing | GameOver | Energy reaches zero | `game_state_enter_terminal_phase` captures results/cause. |
 | Playing | SongComplete | Song finished and obstacles cleared | Uses the same terminal result path as GameOver. |
 | GameOver/SongComplete | Playing | Restart action | Starts a fresh play session. |
-| GameOver/SongComplete | LevelSelect | Level-select action | Clears `LevelSelectState::confirmed` on entry. |
+| GameOver/SongComplete | LevelSelect | Level-select action | Clears `LevelSelectConfirmedTag` on entry. |
 | GameOver/SongComplete | Title | Main-menu action | Returns to the title screen. |
-| Tutorial | Playing | Tutorial continue action | Phase exists, but no shipped controller currently routes into Tutorial. |
+| Tutorial | Playing | Tutorial continue action | Marks FTUE complete and starts gameplay. |
 
 ### Terminal Phases
 

--- a/design-docs/beatmap-integration.md
+++ b/design-docs/beatmap-integration.md
@@ -228,6 +228,9 @@ creates the standard runtime obstacle archetypes via the kind-specific
   │  ✅ energy_bar_system          (HUD bar visual update)          │
   │  ✅ particle_system            (ParticleData timer → cull)      │
   │                                                                  │
+  │  Level select confirmation routes first-time players through     │
+  │  GamePhaseTutorialTag; FTUE-complete players enter Playing.      │
+  │                                                                  │
   │  PLAYING TICK (tick_playing_systems — playing_systems_runner):   │
   │  ✅ beat_log_system            (per-beat diagnostic log)        │
   │  ✅ beat_scheduler_system      (BeatMap → spawn entities)       │

--- a/design-docs/game-flow.md
+++ b/design-docs/game-flow.md
@@ -92,11 +92,11 @@
                      │          │                ┌─────┴───────┐   │
                      │   ┌──────┴────────┐       │   PAUSED    │   │
                      │   │               │       │  (overlay)  │   │
-                     │   │ on energy=0   │ song  │             │   │
-                     │   │               │ ends  │ [RESUME]    │   │
-                     │   ▼               ▼       │ [RESTART]───┼───┤
-                     │ ┌──────────┐ ┌──────────┐ │ [QUIT] ─────┼───┘
-                     │ │ GAMEOVER │ │   SONG   │ └─────────────┘
+                     │   │ on energy=0   │ song  │ [RESUME]    │   │
+                     │   │               │ ends  │ [MAIN MENU]─┼───┤
+                     │   ▼               ▼       └─────────────┘   │
+                     │ ┌──────────┐ ┌──────────┐                   │
+                     │ │ GAMEOVER │ │   SONG   │
                      │ │  SCREEN  │ │ COMPLETE │
                      │ │          │ │  SCREEN  │
                       │ │ ● score  │ │          │
@@ -199,7 +199,8 @@ After tapping "start" on the title screen, the player is taken to the
 **LevelSelect** screen (active `GamePhaseLevelSelectTag`). This screen
 presents a list of available songs and difficulty options. The layout
 is defined in `content/ui/screens/level_select.rgl`. Confirming a
-selection transitions to `GamePhasePlayingTag`.
+selection transitions to `GamePhaseTutorialTag` when FTUE is incomplete;
+otherwise it transitions directly to `GamePhasePlayingTag`.
 
 ---
 
@@ -428,27 +429,23 @@ Not shipped (intentionally absent from this wireframe):
   ║           ║  PAUSED  ║              ║  ← y = 0.30H
   ║                                      ║
   ║                                      ║
-  ║        ╔══════════════════╗          ║  ← y = 0.42H
-  ║        ║   ▸ RESUME       ║          ║     button: 0.50W × 0.08H
+  ║          TAP RESUME TO CONTINUE      ║
+  ║        ╔══════════════════╗          ║
+  ║        ║     RESUME       ║          ║     button: 400×100 px in .rgl
   ║        ╚══════════════════╝          ║
   ║                                      ║
-  ║        ┌──────────────────┐          ║  ← y = 0.54H
-  ║        │   ↺ RESTART      │          ║     button: 0.50W × 0.08H
-  ║        └──────────────────┘          ║
+  ║          OR RETURN TO MAIN MENU      ║
   ║                                      ║
-  ║        ┌──────────────────┐          ║  ← y = 0.66H
-  ║        │   ✕ QUIT         │          ║     button: 0.50W × 0.08H
+  ║        ┌──────────────────┐          ║
+  ║        │   MAIN MENU      │          ║     button: 400×100 px in .rgl
   ║        └──────────────────┘          ║
   ║                                      ║
   ║                                      ║
   ║                                      ║
   ╚══════════════════════════════════════╝
 
-  RESUME button = bright/highlighted (double-bordered)
-  RESTART, QUIT = dim/secondary (single-bordered)
-
   Trigger: tap ⏸ icon at top-center during gameplay
-  Resume also triggers on: tap anywhere outside buttons
+  Actions: RESUME returns to the paused run; MAIN MENU returns to Title.
 ```
 
 ---
@@ -1740,11 +1737,10 @@ Every player action triggers a multi-sensory response.
   t=0.05s  • Dark overlay fades in from 0% → 60% opacity
   t=0.10s  • "PAUSED" text fades in (from above, 0.15s)
   t=0.15s  • Resume button slides in from left (0.10s)
-  t=0.18s  • Restart button slides in from left (0.10s)
-  t=0.21s  • Quit button slides in from left (0.10s)
+  t=0.18s  • Main Menu button slides in from left (0.10s)
   t=0.25s  • All elements visible, input enabled
 
-  EXIT (tap RESUME or tap outside):
+  EXIT (tap RESUME):
   ══════════════════════════════════
 
   DURATION: 0.15 seconds (faster exit than enter!)
@@ -1765,9 +1761,9 @@ Every player action triggers a multi-sensory response.
   ║ SPD ██████ ×1.8   ║  ║▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓║  ║▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓║
   ║                   ║  ║▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓║  ║▓▓  ║ PAUSED ║  ▓▓║
   ║ ─────┬─────┬────  ║  ║▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓║  ║▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓║
-  ║      │     │      ║  ║▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓║  ║▓▓ [▸ RESUME]   ▓▓║
-  ║      │  ●  │      ║  ║▓▓▓(dimming)▓▓▓▓▓▓║  ║▓▓ [↺ RESTART]  ▓▓║
-  ║      │     │      ║  ║▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓║  ║▓▓ [✕ QUIT]     ▓▓║
+  ║      │     │      ║  ║▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓║  ║▓▓ [ RESUME ]   ▓▓║
+  ║      │  ●  │      ║  ║▓▓▓(dimming)▓▓▓▓▓▓║  ║▓▓              ▓▓║
+  ║      │     │      ║  ║▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓║  ║▓▓ [MAIN MENU]  ▓▓║
   ║ ─────┴─────┴────  ║  ║▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓║  ║▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓║
   ║ ENERGY █████░░░░  ║  ║▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓║  ║▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓║
   ║ [ ● ] [ ■ ] [ ▲ ] ║  ║▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓║  ║▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓║


### PR DESCRIPTION
## Summary\n- Align paused overlay docs with the generated screen: RESUME and MAIN MENU only.\n- Document the Level Select -> Tutorial detour for incomplete FTUE before Playing.\n- Refresh the architecture transition table to use LevelSelectConfirmedTag and shipped Tutorial routing.\n\nCloses #1690\n\n## Validation\n- git diff --check\n- searched docs for stale pause/FTUE wording