### PR TITLE
Replace ActionId UI dispatch with action tags

### DIFF
--- a/app/.allowed-enums.txt
+++ b/app/.allowed-enums.txt
@@ -41,12 +41,10 @@ Shape              # lookup key — perfect-hash index into per-shape function-p
                    # are lookup-key passthroughs (function args, return values,
                    # per-shape literal iteration) — exactly Fabian's Keep category.
 ActionId           # UI button-action label (issue #1193). Convention: each `.rgl`
-                   # button control's `name` field maps to an enumerator. Carried
-                   # by `OnPress` on button entities spawned by the rguilayout
-                   # codegen. No consumer system dispatches on ActionId today; the
-                   # future ui_update_system will use it as a lookup-key index
-                   # into a per-action function-pointer table (same mechanic as
-                   # `kShapeFlatDrawFns`), never as a `switch` discriminator.
+                   # button control's `name` field maps to an enumerator for
+                   # codegen verification. Runtime buttons carry matching
+                   # `UiAction*Tag` membership rows; no consumer system
+                   # dispatches on ActionId.
 
 # --- Pending eradication per #1202 / #1204 (set must shrink, never grow) ----
 # Each row below is a control-flow enum awaiting migration to per-case tags

--- a/app/components/actions.h
+++ b/app/components/actions.h
@@ -3,19 +3,19 @@
 #include <cstdint>
 
 // ActionId enumerates every button control name that appears across
-// `content/ui/screens/*.rgl`. Carried by the `OnPress` component on button
-// entities spawned by the rguilayout codegen (see `tools/rguilayout/codegen.py`).
+// `content/ui/screens/*.rgl`. The rguilayout codegen verifies button names
+// against this enum, then emits a matching `UiAction<Name>Tag` on the button
+// entity (see `tools/rguilayout/codegen.py`).
 //
 // Convention (per #1193): the control name in the .rgl IS the ActionId
 // enumerator name. Two buttons named identically on different screens map to
-// the same ActionId; consumer systems disambiguate by also reading the
-// entity's per-screen tag (`GameOverScreenTag` vs `SongCompleteScreenTag`,
-// etc., from `app/tags/tags.h`).
+// the same ActionId and therefore the same generated action tag; consumer
+// systems can further disambiguate by reading per-screen tags when needed
+// (`GameOverScreenTag` vs `SongCompleteScreenTag`, etc., from
+// `app/tags/tags.h`).
 //
-// NOTE: no consumer system currently dispatches on ActionId. Building the
-// UI-input system that reads this enum is the next ECS work item; see #1193
-// "Out of scope" section for the follow-up issue list. Until then, the enum
-// is data declaration only — no `switch` on it anywhere in `app/`.
+// Consumer systems do not dispatch on ActionId. It is a codegen validation
+// label only; runtime press behavior is selected by ECS tag membership.
 //
 // Maintenance: when a new button control name appears in a .rgl file the
 // codegen verifies it against this enum and errors out if an enumerator is

--- a/app/components/ui.h
+++ b/app/components/ui.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "actions.h"
-
 #include <array>
 #include <cstddef>
 #include <cstdio>
@@ -22,12 +20,10 @@
 //   * `UiLabel`             — display text. Fixed-size char buffer (no heap),
 //                             matching the `PopupDisplay::text` convention
 //                             elsewhere in this codebase.
-//   * `OnPress`             — buttons only. Carries the `ActionId` that the
-//                             UI-input system will dispatch on press.
+//   * `UiAction*Tag`        — buttons only. Presence selects press behavior
+//                             without dispatching on `ActionId`.
 //
-// No system consumes these components yet. The render / input systems that
-// will read them are out of scope per #1193; see the issue body for the
-// follow-up issue list.
+// Render and input systems consume these rows directly from the registry.
 
 inline constexpr std::size_t kUiLabelMaxLength = 63;
 
@@ -76,10 +72,6 @@ inline void ui_label_set_int(UiLabel& label, int value) noexcept {
     std::snprintf(buf, sizeof(buf), "%d", value);
     ui_label_set(label, buf);
 }
-
-struct OnPress {
-    ActionId action = ActionId::None;
-};
 
 // Per-entity row index for dynamic-spawn UI archetypes (level-select cards
 // and difficulty buttons, issue #1296). Each level-select card carries

--- a/app/systems/generated/game_over_screen.cpp
+++ b/app/systems/generated/game_over_screen.cpp
@@ -4,7 +4,6 @@
 // per-screen tag + per-kind tag + atomic UI components.
 // Regenerate via `cmake --build` (codegen runs on .rgl change).
 
-#include "components/actions.h"
 #include "components/ui.h"
 #include "tags/tags.h"
 
@@ -111,7 +110,7 @@ void spawn_game_over_screen(entt::registry& reg) {
         reg.emplace<UiBounds>(e, 280.0f, 50.0f);
         auto& label = reg.emplace<UiLabel>(e);
         ui_label_set(label, "RESTART");
-        reg.emplace<OnPress>(e, ActionId::RestartButton);
+        reg.emplace<UiActionRestartButtonTag>(e);
     }
     {
         // LevelSelectButton (button)
@@ -122,7 +121,7 @@ void spawn_game_over_screen(entt::registry& reg) {
         reg.emplace<UiBounds>(e, 280.0f, 50.0f);
         auto& label = reg.emplace<UiLabel>(e);
         ui_label_set(label, "LEVEL SELECT");
-        reg.emplace<OnPress>(e, ActionId::LevelSelectButton);
+        reg.emplace<UiActionLevelSelectButtonTag>(e);
     }
     {
         // MenuButton (button)
@@ -133,7 +132,7 @@ void spawn_game_over_screen(entt::registry& reg) {
         reg.emplace<UiBounds>(e, 280.0f, 50.0f);
         auto& label = reg.emplace<UiLabel>(e);
         ui_label_set(label, "MAIN MENU");
-        reg.emplace<OnPress>(e, ActionId::MenuButton);
+        reg.emplace<UiActionMenuButtonTag>(e);
     }
 }
 

--- a/app/systems/generated/gameplay_screen.cpp
+++ b/app/systems/generated/gameplay_screen.cpp
@@ -4,7 +4,6 @@
 // per-screen tag + per-kind tag + atomic UI components.
 // Regenerate via `cmake --build` (codegen runs on .rgl change).
 
-#include "components/actions.h"
 #include "components/ui.h"
 #include "tags/tags.h"
 
@@ -107,7 +106,7 @@ void spawn_gameplay_screen(entt::registry& reg) {
         reg.emplace<UiBounds>(e, 80.0f, 50.0f);
         auto& label = reg.emplace<UiLabel>(e);
         ui_label_set(label, "||");
-        reg.emplace<OnPress>(e, ActionId::PauseButton);
+        reg.emplace<UiActionPauseButtonTag>(e);
     }
     {
         // ChainSlot (label)

--- a/app/systems/generated/level_select_screen.cpp
+++ b/app/systems/generated/level_select_screen.cpp
@@ -4,7 +4,6 @@
 // per-screen tag + per-kind tag + atomic UI components.
 // Regenerate via `cmake --build` (codegen runs on .rgl change).
 
-#include "components/actions.h"
 #include "components/ui.h"
 #include "tags/tags.h"
 
@@ -31,7 +30,7 @@ void spawn_level_select_screen(entt::registry& reg) {
         reg.emplace<UiBounds>(e, 300.0f, 60.0f);
         auto& label = reg.emplace<UiLabel>(e);
         ui_label_set(label, "START");
-        reg.emplace<OnPress>(e, ActionId::StartButton);
+        reg.emplace<UiActionStartButtonTag>(e);
     }
 }
 

--- a/app/systems/generated/paused_screen.cpp
+++ b/app/systems/generated/paused_screen.cpp
@@ -4,7 +4,6 @@
 // per-screen tag + per-kind tag + atomic UI components.
 // Regenerate via `cmake --build` (codegen runs on .rgl change).
 
-#include "components/actions.h"
 #include "components/ui.h"
 #include "tags/tags.h"
 
@@ -41,7 +40,7 @@ void spawn_paused_screen(entt::registry& reg) {
         reg.emplace<UiBounds>(e, 400.0f, 100.0f);
         auto& label = reg.emplace<UiLabel>(e);
         ui_label_set(label, "RESUME");
-        reg.emplace<OnPress>(e, ActionId::ResumeButton);
+        reg.emplace<UiActionResumeButtonTag>(e);
     }
     {
         // MenuInstruction (label)
@@ -62,7 +61,7 @@ void spawn_paused_screen(entt::registry& reg) {
         reg.emplace<UiBounds>(e, 400.0f, 100.0f);
         auto& label = reg.emplace<UiLabel>(e);
         ui_label_set(label, "MAIN MENU");
-        reg.emplace<OnPress>(e, ActionId::MenuButton);
+        reg.emplace<UiActionMenuButtonTag>(e);
     }
 }
 

--- a/app/systems/generated/screen_spawners.h
+++ b/app/systems/generated/screen_spawners.h
@@ -6,7 +6,7 @@
 // `tools/rguilayout/codegen.py` (one pair per `.rgl` in
 // `content/ui/screens/`). Per #1193: each call creates one entity per
 // control row in its `.rgl`, carrying atomic `UiPosition` / `UiBounds` /
-// `UiLabel` (+ `OnPress` for buttons) plus a per-screen tag (e.g.
+// `UiLabel` (+ `UiAction*Tag` for buttons) plus a per-screen tag (e.g.
 // `PausedScreenTag`) and a per-kind tag (`UiLabelTag` / `UiButtonTag` /
 // `UiDummyRecTag`) — see `app/components/ui.h` and `app/tags/tags.h`.
 //

--- a/app/systems/generated/settings_screen.cpp
+++ b/app/systems/generated/settings_screen.cpp
@@ -4,7 +4,6 @@
 // per-screen tag + per-kind tag + atomic UI components.
 // Regenerate via `cmake --build` (codegen runs on .rgl change).
 
-#include "components/actions.h"
 #include "components/ui.h"
 #include "tags/tags.h"
 
@@ -41,7 +40,7 @@ void spawn_settings_screen(entt::registry& reg) {
         reg.emplace<UiBounds>(e, 72.0f, 77.0f);
         auto& label = reg.emplace<UiLabel>(e);
         ui_label_set(label, "-");
-        reg.emplace<OnPress>(e, ActionId::AudioOffsetMinus);
+        reg.emplace<UiActionAudioOffsetMinusTag>(e);
     }
     {
         // AudioOffsetDisplay (label)
@@ -62,7 +61,7 @@ void spawn_settings_screen(entt::registry& reg) {
         reg.emplace<UiBounds>(e, 72.0f, 77.0f);
         auto& label = reg.emplace<UiLabel>(e);
         ui_label_set(label, "+");
-        reg.emplace<OnPress>(e, ActionId::AudioOffsetPlus);
+        reg.emplace<UiActionAudioOffsetPlusTag>(e);
     }
     {
         // HapticsToggle (button)
@@ -75,7 +74,7 @@ void spawn_settings_screen(entt::registry& reg) {
         reg.emplace<UiBounds>(e, 416.0f, 100.0f);
         auto& label = reg.emplace<UiLabel>(e);
         ui_label_set(label, "HAPTICS: ON");
-        reg.emplace<OnPress>(e, ActionId::HapticsToggle);
+        reg.emplace<UiActionHapticsToggleTag>(e);
     }
     {
         // HapticsValue (label)
@@ -98,7 +97,7 @@ void spawn_settings_screen(entt::registry& reg) {
         reg.emplace<UiBounds>(e, 416.0f, 100.0f);
         auto& label = reg.emplace<UiLabel>(e);
         ui_label_set(label, "MOTION: OFF");
-        reg.emplace<OnPress>(e, ActionId::ReduceMotionToggle);
+        reg.emplace<UiActionReduceMotionToggleTag>(e);
     }
     {
         // ReduceMotionValue (label)
@@ -119,7 +118,7 @@ void spawn_settings_screen(entt::registry& reg) {
         reg.emplace<UiBounds>(e, 200.0f, 100.0f);
         auto& label = reg.emplace<UiLabel>(e);
         ui_label_set(label, "BACK");
-        reg.emplace<OnPress>(e, ActionId::CloseButton);
+        reg.emplace<UiActionCloseButtonTag>(e);
     }
 }
 

--- a/app/systems/generated/song_complete_screen.cpp
+++ b/app/systems/generated/song_complete_screen.cpp
@@ -4,7 +4,6 @@
 // per-screen tag + per-kind tag + atomic UI components.
 // Regenerate via `cmake --build` (codegen runs on .rgl change).
 
-#include "components/actions.h"
 #include "components/ui.h"
 #include "tags/tags.h"
 
@@ -121,7 +120,7 @@ void spawn_song_complete_screen(entt::registry& reg) {
         reg.emplace<UiBounds>(e, 280.0f, 50.0f);
         auto& label = reg.emplace<UiLabel>(e);
         ui_label_set(label, "RESTART");
-        reg.emplace<OnPress>(e, ActionId::RestartButton);
+        reg.emplace<UiActionRestartButtonTag>(e);
     }
     {
         // LevelSelectButton (button)
@@ -132,7 +131,7 @@ void spawn_song_complete_screen(entt::registry& reg) {
         reg.emplace<UiBounds>(e, 280.0f, 50.0f);
         auto& label = reg.emplace<UiLabel>(e);
         ui_label_set(label, "LEVEL SELECT");
-        reg.emplace<OnPress>(e, ActionId::LevelSelectButton);
+        reg.emplace<UiActionLevelSelectButtonTag>(e);
     }
     {
         // MenuButton (button)
@@ -143,7 +142,7 @@ void spawn_song_complete_screen(entt::registry& reg) {
         reg.emplace<UiBounds>(e, 280.0f, 50.0f);
         auto& label = reg.emplace<UiLabel>(e);
         ui_label_set(label, "MAIN MENU");
-        reg.emplace<OnPress>(e, ActionId::MenuButton);
+        reg.emplace<UiActionMenuButtonTag>(e);
     }
 }
 

--- a/app/systems/generated/title_screen.cpp
+++ b/app/systems/generated/title_screen.cpp
@@ -4,7 +4,6 @@
 // per-screen tag + per-kind tag + atomic UI components.
 // Regenerate via `cmake --build` (codegen runs on .rgl change).
 
-#include "components/actions.h"
 #include "components/ui.h"
 #include "tags/tags.h"
 
@@ -75,7 +74,7 @@ void spawn_title_screen(entt::registry& reg) {
         reg.emplace<UiBounds>(e, 200.0f, 56.0f);
         auto& label = reg.emplace<UiLabel>(e);
         ui_label_set(label, "EXIT");
-        reg.emplace<OnPress>(e, ActionId::ExitButton);
+        reg.emplace<UiActionExitButtonTag>(e);
     }
     {
         // SettingsButton (button)
@@ -86,7 +85,7 @@ void spawn_title_screen(entt::registry& reg) {
         reg.emplace<UiBounds>(e, 64.0f, 64.0f);
         auto& label = reg.emplace<UiLabel>(e);
         ui_label_set(label, "#142#");
-        reg.emplace<OnPress>(e, ActionId::SettingsButton);
+        reg.emplace<UiActionSettingsButtonTag>(e);
     }
 }
 

--- a/app/systems/generated/tutorial_screen.cpp
+++ b/app/systems/generated/tutorial_screen.cpp
@@ -4,7 +4,6 @@
 // per-screen tag + per-kind tag + atomic UI components.
 // Regenerate via `cmake --build` (codegen runs on .rgl change).
 
-#include "components/actions.h"
 #include "components/ui.h"
 #include "tags/tags.h"
 
@@ -131,7 +130,7 @@ void spawn_tutorial_screen(entt::registry& reg) {
         reg.emplace<UiBounds>(e, 360.0f, 102.0f);
         auto& label = reg.emplace<UiLabel>(e);
         ui_label_set(label, "START");
-        reg.emplace<OnPress>(e, ActionId::ContinueButton);
+        reg.emplace<UiActionContinueButtonTag>(e);
     }
 }
 

--- a/app/systems/level_select_dynamic_spawn_system.cpp
+++ b/app/systems/level_select_dynamic_spawn_system.cpp
@@ -1,6 +1,5 @@
 #include "level_select_dynamic_spawn_system.h"
 
-#include "../components/actions.h"
 #include "../components/ui.h"
 #include "../tags/tags.h"
 #include "generated/screen_spawners.h"
@@ -25,11 +24,17 @@ constexpr float kDiffBtnGap   = 30.0f;
 constexpr float kDiffStartX   = kCardX + 50.0f;
 constexpr float kDiffYOffset  = 120.0f;
 
-// Per Fabian Principle 1: indexed table, no switch on the discriminator.
-constexpr ActionId kDifficultyAction[content_config::DIFFICULTY_COUNT] = {
-    ActionId::DifficultyEasy,
-    ActionId::DifficultyMedium,
-    ActionId::DifficultyHard,
+using DifficultyActionTagFn = void (*)(entt::registry&, entt::entity);
+
+template <typename ActionTag>
+void emplace_difficulty_action_tag(entt::registry& reg, entt::entity entity) {
+    reg.emplace<ActionTag>(entity);
+}
+
+constexpr DifficultyActionTagFn kDifficultyActionTags[content_config::DIFFICULTY_COUNT] = {
+    &emplace_difficulty_action_tag<UiActionDifficultyEasyTag>,
+    &emplace_difficulty_action_tag<UiActionDifficultyMediumTag>,
+    &emplace_difficulty_action_tag<UiActionDifficultyHardTag>,
 };
 
 float card_y_for(int level_index) {
@@ -62,8 +67,8 @@ void level_select_dynamic_spawn(entt::registry& reg) {
     // Difficulty buttons — one per (level, difficulty) pair. Position is
     // baked at spawn time; the render path filters to the active level
     // via `LevelIndex == LevelSelectState::selected_level`. Each button
-    // carries the matching `ActionId::Difficulty*` so the dispatch table
-    // already knows what to do.
+    // carries a matching `UiActionDifficulty*Tag` so press behavior is
+    // selected by ECS membership.
     for (int li = 0; li < content_config::LEVEL_COUNT; ++li) {
         const float diff_y = card_y_for(li) + kDiffYOffset;
         for (int di = 0; di < content_config::DIFFICULTY_COUNT; ++di) {
@@ -79,7 +84,7 @@ void level_select_dynamic_spawn(entt::registry& reg) {
             reg.emplace<UiBounds>(e, kDiffBtnW, kDiffBtnH);
             auto& label = reg.emplace<UiLabel>(e);
             ui_label_set(label, content_config::DIFFICULTY_NAMES[di]);
-            reg.emplace<OnPress>(e, kDifficultyAction[di]);
+            kDifficultyActionTags[di](reg, e);
         }
     }
 }

--- a/app/systems/ui_render_system.cpp
+++ b/app/systems/ui_render_system.cpp
@@ -1,7 +1,7 @@
 #include "all_systems.h"
 #include "camera_system.h"
 #include "settings_system.h"
-#include "../components/actions.h"
+
 #include "../components/energy_bar.h"
 #include "../components/player.h"
 #include "../components/rendering.h"
@@ -46,7 +46,7 @@ namespace {
 //
 // Migration boundary: a button press dispatch lives in
 // `app/systems/ui_update_system.cpp` — that system hit-tests against
-// `view<UiPosition, UiBounds, OnPress, UiButtonTag>()`. The GuiButton call
+// `view<UiPosition, UiBounds, UiButtonTag>()`. The GuiButton call
 // here renders only; its return value is ignored.
 
 constexpr int kEntityLabelTextSize  = 24;

--- a/app/systems/ui_update_system.cpp
+++ b/app/systems/ui_update_system.cpp
@@ -1,6 +1,5 @@
 #include "ui_update_system.h"
 
-#include "../components/actions.h"
 #include "../components/game_state.h"
 #include "../components/settings.h"
 #include "../components/ui.h"
@@ -23,7 +22,7 @@
 // Marks FTUE complete + persists settings + requests Playing phase.
 // Exposed via `ui_update_system.h` so the FTUE end-to-end test in
 // `tests/test_game_state_extended.cpp` can drive it directly; the
-// `ContinueButton` row of `kActionHandlers` below dispatches to it.
+// `UiActionContinueButtonTag` button path below dispatches to it.
 void tutorial_screen_continue(entt::registry& reg) {
     if (auto* settings_ptr = find_settings_state(reg)) {
         settings::mark_ftue_complete(*settings_ptr);
@@ -32,36 +31,15 @@ void tutorial_screen_continue(entt::registry& reg) {
     request_phase_transition<NextPhasePlayingTag>(reg);
 }
 
-// ── ActionId dispatch table ─────────────────────────────────────────────────
+// ── UI action membership dispatch ───────────────────────────────────────────
 //
-// Per Fabian Principle 1 (and the explicit Keep-set rationale for
-// `ActionId` in `app/.allowed-enums.txt`), the enum value is a perfect-hash
-// index into a per-action function-pointer column. Each row owns the
-// effect of "the user pressed this button". No central switch.
-//
-// Adding a new action: append the enumerator to `ActionId` (alphabetically),
-// then add a row below. Codegen + the table-size assertion below catch
-// mismatches at build time.
+// Button behavior is selected by ECS membership: generated buttons carry a
+// `UiAction*Tag`, and the hit-test path invokes the system whose tag is present.
+// `ActionId` remains only as a codegen validation label for `.rgl` names.
 
 namespace {
 
-using ActionHandler = void (*)(entt::registry&, entt::entity);
-
-// ── Per-action handlers ─────────────────────────────────────────────
-//
-// `noop_action_handler` fills the `ActionId::None` slot so the lookup
-// table is dense (every `ActionId` ordinal maps to a valid handler).
-// Real handlers below own the effect of "the user pressed this button"
-// for each migrated screen.
-
-void noop_action_handler(entt::registry& /*reg*/, entt::entity /*entity*/) {
-    // `ActionId::None` is the sentinel "no action" value used by buttons
-    // whose press is consumed by a screen-specific bind system rather
-    // than the central `kActionHandlers` table (e.g. level-select cards
-    // — see Pass C of `ui_update_system`). Dispatching it is a no-op.
-}
-
-// Paused screen actions (migrated this cycle).
+// Paused screen actions.
 void resume_button_action(entt::registry& reg, entt::entity /*entity*/) {
     request_phase_transition<NextPhasePlayingTag>(reg);
 }
@@ -93,10 +71,10 @@ void restart_button_action(entt::registry& reg, entt::entity /*entity*/) {
 }
 
 // `LevelSelectButton` is emitted only from end screens (Song Complete /
-// Game Over). On the Level Select screen itself, card presses skip the
-// `ActionId` dispatch entirely — see Pass C in `ui_update_system` below,
-// which writes the card's `LevelIndex` into `LevelSelectState` directly
-// (cards carry no `OnPress`, by design — issue #1296).
+// Game Over). On the Level Select screen itself, card presses skip button
+// action dispatch entirely — see Pass C in `ui_update_system` below, which
+// writes the card's `LevelIndex` into `LevelSelectState` directly (cards
+// carry no `UiButtonTag`, by design — issue #1296).
 void level_select_button_action(entt::registry& reg, entt::entity /*entity*/) {
     reg.ctx().insert_or_assign(EndChoiceLevelSelect{});
 }
@@ -130,7 +108,7 @@ void settings_button_action(entt::registry& reg, entt::entity /*entity*/) {
 //
 // AudioOffsetMinus / AudioOffsetPlus step `SettingsState::audio_offset_ms`
 // by `AUDIO_OFFSET_STEP_MS` and clamp to [MIN, MAX]. CloseButton routes
-// back to Title (no other screen currently emits ActionId::CloseButton).
+// back to Title (no other screen currently emits `UiActionCloseButtonTag`).
 // HapticsToggle / ReduceMotionToggle flip their respective bool and
 // persist via `settings::mark_dirty_and_save`. Enabling haptics also
 // warms up the platform backend so the first vibration after enable is
@@ -187,12 +165,10 @@ void reduce_motion_toggle_action(entt::registry& reg, entt::entity /*entity*/) {
 // `game_state_system` LevelSelect block consumes it after the entry
 // debounce and routes to Tutorial (if FTUE incomplete) or Playing.
 //
-// `DifficultyEasy/Medium/Hard` write the button's `DifficultyIndex` into
-// `LevelSelectState::selected_difficulty`. Per Fabian Principle 1 the
-// effect lives in one handler reading from the entity's
-// `DifficultyIndex` rather than three near-identical handlers — the
-// dispatch table still indexes by `ActionId` (#1287 invariant) and each
-// row points at this shared transform.
+// `UiActionDifficultyEasy/Medium/HardTag` buttons write the button's
+// `DifficultyIndex` into `LevelSelectState::selected_difficulty`. Per
+// Fabian Principle 1 the selected difficulty is carried by the entity row,
+// not a behavior discriminator.
 //
 // Both write-paths are gated by the entity's `LevelIndex` matching the
 // currently selected level. Diff buttons for non-active cards exist but
@@ -222,43 +198,33 @@ void pause_button_action(entt::registry& reg, entt::entity /*entity*/) {
     request_phase_transition<NextPhasePausedTag>(reg);
 }
 
-// ── Dispatch table ──────────────────────────────────────────────────
-//
-// Order must match the `ActionId` enumerator order in
-// `app/components/actions.h`. A compile-time check at the bottom verifies
-// the count.
+template <typename ActionTag>
+bool try_run_action(entt::registry& reg,
+                    entt::entity entity,
+                    void (*handler)(entt::registry&, entt::entity)) {
+    if (!reg.all_of<ActionTag>(entity)) return false;
+    handler(reg, entity);
+    return true;
+}
 
-constexpr std::array<ActionHandler, 18> kActionHandlers = {
-    /* None                 */ &noop_action_handler,
-    /* AudioOffsetMinus     */ &audio_offset_minus_action,
-    /* AudioOffsetPlus      */ &audio_offset_plus_action,
-    /* CloseButton          */ &close_button_action,
-    /* ContinueButton       */ &continue_button_action,
-    /* DifficultyEasy       */ &apply_difficulty_action,
-    /* DifficultyHard       */ &apply_difficulty_action,
-    /* DifficultyMedium     */ &apply_difficulty_action,
-    /* ExitButton           */ &exit_button_action,
-    /* HapticsToggle        */ &haptics_toggle_action,
-    /* LevelSelectButton    */ &level_select_button_action,
-    /* MenuButton           */ &menu_button_action,
-    /* PauseButton          */ &pause_button_action,
-    /* ReduceMotionToggle   */ &reduce_motion_toggle_action,
-    /* RestartButton        */ &restart_button_action,
-    /* ResumeButton         */ &resume_button_action,
-    /* SettingsButton       */ &settings_button_action,
-    /* StartButton          */ &start_button_action,
-};
-
-// Bumping ActionId without bumping kActionHandlers (or vice versa) is a
-// build-time error.
-static_assert(kActionHandlers.size() ==
-              static_cast<std::size_t>(ActionId::StartButton) + 1,
-              "kActionHandlers size must match ActionId enumerator count");
-
-void dispatch_action(entt::registry& reg, ActionId action, entt::entity entity) {
-    const auto idx = static_cast<std::size_t>(action);
-    if (idx >= kActionHandlers.size()) return;
-    kActionHandlers[idx](reg, entity);
+void dispatch_pressed_button(entt::registry& reg, entt::entity entity) {
+    if (try_run_action<UiActionAudioOffsetMinusTag>(reg, entity, &audio_offset_minus_action)) return;
+    if (try_run_action<UiActionAudioOffsetPlusTag>(reg, entity, &audio_offset_plus_action)) return;
+    if (try_run_action<UiActionCloseButtonTag>(reg, entity, &close_button_action)) return;
+    if (try_run_action<UiActionContinueButtonTag>(reg, entity, &continue_button_action)) return;
+    if (try_run_action<UiActionDifficultyEasyTag>(reg, entity, &apply_difficulty_action)) return;
+    if (try_run_action<UiActionDifficultyHardTag>(reg, entity, &apply_difficulty_action)) return;
+    if (try_run_action<UiActionDifficultyMediumTag>(reg, entity, &apply_difficulty_action)) return;
+    if (try_run_action<UiActionExitButtonTag>(reg, entity, &exit_button_action)) return;
+    if (try_run_action<UiActionHapticsToggleTag>(reg, entity, &haptics_toggle_action)) return;
+    if (try_run_action<UiActionLevelSelectButtonTag>(reg, entity, &level_select_button_action)) return;
+    if (try_run_action<UiActionMenuButtonTag>(reg, entity, &menu_button_action)) return;
+    if (try_run_action<UiActionPauseButtonTag>(reg, entity, &pause_button_action)) return;
+    if (try_run_action<UiActionReduceMotionToggleTag>(reg, entity, &reduce_motion_toggle_action)) return;
+    if (try_run_action<UiActionRestartButtonTag>(reg, entity, &restart_button_action)) return;
+    if (try_run_action<UiActionResumeButtonTag>(reg, entity, &resume_button_action)) return;
+    if (try_run_action<UiActionSettingsButtonTag>(reg, entity, &settings_button_action)) return;
+    if (try_run_action<UiActionStartButtonTag>(reg, entity, &start_button_action)) return;
 }
 
 // ── Per-active-phase input-delay table ──────────────────────────────────
@@ -391,7 +357,7 @@ void ui_update_system(entt::registry& reg) {
     {
         const auto* lss = reg.ctx().find<LevelSelectState>();
         if (lss != nullptr) {
-            auto diff_view = reg.view<UiPosition, UiBounds, OnPress,
+            auto diff_view = reg.view<UiPosition, UiBounds,
                                       UiButtonTag, DifficultyButtonTag,
                                       LevelIndex>();
             for (auto entity : diff_view) {
@@ -401,8 +367,7 @@ void ui_update_system(entt::registry& reg) {
                 const auto& sz  = diff_view.template get<UiBounds>(entity);
                 const Rectangle rect{pos.x, pos.y, sz.w, sz.h};
                 if (!CheckCollisionPointRec(pointer, rect)) continue;
-                const auto& on_press = diff_view.template get<OnPress>(entity);
-                dispatch_action(reg, on_press.action, entity);
+                dispatch_pressed_button(reg, entity);
                 return;
             }
         }
@@ -417,23 +382,23 @@ void ui_update_system(entt::registry& reg) {
     // excluded so Pass A is the sole handler for that archetype (its
     // active-level filter is the entire selection rule).
     {
-        auto view = reg.view<UiPosition, UiBounds, OnPress, UiButtonTag>(
+        auto view = reg.view<UiPosition, UiBounds, UiButtonTag>(
             entt::exclude<DifficultyButtonTag
 #ifdef PLATFORM_WEB
                           , UiHiddenOnWebTag
 #endif
                           >
         );
-        for (auto [e, pos, sz, on_press] : view.each()) {
+        for (auto [e, pos, sz] : view.each()) {
             const Rectangle rect{pos.x, pos.y, sz.w, sz.h};
             if (!CheckCollisionPointRec(pointer, rect)) continue;
-            dispatch_action(reg, on_press.action, e);
+            dispatch_pressed_button(reg, e);
             return;
         }
     }
 
     // Pass C — Level Select cards (issue #1296). Cards are not buttons in
-    // the existential sense (they carry no `OnPress`); a card click sets
+    // the existential sense (they carry no `UiButtonTag`); a card click sets
     // `LevelSelectState::selected_level` directly. Running last means
     // diff buttons (Pass A) and other buttons (Pass B) get priority,
     // since the card rectangle visually contains the diff button row.

--- a/app/systems/ui_update_system.h
+++ b/app/systems/ui_update_system.h
@@ -4,12 +4,10 @@
 
 // Entity-driven UI input system (issue #1287, refs #1193 OoS-A).
 //
-// Hit-tests `view<UiPosition, UiBounds, OnPress, UiButtonTag>` against the
-// frame's pointer-release event read from `InputState` (mouse click or
-// touch lift). On a hit, dispatches the entity's `OnPress::action` through
-// a per-`ActionId` function-pointer table — no `switch` on the
-// discriminator (Fabian Principle 1; `ActionId` is in the enum allowlist
-// specifically as a lookup-key index).
+// Hit-tests `view<UiPosition, UiBounds, UiButtonTag>` against the frame's
+// pointer-release event read from `InputState` (mouse click or touch lift).
+// On a hit, press behavior is selected by the entity's `UiAction*Tag`
+// membership, not by an `ActionId` ordinal.
 //
 // Honours the per-active-phase input-delay table (Game Over uses
 // `GAME_OVER_INPUT_DELAY`, Song Complete uses `SONG_COMPLETE_INPUT_DELAY`,
@@ -20,7 +18,7 @@ void ui_update_system(entt::registry& reg);
 
 // Tutorial-screen "Continue" action (issue #1291). Marks FTUE complete,
 // persists the settings entity, and requests the Playing phase. Invoked
-// by the `ContinueButton` row of `kActionHandlers` in
-// `ui_update_system.cpp`; exposed here so the FTUE end-to-end test in
+// by the `UiActionContinueButtonTag` button path in `ui_update_system.cpp`;
+// exposed here so the FTUE end-to-end test in
 // `tests/test_game_state_extended.cpp` can drive it directly.
 void tutorial_screen_continue(entt::registry& reg);

--- a/app/tags/tags.h
+++ b/app/tags/tags.h
@@ -405,6 +405,29 @@ struct UiShapeIconHexagonTag  {};
 // NAME_EXTRA_TAGS web-hidden list (`tools/rguilayout/codegen.py`).
 struct UiHiddenOnWebTag {};
 
+// ── UI action membership (per-action tag tables) ─────────────────────
+// Button behavior is selected by entity membership in one of these action
+// tables, not by dispatching an ActionId ordinal. Codegen attaches the tag
+// whose suffix matches each `.rgl` button control name; dynamic level-select
+// difficulty buttons attach their matching difficulty action tag at spawn.
+struct UiActionAudioOffsetMinusTag {};
+struct UiActionAudioOffsetPlusTag {};
+struct UiActionCloseButtonTag {};
+struct UiActionContinueButtonTag {};
+struct UiActionDifficultyEasyTag {};
+struct UiActionDifficultyHardTag {};
+struct UiActionDifficultyMediumTag {};
+struct UiActionExitButtonTag {};
+struct UiActionHapticsToggleTag {};
+struct UiActionLevelSelectButtonTag {};
+struct UiActionMenuButtonTag {};
+struct UiActionPauseButtonTag {};
+struct UiActionReduceMotionToggleTag {};
+struct UiActionRestartButtonTag {};
+struct UiActionResumeButtonTag {};
+struct UiActionSettingsButtonTag {};
+struct UiActionStartButtonTag {};
+
 // ── UI toggle kind (per-kind specialization of UiButtonTag) ──────────
 // Per Fabian's existential processing, "is this button a two-state
 // toggle?" is presence of this tag rather than a `UiButtonKind` enum
@@ -425,12 +448,11 @@ struct UiToggleOffTag {};
 // `content_config::LEVELS` and `content_config::DIFFICULTY_COUNT` — no
 // hard-coded counts in the `.rgl`). Each card carries `LevelCardTag` +
 // `LevelIndex`; each difficulty button carries `DifficultyButtonTag` +
-// `LevelIndex` (owning card) + `DifficultyIndex` (which difficulty row).
-// Both kinds also carry `UiButtonTag` + `OnPress` so the existing
-// `ui_update_system` hit-test path dispatches presses; the render path
-// excludes them from the generic GuiButton pass via `entt::exclude` and
-// runs dedicated per-tag passes that paint the rounded-rect card visual
-// and the active-state emphasis (thick border + selection bar, #469).
+// `LevelIndex` (owning card) + `DifficultyIndex` (which difficulty row) +
+// a `UiActionDifficulty*Tag` matching its row. The render path excludes
+// them from the generic GuiButton pass via `entt::exclude` and runs
+// dedicated per-tag passes that paint the rounded-rect card visual and
+// the active-state emphasis (thick border + selection bar, #469).
 // Despawn falls out for free — all entities also carry
 // `LevelSelectScreenTag` so the codegen-emitted `despawn_level_select_screen`
 // destroys them.

--- a/tests/test_level_select_dynamic_spawn_system.cpp
+++ b/tests/test_level_select_dynamic_spawn_system.cpp
@@ -3,7 +3,7 @@
 // `level_select_dynamic_spawn_system` paints the per-level cards and
 // per-(level, difficulty) buttons that the legacy controller drew
 // imperatively. The system runs every time the player enters Level
-// Select; a regression in card/button geometry or `ActionId` assignment
+// Select; a regression in card/button geometry or action-tag assignment
 // would silently break level selection.
 
 #include <catch2/catch_test_macros.hpp>
@@ -11,7 +11,6 @@
 #include <string>
 
 #include "test_helpers.h"
-#include "components/actions.h"
 #include "components/ui.h"
 #include "systems/level_select_dynamic_spawn_system.h"
 #include "systems/generated/screen_spawners.h"
@@ -89,24 +88,18 @@ TEST_CASE("level_select_dynamic_spawn: spawns one card per level with monotonica
     CHECK(card_ui_button_count == 0);
 }
 
-TEST_CASE("level_select_dynamic_spawn: spawns 3 difficulty buttons per card with matching ActionId",
+TEST_CASE("level_select_dynamic_spawn: spawns 3 difficulty buttons per card with matching action tag",
           "[level_select][ui][issue1296][issue1333]") {
     auto reg = make_registry();
     spawn_level_select_screen_full(reg);
 
     auto diff_view = reg.view<DifficultyButtonTag, UiButtonTag,
                               LevelSelectScreenTag, LevelIndex,
-                              DifficultyIndex, UiPosition, UiBounds, OnPress,
+                              DifficultyIndex, UiPosition, UiBounds,
                               UiLabel>();
 
     constexpr int kExpectedTotal =
         content_config::LEVEL_COUNT * content_config::DIFFICULTY_COUNT;
-
-    constexpr ActionId kExpectedAction[content_config::DIFFICULTY_COUNT] = {
-        ActionId::DifficultyEasy,
-        ActionId::DifficultyMedium,
-        ActionId::DifficultyHard,
-    };
 
     int total = 0;
     bool seen[content_config::LEVEL_COUNT][content_config::DIFFICULTY_COUNT] = {};
@@ -117,7 +110,6 @@ TEST_CASE("level_select_dynamic_spawn: spawns 3 difficulty buttons per card with
         const auto& di      = diff_view.get<DifficultyIndex>(entity);
         const auto& pos     = diff_view.get<UiPosition>(entity);
         const auto& bounds  = diff_view.get<UiBounds>(entity);
-        const auto& press   = diff_view.get<OnPress>(entity);
         const auto& label   = diff_view.get<UiLabel>(entity);
 
         REQUIRE(li.value >= 0);
@@ -137,7 +129,13 @@ TEST_CASE("level_select_dynamic_spawn: spawns 3 difficulty buttons per card with
         CHECK(near(bounds.w, kDiffBtnW));
         CHECK(near(bounds.h, kDiffBtnH));
 
-        CHECK(press.action == kExpectedAction[di.value]);
+        if (di.value == 0) {
+            CHECK(reg.all_of<UiActionDifficultyEasyTag>(entity));
+        } else if (di.value == 1) {
+            CHECK(reg.all_of<UiActionDifficultyMediumTag>(entity));
+        } else {
+            CHECK(reg.all_of<UiActionDifficultyHardTag>(entity));
+        }
 
         const std::string expected_label{content_config::DIFFICULTY_NAMES[di.value]};
         CHECK(std::string(label.text.data()) == expected_label);

--- a/tests/test_ui_update_system.cpp
+++ b/tests/test_ui_update_system.cpp
@@ -1,8 +1,8 @@
 // Tests for the entity-driven UI update system (issue #1287 / refs #1193 OoS-A).
 //
-// `ui_update_system` hit-tests `view<UiPosition, UiBounds, OnPress,
-// UiButtonTag>` against the frame's pointer-release event and dispatches the
-// matching `ActionId` via a per-action function-pointer table. These tests
+// `ui_update_system` hit-tests `view<UiPosition, UiBounds, UiButtonTag>`
+// against the frame's pointer-release event and dispatches via the matching
+// `UiAction*Tag` membership row. These tests
 // pin the dispatch semantics for the Paused-screen pilot:
 //
 //   * pointer hit on Resume button → `NextPhasePlayingTag` requested
@@ -21,7 +21,6 @@
 
 #include "test_helpers.h"
 
-#include "components/actions.h"
 #include "components/game_state.h"
 #include "components/ui.h"
 #include "constants.h"
@@ -744,11 +743,11 @@ TEST_CASE("Title ExitButton carries UiHiddenOnWebTag (#511, issue #1294)",
     entt::registry reg;
     spawn_title_screen(reg);
 
-    auto exit_view = reg.view<OnPress, UiHiddenOnWebTag, TitleScreenTag>();
+    auto exit_view = reg.view<UiActionExitButtonTag, UiHiddenOnWebTag,
+                              TitleScreenTag>();
     int matches = 0;
-    for (auto [e, on_press] : exit_view.each()) {
+    for (auto e : exit_view) {
         (void)e;
-        CHECK(on_press.action == ActionId::ExitButton);
         ++matches;
     }
     CHECK(matches == 1);
@@ -934,17 +933,8 @@ TEST_CASE("Settings toggle buttons carry UiToggleTag (issue #1295)",
     auto toggles = reg.view<UiToggleTag, UiButtonTag, SettingsScreenTag>();
     CHECK(toggles.size_hint() == 2);
 
-    int haptics = 0, motion = 0, other = 0;
-    auto with_action = reg.view<UiToggleTag, OnPress>();
-    for (auto [e, on_press] : with_action.each()) {
-        (void)e;
-        if (on_press.action == ActionId::HapticsToggle) ++haptics;
-        else if (on_press.action == ActionId::ReduceMotionToggle) ++motion;
-        else ++other;
-    }
-    CHECK(haptics == 1);
-    CHECK(motion == 1);
-    CHECK(other == 0);
+    CHECK(reg.view<UiToggleTag, UiActionHapticsToggleTag>().size_hint() == 1);
+    CHECK(reg.view<UiToggleTag, UiActionReduceMotionToggleTag>().size_hint() == 1);
 
     // Non-toggle Settings buttons (audio +/- and CloseButton) must NOT
     // carry the toggle tag — otherwise the render system would apply
@@ -1230,7 +1220,7 @@ TEST_CASE("screen_lifecycle_system: spawns Level Select entities on phase entry,
     CHECK(reg.view<LevelSelectScreenTag>().size() == 0);
 }
 
-TEST_CASE("Level Select cards carry LevelCardTag + LevelIndex; no OnPress (#1296)",
+TEST_CASE("Level Select cards carry LevelCardTag + LevelIndex; no UiButtonTag (#1296)",
           "[ui][level_select][issue1296]") {
     entt::registry reg = make_registry();
     sync_game_phase_tags<GamePhaseLevelSelectTag>(reg);
@@ -1250,7 +1240,6 @@ TEST_CASE("Level Select cards carry LevelCardTag + LevelIndex; no OnPress (#1296
         // generic button view means diff buttons (Pass A) and other UI
         // buttons (Pass B) win priority when they overlap the card region.
         CHECK_FALSE(reg.all_of<UiButtonTag>(e));
-        CHECK_FALSE(reg.all_of<OnPress>(e));
     }
     CHECK(card_count == content_config::LEVEL_COUNT);
     for (int i = 0; i < content_config::LEVEL_COUNT; ++i) {
@@ -1259,28 +1248,30 @@ TEST_CASE("Level Select cards carry LevelCardTag + LevelIndex; no OnPress (#1296
 }
 
 TEST_CASE("Level Select difficulty buttons carry DifficultyButtonTag + LevelIndex + "
-          "DifficultyIndex + matching ActionId (#1296)",
+          "DifficultyIndex + matching action tag (#1296)",
           "[ui][level_select][issue1296]") {
     entt::registry reg = make_registry();
     sync_game_phase_tags<GamePhaseLevelSelectTag>(reg);
     screen_lifecycle_system(reg);
 
     auto diffs = reg.view<DifficultyButtonTag, LevelIndex, DifficultyIndex,
-                          UiButtonTag, OnPress, LevelSelectScreenTag>();
+                          UiButtonTag, LevelSelectScreenTag>();
     int per_pair[content_config::LEVEL_COUNT][content_config::DIFFICULTY_COUNT] = {};
     int total = 0;
     for (auto e : diffs) {
         ++total;
         const auto& li = diffs.get<LevelIndex>(e);
         const auto& di = diffs.get<DifficultyIndex>(e);
-        const auto& op = diffs.get<OnPress>(e);
         REQUIRE(content_config::is_valid_level_index(li.value));
         REQUIRE(content_config::is_valid_difficulty_index(di.value));
         ++per_pair[li.value][di.value];
-        const ActionId expected = (di.value == 0)   ? ActionId::DifficultyEasy
-                                : (di.value == 1)   ? ActionId::DifficultyMedium
-                                                    : ActionId::DifficultyHard;
-        CHECK(op.action == expected);
+        if (di.value == 0) {
+            CHECK(reg.all_of<UiActionDifficultyEasyTag>(e));
+        } else if (di.value == 1) {
+            CHECK(reg.all_of<UiActionDifficultyMediumTag>(e));
+        } else {
+            CHECK(reg.all_of<UiActionDifficultyHardTag>(e));
+        }
     }
     CHECK(total
           == content_config::LEVEL_COUNT * content_config::DIFFICULTY_COUNT);

--- a/tools/rguilayout/INTEGRATION.md
+++ b/tools/rguilayout/INTEGRATION.md
@@ -27,7 +27,7 @@ Each `.rgl` row becomes one ECS entity carrying:
 | `UiPosition { x, y }`     | `app/components/ui.h` |
 | `UiBounds   { w, h }`     | `app/components/ui.h` |
 | `UiLabel    { text[64] }` | `app/components/ui.h` |
-| `OnPress    { action }`   | `app/components/ui.h` — buttons only |
+| `UiAction*Tag`            | `app/tags/tags.h` — buttons only |
 
 For each `.rgl <screen>.rgl` the codegen emits:
 
@@ -42,7 +42,8 @@ void despawn_<screen>_screen(entt::registry& reg);   // destroys all entities wi
    (or by hand — the format is plain text, see `USAGE.md`).
 2. If the edit introduces a new button control whose name is not already in
    `app/components/actions.h::ActionId`, add the new enumerator (sorted
-   alphabetically; the codegen will print a clear error otherwise).
+   alphabetically; the codegen will print a clear error otherwise). Also add
+   the matching `UiAction<Name>Tag` to `app/tags/tags.h`.
 3. If you add a new screen file, register its stem in
    `tools/rguilayout/codegen.py::SCREEN_TAGS` AND add the matching per-screen
    tag struct to `app/tags/tags.h` AND add the new file to the
@@ -69,7 +70,7 @@ It is idempotent — running twice on unchanged inputs produces zero file writes
 | Code | Meaning  | Maps to        |
 |------|----------|----------------|
 | 4    | Label    | `UiLabelTag`    |
-| 5    | Button   | `UiButtonTag` + `OnPress<ActionId::<name>>` |
+| 5    | Button   | `UiButtonTag` + `UiAction<Name>Tag` |
 | 24   | DummyRec | `UiDummyRecTag` (visual placeholder / icon slot) |
 
 Add new entries to `RGL_TYPES` in `codegen.py` to extend the table.
@@ -86,8 +87,8 @@ end-to-end by ECS:
   entity views directly (`UiLabelTag` / `UiButtonTag` / `UiDummyRecTag`); no
   `GamePhase` switch.
 - `app/systems/ui_update_system.cpp` — hit-tests `UiButtonTag` entities
-  against the pointer-release event and dispatches `OnPress::action` through
-  the per-`ActionId` function-pointer table (`kActionHandlers`).
+  against the pointer-release event and selects behavior by `UiAction*Tag`
+  membership.
 
 The single `RAYGUI_IMPLEMENTATION` translation unit lives at
 `app/util/raygui_impl.cpp`; the codegen output lives under

--- a/tools/rguilayout/codegen.py
+++ b/tools/rguilayout/codegen.py
@@ -9,8 +9,8 @@ becomes one `<screen>_screen.cpp` that exposes:
     void despawn_<screen>_screen(entt::registry& reg);
 
 Each control row in the `.rgl` becomes one ECS entity carrying atomic
-components (`UiPosition`, `UiBounds`, `UiLabel`, optionally `OnPress`) plus
-two existential tags: a per-screen tag and a per-kind tag. See
+components (`UiPosition`, `UiBounds`, `UiLabel`) plus existential tags:
+a per-screen tag, a per-kind tag, and a per-action tag for buttons. See
 `app/components/ui.h`, `app/components/actions.h`, and `app/tags/tags.h`
 for the component / tag declarations.
 
@@ -46,7 +46,7 @@ from typing import Dict, List, Tuple
 
 
 # ── .rgl type-code table ────────────────────────────────────────────────
-# Maps the type code in the .rgl row to a (per-kind tag, needs-OnPress) tuple.
+# Maps the type code in the .rgl row to a (per-kind tag, needs-action-tag) tuple.
 RGL_TYPES: Dict[int, Tuple[str, bool]] = {
     4:  ("UiLabelTag",    False),  # static text
     5:  ("UiButtonTag",   True),   # pressable
@@ -252,7 +252,6 @@ def emit_spawner_cpp(layout: Layout, path: Path) -> str:
     a("// per-screen tag + per-kind tag + atomic UI components.")
     a("// Regenerate via `cmake --build` (codegen runs on .rgl change).")
     a("")
-    a('#include "components/actions.h"')
     a('#include "components/ui.h"')
     a('#include "tags/tags.h"')
     a("")
@@ -265,7 +264,7 @@ def emit_spawner_cpp(layout: Layout, path: Path) -> str:
         if kind is None:
             _fail(path, f"control {c.name!r} uses unknown type code "
                         f"{c.type_code} (known: {sorted(RGL_TYPES)})")
-        kind_tag, needs_onpress = kind
+        kind_tag, needs_action_tag = kind
         anc_x, anc_y = _anchor_offset(layout, c.anchor_id, path)
         # Absolute (anchor + relative) pixel offset, baked at codegen time.
         abs_x = anc_x + c.x
@@ -284,8 +283,8 @@ def emit_spawner_cpp(layout: Layout, path: Path) -> str:
             a(f'        ui_label_set(label, "{_cpp_escape(c.text)}");')
         else:
             a(f"        (void)label;  // dynamic-text slot; bound by render system")
-        if needs_onpress:
-            a(f"        reg.emplace<OnPress>(e, ActionId::{c.name});")
+        if needs_action_tag:
+            a(f"        reg.emplace<UiAction{c.name}Tag>(e);")
         a(f"    }}")
     a("}")
     a("")

--- a/tools/test_rguilayout_codegen.py
+++ b/tools/test_rguilayout_codegen.py
@@ -75,8 +75,9 @@ class EmitterTests(unittest.TestCase):
         self.assertIn("SettingsScreenTag", out)
         self.assertIn("UiButtonTag", out)
         self.assertIn("UiLabelTag", out)
-        self.assertIn("OnPress", out)
-        self.assertIn("ActionId::HapticsToggle", out)
+        self.assertIn("UiActionHapticsToggleTag", out)
+        self.assertNotIn("OnPress", out)
+        self.assertNotIn("ActionId::HapticsToggle", out)
 
     def test_emit_does_not_use_uikind_enum_or_god_struct(self):
         # Doctrinal: existential per-kind tags replace the spec's UiKind enum.


### PR DESCRIPTION
## Summary
- replace runtime `ActionId`/`OnPress` UI press dispatch with per-button `UiAction*Tag` membership
- regenerate rguilayout screen spawners to emit action tags for buttons
- update tests and rguilayout docs to pin tag-based UI actions

Closes #1691

## Verification
- `cmake -B build -S . -Wno-dev`
- `cmake --build build`
- `./build/shapeshifter_tests`
- `python3 tools/test_rguilayout_codegen.py`
- `python3 tools/check_enum_allowlist.py`