### PR TITLE
Stop skipped startup smoke runs in macOS and Windows CI

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -104,7 +104,8 @@ jobs:
             | sort -u > build/ci/catch-nonbench.txt
           diff -u build/ci/ctest-nonbench-catch.txt build/ci/catch-nonbench.txt
           ./build/shapeshifter_tests "~[bench]"
-          ctest --test-dir build --output-on-failure -R "^startup_shutdown_smoke$"
+          # startup_shutdown_smoke requires a reliable OpenGL window context;
+          # Linux CI runs it under Xvfb for native lifecycle coverage.
           ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|validate_required_cross_lane_jump_time|check_shape_change_gap|check_enum_allowlist|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
 
       - name: Upload artifact

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -99,7 +99,8 @@ jobs:
             | sort -u > build/ci/catch-nonbench.txt
           diff -u build/ci/ctest-nonbench-catch.txt build/ci/catch-nonbench.txt
           ./build/shapeshifter_tests.exe "~[bench]"
-          ctest --test-dir build --output-on-failure -R "^startup_shutdown_smoke$"
+          # startup_shutdown_smoke requires a reliable OpenGL window context;
+          # Linux CI runs it under Xvfb for native lifecycle coverage.
           ctest --test-dir build --output-on-failure -R "^(python_tool_tests|loop2_content_gates_strict|validate_loop1_diagnostics|validate_difficulty_ramp|validate_offset_semantics|validate_max_beat_gap|validate_no_simultaneous_shape_gates|validate_required_cross_lane_jump_time|check_shape_change_gap|check_enum_allowlist|beatmap_editor_node_tests|service_worker_cache_policy_node_tests)$"
         shell: bash
 


### PR DESCRIPTION
## Summary\n- remove startup_shutdown_smoke invocations from macOS and Windows CI where the smoke can only skip\n- document Linux/Xvfb as the native startup/shutdown smoke coverage lane\n\nFixes #1703\n\n## Validation\n- git diff --check\n- cmake --build build\n- ./build/shapeshifter_tests "~[bench]"