### PR TITLE
Fix SongComplete live obstacle gate

### DIFF
--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -180,8 +180,8 @@ void game_state_system(entt::registry& reg, float dt) {
         }
 
         if (song && reg.ctx().contains<SongFinishedTag>()) {
-            // Wait until all obstacle entities have been destroyed.
-            if (reg.view<ObstacleTag>().empty()) {
+            const auto live_obstacles = reg.view<ObstacleTag, Obstacle>();
+            if (live_obstacles.begin() == live_obstacles.end()) {
                 request_phase_transition<NextPhaseSongCompleteTag>(reg);
             }
         }

--- a/tests/test_game_state_extended.cpp
+++ b/tests/test_game_state_extended.cpp
@@ -63,6 +63,7 @@ TEST_CASE("game_state: song complete waits for obstacles to clear", "[gamestate]
     // Create an unscored obstacle
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
+    reg.emplace<Obstacle>(obs, int16_t{200});
     reg.emplace<WorldPosition>(obs, WorldPosition{{0.0f, 0.0f}});
 
     game_state_system(reg, 0.016f);
@@ -96,12 +97,28 @@ TEST_CASE("game_state: song complete waits for scored obstacle to be destroyed",
     // Obstacle scored but still alive (obstacle_despawn_system has not yet destroyed it)
     auto obs = reg.create();
     reg.emplace<ObstacleTag>(obs);
+    reg.emplace<Obstacle>(obs, int16_t{200});
     reg.emplace<ScoredTag>(obs);
     reg.emplace<WorldPosition>(obs, WorldPosition{{0.0f, 0.0f}});
 
     game_state_system(reg, 0.016f);
 
     CHECK_FALSE(is_phase_transition_pending(reg));
+}
+
+TEST_CASE("game_state: song complete ignores visual obstacle leftovers", "[gamestate][regression]") {
+    auto reg = make_rhythm_registry();
+    set_test_phase<GamePhasePlayingTag>(reg);
+    reg.ctx().emplace<SongFinishedTag>();
+    reg.ctx().erase<SongPlayingTag>();
+
+    auto visual_leftover = reg.create();
+    reg.emplace<ObstacleTag>(visual_leftover);
+    reg.emplace<WorldPosition>(visual_leftover, WorldPosition{{0.0f, 0.0f}});
+
+    game_state_system(reg, 0.016f);
+
+    CHECK(reg.ctx().contains<NextPhaseSongCompleteTag>());
 }
 
 TEST_CASE("game_state: enter_song_complete updates high score", "[gamestate]") {

--- a/tests/test_signal_lifecycle_nogated.cpp
+++ b/tests/test_signal_lifecycle_nogated.cpp
@@ -30,6 +30,7 @@ TEST_CASE("game_state: finished song waits for obstacle drain before SongComplet
 
     auto e = reg.create();
     reg.emplace<ObstacleTag>(e);
+    reg.emplace<Obstacle>(e, int16_t{200});
 
     game_state_system(reg, 1.0f / 60.0f);
     CHECK_FALSE(is_phase_transition_pending(reg));


### PR DESCRIPTION
## Summary
- Fixes #1709 by making SongComplete wait only on live gameplay obstacles (`ObstacleTag` + `Obstacle`) instead of tag-only visual leftovers.
- Keeps live-obstacle blocking explicit in tests and adds regression coverage for visual leftovers.

## Validation
- `cmake --build build`
- `./build/shapeshifter_tests`
- `ctest --test-dir build -R check_enum_allowlist --output-on-failure`