### PR TITLE
Make web persistence init testable

### DIFF
--- a/app/systems/persistence_policy_system.cpp
+++ b/app/systems/persistence_policy_system.cpp
@@ -50,13 +50,7 @@ Result sync_web_filesystem(const bool populate, const Status failure_status) {
     return sync_failed != 0 ? Result{failure_status, std::make_error_code(std::errc::io_error)} : Result{};
 }
 
-Result ensure_web_persistence_ready() {
-    static bool initialized = false;
-
-    if (initialized) {
-        return Result{};
-    }
-
+Result bootstrap_web_persistence(void*) {
     const int mount_status = EM_ASM_INT(
         {
             if (typeof FS === 'undefined' || typeof IDBFS === 'undefined') {
@@ -81,11 +75,17 @@ Result ensure_web_persistence_ready() {
         return Result{Status::PathUnavailable, std::make_error_code(std::errc::io_error)};
     }
 
-    const auto init_result = sync_web_filesystem(true, Status::FileReadFailed);
-    if (init_result.ok()) {
-        initialized = true;
-    }
-    return init_result;
+    return sync_web_filesystem(true, Status::FileReadFailed);
+}
+
+WebPersistenceInitState& web_persistence_init_state() {
+    static WebPersistenceInitState state;
+    return state;
+}
+
+Result ensure_web_persistence_ready() {
+    return persistence::ensure_web_persistence_ready(
+        web_persistence_init_state(), bootstrap_web_persistence, nullptr);
 }
 
 bool path_uses_web_persistence(const std::filesystem::path& path) {
@@ -96,6 +96,20 @@ bool path_uses_web_persistence(const std::filesystem::path& path) {
 #endif
 
 }  // namespace
+
+Result ensure_web_persistence_ready(WebPersistenceInitState& state,
+                                    const WebPersistenceBootstrap bootstrap,
+                                    void* context) {
+    if (state.initialized) {
+        return Result{};
+    }
+
+    const auto init_result = bootstrap(context);
+    if (init_result.ok()) {
+        state.initialized = true;
+    }
+    return init_result;
+}
 
 std::error_code ensure_directory_exists(const std::filesystem::path& dir) {
     if (dir.empty()) return {};

--- a/app/systems/persistence_policy_system.h
+++ b/app/systems/persistence_policy_system.h
@@ -31,6 +31,16 @@ struct Paths {
     std::filesystem::path high_scores_file;
 };
 
+struct WebPersistenceInitState {
+    bool initialized{false};
+};
+
+using WebPersistenceBootstrap = Result (*)(void* context);
+
+Result ensure_web_persistence_ready(WebPersistenceInitState& state,
+                                    WebPersistenceBootstrap bootstrap,
+                                    void* context);
+
 Result resolve_paths(Paths& out_paths, const std::filesystem::path& root_override = {});
 
 std::error_code ensure_directory_exists(const std::filesystem::path& dir);

--- a/tests/test_settings_persistence.cpp
+++ b/tests/test_settings_persistence.cpp
@@ -4,28 +4,9 @@
 #include "tags/tags.h"
 #include <filesystem>
 #include <fstream>
-#include <sstream>
-#include <string>
 #include "temp_paths.h"
 
 using Catch::Matchers::WithinAbs;
-
-namespace {
-
-std::filesystem::path persistence_policy_source_path() {
-    return std::filesystem::path{SHAPESHIFTER_SOURCE_DIR} / "app/systems/persistence_policy_system.cpp";
-}
-
-std::string load_persistence_policy_source() {
-    std::ifstream file(persistence_policy_source_path());
-    if (!file.is_open()) return {};
-
-    std::ostringstream buffer;
-    buffer << file.rdbuf();
-    return buffer.str();
-}
-
-}  // namespace
 
 TEST_CASE("Settings: audio_offset_seconds() converts milliseconds correctly", "[settings]") {
     SettingsState state;
@@ -354,34 +335,32 @@ TEST_CASE("Persistence sync seams skip paths outside the web persistence root", 
 
 TEST_CASE("Web persistence initialization failures remain retryable",
           "[settings][persistence][issue-970]") {
-    const std::string source = load_persistence_policy_source();
-    INFO("Expected persistence_policy.cpp at " << persistence_policy_source_path().string());
-    REQUIRE_FALSE(source.empty());
+    struct RetryContext {
+        int calls{0};
+        int failures_before_success{1};
+    } context;
 
-    const auto function_begin = source.find("Result ensure_web_persistence_ready()");
-    REQUIRE(function_begin != std::string::npos);
-    const auto function_end = source.find("bool path_uses_web_persistence", function_begin);
-    REQUIRE(function_end != std::string::npos);
-    const std::string function_source =
-        source.substr(function_begin, function_end - function_begin);
+    auto bootstrap = [](void* raw_context) -> persistence::Result {
+        auto& ctx = *static_cast<RetryContext*>(raw_context);
+        ++ctx.calls;
+        if (ctx.calls <= ctx.failures_before_success) {
+            return {persistence::Status::FileReadFailed,
+                    std::make_error_code(std::errc::io_error)};
+        }
+        return {};
+    };
 
-    CHECK(function_source.find("static bool initialized = false;") != std::string::npos);
-    CHECK(function_source.find("static Result") == std::string::npos);
+    persistence::WebPersistenceInitState state;
+    CHECK_FALSE(persistence::ensure_web_persistence_ready(state, bootstrap, &context).ok());
+    CHECK_FALSE(state.initialized);
+    CHECK(context.calls == 1);
 
-    const auto mount_failure = function_source.find("if (mount_status != 0)");
-    const auto sync_result = function_source.find("const auto init_result");
-    const auto success_guard = function_source.find("if (init_result.ok())");
-    REQUIRE(mount_failure != std::string::npos);
-    REQUIRE(sync_result != std::string::npos);
-    REQUIRE(success_guard != std::string::npos);
-    CHECK(mount_failure < sync_result);
+    CHECK(persistence::ensure_web_persistence_ready(state, bootstrap, &context).ok());
+    CHECK(state.initialized);
+    CHECK(context.calls == 2);
 
-    const auto initialized_assignment =
-        function_source.find("initialized = true", success_guard);
-    REQUIRE(initialized_assignment != std::string::npos);
-    CHECK(success_guard < initialized_assignment);
-    CHECK(function_source.find("initialized = true", initialized_assignment + 1)
-        == std::string::npos);
+    CHECK(persistence::ensure_web_persistence_ready(state, bootstrap, &context).ok());
+    CHECK(context.calls == 2);
 }
 
 TEST_CASE("Settings persistence helper: file path resolution reports failure without CWD fallback", "[settings]") {

--- a/tests/test_wasm_beforeunload_lifecycle.cpp
+++ b/tests/test_wasm_beforeunload_lifecycle.cpp
@@ -4,6 +4,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "systems/persistence_policy_system.h"
+
 #include <filesystem>
 #include <fstream>
 #include <sstream>
@@ -97,21 +99,30 @@ TEST_CASE("wasm persistence uses explicit IDBFS policy and save flush hooks", "[
 
 TEST_CASE("wasm persistence readiness retries after initialization failure",
           "[persistence][architecture][issue887]") {
-    const fs::path root = find_repo_root();
-    const std::string policy_source = read_file(root / "app" / "systems" / "persistence_policy_system.cpp");
+    struct RetryContext {
+        int calls{0};
+        int failures_before_success{1};
+    } context;
 
-    const std::size_t mount_failure_return = policy_source.find(
-        "return Result{Status::PathUnavailable, std::make_error_code(std::errc::io_error)};");
-    const std::size_t sync_result = policy_source.find(
-        "const auto init_result = sync_web_filesystem(true, Status::FileReadFailed);");
-    const std::size_t success_guard = policy_source.find("if (init_result.ok()) {", sync_result);
-    const std::size_t initialized_true = policy_source.find("initialized = true;", success_guard);
+    auto bootstrap = [](void* raw_context) -> persistence::Result {
+        auto& ctx = *static_cast<RetryContext*>(raw_context);
+        ++ctx.calls;
+        if (ctx.calls <= ctx.failures_before_success) {
+            return {persistence::Status::PathUnavailable,
+                    std::make_error_code(std::errc::io_error)};
+        }
+        return {};
+    };
 
-    REQUIRE(mount_failure_return != std::string::npos);
-    REQUIRE(sync_result != std::string::npos);
-    REQUIRE(success_guard != std::string::npos);
-    REQUIRE(initialized_true != std::string::npos);
-    CHECK(mount_failure_return < sync_result);
-    CHECK(sync_result < success_guard);
-    CHECK(success_guard < initialized_true);
+    persistence::WebPersistenceInitState state;
+    CHECK_FALSE(persistence::ensure_web_persistence_ready(state, bootstrap, &context).ok());
+    CHECK_FALSE(state.initialized);
+    CHECK(context.calls == 1);
+
+    CHECK(persistence::ensure_web_persistence_ready(state, bootstrap, &context).ok());
+    CHECK(state.initialized);
+    CHECK(context.calls == 2);
+
+    CHECK(persistence::ensure_web_persistence_ready(state, bootstrap, &context).ok());
+    CHECK(context.calls == 2);
 }


### PR DESCRIPTION
## Summary
- move web persistence init success state into an explicit state object
- keep production IDBFS bootstrap behavior behind the existing readiness path
- replace brittle source-text assertions with runtime retry/one-time-success tests

Fixes #1717

## Validation
- cmake --build build
- ./build/shapeshifter_tests