### PR TITLE
Use HighScoreSession presence for active sessions

### DIFF
--- a/app/components/high_score.h
+++ b/app/components/high_score.h
@@ -35,8 +35,9 @@ struct HighScoreEntry {
 // meaning depends on the surrounding lifecycle belongs in its own table).
 struct HighScoreSession {
     // FNV-1a 32-bit hash of the current session's "song_id|difficulty" key.
-    // Set once per session via high_score::make_key_hash(); zero means no active session.
-    // Using a hash avoids a heap std::string allocation on the session-start path.
+    // Presence of this ctx row means a high-score session is active; absence
+    // means no active session. Using a hash avoids a heap std::string
+    // allocation on the session-start path.
     // Collision risk: negligible across MAX_ENTRIES=9 keys (e.g. "1_stomper|easy").
     entt::hashed_string::hash_type key_hash{0};
 };

--- a/app/game_loop.cpp
+++ b/app/game_loop.cpp
@@ -234,8 +234,8 @@ bool game_loop_init(entt::registry& reg,
 
     // High scores — load from disk; defaults remain if file is missing/corrupt/path-invalid.
     // Entries live as `HighScoreEntry` rows in the registry (Fabian Principle 3 /
-    // issue #1560); only the persistence bookkeeping + active-session pointer remain
-    // as ctx singletons.
+    // issue #1560); only persistence bookkeeping is initialized here. The
+    // active-session ctx row is emplaced by setup_play_session once a key exists.
     {
         HighScorePersistence persistence_state;
         if (path_result.ok()) {
@@ -246,7 +246,6 @@ bool game_loop_init(entt::registry& reg,
         }
         log_persistence_result("high score load", persistence_state.last_load);
         reset_ctx_singleton<HighScorePersistence>(reg, persistence_state);
-        reset_ctx_singleton<HighScoreSession>(reg);
     }
 
     // Cameras + render targets + GPU meshes

--- a/app/systems/game_state_terminal_phase_system.cpp
+++ b/app/systems/game_state_terminal_phase_system.cpp
@@ -18,15 +18,14 @@ bool update_and_persist_high_score(entt::registry& reg) {
     bool recorded_new_high_score = score_exceeds_high_score;
 
     const auto* session = reg.ctx().find<HighScoreSession>();
-    const bool has_active_high_score_key = session && (session->key_hash != 0);
-    if (score_exceeds_high_score && has_active_high_score_key) {
+    if (score_exceeds_high_score && session) {
         recorded_new_high_score = high_score::update_if_higher(reg, *session, score.score);
     }
     if (score_exceeds_high_score && recorded_new_high_score) {
         current.value = score.score;
     }
     if (auto* hp = reg.ctx().find<HighScorePersistence>()) {
-        if (score_exceeds_high_score && recorded_new_high_score && has_active_high_score_key) {
+        if (score_exceeds_high_score && recorded_new_high_score && session) {
             reg.ctx().insert_or_assign(HighScoreDirtyTag{});
         }
         if (reg.ctx().contains<HighScoreDirtyTag>()) {

--- a/app/systems/high_score_system.cpp
+++ b/app/systems/high_score_system.cpp
@@ -143,7 +143,7 @@ bool ensure_entry(entt::registry& reg, const char* key) {
 }
 
 int32_t get_current_high_score(const entt::registry& reg, const HighScoreSession& session) {
-    return session.key_hash == 0 ? 0 : get_score_by_hash(reg, session.key_hash);
+    return get_score_by_hash(reg, session.key_hash);
 }
 
 namespace {
@@ -286,19 +286,19 @@ persistence::Result save_high_scores(const entt::registry& reg, const std::files
 }
 
 bool update_if_higher(entt::registry& reg, const HighScoreSession& session, int32_t new_score) {
-    const bool has_session_key = session.key_hash != 0;
     new_score = std::max(new_score, 0);
-    const int32_t stored = has_session_key ? get_score_by_hash(reg, session.key_hash) : 0;
-    if (has_session_key && new_score > stored) {
-        const auto entity = find_entry_by_hash(reg, session.key_hash);
-        if (entity == entt::null) {
-            TraceLog(LOG_WARNING, "High score entry hash %u not found; score update skipped",
-                     static_cast<unsigned int>(session.key_hash));
-            return false;
-        }
-        reg.get<HighScoreEntry>(entity).score = new_score;
+    const auto entity = find_entry_by_hash(reg, session.key_hash);
+    if (entity == entt::null) {
+        TraceLog(LOG_WARNING, "High score entry hash %u not found; score update skipped",
+                 static_cast<unsigned int>(session.key_hash));
+        return false;
     }
-    return has_session_key;
+    auto& entry = reg.get<HighScoreEntry>(entity);
+    const int32_t stored = entry.score;
+    if (new_score > stored) {
+        entry.score = new_score;
+    }
+    return true;
 }
 
 }  // namespace high_score

--- a/app/systems/high_score_system.h
+++ b/app/systems/high_score_system.h
@@ -21,8 +21,8 @@ persistence::Result get_high_scores_file_path(
     const std::filesystem::path& root_override = {});
 
 // Update the stored score for session.key_hash if new_score is strictly higher.
-// Negative new_score is clamped to 0. Returns false when no active key exists
-// or the active key is missing from the entry table.
+// Negative new_score is clamped to 0. Returns false when the active key is
+// missing from the entry table.
 bool update_if_higher(entt::registry& reg, const HighScoreSession& session, int32_t new_score);
 
 // Build "song_id|difficulty" into caller-supplied buf (no heap allocation).
@@ -47,7 +47,7 @@ bool set_score(entt::registry& reg, const char* key, int32_t score);
 // Returns false if the table is full.
 bool ensure_entry(entt::registry& reg, const char* key);
 
-// Returns the stored score for the current session key, or 0 if no session active.
+// Returns the stored score for the current session key, or 0 if no entry exists.
 int32_t get_current_high_score(const entt::registry& reg, const HighScoreSession& session);
 
 // Count of stored entries (rows in the HighScoreEntry table).

--- a/app/systems/play_session.cpp
+++ b/app/systems/play_session.cpp
@@ -171,9 +171,7 @@ void setup_play_session(entt::registry& reg) {
         reg.ctx().erase<MusicContext>();
         reg.ctx().erase<MusicPlayingTag>();
         reg.ctx().erase<MusicPausedTag>();
-        if (auto* session = reg.ctx().find<HighScoreSession>()) {
-            session->key_hash = 0;
-        }
+        erase_ctx_if_exists<HighScoreSession>(reg);
         erase_ctx_if_exists<ScoreState>(reg);
         erase_ctx_if_exists<ScoreDisplay>(reg);
         erase_ctx_if_exists<CurrentSongHighScore>(reg);
@@ -199,12 +197,13 @@ void setup_play_session(entt::registry& reg) {
     assign_or_emplace_ctx(reg, ScoreDisplay{});
     assign_or_emplace_ctx(reg, CurrentSongHighScore{});
 
-    // Wire high score: derive song_id from beatmap filename and set HighScoreSession::key_hash.
+    // Wire high score: derive song_id from beatmap filename and emplace HighScoreSession.
     // The key string is built once in a stack buffer (no heap); ensure_entry pre-registers
     // the entry so update_if_higher can later update by hash without the key string.
     // HighScoreEntry rows live in the registry (issue #1560), so the operations don't
     // need a HighScoreState ctx-singleton gate any more.
     {
+        erase_ctx_if_exists<HighScoreSession>(reg);
         std::string stem = std::filesystem::path(beatmap_path).stem().string();
         static const std::string BEATMAP_SUFFIX = "_beatmap";
         if (stem.size() > BEATMAP_SUFFIX.size() &&
@@ -214,12 +213,9 @@ void setup_play_session(entt::registry& reg) {
         char key_buf[HighScoreState::KEY_CAP]{};
         const int32_t key_len = high_score::make_key_str(
             key_buf, HighScoreState::KEY_CAP, stem.c_str(), beatmap.difficulty.c_str());
-        assign_or_emplace_ctx(
-            reg,
-            HighScoreSession{key_len >= 0
-                ? entt::hashed_string::value(static_cast<const char*>(key_buf))
-                : 0});
         if (key_len >= 0) {
+            reg.ctx().emplace<HighScoreSession>(
+                HighScoreSession{entt::hashed_string::value(static_cast<const char*>(key_buf))});
             high_score::ensure_entry(reg, key_buf);
         } else {
             TraceLog(LOG_WARNING,

--- a/tests/test_component_boundary_wave2.cpp
+++ b/tests/test_component_boundary_wave2.cpp
@@ -53,9 +53,13 @@ TEST_CASE("HighScoreEntry: default-constructed row is empty", "[boundary_wave2][
     CHECK(e.score == 0);
 }
 
-TEST_CASE("HighScoreSession: default-constructed has zero key hash", "[boundary_wave2][high_score]") {
-    HighScoreSession session{};
-    CHECK(session.key_hash == 0u);
+TEST_CASE("HighScoreSession: ctx row presence represents active session", "[boundary_wave2][high_score]") {
+    auto reg = make_registry();
+    CHECK_FALSE(reg.ctx().contains<HighScoreSession>());
+
+    reg.ctx().emplace<HighScoreSession>(
+        HighScoreSession{high_score::make_key_hash("song_001", "easy")});
+    CHECK(reg.ctx().contains<HighScoreSession>());
 }
 
 TEST_CASE("HighScoreEntry: rows live as registry entities, not in ctx", "[boundary_wave2][high_score]") {

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -58,7 +58,6 @@ inline entt::registry make_registry() {
     reg.ctx().emplace<EnergyState>();
     reg.ctx().emplace<SongResults>();
     reg.ctx().emplace<HighScorePersistence>();
-    reg.ctx().emplace<HighScoreSession>();
     runtime_system_scratch_init(reg);
     return reg;
 }

--- a/tests/test_high_score_integration.cpp
+++ b/tests/test_high_score_integration.cpp
@@ -118,8 +118,8 @@ TEST_CASE("Play session: missing selected beatmap returns to level select withou
     auto reg = make_registry();
     auto& lss = reg.ctx().get<LevelSelectState>();
     high_score::set_score(reg, "1_stomper|medium", 4321);
-    auto& session = reg.ctx().get<HighScoreSession>();
-    session.key_hash = high_score::make_key_hash("1_stomper", "medium");
+    reg.ctx().emplace<HighScoreSession>(
+        HighScoreSession{high_score::make_key_hash("1_stomper", "medium")});
     reg.ctx().insert_or_assign(LevelSelectConfirmedTag{});
 
     reg.ctx().emplace<PlaySessionContentOverride>(
@@ -135,7 +135,7 @@ TEST_CASE("Play session: missing selected beatmap returns to level select withou
     }
     CHECK(reg.view<PlayerTag>().empty());
     CHECK(reg.ctx().find<ScoreState>() == nullptr);
-    CHECK(session.key_hash == 0);
+    CHECK_FALSE(reg.ctx().contains<HighScoreSession>());
     CHECK(high_score::entry_count(reg) == 1);
 
     reg.ctx().erase<PlaySessionContentOverride>();
@@ -147,6 +147,7 @@ TEST_CASE("Play session: missing selected beatmap returns to level select withou
     CHECK(reg.ctx().find<SongState>() != nullptr);
     CHECK(reg.ctx().find<ScoreState>() != nullptr);
     CHECK(reg.ctx().contains<GamePhasePlayingTag>());
+    CHECK(reg.ctx().contains<HighScoreSession>());
     CHECK_FALSE(reg.view<PlayerTag>().empty());
 }
 
@@ -207,7 +208,7 @@ TEST_CASE("Play session: overlong high-score key disables session score entry",
 
     setup_play_session(reg);
 
-    CHECK(reg.ctx().get<HighScoreSession>().key_hash == 0);
+    CHECK_FALSE(reg.ctx().contains<HighScoreSession>());
     CHECK(reg.ctx().get<CurrentSongHighScore>().value == 0);
     CHECK(high_score::entry_count(reg) == 0);
 }
@@ -250,7 +251,8 @@ TEST_CASE("High score integration: new song-complete high score persists",
     auto reg = make_registry();
     reg.ctx().get<HighScorePersistence>().path = file.string();
     high_score::ensure_entry(reg, "song_001|easy");
-    reg.ctx().get<HighScoreSession>().key_hash = high_score::make_key_hash("song_001", "easy");
+    reg.ctx().emplace<HighScoreSession>(
+        HighScoreSession{high_score::make_key_hash("song_001", "easy")});
     high_score::set_score(reg, "song_001|easy", 1000);
 
     auto& score = reg.ctx().get<ScoreState>();
@@ -280,7 +282,8 @@ TEST_CASE("High score integration: lower game-over score does not overwrite pers
     auto reg = make_registry();
     reg.ctx().get<HighScorePersistence>().path = file.string();
     high_score::ensure_entry(reg, "song_001|easy");
-    reg.ctx().get<HighScoreSession>().key_hash = high_score::make_key_hash("song_001", "easy");
+    reg.ctx().emplace<HighScoreSession>(
+        HighScoreSession{high_score::make_key_hash("song_001", "easy")});
     high_score::set_score(reg, "song_001|easy", 3000);
 
     auto& score = reg.ctx().get<ScoreState>();
@@ -306,7 +309,8 @@ TEST_CASE("High score integration: missing active entry does not report new best
         const std::string key = "song_" + std::to_string(i) + "|easy";
         REQUIRE(high_score::set_score(reg, key.c_str(), i * 100));
     }
-    reg.ctx().get<HighScoreSession>().key_hash = high_score::make_key_hash("overflow", "hard");
+    reg.ctx().emplace<HighScoreSession>(
+        HighScoreSession{high_score::make_key_hash("overflow", "hard")});
 
     auto& score = reg.ctx().get<ScoreState>();
     auto& current = reg.ctx().get<CurrentSongHighScore>();
@@ -341,7 +345,8 @@ TEST_CASE("High score integration: failed save keeps dirty state for retry",
     auto reg = make_registry();
     reg.ctx().get<HighScorePersistence>().path = blocked_file.string();
     high_score::ensure_entry(reg, "song_001|easy");
-    reg.ctx().get<HighScoreSession>().key_hash = high_score::make_key_hash("song_001", "easy");
+    reg.ctx().emplace<HighScoreSession>(
+        HighScoreSession{high_score::make_key_hash("song_001", "easy")});
     high_score::set_score(reg, "song_001|easy", 1000);
 
     auto& score = reg.ctx().get<ScoreState>();
@@ -408,7 +413,8 @@ TEST_CASE("High score bootstrap: persistence path is populated for save call sit
     score.score = 2500;
 
     high_score::ensure_entry(reg, "song_001|easy");
-    reg.ctx().get<HighScoreSession>().key_hash = high_score::make_key_hash("song_001", "easy");
+    reg.ctx().emplace<HighScoreSession>(
+        HighScoreSession{high_score::make_key_hash("song_001", "easy")});
 
     const auto& persistence = reg.ctx().get<HighScorePersistence>();
     REQUIRE_FALSE(persistence.path.empty());

--- a/tests/test_high_score_persistence.cpp
+++ b/tests/test_high_score_persistence.cpp
@@ -87,12 +87,10 @@ TEST_CASE("High score: no hash collisions across all 9 shipped song+difficulty k
 
 TEST_CASE("High score: current score lookup and update never lowers stored score", "[high_score]") {
     entt::registry reg;
-    HighScoreSession session;
-    CHECK(high_score::get_current_high_score(reg, session) == 0);
 
-    // ensure_entry + session.key_hash mirrors the production setup_play_session path.
+    // ensure_entry + HighScoreSession mirrors the production setup_play_session path.
     REQUIRE(high_score::ensure_entry(reg, "song_001|easy"));
-    session.key_hash = high_score::make_key_hash("song_001", "easy");
+    HighScoreSession session{high_score::make_key_hash("song_001", "easy")};
     CHECK(high_score::get_current_high_score(reg, session) == 0);
 
     CHECK(high_score::update_if_higher(reg, session, 5000));
@@ -104,7 +102,6 @@ TEST_CASE("High score: current score lookup and update never lowers stored score
 
 TEST_CASE("High score: saturated table reports insert and hash update failures", "[high_score][issue1004]") {
     entt::registry reg;
-    HighScoreSession session;
     for (int32_t i = 0; i < HighScoreState::MAX_ENTRIES; ++i) {
         const std::string key = "song_" + std::to_string(i) + "|easy";
         REQUIRE(high_score::set_score(reg, key.c_str(), i * 100));
@@ -114,7 +111,7 @@ TEST_CASE("High score: saturated table reports insert and hash update failures",
     CHECK_FALSE(high_score::set_score(reg, "overflow|easy", 9000));
     CHECK_FALSE(high_score::ensure_entry(reg, "overflow|medium"));
 
-    session.key_hash = high_score::make_key_hash("overflow", "hard");
+    HighScoreSession session{high_score::make_key_hash("overflow", "hard")};
     CHECK_FALSE(high_score::update_if_higher(reg, session, 9000));
     CHECK(high_score::get_score(reg, "overflow|hard") == 0);
 
@@ -125,10 +122,9 @@ TEST_CASE("High score: saturated table reports insert and hash update failures",
 
 TEST_CASE("High score: tracks songs and difficulties independently", "[high_score]") {
     entt::registry reg;
-    HighScoreSession session;
+    HighScoreSession session{high_score::make_key_hash("song_001", "easy")};
 
     REQUIRE(high_score::ensure_entry(reg, "song_001|easy"));
-    session.key_hash = high_score::make_key_hash("song_001", "easy");
     CHECK(high_score::update_if_higher(reg, session, 1000));
 
     REQUIRE(high_score::ensure_entry(reg, "song_001|hard"));
@@ -330,10 +326,9 @@ TEST_CASE("High score persistence: load does not touch session key", "[high_scor
     REQUIRE(high_score::save_high_scores(original, file).ok());
 
     entt::registry loaded;
-    HighScoreSession session;
     // Simulate a session already active on song_002|hard before the load.
     const auto pre_load_hash = high_score::make_key_hash("song_002", "hard");
-    session.key_hash = pre_load_hash;
+    HighScoreSession session{pre_load_hash};
     REQUIRE(high_score::load_high_scores(loaded, file).ok());
 
     // Load must not clobber the in-progress session key.


### PR DESCRIPTION
## Summary
- Stop default-emplacing inactive HighScoreSession ctx rows during bootstrap/test setup
- Erase HighScoreSession on failed session setup and only emplace it after a valid key is built
- Remove key_hash == 0 active-session branching from high-score lookup/update and terminal persistence

## Root cause
HighScoreSession encoded inactive state with a zero key_hash sentinel, so a ctx row could exist while meaning no active high-score session.

## Verification
- cmake --build build --target shapeshifter_tests -- -j2
- ./build/shapeshifter_tests "[high_score]"
- ./build/shapeshifter_tests

Closes #1693