### PR TITLE
Fix LaneTransition target sentinel drift

### DIFF
--- a/app/components/player.h
+++ b/app/components/player.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <array>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <string_view>
+#include "constants.h"
 #include "tags/tags.h"
 
 enum class Shape : uint8_t {
@@ -93,8 +95,14 @@ struct Lane {
 // world x-position; `test_player_system` reads `target` to compute the
 // player's effective lane during action planning.
 struct LaneTransition {
-    int8_t target = -1;
-    float  lerp_t = 0.0f;
+    LaneTransition() = delete;
+    explicit LaneTransition(int8_t target_lane, float transition_t = 0.0f)
+        : target(target_lane), lerp_t(transition_t) {
+        assert(constants::is_valid_lane(target_lane));
+    }
+
+    int8_t target;
+    float  lerp_t;
 };
 
 // ── Vertical motion state (per-state component tables) ──────

--- a/app/systems/player_movement_system.cpp
+++ b/app/systems/player_movement_system.cpp
@@ -8,6 +8,7 @@
 #include "../constants.h"
 #include "../util/lane_utils.h"
 #include <raymath.h>
+#include <cassert>
 
 void player_movement_system(entt::registry& reg, float dt) {
     auto* song = reg.ctx().find<SongState>();
@@ -35,7 +36,8 @@ void player_movement_system(entt::registry& reg, float dt) {
             transform.position.x = constants::LANE_X[lane.current];
             transition = nullptr;
         }
-        if (transition && lane_utils::is_valid(transition->target)) {
+        if (transition) {
+            assert(lane_utils::is_valid(transition->target));
             transition->lerp_t += dt * constants::LANE_SWITCH_SPEED;
             const float from_x = constants::LANE_X[lane.current];
             const float to_x   = constants::LANE_X[transition->target];

--- a/app/util/lane_utils.h
+++ b/app/util/lane_utils.h
@@ -40,15 +40,13 @@ inline int8_t nearest_lane_for_x(float x) {
     return nearest_lane;
 }
 
-// Validates the player's lane row + any in-flight `LaneTransition` row
-// (issue #1533): an invalid `current` snaps back to the default lane and
-// cancels the transition; an invalid `LaneTransition::target` cancels the
-// transition. Returns true if anything was repaired.
+// Validates the player's lane row (issue #1533): an invalid `current` snaps
+// back to the default lane and cancels any in-flight transition. Transition
+// targets are guaranteed by `LaneTransition` construction.
 inline bool normalize(entt::registry& reg,
                       entt::entity entity,
                       Lane& lane,
                       WorldPosition* transform = nullptr) {
-    bool repaired = false;
     if (!is_valid(lane.current)) {
         lane.current = kDefaultLane;
         if (reg.all_of<LaneTransition>(entity)) {
@@ -60,16 +58,7 @@ inline bool normalize(entt::registry& reg,
         return true;
     }
 
-    if (auto* transition = reg.try_get<LaneTransition>(entity);
-        transition && !is_valid(transition->target)) {
-        reg.remove<LaneTransition>(entity);
-        if (transform) {
-            snap_to_current_lane(lane, *transform);
-        }
-        repaired = true;
-    }
-
-    return repaired;
+    return false;
 }
 
 }  // namespace lane_utils

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -58,13 +58,13 @@ TEST_CASE("components: Lane defaults to center", "[components]") {
     CHECK(l.current == 1);
 }
 
-TEST_CASE("components: LaneTransition defaults to invalid target", "[components]") {
+TEST_CASE("components: LaneTransition requires an explicit target", "[components]") {
     // Presence of `LaneTransition` IS "lane transition in flight" — both
-    // columns are always meaningful while the row exists. The defaulted
-    // `target == -1` only surfaces if a caller emplaces the row without
-    // initializing it; normal writers always set `target` to a valid lane.
-    LaneTransition lt{};
-    CHECK(lt.target == -1);
+    // columns are always meaningful while the row exists, so callers must
+    // provide the destination lane when creating the row.
+    CHECK_FALSE(std::is_default_constructible_v<LaneTransition>);
+    LaneTransition lt{int8_t{2}};
+    CHECK(lt.target == 2);
     CHECK(lt.lerp_t == 0.0f);
 }
 

--- a/tests/test_player_systems.cpp
+++ b/tests/test_player_systems.cpp
@@ -237,21 +237,21 @@ TEST_CASE("player_movement: normalizes invalid current lane", "[player][issue900
     CHECK(transform.position.x == constants::LANE_X[constants::DEFAULT_LANE]);
 }
 
-TEST_CASE("player_movement: normalizes invalid target lane", "[player][issue900]") {
+TEST_CASE("player_movement: lane transition row carries a valid explicit target", "[player][issue900]") {
     auto reg = make_registry();
     auto p = make_player(reg);
     auto& lane = reg.get<Lane>(p);
     auto& transform = reg.get<WorldPosition>(p);
     lane.current = 1;
-    reg.emplace<LaneTransition>(p,
-        LaneTransition{static_cast<int8_t>(constants::LANE_COUNT), 0.0f});
-    transform.position.x = (constants::LANE_X[1] + constants::LANE_X[2]) * 0.5f;
+    reg.emplace<LaneTransition>(p, LaneTransition{2, 0.0f});
+    transform.position.x = constants::LANE_X[1];
 
     player_movement_system(reg, 0.016f);
 
     CHECK(lane.current == 1);
-    CHECK_FALSE(reg.all_of<LaneTransition>(p));
-    CHECK(transform.position.x == constants::LANE_X[1]);
+    REQUIRE(reg.all_of<LaneTransition>(p));
+    CHECK(reg.get<LaneTransition>(p).target == 2);
+    CHECK(transform.position.x > constants::LANE_X[1]);
 }
 
 TEST_CASE("player_movement: jump creates negative y_offset", "[player]") {


### PR DESCRIPTION
## Summary
- require LaneTransition rows to be created with an explicit destination lane
- remove the invalid LaneTransition target repair branch so row presence means a meaningful transition
- update component/player movement tests for the valid-row invariant

Fixes #1700

## Verification
- cmake --build build
- ./build/shapeshifter_tests