### PR TITLE
Share phase input debounce helper

### DIFF
--- a/app/systems/game_state_routing.cpp
+++ b/app/systems/game_state_routing.cpp
@@ -3,6 +3,7 @@
 #include "game_phase_transition.h"
 #include "input.h"
 #include "input_events.h"
+#include "phase_input.h"
 #include "audio_events.h"
 #include "haptics.h"
 #include "../entities/settings.h"
@@ -50,9 +51,8 @@ namespace {
 // produced the same resume request. Per-direction handlers below
 // preserve that semantics with no Direction enum involvement.
 void resume_from_pause_if_eligible(entt::registry& reg) {
-    auto& gs = reg.ctx().get<GameState>();
     if (!reg.ctx().contains<GamePhasePausedTag>()) return;
-    if (gs.phase_timer <= constants::UI_ENTRY_DEBOUNCE) return;
+    if (!phase_input_unlocked(reg)) return;
     // Deferred per #482 — let game_state_system perform the resume swap.
     request_phase_transition<NextPhasePlayingTag>(reg);
 }
@@ -80,7 +80,7 @@ void game_state_handle_confirm(entt::registry& reg, const MenuConfirmEvent&) {
     }
 
     if (ctx.contains<GamePhaseTutorialTag>()) {
-        if (gs.phase_timer <= constants::UI_ENTRY_DEBOUNCE) return;
+        if (!phase_input_unlocked(gs)) return;
         if (auto* settings_state = find_settings_state(reg)) {
             settings::mark_ftue_complete(*settings_state);
             settings::mark_dirty_and_save(reg, *settings_state);
@@ -90,7 +90,7 @@ void game_state_handle_confirm(entt::registry& reg, const MenuConfirmEvent&) {
     }
 
     if (ctx.contains<GamePhasePausedTag>()) {
-        if (gs.phase_timer <= constants::UI_ENTRY_DEBOUNCE) return;
+        if (!phase_input_unlocked(gs)) return;
         // Deferred per #482 — see game_state_handle_go above.
         request_phase_transition<NextPhasePlayingTag>(reg);
         return;

--- a/app/systems/game_state_system.cpp
+++ b/app/systems/game_state_system.cpp
@@ -3,6 +3,7 @@
 #include "game_state_system.h"
 #include "input_system_private.h"
 #include "play_session.h"
+#include "phase_input.h"
 #include "../components/game_state.h"
 #include "input.h"
 #include "../components/obstacle.h"
@@ -126,7 +127,7 @@ void game_state_system(entt::registry& reg, float dt) {
 
     // LevelSelect input handling
     if (reg.ctx().contains<GamePhaseLevelSelectTag>() &&
-        gs.phase_timer > constants::UI_ENTRY_DEBOUNCE) {
+        phase_input_unlocked(gs)) {
         if (reg.ctx().find<LevelSelectConfirmedTag>()) {
             reg.ctx().erase<LevelSelectConfirmedTag>();
             const auto* settings_ptr = find_settings_state(reg);

--- a/app/systems/phase_input.h
+++ b/app/systems/phase_input.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "../components/game_state.h"
+#include "../constants.h"
+
+#include <entt/entt.hpp>
+
+[[nodiscard]] inline bool phase_input_unlocked(const GameState& state,
+                                               const float debounce_sec = constants::UI_ENTRY_DEBOUNCE) {
+    return state.phase_timer > debounce_sec;
+}
+
+[[nodiscard]] inline bool phase_input_unlocked(entt::registry& reg,
+                                               const float debounce_sec = constants::UI_ENTRY_DEBOUNCE) {
+    return phase_input_unlocked(reg.ctx().get<GameState>(), debounce_sec);
+}

--- a/app/systems/test_player_system.cpp
+++ b/app/systems/test_player_system.cpp
@@ -2,6 +2,7 @@
 #include "test_player.h"
 #include "../components/game_state.h"
 #include "input_events.h"
+#include "phase_input.h"
 #include "../components/player.h"
 #include "../components/transform.h"
 #include "../components/obstacle.h"
@@ -211,7 +212,7 @@ void test_player_system(entt::registry& reg, float dt) {
     }
 
     // Auto-confirm on LevelSelect (level/difficulty already set in main.cpp)
-    if (level_select_phase && gs.phase_timer > constants::UI_ENTRY_DEBOUNCE) {
+    if (level_select_phase && phase_input_unlocked(gs)) {
         disp.enqueue<MenuConfirmEvent>({});
         return;
     }

--- a/app/systems/title_start_tap_system.cpp
+++ b/app/systems/title_start_tap_system.cpp
@@ -6,6 +6,7 @@
 #include "../tags/tags.h"
 #include "game_phase_transition.h"
 #include "input.h"
+#include "phase_input.h"
 
 #include <raylib.h>  // CheckCollisionPointRec, Rectangle, Vector2
 
@@ -16,7 +17,7 @@ void title_start_tap_system(entt::registry& reg) {
     if (!(input.click || input.touch_up)) return;
 
     const auto& gs = reg.ctx().get<GameState>();
-    if (gs.phase_timer <= constants::UI_ENTRY_DEBOUNCE) return;
+    if (!phase_input_unlocked(gs)) return;
 
     const Vector2 pointer{input.end_x, input.end_y};
 

--- a/app/systems/ui_update_system.cpp
+++ b/app/systems/ui_update_system.cpp
@@ -11,6 +11,7 @@
 #include "haptics_backend.h"
 #include "input.h"
 #include "input_events.h"
+#include "phase_input.h"
 #include "settings_system.h"
 
 #include <array>
@@ -336,7 +337,7 @@ void ui_update_system(entt::registry& reg) {
     for (const auto& row : kPhaseDebounceRows) {
         if (row.phase_active(reg)) { debounce_sec = row.seconds; break; }
     }
-    if (gs.phase_timer <= debounce_sec) return;
+    if (!phase_input_unlocked(gs, debounce_sec)) return;
 
     // ── Pass D — Gameplay HUD lane buttons (issue #1297) ─────────────
     //

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -4,6 +4,7 @@
 #include "components/audio.h"
 #include "systems/audio_events.h"
 #include "systems/game_phase_transition.h"
+#include "systems/phase_input.h"
 #include "entities/obstacle_entity.h"
 #include "entities/obstacle_render_entity.h"
 
@@ -120,6 +121,15 @@ TEST_CASE("components: GameState defaults to title", "[components]") {
     CHECK(gs.phase_timer == 0.0f);
     CHECK(reg.ctx().contains<GamePhaseTitleTag>());
     CHECK_FALSE(is_phase_transition_pending(reg));
+}
+
+TEST_CASE("systems: phase_input_unlocked uses strict debounce boundary", "[systems][input]") {
+    GameState gs;
+    gs.phase_timer = constants::UI_ENTRY_DEBOUNCE;
+    CHECK_FALSE(phase_input_unlocked(gs));
+
+    gs.phase_timer = constants::UI_ENTRY_DEBOUNCE + 0.001f;
+    CHECK(phase_input_unlocked(gs));
 }
 
 TEST_CASE("ecs: make_registry creates all singletons", "[ecs]") {


### PR DESCRIPTION
## Summary
- add a shared `phase_input_unlocked` helper for strict phase-entry debounce checks
- use it from title tap, game-state routing, level-select confirmation, test-player auto-confirm, and UI update gates
- add a focused boundary test for the shared gate

Fixes #1718

## Validation
- cmake --build build
- ./build/shapeshifter_tests