### PR TITLE
Docs: clarify shape tag helper boundary

### DIFF
--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -3284,6 +3284,10 @@ Verbatim user input:
 - Tag types are empty marker structs (zero-size, used as `registry.view<...>()` filters or `excludes`).
 - All tag declarations co-locate in `app/tags/tags.h`. Adding a new tag = adding one line to that header.
 - No `app/tags/player_tag.h`, `app/tags/scored_tag.h`, etc. The folder houses one file.
+- Pure helpers that operate on tags but are not tag declarations stay in `app/util/`.
+  Example: `app/util/shape_tag.h` is a dispatch helper for Shape-indexed
+  `emplace/remove/has` table operations; it is exempt because it declares no
+  tags and depends on the non-tag `Shape` type from `app/components/player.h`.
 
 Single-file convention keeps tag inventory discoverable in one place and avoids file-explosion. Tags are conceptually a flat catalog, not a per-domain partition.
 

--- a/app/components/obstacle.h
+++ b/app/components/obstacle.h
@@ -17,9 +17,9 @@ struct Obstacle {
 // eradicated in issue #1202/#1204; the obstacle's required shape lives as
 // one of `RequiredShapeCircleTag` / `RequiredShapeSquareTag` /
 // `RequiredShapeTriangleTag` / `RequiredShapeHexagonTag` on the obstacle
-// entity. Use `set_required_shape_tag()` from `app/util/shape_tag.h` to
-// emplace it, and `current_required_shape()` / `has_required_shape_tag()`
-// to read it back.
+// entity. Use `set_required_shape_tag()` from the non-tag helper
+// `app/util/shape_tag.h` to emplace it, and `current_required_shape()` /
+// `has_required_shape_tag()` to read it back.
 
 // The former `ShapeGateLane { int8_t lane }` and `RequiredLane { int8_t lane }`
 // single-field wrappers were deleted per issue #1198 (companion to the

--- a/app/components/player.h
+++ b/app/components/player.h
@@ -40,8 +40,8 @@ constexpr std::string_view to_string(Shape shape) noexcept {
 // Hot render data — read by game_camera_system, player_movement_system every frame.
 // The player's current shape identity lives as one of `ShapeCircleTag` /
 // `ShapeSquareTag` / `ShapeTriangleTag` / `ShapeHexagonTag` on the player
-// entity (issue #1202/#1204); see `app/util/shape_tag.h` for the helper
-// dispatch and the rationale for the per-tag table mechanic.
+// entity (issue #1202/#1204); see the non-tag helper `app/util/shape_tag.h`
+// for dispatch and the rationale for the per-tag table mechanic.
 struct PlayerShape {
     float morph_t  = 1.0f;
 };

--- a/app/tags/tags.h
+++ b/app/tags/tags.h
@@ -28,8 +28,9 @@ struct WindowGraded {};
 // discriminator, no `if (x == Shape::Bar)` branches.
 //
 // Maintenance invariant: exactly one `Shape*Tag` is present on any player
-// entity. Use `set_player_shape_tag()` in `app/util/shape_tag.h` to keep
-// the invariant; it removes all four tags before emplacing the matching one.
+// entity. Use the non-tag dispatch helper `set_player_shape_tag()` in
+// `app/util/shape_tag.h` to keep the invariant; it removes all four tags before
+// emplacing the matching one.
 struct ShapeCircleTag   {};
 struct ShapeSquareTag   {};
 struct ShapeTriangleTag {};
@@ -66,8 +67,8 @@ struct ObstacleTag {};
 // #1202/#1204). The whole `RequiredShape` struct was a single-column table;
 // per Fabian's relational-database mechanic the column collapses into the
 // tag set itself. Each ShapeGate / SplitPath obstacle carries exactly one
-// `RequiredShape*Tag`; obstacle factories emplace it via
-// `set_required_shape_tag()` in `app/util/shape_tag.h`.
+// `RequiredShape*Tag`; obstacle factories emplace it via the non-tag dispatch
+// helper `set_required_shape_tag()` in `app/util/shape_tag.h`.
 struct RequiredShapeCircleTag   {};
 struct RequiredShapeSquareTag   {};
 struct RequiredShapeTriangleTag {};

--- a/app/util/shape_tag.h
+++ b/app/util/shape_tag.h
@@ -7,12 +7,16 @@
 #include <array>
 #include <entt/entt.hpp>
 
-// Per-shape tag table dispatch (issue #1202/#1204). Replaces the former
-// Shape-typed on-entity fields (`PlayerShape::current`,
+// Non-tag helper for per-shape tag table dispatch (issue #1202/#1204).
+// Replaces the former Shape-typed on-entity fields (`PlayerShape::current`,
 // `ShapeWindow::target_shape`, `RequiredShape::shape`) with per-shape tag
 // presence. Same lookup-table mechanic as `kShapeFlatDrawFns` in PR #1259
 // — function-pointer-per-row, indexed by `shape_index(shape)`, no `switch`
 // on a discriminator.
+//
+// `app/tags/tags.h` remains the only tag declaration header. This helper lives
+// in `app/util/` because it declares no tags and depends on the non-tag `Shape`
+// type from `app/components/player.h`.
 //
 // Each table has the same shape: four rows, one per former `Shape` value.
 // `set_*_shape_tag` writes the table (removes all four tags, emplaces the


### PR DESCRIPTION
## Root cause
Issue #1708 flagged `app/util/shape_tag.h` as tag single-header drift because the canon only said all tag declarations belong in `app/tags/tags.h`, without defining where non-tag helpers that operate on tag tables belong.

## Fix
- Clarify in `.squad/decisions.md` that pure helpers operating on tags stay in `app/util/` when they declare no tag structs.
- Document `app/util/shape_tag.h` as the explicit exemption because it depends on the non-tag `Shape` type and only provides dispatch functions.
- Update nearby comments to call it a non-tag dispatch helper.

## Verification
- `cmake --build build && ./build/shapeshifter_tests`

Fixes #1708