### PR TITLE
Fix CLI level select seeding

### DIFF
--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -200,7 +200,8 @@ bool game_loop_init(entt::registry& reg,
     reset_ctx_singleton<ScoreState>(reg);
     reset_ctx_singleton<ScoreDisplay>(reg);
     reset_ctx_singleton<CurrentSongHighScore>(reg);
-    reset_ctx_singleton<LevelSelectState>(reg);
+    reset_ctx_singleton<LevelSelectState>(
+        reg, make_startup_level_select_state(difficulty, selected_level));
     reset_ctx_singleton<EnergyState>(reg);
     reset_ctx_singleton<SongResults>(reg);
     // `TestPlayerState` is no longer pre-emplaced at startup — its presence

--- a/app/game_loop.h
+++ b/app/game_loop.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <entt/entt.hpp>
+#include "components/game_state.h"
 #include "util/level_content_config.h"
 #include "systems/test_player.h"
 
@@ -16,6 +17,16 @@ inline constexpr float kMaxFrameDt = 0.1f;
 // game_loop_frame; exported so tests can pin the contract without raylib init.
 inline constexpr float clamp_frame_dt(float raw_dt) noexcept {
     return raw_dt < kMaxFrameDt ? raw_dt : kMaxFrameDt;
+}
+
+// Build the initial level-select row from startup CLI options. Used before
+// normal play and test-player setup so both entry paths share the same seed.
+[[nodiscard]] inline LevelSelectState make_startup_level_select_state(const char* difficulty,
+                                                                      int selected_level) noexcept {
+    LevelSelectState state{};
+    state.selected_level = content_config::level_index_or_default(selected_level);
+    state.selected_difficulty = content_config::difficulty_index_for_key_or_default(difficulty);
+    return state;
 }
 
 // Initialize platform (window, audio), all game singletons, cameras, meshes, UI.

--- a/app/systems/test_player_session.cpp
+++ b/app/systems/test_player_session.cpp
@@ -9,7 +9,6 @@
 #include <raylib.h>
 #include <ctime>
 #include <cstdio>
-#include <cstring>
 #include <cstdint>
 #include <string>
 
@@ -26,14 +25,7 @@ void test_player_init(entt::registry& reg, SkillConfig skill,
     auto& lss = reg.ctx().get<LevelSelectState>();
     lss.selected_level = content_config::level_index_or_default(selected_level);
 
-    int sel_diff = content_config::DEFAULT_DIFFICULTY_INDEX;
-    for (int d = 0; d < content_config::DIFFICULTY_COUNT; ++d) {
-        if (std::strcmp(content_config::DIFFICULTY_KEYS[d], difficulty) == 0) {
-            sel_diff = d;
-            break;
-        }
-    }
-    lss.selected_difficulty = sel_diff;
+    lss.selected_difficulty = content_config::difficulty_index_for_key_or_default(difficulty);
 
     auto* session_state = reg.ctx().find<TestPlayerSessionState>();
     if (!session_state) {

--- a/app/util/level_content_config.h
+++ b/app/util/level_content_config.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstring>
+
 struct LevelInfo {
     const char* title;
     const char* beatmap_path;
@@ -44,6 +46,18 @@ inline constexpr const char* const DIFFICULTY_KEYS[DIFFICULTY_COUNT] = {
 
 [[nodiscard]] constexpr int difficulty_index_or_default(int index) noexcept {
     return is_valid_difficulty_index(index) ? index : DEFAULT_DIFFICULTY_INDEX;
+}
+
+[[nodiscard]] inline int difficulty_index_for_key_or_default(const char* key) noexcept {
+    if (!key) {
+        return DEFAULT_DIFFICULTY_INDEX;
+    }
+    for (int index = 0; index < DIFFICULTY_COUNT; ++index) {
+        if (std::strcmp(DIFFICULTY_KEYS[index], key) == 0) {
+            return index;
+        }
+    }
+    return DEFAULT_DIFFICULTY_INDEX;
 }
 
 }  // namespace content_config

--- a/tests/test_game_loop_raw_dt_hitch_clamp.cpp
+++ b/tests/test_game_loop_raw_dt_hitch_clamp.cpp
@@ -39,6 +39,22 @@ TEST_CASE("clamp_frame_dt: caps any hitch reading at kMaxFrameDt", "[game_loop][
     CHECK(clamp_frame_dt(5.0f) == kMaxFrameDt);
 }
 
+TEST_CASE("startup level select state applies CLI level and difficulty",
+          "[game_loop][issue-1701]") {
+    const LevelSelectState state = make_startup_level_select_state("hard", 2);
+
+    CHECK(state.selected_level == 2);
+    CHECK(state.selected_difficulty == 2);
+}
+
+TEST_CASE("startup level select state falls back for invalid CLI values",
+          "[game_loop][issue-1701]") {
+    const LevelSelectState state = make_startup_level_select_state("unknown", -1);
+
+    CHECK(state.selected_level == content_config::DEFAULT_LEVEL_INDEX);
+    CHECK(state.selected_difficulty == content_config::DEFAULT_DIFFICULTY_INDEX);
+}
+
 TEST_CASE("test_player_system: action timers advance by at most kMaxFrameDt under a hitch",
           "[test_player][game_loop][issue-1352]") {
     auto reg = make_rhythm_registry();


### PR DESCRIPTION
## Summary
- Fixes #1701.
- Seeds `LevelSelectState` from parsed `--level` / `--difficulty` options during normal game-loop initialization.
- Shares difficulty-key normalization with test-player setup and adds regression coverage for startup selection defaults.

## Verification
- `cmake --build build --parallel`
- `./build/shapeshifter_tests "[game_loop][issue-1701]"`
- `ctest --test-dir build --output-on-failure`
